### PR TITLE
Clean up deprecation warnings in NodeJsRootExtension.kt

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/NodeJsRootExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/NodeJsRootExtension.kt
@@ -50,52 +50,52 @@ open class NodeJsRootExtension(
     }
 
     @Deprecated(
-        "Use installationDir from NodeJsEnvSpec (not NodeJsRootExtension) instead." +
+        "Use installationDir from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var installationDir: File = gradleHome.resolve("nodejs")
 
     @Deprecated(
-        "Use download from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use download from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var download = true
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use downloadBaseUrl from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use downloadBaseUrl from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var nodeDownloadBaseUrl by ::downloadBaseUrl
 
     @Deprecated(
-        "Use downloadBaseUrl from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use downloadBaseUrl from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var downloadBaseUrl: String? = "https://nodejs.org/dist"
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use version from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use version from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var nodeVersion by ::version
 
     @Deprecated(
-        "Use downloadBaseUrl from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use downloadBaseUrl from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var version = "22.0.0"
 
     @Deprecated(
-        "Use command from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use command from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var command = "node"
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use command from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use command from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin. This will be removed in 2.2"
     )
     var nodeCommand by ::command
@@ -133,7 +133,7 @@ open class NodeJsRootExtension(
         get() = project.tasks.withType(KotlinNpmCachesSetup::class.java).named(KotlinNpmCachesSetup.NAME)
 
     @Deprecated(
-        "Use nodeJsSetupTaskProvider from NodeJsEnvSpec (not NodeJsRootExtension) instead" +
+        "Use nodeJsSetupTaskProvider from NodeJsEnvSpec (not NodeJsRootExtension) instead. " +
                 "You can find this extension after applying NodeJsPlugin"
     )
     val nodeJsSetupTaskProvider: TaskProvider<out NodeJsSetupTask>


### PR DESCRIPTION
Before this change you'd get warnings that said "insteadYou" without space making it hard to read.