### PR TITLE
Remove allocation from Collection.toTypedArray()

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/collections/ArraysJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/ArraysJVM.kt
@@ -35,7 +35,7 @@ public inline fun ByteArray.toString(charset: Charset): String = String(this, ch
 public actual inline fun <reified T> Collection<T>.toTypedArray(): Array<T> {
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     val thisCollection = this as java.util.Collection<T>
-    return thisCollection.toArray(arrayOfNulls<T>(0)) as Array<T>
+    return thisCollection.toArray(arrayOfNulls<T>(thisCollection.size())) as Array<T>
 }
 
 /** Internal unsafe construction of array based on reference array type */


### PR DESCRIPTION
The underlying API Collection.toArray(Array) will create a new array if the one passed as a parameter isn't large enough. Since we are creating an array anyway, give it the proper size so a second one isn't created. With the new implementation, calling toTypedArray() generates 1 allocation instead of 2.