### PR TITLE
Add `repeat` for a LongRange type

### DIFF
--- a/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
+++ b/libraries/stdlib/samples/test/samples/misc/controlFlow.kt
@@ -24,5 +24,10 @@ class ControlFlow {
         repeat(0) {
             error("We should not get here!")
         }
+
+        // greets with type long.
+        repeat(3L) {
+            println("Hello, type long")
+        }
     }
 }

--- a/libraries/stdlib/src/kotlin/util/Standard.kt
+++ b/libraries/stdlib/src/kotlin/util/Standard.kt
@@ -157,3 +157,21 @@ public inline fun repeat(times: Int, action: (Int) -> Unit) {
         action(index)
     }
 }
+
+/**
+ * Executes the given function [action] specified number of [times].
+ *
+ * A zero-based index of current iteration is passed as a parameter to the [action] function.
+ *
+ * If the [times] parameter is negative or equal to zero, the [action] function is not invoked.
+ *
+ * @sample samples.misc.ControlFlow.repeat
+ */
+@kotlin.internal.InlineOnly
+public inline fun repeat(times: Long, action: (Long) -> Unit) {
+    contract { callsInPlace(action) }
+
+    for (index in 0 until times) {
+        action(index)
+    }
+}


### PR DESCRIPTION
Add repeat that using a long type range.
It can do `repeat` over an Int.MAX_VALUE.