### PR TITLE
FunctionalInterface annotation for JVM1.8+ on Kotlin functions

### DIFF
--- a/generators/builtins/functions.kt
+++ b/generators/builtins/functions.kt
@@ -45,7 +45,7 @@ class GenerateFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) {
     override fun generateBody() {
         for (i in 0..MAX_PARAM_COUNT) {
             generateDocumentation(i)
-            out.print("public interface Function$i")
+            out.print("@FunctionalInterface public interface Function$i")
             generateTypeParameters(i, variance = true)
             generateSuperClass()
             generateFunctionClassBody(i)


### PR DESCRIPTION
All Java built-in function types like `BiFunction`, `IntProvider` have this annotation. Also, this annotation is used by the GraalVM Polyglot library. It can only parse types with this annotation to a JavaScript function, that's why I want to add this.