### PR TITLE
KT-72027: [Gradle, JS] Support Windows on ARM

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/hostUnameOutput.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/hostUnameOutput.kt
@@ -7,12 +7,18 @@ package org.jetbrains.kotlin.gradle.internal
 
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.internal.os.OperatingSystem
 
 internal val ProviderFactory.unameExecResult: Provider<String>
     get() {
         val cmd = exec {
-            it.executable = "uname"
-            it.args = listOf("-m")
+            if (OperatingSystem.current().isWindows){
+                it.executable = "powershell"
+                it.args = listOf("-NoProfile", "-Command", "(Get-WmiObject Win32_Processor).Architecture")
+            } else {
+                it.executable = "uname"
+                it.args = listOf("-m")
+            }
         }
 
         return cmd.standardOutput.asText.map { it.trim() }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/Platform.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/Platform.kt
@@ -13,23 +13,33 @@ internal data class Platform(
     }
 }
 
+internal enum class OsType(val osName: String) {
+    WINDOWS("win"),
+    MAC("darwin"),
+    LINUX("linux"),
+    FREEBSD("linux"), // https://github.com/node-gradle/gradle-node-plugin/issues/178
+    SUN("sunos"),
+}
+
 internal fun parsePlatform(name: String, arch: String, uname: Provider<String>): Platform {
+    val osType = parseOsType(name)
+    val osArch = if (osType == OsType.WINDOWS) parseWindowsArch(arch.toLowerCase(), uname)
+    else parseOsArch(arch.toLowerCase(), uname)
+
     return Platform(
-        parseOsName(name.toLowerCase()),
-        parseOsArch(
-            arch.toLowerCase(),
-            uname
-        )
+        osType.osName,
+        osArch
     )
 }
 
-internal fun parseOsName(name: String): String {
+internal fun parseOsType(type: String): OsType {
+    val name = type.toLowerCase()
     return when {
-        name.contains("windows") -> "win"
-        name.contains("mac") -> "darwin"
-        name.contains("linux") -> "linux"
-        name.contains("freebsd") -> "linux"
-        name.contains("sunos") -> "sunos"
+        name.contains("windows") -> OsType.WINDOWS
+        name.contains("mac") -> OsType.MAC
+        name.contains("linux") -> OsType.LINUX
+        name.contains("freebsd") -> OsType.FREEBSD
+        name.contains("sunos") -> OsType.SUN
         else -> error("Unsupported OS: $name")
     }
 }
@@ -53,6 +63,31 @@ internal fun parseOsArch(arch: String, uname: Provider<String>): String {
             }
         arch == "ppc64le" -> "ppc64le"
         arch == "s390x" -> "s390x"
+        arch.contains("64") -> "x64"
+        else -> "x86"
+    }
+}
+
+internal fun parseWindowsArch(arch: String, uname: Provider<String>): String {
+    return when {
+        arch.startsWith("aarch") || arch.startsWith("arm")
+            -> {
+            val wmiArch = uname.get()
+            return when (wmiArch) {
+                /*
+                 * Parse Win32_Processor.Architectures to real processor type
+                 *
+                 * Table from https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info#members
+                 */
+                "12" -> "arm64"
+                "9" -> "x64"
+                // "6" -> "IA64"
+                // "5" -> "arm" // 32-bit
+                "0" -> "x86"
+                // "0xffff" -> "Unknown"
+                else -> error("Unexpected Win32_Processor.Architecture: $arch")
+            }
+        }
         arch.contains("64") -> "x64"
         else -> "x86"
     }


### PR DESCRIPTION
[KT-72027](https://youtrack.jetbrains.com/issue/KT-72027) JS target build fails on ARM64 Windows

Build fails when building Kotlin Multiplatform JS target on Windows on ARM.
It appears to fail because it is trying to call the uname command, which does not exist in Windows.

This change adds support for the kotlin-gradle-plugin js target for Windows on ARM, which ported from node-gradle changes.
https://github.com/node-gradle/gradle-node-plugin/issues/315
https://github.com/node-gradle/gradle-node-plugin/commit/8b2f4cfb049cfd8f9a1dda08f62e696457410f9e#diff-afa737f9e45b97c369ddea14513270b563ac29801e8b42148f670f18aae703a7.
