### PR TITLE
Return same value as same Index start and end on `replaceRange`

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -515,6 +515,7 @@ public fun String.substringAfterLast(delimiter: String, missingDelimiterValue: S
 public fun CharSequence.replaceRange(startIndex: Int, endIndex: Int, replacement: CharSequence): CharSequence {
     if (endIndex < startIndex)
         throw IndexOutOfBoundsException("End index ($endIndex) is less than start index ($startIndex).")
+    if (endIndex == startIndex) return this
     val sb = StringBuilder()
     sb.appendRange(this, 0, startIndex)
     sb.append(replacement)


### PR DESCRIPTION
This is replaceRange but, It does insert.
When set the same Index on start and end, it have done append CharSequence currently. But it should be nothing changed.

https://pl.kotl.in/3jc8tMz2B

```kotlin
fun main() {
    val origin = "123"
    val replaced = origin.replaceRange(startIndex = 1, endIndex = 1, replacement = "9")
	
    println(replaced)
    // 1923
}
```