### PR TITLE
KT-28492: Include sources in kotlin-osgi-bundle

### DIFF
--- a/libraries/tools/kotlin-osgi-bundle/pom.xml
+++ b/libraries/tools/kotlin-osgi-bundle/pom.xml
@@ -45,6 +45,19 @@
                             <excludes>**/MANIFEST.MF</excludes>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>unpack-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>sources</classifier>
+                            <includeScope>compile</includeScope>
+                            <includeGroupIds>${project.parent.groupId}</includeGroupIds>
+                            <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -86,15 +99,14 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>empty-sources-jar</id>
+                        <id>sources-jar</id>
                         <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <skipIfEmpty>false</skipIfEmpty>
                             <classifier>sources</classifier>
-                            <classesDirectory>${basedir}/sources</classesDirectory>
+                            <classesDirectory>${project.build.directory}/sources</classesDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-osgi-bundle/kotlin-osgi-bundle.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-osgi-bundle/kotlin-osgi-bundle.pom
@@ -45,6 +45,19 @@
                             <excludes>**/MANIFEST.MF</excludes>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>unpack-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>sources</classifier>
+                            <includeScope>compile</includeScope>
+                            <includeGroupIds>${project.parent.groupId}</includeGroupIds>
+                            <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -86,15 +99,14 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>empty-sources-jar</id>
+                        <id>sources-jar</id>
                         <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <skipIfEmpty>false</skipIfEmpty>
                             <classifier>sources</classifier>
-                            <classesDirectory>${basedir}/sources</classesDirectory>
+                            <classesDirectory>${project.build.directory}/sources</classesDirectory>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
With this change, we include the sources of all dependencies of
`kotlin-osgi-bundle` in its source bundle.
This gives users of this library a better IDE and debugging experience
providing documentation and allows users to debug in the stdlib.

This implementation works very similarly on how the class files of the
dependencies are merged. This also means that currently conflicts are
not handled at all.
This is probably fine, since there should actually be no duplicates.

^KT-28492 Fixed


Screenshot of the sources jar:
![grafik](https://github.com/user-attachments/assets/6ddd31db-846c-45e3-b8b2-32d13b0c2a4a)

