### PR TITLE
[KT-20070] Add the bridge for indirectly overridden of Map.entries

### DIFF
--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirBlackBoxCodegenBasedTestGenerated.java
@@ -57935,6 +57935,24 @@ public class LLFirBlackBoxCodegenBasedTestGenerated extends AbstractLLFirBlackBo
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
+++ b/analysis/low-level-api-fir/tests/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/compiler/based/LLFirReversedBlackBoxCodegenBasedTestGenerated.java
@@ -57935,6 +57935,24 @@ public class LLFirReversedBlackBoxCodegenBasedTestGenerated extends AbstractLLFi
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirLightTreeBlackBoxCodegenTestGenerated.java
@@ -57456,6 +57456,24 @@ public class FirLightTreeBlackBoxCodegenTestGenerated extends AbstractFirLightTr
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
+++ b/compiler/fir/fir2ir/tests-gen/org/jetbrains/kotlin/test/runners/codegen/FirPsiBlackBoxCodegenTestGenerated.java
@@ -57520,6 +57520,24 @@ public class FirPsiBlackBoxCodegenTestGenerated extends AbstractFirPsiBlackBoxCo
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt
+++ b/compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt
@@ -1,0 +1,19 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM
+
+class KtMap : AbstractMap<String, String>() {
+    override val entries: HashSet<Map.Entry<String, String>>
+        get() = HashSet<Map.Entry<String, String>>().apply {
+            add(object : Map.Entry<String, String> {
+                override val key: String
+                    get() = "O"
+                override val value: String
+                    get() = "K"
+            })
+        }
+}
+
+fun box(): String {
+    val entry = KtMap().entries.first()
+    return entry.key + entry.value
+}

--- a/compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt
+++ b/compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt
@@ -1,0 +1,46 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM
+abstract class MyMap : AbstractMap<String, String>() {
+    override val keys: Set<String>
+        get() = TODO("Not yet implemented")
+    override val size: Int
+        get() = TODO("Not yet implemented")
+    override val values: Collection<String>
+        get() = TODO("Not yet implemented")
+
+    override fun isEmpty(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun get(key: String): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun containsValue(value: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun containsKey(key: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+}
+
+abstract class MyMap1 : MyMap(), Map<String, String>
+abstract class MyMap2 : MyMap1()
+class KtMap : MyMap2() {
+    override val entries: HashSet<Map.Entry<String, String>>
+        get() = HashSet<Map.Entry<String, String>>().apply {
+            add(object : Map.Entry<String, String> {
+                override val key: String
+                    get() = "O"
+                override val value: String
+                    get() = "K"
+            })
+        }
+}
+
+fun box(): String {
+    val entry = KtMap().entries.first()
+    return entry.key + entry.value
+}

--- a/compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt
+++ b/compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt
@@ -1,0 +1,49 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM
+// FILE: MyMap2.java
+abstract public class MyMap2 extends MyMap1 {}
+
+// FILE: main.kt
+abstract class MyMap : AbstractMap<String, String>() {
+    override val keys: Set<String>
+        get() = TODO("Not yet implemented")
+    override val size: Int
+        get() = TODO("Not yet implemented")
+    override val values: Collection<String>
+        get() = TODO("Not yet implemented")
+
+    override fun isEmpty(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun get(key: String): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun containsValue(value: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun containsKey(key: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+}
+
+abstract class MyMap1 : MyMap(), Map<String, String>
+class KtMap : MyMap2() {
+    override val entries: HashSet<Map.Entry<String, String>>
+        get() = HashSet<Map.Entry<String, String>>().apply {
+            add(object : Map.Entry<String, String> {
+                override val key: String
+                    get() = "O"
+                override val value: String
+                    get() = "K"
+            })
+        }
+}
+
+fun box(): String {
+    val entry = KtMap().entries.first()
+    return entry.key + entry.value
+}

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/JvmAbiConsistencyTestBoxGenerated.java
@@ -56414,6 +56414,24 @@ public class JvmAbiConsistencyTestBoxGenerated extends AbstractJvmAbiConsistency
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenTestGenerated.java
@@ -56686,6 +56686,24 @@ public class IrBlackBoxCodegenTestGenerated extends AbstractIrBlackBoxCodegenTes
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/IrBlackBoxCodegenWithIrInlinerTestGenerated.java
@@ -56686,6 +56686,24 @@ public class IrBlackBoxCodegenWithIrInlinerTestGenerated extends AbstractIrBlack
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
+++ b/compiler/tests-common-new/tests-gen/org/jetbrains/kotlin/test/runners/codegen/inlineScopes/FirBlackBoxCodegenTestWithInlineScopesGenerated.java
@@ -57456,6 +57456,24 @@ public class FirBlackBoxCodegenTestWithInlineScopesGenerated extends AbstractFir
     }
 
     @Test
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @Test
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
+    @Test
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/LightAnalysisModeTestGenerated.java
@@ -45950,6 +45950,21 @@ public class LightAnalysisModeTestGenerated extends AbstractLightAnalysisModeTes
       runTest("compiler/testData/codegen/box/specialBuiltins/javaMapWithCustomEntries.kt");
     }
 
+    @TestMetadata("kt20070_1.kt")
+    public void testKt20070_1() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_1.kt");
+    }
+
+    @TestMetadata("kt20070_2.kt")
+    public void testKt20070_2() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_2.kt");
+    }
+
+    @TestMetadata("kt20070_3.kt")
+    public void testKt20070_3() {
+      runTest("compiler/testData/codegen/box/specialBuiltins/kt20070_3.kt");
+    }
+
     @TestMetadata("mapGetOrDefault.kt")
     public void testMapGetOrDefault() {
       runTest("compiler/testData/codegen/box/specialBuiltins/mapGetOrDefault.kt");


### PR DESCRIPTION
KT-20070 fixed

This issue occurred because we forgot to add "getEntries() Ljava/ tilt/ Set;". The bridge method for kotlin. collections. Map. entries is "entrySet() Ljava/ tilt/ Set;" (see org. jetbrains. kotlin. load. java. BuiltinSpecialProperties. PROPERTY_FQ_NAME_TO_JVM_GETTER_NAME_MAP). But when the above situation occurs, we also need a "getEntries() Ljava/ util/ Set;". So the hardcoded bridge will not affect other situations.