### PR TITLE
Improve `kotlin.uuid.Uuid` hashcode

### DIFF
--- a/libraries/stdlib/src/kotlin/uuid/Uuid.kt
+++ b/libraries/stdlib/src/kotlin/uuid/Uuid.kt
@@ -196,8 +196,7 @@ public class Uuid internal constructor(
     }
 
     override fun hashCode(): Int {
-        val x = mostSignificantBits xor leastSignificantBits
-        return (x shr 32).toInt() xor x.toInt()
+        return (mostSignificantBits xor leastSignificantBits).hashCode()
     }
 
     private fun writeReplace(): Any = serializedUuid(this)


### PR DESCRIPTION
Hi, dear maintainers,

I've found an issue with the new multiplatform implementation of `kotlin.uuid.Uuid`. 
Its hashCode method can be rewritten with utilizing `Long.hashCode()` for better readability.