### PR TITLE
Register LibraryFilterCachingService without using rootProject reference

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/internal/LibraryFilterCachingService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/internal/LibraryFilterCachingService.kt
@@ -37,7 +37,7 @@ internal abstract class LibraryFilterCachingService : BuildService<BuildServiceP
 
     companion object {
         fun registerIfAbsent(project: Project): Provider<LibraryFilterCachingService> =
-            project.rootProject.gradle.sharedServices.registerIfAbsent(
+            project.gradle.sharedServices.registerIfAbsent(
                 "${LibraryFilterCachingService::class.java.canonicalName}_${LibraryFilterCachingService::class.java.classLoader.hashCode()}",
                 LibraryFilterCachingService::class.java
             ) {}.also { serviceProvider ->


### PR DESCRIPTION
LibraryFilterCachingService shared service was being registered through rootProject. That breaks Gradle Isolated Projects (see KT-54105)

Instead, register through the current project, as shared services are shared through the entire build.