### PR TITLE
Optimize Iterable<T>.last() implementation for non-List collections

### DIFF
--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -405,12 +405,10 @@ public fun <T> Iterable<T>.last(): T {
     when (this) {
         is List -> return this.last()
         else -> {
-            val iterator = iterator()
+            val iterator = reversed().iterator()
             if (!iterator.hasNext())
                 throw NoSuchElementException("Collection is empty.")
-            var last = iterator.next()
-            while (iterator.hasNext())
-                last = iterator.next()
+            val last = iterator.next()
             return last
         }
     }


### PR DESCRIPTION
Change the implementation of Iterable<T>.last() for non-List collections from iterating through the entire collection to directly using the reversed iterator to get the last element. 
This simplifies the code and improves performance by reducing the number of iterations.

Files changed:
- libraries/stdlib/common/src/generated/_Collections.kt