### PR TITLE
KT-72172 Dispose URLClassLoader after compilation

### DIFF
--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/js/K2JSCompiler.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/js/K2JSCompiler.kt
@@ -191,7 +191,7 @@ class K2JSCompiler : CLICompiler<K2JSCompilerArguments>() {
             return COMPILATION_ERROR
         }
 
-        val pluginLoadResult = loadPlugins(paths, arguments, configuration)
+        val pluginLoadResult = loadPlugins(paths, arguments, configuration, rootDisposable)
         if (pluginLoadResult != OK) return pluginLoadResult
 
         if (arguments.script) {
@@ -1098,5 +1098,10 @@ fun loadPluginsForTests(configuration: CompilerConfiguration): ExitCode {
         PathUtil.KOTLIN_SCRIPTING_PLUGIN_CLASSPATH_JARS.map { File(libPath, it) }.partition { it.exists() }
     pluginClasspath = jars.map { it.canonicalPath } + pluginClasspath
 
-    return PluginCliParser.loadPluginsSafe(pluginClasspath, listOf(), listOf(), configuration)
+    val rootDisposable = Disposer.newDisposable()
+    try {
+        return PluginCliParser.loadPluginsSafe(pluginClasspath, listOf(), listOf(), configuration, rootDisposable)
+    } finally {
+        rootDisposable.dispose()
+    }
 }

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt
@@ -168,7 +168,7 @@ abstract class CLICompiler<A : CommonCompilerArguments> {
 
     protected abstract fun MutableList<String>.addPlatformOptions(arguments: A)
 
-    protected fun loadPlugins(paths: KotlinPaths?, arguments: A, configuration: CompilerConfiguration): ExitCode {
+    protected fun loadPlugins(paths: KotlinPaths?, arguments: A, configuration: CompilerConfiguration, rootDisposable: Disposable): ExitCode {
         val pluginClasspaths = arguments.pluginClasspaths.orEmpty().toMutableList()
         val pluginOptions = arguments.pluginOptions.orEmpty().toMutableList()
         val pluginConfigurations = arguments.pluginConfigurations.orEmpty().toMutableList()
@@ -212,7 +212,7 @@ abstract class CLICompiler<A : CommonCompilerArguments> {
             return INTERNAL_ERROR
         }
 
-        return PluginCliParser.loadPluginsSafe(pluginClasspaths, pluginOptions, pluginConfigurations, configuration)
+        return PluginCliParser.loadPluginsSafe(pluginClasspaths, pluginOptions, pluginConfigurations, configuration, rootDisposable)
     }
 
     private fun tryLoadScriptingPluginFromCurrentClassLoader(

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt
@@ -56,7 +56,7 @@ class K2JVMCompiler : CLICompiler<K2JVMCompilerArguments>() {
 
         configuration.put(JVMConfigurationKeys.DISABLE_STANDARD_SCRIPT_DEFINITION, arguments.disableStandardScript)
 
-        val pluginLoadResult = loadPlugins(paths, arguments, configuration)
+        val pluginLoadResult = loadPlugins(paths, arguments, configuration, rootDisposable)
         if (pluginLoadResult != ExitCode.OK) return pluginLoadResult
 
         val moduleName = arguments.moduleName ?: JvmProtoBufUtil.DEFAULT_MODULE_NAME

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/KotlinMetadataCompiler.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/metadata/KotlinMetadataCompiler.kt
@@ -68,7 +68,7 @@ class KotlinMetadataCompiler : CLICompiler<K2MetadataCompilerArguments>() {
         val collector = configuration.getNotNull(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY)
         val performanceManager = configuration.getNotNull(CLIConfigurationKeys.PERF_MANAGER)
 
-        val pluginLoadResult = loadPlugins(paths, arguments, configuration)
+        val pluginLoadResult = loadPlugins(paths, arguments, configuration, rootDisposable)
         if (pluginLoadResult != ExitCode.OK) return pluginLoadResult
 
         val commonSources = arguments.commonSources?.toSet() ?: emptySet()

--- a/compiler/test-infrastructure-utils/tests/org/jetbrains/kotlin/script/scriptTestUtil.kt
+++ b/compiler/test-infrastructure-utils/tests/org/jetbrains/kotlin/script/scriptTestUtil.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.script
 
+import com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.utils.PathUtil
@@ -20,9 +21,19 @@ fun loadScriptingPlugin(configuration: CompilerConfiguration) {
             KOTLIN_SCRIPTING_JVM_JAR
         ).map { File(libPath, it).path }
     }
-    PluginCliParser.loadPluginsSafe(pluginClasspath, emptyList(), emptyList(), configuration)
+    val rootDisposable = Disposer.newDisposable()
+    try {
+        PluginCliParser.loadPluginsSafe(pluginClasspath, emptyList(), emptyList(), configuration, rootDisposable)
+    } finally {
+        Disposer.dispose(rootDisposable)
+    }
 }
 
 fun loadScriptingPlugin(configuration: CompilerConfiguration, pluginClasspath: Collection<String>) {
-    PluginCliParser.loadPluginsSafe(pluginClasspath, emptyList(), emptyList(), configuration)
+    val rootDisposable = Disposer.newDisposable()
+    try {
+        PluginCliParser.loadPluginsSafe(pluginClasspath, emptyList(), emptyList(), configuration, rootDisposable)
+    } finally {
+        Disposer.dispose(rootDisposable)
+    }
 }


### PR DESCRIPTION
Closes `URLClassLoader` objects upon compilation completion.

See: https://youtrack.jetbrains.com/issue/KT-72172/File-Leak-occurring-in-Kotlin-Daemon