### PR TITLE
KT-24658 Add downUntil function

### DIFF
--- a/libraries/stdlib/common/src/generated/_Ranges.kt
+++ b/libraries/stdlib/common/src/generated/_Ranges.kt
@@ -968,6 +968,176 @@ public infix fun Short.downTo(to: Short): IntProgression {
 }
 
 /**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Int.downUntil(to: Byte): IntProgression {
+    return IntProgression.fromClosedRange(this, to.toInt() + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Long.downUntil(to: Byte): LongProgression {
+    return LongProgression.fromClosedRange(this, to.toLong() + 1, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Byte.downUntil(to: Byte): IntProgression {
+    return IntProgression.fromClosedRange(this.toInt(), to.toInt() + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Short.downUntil(to: Byte): IntProgression {
+    return IntProgression.fromClosedRange(this.toInt(), to.toInt() + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Char.downUntil(to: Char): CharProgression {
+    return CharProgression.fromClosedRange(this, to + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Int.downUntil(to: Int): IntProgression {
+    return IntProgression.fromClosedRange(this, to + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Long.downUntil(to: Int): LongProgression {
+    return LongProgression.fromClosedRange(this, to.toLong() + 1, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Byte.downUntil(to: Int): IntProgression {
+    return IntProgression.fromClosedRange(this.toInt(), to + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Short.downUntil(to: Int): IntProgression {
+    return IntProgression.fromClosedRange(this.toInt(), to + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Int.downUntil(to: Long): LongProgression {
+    return LongProgression.fromClosedRange(this.toLong(), to + 1, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Long.downUntil(to: Long): LongProgression {
+    return LongProgression.fromClosedRange(this, to + 1, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Byte.downUntil(to: Long): LongProgression {
+    return LongProgression.fromClosedRange(this.toLong(), to + 1, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Short.downUntil(to: Long): LongProgression {
+    return LongProgression.fromClosedRange(this.toLong(), to + 1, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Int.downUntil(to: Short): IntProgression {
+    return IntProgression.fromClosedRange(this, to.toInt() + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Long.downUntil(to: Short): LongProgression {
+    return LongProgression.fromClosedRange(this, to.toLong() + 1, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Byte.downUntil(to: Short): IntProgression {
+    return IntProgression.fromClosedRange(this.toInt(), to.toInt() + 1, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+public infix fun Short.downUntil(to: Short): IntProgression {
+    return IntProgression.fromClosedRange(this.toInt(), to.toInt() + 1, -1)
+}
+
+/**
  * Returns a progression that goes over the same range in the opposite direction with the same step.
  */
 public fun IntProgression.reversed(): IntProgression {

--- a/libraries/stdlib/common/src/generated/_URanges.kt
+++ b/libraries/stdlib/common/src/generated/_URanges.kt
@@ -315,6 +315,54 @@ public infix fun UShort.downTo(to: UShort): UIntProgression {
 }
 
 /**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+@SinceKotlin("1.5")
+@WasExperimental(ExperimentalUnsignedTypes::class)
+public infix fun UByte.downUntil(to: UByte): UIntProgression {
+    return UIntProgression.fromClosedRange(this.toUInt(), to.toUInt() + 1u, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+@SinceKotlin("1.5")
+@WasExperimental(ExperimentalUnsignedTypes::class)
+public infix fun UInt.downUntil(to: UInt): UIntProgression {
+    return UIntProgression.fromClosedRange(this, to + 1u, -1)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+@SinceKotlin("1.5")
+@WasExperimental(ExperimentalUnsignedTypes::class)
+public infix fun ULong.downUntil(to: ULong): ULongProgression {
+    return ULongProgression.fromClosedRange(this, to + 1u, -1L)
+}
+
+/**
+ * Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+ * 
+ * The [to] value should be less than `this` value.
+ * If the [to] value is equal to or greater than `this` value the returned progression is empty.
+ */
+@SinceKotlin("1.5")
+@WasExperimental(ExperimentalUnsignedTypes::class)
+public infix fun UShort.downUntil(to: UShort): UIntProgression {
+    return UIntProgression.fromClosedRange(this.toUInt(), to.toUInt() + 1u, -1)
+}
+
+/**
  * Returns a progression that goes over the same range in the opposite direction with the same step.
  */
 @SinceKotlin("1.5")

--- a/libraries/stdlib/test/ranges/RangeIterationTest.kt
+++ b/libraries/stdlib/test/ranges/RangeIterationTest.kt
@@ -226,6 +226,49 @@ public class RangeIterationTest : RangeIterationTestBase() {
     }
 
 
+    @Test fun emptyDownUntil() {
+        doTest(5 downUntil 10, 5, 11, -1, listOf())
+        doTest(5.toByte() downUntil 10.toByte(), 5, 11, -1, listOf())
+        doTest(5.toShort() downUntil 10.toShort(), 5, 11, -1, listOf())
+        doTest(5L downUntil 10L, 5L, 11L, -1L, listOf())
+
+        doTest('a' downUntil 'z', 'a', '{', -1, listOf())
+
+        doTest(5u downUntil 10u, 5u, 11u, -1, listOf())
+        doTest(5u.toUByte() downUntil 10u.toUByte(), 5u, 11u, -1, listOf())
+        doTest(5u.toUShort() downUntil 10u.toUShort(), 5u, 11u, -1, listOf())
+        doTest(5uL downUntil 10uL, 5uL, 11uL, -1L, listOf())
+    }
+
+    @Test fun oneElementDownUntil() {
+        doTest(5 downUntil 4, 5, 5, -1, listOf(5))
+        doTest(5.toByte() downUntil 4.toByte(), 5, 5, -1, listOf(5))
+        doTest(5.toShort() downUntil 4.toShort(), 5, 5, -1, listOf(5))
+        doTest(5L downUntil 4L, 5L, 5L, -1L, listOf(5L))
+
+        doTest('k' downUntil 'j', 'k', 'k', -1, listOf('k'))
+
+        doTest(5u downUntil 4u, 5u, 5u, -1, listOf(5u))
+        doTest(5u.toUByte() downUntil 4u.toUByte(), 5u, 5u, -1, listOf(5u))
+        doTest(5u.toUShort() downUntil 4u.toUShort(), 5u, 5u, -1, listOf(5u))
+        doTest(5uL downUntil 4uL, 5uL, 5uL, -1L, listOf(5uL))
+    }
+
+    @Test fun simpleDownUntil() {
+        doTest(9 downUntil 3, 9, 4, -1, listOf(9, 8, 7, 6, 5, 4))
+        doTest(9.toByte() downUntil 3.toByte(), 9, 4, -1, listOf(9, 8, 7, 6, 5, 4))
+        doTest(9.toShort() downUntil 3.toShort(), 9, 4, -1, listOf(9, 8, 7, 6, 5, 4))
+        doTest(9L downUntil 3L, 9L, 4L, -1L, listOf(9, 8, 7, 6, 5, 4))
+
+        doTest('g' downUntil 'c', 'g', 'd', -1, listOf('g', 'f', 'e', 'd'))
+
+        doTest(5u downUntil 3u, 5u, 4u, -1, listOf(5u, 4u))
+        doTest(5u.toUByte() downUntil 3u.toUByte(), 5u, 4u, -1, listOf(5u, 4u))
+        doTest(5u.toUShort() downUntil 3u.toUShort(), 5u, 4u, -1, listOf(5u, 4u))
+        doTest(5uL downUntil 3uL, 5uL, 4uL, -1L, listOf(5u, 4u))
+    }
+
+
     @Test fun simpleSteppedRange() {
         doTest(3..9 step 2, 3, 9, 2, listOf(3, 5, 7, 9))
         doTest(3.toByte()..9.toByte() step 2, 3, 9, 2, listOf(3, 5, 7, 9))

--- a/libraries/tools/binary-compatibility-validator/klib-public-api/kotlin-stdlib.api
+++ b/libraries/tools/binary-compatibility-validator/klib-public-api/kotlin-stdlib.api
@@ -13793,6 +13793,21 @@ abstract interface <#A: out kotlin/Any?> kotlin.reflect/KCallable { // kotlin.re
 final fun (kotlin/Any?).kotlin/toString(): kotlin/String // kotlin/toString|toString@kotlin.Any?(){}[0]
 
 // Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Byte).kotlin.ranges/downUntil(kotlin/Byte): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Byte(kotlin.Byte){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Byte).kotlin.ranges/downUntil(kotlin/Int): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Byte(kotlin.Int){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Byte).kotlin.ranges/downUntil(kotlin/Long): kotlin.ranges/LongProgression // kotlin.ranges/downUntil|downUntil@kotlin.Byte(kotlin.Long){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Byte).kotlin.ranges/downUntil(kotlin/Short): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Byte(kotlin.Short){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Char).kotlin.ranges/downUntil(kotlin/Char): kotlin.ranges/CharProgression // kotlin.ranges/downUntil|downUntil@kotlin.Char(kotlin.Char){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
 final fun (kotlin/Double).kotlin/toBits(): kotlin/Long // kotlin/toBits|toBits@kotlin.Double(){}[0]
 
 // Targets: [js, wasmJs, wasmWasi]
@@ -13805,10 +13820,46 @@ final fun (kotlin/Float).kotlin/toBits(): kotlin/Int // kotlin/toBits|toBits@kot
 final fun (kotlin/Float).kotlin/toRawBits(): kotlin/Int // kotlin/toRawBits|toRawBits@kotlin.Float(){}[0]
 
 // Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Int).kotlin.ranges/downUntil(kotlin/Byte): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Int(kotlin.Byte){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Int).kotlin.ranges/downUntil(kotlin/Int): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Int(kotlin.Int){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Int).kotlin.ranges/downUntil(kotlin/Long): kotlin.ranges/LongProgression // kotlin.ranges/downUntil|downUntil@kotlin.Int(kotlin.Long){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Int).kotlin.ranges/downUntil(kotlin/Short): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Int(kotlin.Short){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
 final fun (kotlin/Int).kotlin.text/toString(kotlin/Int): kotlin/String // kotlin.text/toString|toString@kotlin.Int(kotlin.Int){}[0]
 
 // Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Long).kotlin.ranges/downUntil(kotlin/Byte): kotlin.ranges/LongProgression // kotlin.ranges/downUntil|downUntil@kotlin.Long(kotlin.Byte){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Long).kotlin.ranges/downUntil(kotlin/Int): kotlin.ranges/LongProgression // kotlin.ranges/downUntil|downUntil@kotlin.Long(kotlin.Int){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Long).kotlin.ranges/downUntil(kotlin/Long): kotlin.ranges/LongProgression // kotlin.ranges/downUntil|downUntil@kotlin.Long(kotlin.Long){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Long).kotlin.ranges/downUntil(kotlin/Short): kotlin.ranges/LongProgression // kotlin.ranges/downUntil|downUntil@kotlin.Long(kotlin.Short){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
 final fun (kotlin/Long).kotlin.text/toString(kotlin/Int): kotlin/String // kotlin.text/toString|toString@kotlin.Long(kotlin.Int){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Short).kotlin.ranges/downUntil(kotlin/Byte): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Short(kotlin.Byte){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Short).kotlin.ranges/downUntil(kotlin/Int): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Short(kotlin.Int){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Short).kotlin.ranges/downUntil(kotlin/Long): kotlin.ranges/LongProgression // kotlin.ranges/downUntil|downUntil@kotlin.Short(kotlin.Long){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/Short).kotlin.ranges/downUntil(kotlin/Short): kotlin.ranges/IntProgression // kotlin.ranges/downUntil|downUntil@kotlin.Short(kotlin.Short){}[0]
 
 // Targets: [js, wasmJs, wasmWasi]
 final fun (kotlin/String).kotlin.text/substring(kotlin/Int): kotlin/String // kotlin.text/substring|substring@kotlin.String(kotlin.Int){}[0]
@@ -13848,6 +13899,18 @@ final fun (kotlin/String?).kotlin/plus(kotlin/Any?): kotlin/String // kotlin/plu
 
 // Targets: [js, wasmJs, wasmWasi]
 final fun (kotlin/Throwable).kotlin/printStackTrace() // kotlin/printStackTrace|printStackTrace@kotlin.Throwable(){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/UByte).kotlin.ranges/downUntil(kotlin/UByte): kotlin.ranges/UIntProgression // kotlin.ranges/downUntil|downUntil@kotlin.UByte(kotlin.UByte){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/UInt).kotlin.ranges/downUntil(kotlin/UInt): kotlin.ranges/UIntProgression // kotlin.ranges/downUntil|downUntil@kotlin.UInt(kotlin.UInt){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/ULong).kotlin.ranges/downUntil(kotlin/ULong): kotlin.ranges/ULongProgression // kotlin.ranges/downUntil|downUntil@kotlin.ULong(kotlin.ULong){}[0]
+
+// Targets: [js, wasmJs, wasmWasi]
+final fun (kotlin/UShort).kotlin.ranges/downUntil(kotlin/UShort): kotlin.ranges/UIntProgression // kotlin.ranges/downUntil|downUntil@kotlin.UShort(kotlin.UShort){}[0]
 
 // Targets: [js, wasmJs, wasmWasi]
 final fun <#A: kotlin/Any?> kotlin.collections/copyToArray(kotlin.collections/Collection<#A>): kotlin/Array<#A> // kotlin.collections/copyToArray|copyToArray(kotlin.collections.Collection<0:0>){0§<kotlin.Any?>}[0]

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -4838,6 +4838,23 @@ public final class kotlin/ranges/RangesKt {
 	public static final fun downTo (SI)Lkotlin/ranges/IntProgression;
 	public static final fun downTo (SJ)Lkotlin/ranges/LongProgression;
 	public static final fun downTo (SS)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (BB)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (BI)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (BJ)Lkotlin/ranges/LongProgression;
+	public static final fun downUntil (BS)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (CC)Lkotlin/ranges/CharProgression;
+	public static final fun downUntil (IB)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (II)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (IJ)Lkotlin/ranges/LongProgression;
+	public static final fun downUntil (IS)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (JB)Lkotlin/ranges/LongProgression;
+	public static final fun downUntil (JI)Lkotlin/ranges/LongProgression;
+	public static final fun downUntil (JJ)Lkotlin/ranges/LongProgression;
+	public static final fun downUntil (JS)Lkotlin/ranges/LongProgression;
+	public static final fun downUntil (SB)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (SI)Lkotlin/ranges/IntProgression;
+	public static final fun downUntil (SJ)Lkotlin/ranges/LongProgression;
+	public static final fun downUntil (SS)Lkotlin/ranges/IntProgression;
 	public static final fun first (Lkotlin/ranges/CharProgression;)C
 	public static final fun first (Lkotlin/ranges/IntProgression;)I
 	public static final fun first (Lkotlin/ranges/LongProgression;)J
@@ -5015,6 +5032,10 @@ public final class kotlin/ranges/URangesKt {
 	public static final fun downTo-J1ME1BU (II)Lkotlin/ranges/UIntProgression;
 	public static final fun downTo-Kr8caGY (BB)Lkotlin/ranges/UIntProgression;
 	public static final fun downTo-eb3DHEI (JJ)Lkotlin/ranges/ULongProgression;
+	public static final fun downUntil-5PvTz6A (SS)Lkotlin/ranges/UIntProgression;
+	public static final fun downUntil-J1ME1BU (II)Lkotlin/ranges/UIntProgression;
+	public static final fun downUntil-Kr8caGY (BB)Lkotlin/ranges/UIntProgression;
+	public static final fun downUntil-eb3DHEI (JJ)Lkotlin/ranges/ULongProgression;
 	public static final fun first (Lkotlin/ranges/UIntProgression;)I
 	public static final fun first (Lkotlin/ranges/ULongProgression;)J
 	public static final fun firstOrNull (Lkotlin/ranges/UIntProgression;)Lkotlin/UInt;

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Ranges.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Ranges.kt
@@ -112,6 +112,39 @@ object RangeOps : TemplateGroupBase() {
         }
     }
 
+    val f_downUntil = fn("downUntil(to: Primitive)").byTwoPrimitives {
+        include(Primitives, integralCombinations + unsignedMappings)
+    } builderWith { (fromType, toType) ->
+        val elementType = rangeElementType(fromType, toType)
+        val progressionType = elementType.name + "Progression"
+
+        infix()
+        signature("downUntil(to: $toType)")
+        returns(progressionType)
+
+        doc {
+            """
+            Returns a progression from this value down to but excluding the specified [to] value with the step -1.
+
+            The [to] value should be less than `this` value.
+            If the [to] value is equal to or greater than `this` value the returned progression is empty.
+            """
+        }
+
+        val fromExpr = if (elementType == fromType) "this" else "this.to$elementType()"
+        val toExpr = if (elementType == toType) "to" else "to.to$elementType()"
+        val u = if (elementType.isUnsigned()) "u" else ""
+        val incrementExpr = when (elementType) {
+            PrimitiveType.Long, PrimitiveType.ULong -> "-1L"
+            PrimitiveType.Float -> "-1.0F"
+            PrimitiveType.Double -> "-1.0"
+            else -> "-1"
+        }
+
+        body {
+            "return $progressionType.fromClosedRange($fromExpr, $toExpr + 1$u, $incrementExpr)"
+        }
+    }
 
     val f_until = fn("until(to: Primitive)").byTwoPrimitives {
         include(Primitives, integralCombinations + unsignedMappings)


### PR DESCRIPTION
I thought https://youtrack.jetbrains.com/issue/KT-24658 would be an easy one for me to do and contribute, first time contributor here.

downUntil feels like a simple but missing stdlib function in my opinion. As said in the issue 6 years ago, "Kotlin has .. for upward closed ranges, downTo for downward closed ranges, and until for upward half-open ranges.", but no downUntil for downward half-open ranges.