### PR TITLE
KT-49155 Fix KGP compatibility with test-retry and test-distribution plugins

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/tasks/KotlinJvmTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/tasks/KotlinJvmTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.jvm.tasks
 
 import org.gradle.api.internal.tasks.testing.*
+import org.gradle.api.internal.tasks.testing.detection.DefaultTestExecuter
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -17,12 +18,18 @@ abstract class KotlinJvmTest : Test() {
     @Optional
     var targetName: String? = null
 
-    override fun createTestExecuter(): TestExecuter<JvmTestExecutionSpec> =
-        if (targetName != null) Executor(
-            super.createTestExecuter(),
-            targetName!!,
-        )
-        else super.createTestExecuter()
+    override fun createTestExecuter(): TestExecuter<JvmTestExecutionSpec> {
+        val originalExecutor = super.createTestExecuter()
+
+        // If the executor is not an instance of DefaultTestExecutor it means that it was created before
+        // and set to `Test.testExecuter` by Gradle plugins like test-distribution and test-retry.
+        // We can return the executor "as is" in this case as it is already wrapped with our Executor.
+        return if (targetName != null && originalExecutor is DefaultTestExecuter) {
+            Executor(originalExecutor, targetName!!)
+        } else {
+            originalExecutor
+        }
+    }
 
     class Executor(
         private val delegate: TestExecuter<JvmTestExecutionSpec>,


### PR DESCRIPTION
Gradle plugins can use internal API to wrap test executor and set it to `Test.testExecuter` field. KGP overrides `createTestExecutor` ignoring this possibility. So in result `testExecutor` might be wrapped several times with KGP's executor.

For example, when the [test-retry plugin](https://github.com/gradle/test-retry-gradle-plugin) is applied, we get the following test executor hierarchy:
```kotlin
KotlinJvmTarget$Executor(
  RetryTestExecuter(
    KotlinJvmTarget$Executor(
      DefaultTestExecuter
    )
  )
)
```
This breaks two things:
- Tests naming as `targetName` is appended twice
- Test retry itself, as it needs the executor to be an instance of `RetryTestExecutor`.

**Fixes:**
- [KT-49155](https://youtrack.jetbrains.com/issue/KT-49155) MPP, Gradle: Cannot use `test-retry-gradle-plugin` with Kotlin multiplatform tests
- https://github.com/gradle/test-retry-gradle-plugin/issues/116