### PR TITLE
Fix a couple of issues in Duration.parse

### DIFF
--- a/libraries/stdlib/src/kotlin/time/Duration.kt
+++ b/libraries/stdlib/src/kotlin/time/Duration.kt
@@ -995,10 +995,18 @@ private fun parseDuration(value: String, strictIso: Boolean): Duration {
 
 
 private fun parseOverLongIsoComponent(value: String): Long {
+    require(
+        value.isNotEmpty()
+        && (value[0] in "+-" || value[0] in '0'..'9')
+        && (1..value.lastIndex).all { value[it] in '0'..'9' }
+    ) {
+        "Invalid number '$value'"
+    }
     val length = value.length
     var startIndex = 0
-    if (length > 0 && value[0] in "+-") startIndex++
-    if ((length - startIndex) > 16 && (startIndex..value.lastIndex).all { value[it] in '0'..'9' }) {
+    // skipping leading zeroes and signs to calculate how many digits there are in the number
+    while (startIndex < length && value[startIndex] in "+-0") startIndex++
+    if ((length - startIndex) > 16) {
         // all chars are digits, but more than ceiling(log10(MAX_MILLIS / 1000)) of them
         return if (value[0] == '-') Long.MIN_VALUE else Long.MAX_VALUE
     }

--- a/libraries/stdlib/test/time/DurationTest.kt
+++ b/libraries/stdlib/test/time/DurationTest.kt
@@ -553,7 +553,7 @@ class DurationTest {
         }
 
         // zero
-        test(Duration.ZERO, "PT0S", "P0D", "PT0H", "PT0M", "P0DT0H", "PT0H0M", "PT0H0S")
+        test(Duration.ZERO, "PT0S", "P0D", "PT0H", "PT0M", "P0DT0H", "PT0H0M", "PT0H0S", "PT000000000000000000000000H")
 
         // single unit
         test(1.days, "PT24H", "P1D", "PT1440M", "PT86400S")
@@ -600,6 +600,7 @@ class DurationTest {
             "PT1S2S", "PT1S2H",
             "P9999999999999DT-9999999999999H",
             "PT1.5H", "PT0.5D", "PT.5S", "PT0.25.25S",
+            "PT+-2H", "PT-+2H",
         )) {
             assertNull(Duration.parseIsoStringOrNull(invalidValue), invalidValue)
             assertFailsWith<IllegalArgumentException>(invalidValue) { Duration.parseIsoString(invalidValue) }.let { e ->


### PR DESCRIPTION
- PT000000000000000000000000000H used to be treated as an infinite value
- PT+-2H used to be parsed as "-2 hours", even though that's an incorrect ISO 8601 string

Fixes the `kotlin.time.Duration`-related issues reported in
https://gist.github.com/ilma4/a5ad5b5c284969e24f4e2149a2f8b273