### PR TITLE
Optimize Float/Double.isFinite()

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/util/NumbersJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/util/NumbersJVM.kt
@@ -37,13 +37,13 @@ public actual inline fun Float.isInfinite(): Boolean = java.lang.Float.isInfinit
  * Returns `true` if the argument is a finite floating-point value; returns `false` otherwise (for `NaN` and infinity arguments).
  */
 @kotlin.internal.InlineOnly
-public actual inline fun Double.isFinite(): Boolean = !isInfinite() && !isNaN()
+public actual inline fun Double.isFinite(): Boolean = (toRawBits() and 0x7fffffff_ffffffffL) < 0x7ff00000_00000000L
 
 /**
  * Returns `true` if the argument is a finite floating-point value; returns `false` otherwise (for `NaN` and infinity arguments).
  */
 @kotlin.internal.InlineOnly
-public actual inline fun Float.isFinite(): Boolean = !isInfinite() && !isNaN()
+public actual inline fun Float.isFinite(): Boolean = (toRawBits() and 0x7fffffff) < 0x7f800000
 
 /**
  * Returns a bit representation of the specified floating-point value as [Long]


### PR DESCRIPTION
The current implementation calls !isInfinite() && !isNaN(), leading to code that tests both cases separately. However, floats and doubles are encoded such that any positive finite value is, under integer representation of the raw bits, less than positive infinity.

The new implementation masks out the sign bit, and simply applies that test (< infinity).

When compiling the existing code on Android, using R8 and AOT compilation on a Pixel 6 running Android 14, we obtain the following aarch64 assembly:

```
fmov w0, s0
eor  w0, w0, #0x7f800000
tst  w0, #0x7fffffff
cset w0, eq
cbnz w0, #+0x14 (addr 0x1034)
fcmp s0, s0
b.ne #+0xc (addr 0x1034)
mov  w0, #0x1
b    #+0x8 (addr 0x1038)
mov  w0, #0x0
ret
```

There is a total of 11 instructions, including 3 branches. The new implementation yields the following branchless code instead, using only 6 instructions:

```
fmov w0, s0
and  w0, w0, #0x7fffffff
mov  w16, #0x7f800000
cmp  w0, w16
cset w0, lt
ret
```

When benchmarking the original (`isFinite()`) and new (`fastIsFinite()`) implementation on a 2021 MacBook M1 Pro using OpenJDK 22, we obtain the following results:

```
Benchmark                      Mode  Cnt    Score   Error  Units
KotlinBenchmark.fastIsFinite  thrpt       180.699          ops/s
KotlinBenchmark.isFinite      thrpt        93.578          ops/s
KotlinBenchmark.fastIsFinite   avgt         5.601          ms/op
KotlinBenchmark.isFinite       avgt        10.746          ms/op
```

Measuring throughput or time, the new implementation is twice as fast as the existing implementation (the benchmark calls the implementation over 16,777,215 unique float values).