### PR TITLE
Docs: Replace "Twitter" with "X" in ReadMe

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ Some handy links:
  * [Forum](https://discuss.kotlinlang.org/)
  * [Kotlin Blog](https://blog.jetbrains.com/kotlin/)
  * [Subscribe to Kotlin YouTube channel](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
- * [Follow Kotlin on Twitter](https://twitter.com/kotlin)
+ * [Follow Kotlin on X](https://x.com/kotlin)
  * [Public Slack channel](https://slack.kotlinlang.org/)
  * [TeamCity CI build](https://teamcity.jetbrains.com/project.html?tab=projectOverview&projectId=Kotlin)
 


### PR DESCRIPTION
Twitter service is now renamed as X.
i updated ReadMe to follow it