### PR TITLE
Check for Deno before checking for Node.js

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
@@ -327,8 +327,8 @@ $jsCodeBodyIndented
     let require; 
     let wasmExports;
 
-    const isNodeJs = (typeof process !== 'undefined') && (process.release.name === 'node');
-    const isDeno = !isNodeJs && (typeof Deno !== 'undefined')
+    const isDeno = typeof Deno !== 'undefined'
+    const isNodeJs = !isDeno && (typeof process !== 'undefined') && (process.release.name === 'node');
     const isStandaloneJsVM =
         !isDeno && !isNodeJs && (
             typeof d8 !== 'undefined' // V8


### PR DESCRIPTION
As Deno emulates Node.js to the point that Deno programs always run the Node.js code due to passing the checks for Node.js, checking for Deno first causes the correct code to run on each JS runtime.