### PR TITLE
Added `distinctObservable()` to `Delegates`

### DIFF
--- a/libraries/stdlib/samples/test/samples/properties/delegates.kt
+++ b/libraries/stdlib/samples/test/samples/properties/delegates.kt
@@ -76,4 +76,23 @@ class Delegates {
         assertPrints(max, "10")
         assertTrue(observed)
     }
+
+    @Sample
+    fun distinctObservableDelegate() {
+        var observed = false
+        var max: Int by Delegates.distinctObservable(0) { property, oldValue, newValue ->
+            observed = true
+        }
+
+        assertPrints(max, "0")
+        assertFalse(observed)
+
+        max = 0
+        assertPrints(max, "0")
+        assertFalse(observed)
+
+        max = 10
+        assertPrints(max, "10")
+        assertTrue(observed)
+    }
 }

--- a/libraries/stdlib/src/kotlin/properties/Delegates.kt
+++ b/libraries/stdlib/src/kotlin/properties/Delegates.kt
@@ -36,6 +36,23 @@ public object Delegates {
 
     /**
      * Returns a property delegate for a read/write property that calls a specified callback function when changed,
+     * but only if the new value is different from the old value.
+     * @param initialValue the initial value of the property.
+     * @param onChange the callback which is called after the change of the property is made. The value of the property
+     *  has already been changed when this callback is invoked.
+     *
+     *  @sample samples.properties.Delegates.distinctObservableDelegate
+     */
+    public inline fun <T> distinctObservable(initialValue: T, crossinline onChange: (property: KProperty<*>, oldValue: T, newValue: T) -> Unit):
+            ReadWriteProperty<Any?, T> =
+        object : ObservableProperty<T>(initialValue) {
+            override fun beforeChange(property: KProperty<*>, oldValue: T, newValue: T) = oldValue != newValue
+
+            override fun afterChange(property: KProperty<*>, oldValue: T, newValue: T) = onChange(property, oldValue, newValue)
+        }
+
+    /**
+     * Returns a property delegate for a read/write property that calls a specified callback function when changed,
      * allowing the callback to veto the modification.
      * @param initialValue the initial value of the property.
      * @param onChange the callback which is called before a change to the property value is attempted.


### PR DESCRIPTION
Added `kotlin.properties.Delegates.distinctObservable` delegate.

`Delegates.observable` is triggered even when the value hasn't changed (set to the same value). This was unintuitive for me, and not mentioned in the docs.
It was still achievable with `Delegates.vetoable`, but that requires more work for a much needed function like this.
I know we can't change `Delegates.observable` itself. So, I added `distinctObservable`, which does what `observable` should have done (imo).

[YouTrack issue](https://youtrack.jetbrains.com/issue/KT-76072)