### PR TITLE
[KT-75060] Fir FileBasedKotlinClass parse innerclass with 1.1.16 metadata library compatibility

### DIFF
--- a/compiler/frontend.common.jvm/src/org/jetbrains/kotlin/load/kotlin/FileBasedKotlinClass.java
+++ b/compiler/frontend.common.jvm/src/org/jetbrains/kotlin/load/kotlin/FileBasedKotlinClass.java
@@ -339,7 +339,7 @@ public abstract class FileBasedKotlinClass implements KotlinJvmBinaryClass {
         }
 
         FqName outermostClassFqName = new FqName(name.replace('/', '.'));
-        classes.add(outermostClassFqName.shortName().asString());
+        classes.add(outermostClassFqName.shortName().asString().replace("$", "."));
 
         Collections.reverse(classes);
 


### PR DESCRIPTION
When using a project dependency library which compiled by 1.3.72 or below kotlin version, metadata is 1.1.6 or below, an issue occurs when referencing an enum defined as an inner class using in the annotation. This leads to an issue similar to: Unresolved reference: <Strange deserialized enum value: androidx/annotation/RestrictTo/Scope.LIBRARY>#' type=androidx.annotation.RestrictTo.Scope

Caused by metadata 1.1.6 and below library missing the innerclass struct for annotation type, add a fallback logic for internal class parsing to convert the jvm classname for $ symbol

See [KT-75060](https://youtrack.jetbrains.com/issue/KT-75060) Issue with FileBasedKotlinClass InnerClass Parse with 1.1.16 Metadata Compatibility

^KT-75060 Fixed