### PR TITLE
KT-71866 Fix withAndroidNativeArm32 selector

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/hierarchy/KotlinHierarchyBuilderImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/hierarchy/KotlinHierarchyBuilderImpl.kt
@@ -186,7 +186,7 @@ private class KotlinHierarchyBuilderImpl(
     }
 
     override fun withAndroidNativeArm32() = withTargets {
-        it is KotlinNativeTarget && it.konanTarget == KonanTarget.ANDROID_X86
+        it is KotlinNativeTarget && it.konanTarget == KonanTarget.ANDROID_ARM32
     }
 
     override fun withAndroidNativeArm64() = withTargets {


### PR DESCRIPTION
Fixes: [KT-71866](https://youtrack.jetbrains.com/issue/KT-71866/KotlinHierarchyBuilder.withAndroidNativeArm32-selects-the-wrong-KonanTarget)