### PR TITLE
KotlinCliJavaFileManagerImpl: don't cache empty search result

### DIFF
--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCliJavaFileManagerImpl.kt
@@ -62,7 +62,7 @@ class KotlinCliJavaFileManagerImpl(private val myPsiManager: PsiManager) : CoreJ
      * able to find its own correct version of the globally ambiguous class. But since [topLevelClassesCache] is global as well and not tied
      * to a specific module or scope, we need to cache that global view.
      */
-    private val topLevelClassesCache: MutableMap<FqName, SmartList<VirtualFile>> = Object2ObjectOpenHashMap()
+    private val topLevelClassesCache: MutableMap<FqName, SmartList<VirtualFile>?> = Object2ObjectOpenHashMap()
 
     private val allScope = GlobalSearchScope.allScope(myPsiManager.project)
     private var usePsiClassFilesReading = false
@@ -106,8 +106,8 @@ class KotlinCliJavaFileManagerImpl(private val myPsiManager: PsiManager) : CoreJ
                     index.findClasses(outerMostClassId) { dir, type ->
                         findVirtualFileGivenPackage(dir, relativeClassName, type)
                     }
-                )
-        }.firstOrNull { it in searchScope }
+                ).takeIf { it.isNotEmpty() }
+        }?.firstOrNull { it in searchScope }
     }
 
     private val binaryCache: MutableMap<ClassId, JavaClass?> = Object2ObjectOpenHashMap()


### PR DESCRIPTION
The result wasn't cached if `findVirtualFileForTopLevelClass` failed prior to 23e5f77ff, which makes the empty list cached. AnalysisHandlers like KSP rely on the previous behavior to introduce new Java files in repeated analyses.

This patch reverts to the old behavior with minimal changes.

A better fix might be exposing the ability to let callers of `KotlinCliJavaFileManager` invalidate the cache but that would be a larger change.