### PR TITLE
Use SPDX identifier in POMs

### DIFF
--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/abi-tools-api/abi-tools-api.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/abi-tools-api/abi-tools-api.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/abi-tools/abi-tools.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/abi-tools/abi-tools.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/analysis-api-test-framework/analysis-api-test-framework.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/analysis-api-test-framework/analysis-api-test-framework.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/android/extensions/org.jetbrains.kotlin.android.extensions.gradle.plugin/org.jetbrains.kotlin.android.extensions.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/android/extensions/org.jetbrains.kotlin.android.extensions.gradle.plugin/org.jetbrains.kotlin.android.extensions.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/android/org.jetbrains.kotlin.android.gradle.plugin/org.jetbrains.kotlin.android.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/android/org.jetbrains.kotlin.android.gradle.plugin/org.jetbrains.kotlin.android.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/atomicfu/atomicfu.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/atomicfu/atomicfu.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/compose-compiler-gradle-plugin/compose-compiler-gradle-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/compose-compiler-gradle-plugin/compose-compiler-gradle-plugin.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/fus-statistics-gradle-plugin/fus-statistics-gradle-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/fus-statistics-gradle-plugin/fus-statistics-gradle-plugin.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/js-plain-objects/js-plain-objects.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/js-plain-objects/js-plain-objects.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/js/org.jetbrains.kotlin.js.gradle.plugin/org.jetbrains.kotlin.js.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/js/org.jetbrains.kotlin.js.gradle.plugin/org.jetbrains.kotlin.js.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/jvm-abi-gen-embeddable/jvm-abi-gen-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/jvm-abi-gen-embeddable/jvm-abi-gen-embeddable.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/jvm-abi-gen/jvm-abi-gen.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/jvm-abi-gen/jvm-abi-gen.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/org.jetbrains.kotlin.jvm.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/org.jetbrains.kotlin.jvm.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kapt/org.jetbrains.kotlin.kapt.gradle.plugin/org.jetbrains.kotlin.kapt.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kapt/org.jetbrains.kotlin.kapt.gradle.plugin/org.jetbrains.kotlin.kapt.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-allopen-compiler-plugin-embeddable/kotlin-allopen-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-allopen-compiler-plugin-embeddable/kotlin-allopen-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-allopen-compiler-plugin/kotlin-allopen-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-allopen-compiler-plugin/kotlin-allopen-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-allopen/kotlin-allopen.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-allopen/kotlin-allopen.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing-embeddable/kotlin-annotation-processing-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing-embeddable/kotlin-annotation-processing-embeddable.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing-gradle/kotlin-annotation-processing-gradle.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing-gradle/kotlin-annotation-processing-gradle.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing-runtime/kotlin-annotation-processing-runtime.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing-runtime/kotlin-annotation-processing-runtime.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing/kotlin-annotation-processing.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotation-processing/kotlin-annotation-processing.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotations-jvm/kotlin-annotations-jvm.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-annotations-jvm/kotlin-annotations-jvm.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-assignment-compiler-plugin-embeddable/kotlin-assignment-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-assignment-compiler-plugin-embeddable/kotlin-assignment-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-assignment-compiler-plugin/kotlin-assignment-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-assignment-compiler-plugin/kotlin-assignment-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-assignment/kotlin-assignment.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-assignment/kotlin-assignment.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-atomicfu-compiler-plugin-embeddable/kotlin-atomicfu-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-atomicfu-compiler-plugin-embeddable/kotlin-atomicfu-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-atomicfu-compiler-plugin/kotlin-atomicfu-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-atomicfu-compiler-plugin/kotlin-atomicfu-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-build-statistics/kotlin-build-statistics.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-build-statistics/kotlin-build-statistics.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-build-tools-api/kotlin-build-tools-api.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-build-tools-api/kotlin-build-tools-api.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-build-tools-impl/kotlin-build-tools-impl.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-build-tools-impl/kotlin-build-tools-impl.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-client-embeddable/kotlin-compiler-client-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-client-embeddable/kotlin-compiler-client-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-embeddable/kotlin-compiler-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-embeddable/kotlin-compiler-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-internal-test-framework/kotlin-compiler-internal-test-framework.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-internal-test-framework/kotlin-compiler-internal-test-framework.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-runner/kotlin-compiler-runner.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler-runner/kotlin-compiler-runner.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler/kotlin-compiler.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compiler/kotlin-compiler.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/kotlin-compose-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/kotlin-compose-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compose-compiler-plugin/kotlin-compose-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-compose-compiler-plugin/kotlin-compose-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-daemon-client/kotlin-daemon-client.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-daemon-client/kotlin-daemon-client.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-daemon-embeddable/kotlin-daemon-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-daemon-embeddable/kotlin-daemon-embeddable.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-daemon/kotlin-daemon.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-daemon/kotlin-daemon.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-embeddable/kotlin-dataframe-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-embeddable/kotlin-dataframe-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-experimental/kotlin-dataframe-compiler-plugin-experimental.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-experimental/kotlin-dataframe-compiler-plugin-experimental.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dataframe/kotlin-dataframe.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dataframe/kotlin-dataframe.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dom-api-compat/kotlin-dom-api-compat.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-dom-api-compat/kotlin-dom-api-compat.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-build-metrics/kotlin-gradle-build-metrics.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-build-metrics/kotlin-gradle-build-metrics.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/kotlin-gradle-plugin-annotations.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/kotlin-gradle-plugin-annotations.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-api/kotlin-gradle-plugin-api.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-api/kotlin-gradle-plugin-api.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/kotlin-gradle-plugin-idea-proto.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/kotlin-gradle-plugin-idea-proto.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/kotlin-gradle-plugin-idea.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/kotlin-gradle-plugin-idea.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-model/kotlin-gradle-plugin-model.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin-model/kotlin-gradle-plugin-model.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin/kotlin-gradle-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugin/kotlin-gradle-plugin.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/kotlin-gradle-plugins-bom.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/kotlin-gradle-plugins-bom.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-statistics/kotlin-gradle-statistics.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-statistics/kotlin-gradle-statistics.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-jps-plugin/kotlin-jps-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-jps-plugin/kotlin-jps-plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-js-plain-objects/kotlin-js-plain-objects.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-js-plain-objects/kotlin-js-plain-objects.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-klib-commonizer-api/kotlin-klib-commonizer-api.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-klib-commonizer-api/kotlin-klib-commonizer-api.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/kotlin-klib-commonizer-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-klib-commonizer-embeddable/kotlin-klib-commonizer-embeddable.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-klib-commonizer/kotlin-klib-commonizer.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-klib-commonizer/kotlin-klib-commonizer.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-lombok-compiler-plugin-embeddable/kotlin-lombok-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-lombok-compiler-plugin-embeddable/kotlin-lombok-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-lombok-compiler-plugin/kotlin-lombok-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-lombok-compiler-plugin/kotlin-lombok-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-lombok/kotlin-lombok.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-lombok/kotlin-lombok.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-main-kts/kotlin-main-kts.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-main-kts/kotlin-main-kts.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-maven-serialization-for-jps-avoid-using-this/kotlin-maven-serialization-for-jps-avoid-using-this.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-maven-serialization-for-jps-avoid-using-this/kotlin-maven-serialization-for-jps-avoid-using-this.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-metadata-jvm/kotlin-metadata-jvm.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-metadata-jvm/kotlin-metadata-jvm.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-native-utils/kotlin-native-utils.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-native-utils/kotlin-native-utils.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-noarg-compiler-plugin-embeddable/kotlin-noarg-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-noarg-compiler-plugin-embeddable/kotlin-noarg-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-noarg-compiler-plugin/kotlin-noarg-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-noarg-compiler-plugin/kotlin-noarg-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-noarg/kotlin-noarg.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-noarg/kotlin-noarg.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-parcelize-compiler/kotlin-parcelize-compiler.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-parcelize-compiler/kotlin-parcelize-compiler.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-parcelize-runtime/kotlin-parcelize-runtime.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-parcelize-runtime/kotlin-parcelize-runtime.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-power-assert-compiler-plugin-embeddable/kotlin-power-assert-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-power-assert-compiler-plugin-embeddable/kotlin-power-assert-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-power-assert-compiler-plugin/kotlin-power-assert-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-power-assert-compiler-plugin/kotlin-power-assert-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-power-assert/kotlin-power-assert.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-power-assert/kotlin-power-assert.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-reflect/kotlin-reflect.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-reflect/kotlin-reflect.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-sam-with-receiver-compiler-plugin-embeddable/kotlin-sam-with-receiver-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-sam-with-receiver-compiler-plugin-embeddable/kotlin-sam-with-receiver-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-sam-with-receiver-compiler-plugin/kotlin-sam-with-receiver-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-sam-with-receiver-compiler-plugin/kotlin-sam-with-receiver-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-sam-with-receiver/kotlin-sam-with-receiver.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-sam-with-receiver/kotlin-sam-with-receiver.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-script-runtime/kotlin-script-runtime.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-script-runtime/kotlin-script-runtime.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-common/kotlin-scripting-common.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-common/kotlin-scripting-common.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/kotlin-scripting-compiler-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/kotlin-scripting-compiler-embeddable.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/kotlin-scripting-compiler-impl-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/kotlin-scripting-compiler-impl-embeddable.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler-impl/kotlin-scripting-compiler-impl.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler-impl/kotlin-scripting-compiler-impl.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler/kotlin-scripting-compiler.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-compiler/kotlin-scripting-compiler.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-dependencies-maven-all/kotlin-scripting-dependencies-maven-all.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-dependencies-maven-all/kotlin-scripting-dependencies-maven-all.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-dependencies-maven/kotlin-scripting-dependencies-maven.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-dependencies-maven/kotlin-scripting-dependencies-maven.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-dependencies/kotlin-scripting-dependencies.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-dependencies/kotlin-scripting-dependencies.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-ide-services-unshaded/kotlin-scripting-ide-services-unshaded.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-ide-services-unshaded/kotlin-scripting-ide-services-unshaded.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-ide-services/kotlin-scripting-ide-services.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-ide-services/kotlin-scripting-ide-services.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-intellij/kotlin-scripting-intellij.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-intellij/kotlin-scripting-intellij.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jsr223-unshaded/kotlin-scripting-jsr223-unshaded.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jsr223-unshaded/kotlin-scripting-jsr223-unshaded.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jsr223/kotlin-scripting-jsr223.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jsr223/kotlin-scripting-jsr223.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jvm-host-unshaded/kotlin-scripting-jvm-host-unshaded.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jvm-host-unshaded/kotlin-scripting-jvm-host-unshaded.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jvm-host/kotlin-scripting-jvm-host.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jvm-host/kotlin-scripting-jvm-host.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jvm/kotlin-scripting-jvm.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-scripting-jvm/kotlin-scripting-jvm.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/kotlin-serialization-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/kotlin-serialization-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin/kotlin-serialization-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin/kotlin-serialization-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization-unshaded/kotlin-serialization-unshaded.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization-unshaded/kotlin-serialization-unshaded.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization/kotlin-serialization.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-serialization/kotlin-serialization.pom
@@ -14,7 +14,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-common/kotlin-stdlib-common.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-common/kotlin-stdlib-common.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-jdk7/kotlin-stdlib-jdk7.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-jdk7/kotlin-stdlib-jdk7.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-jdk8/kotlin-stdlib-jdk8.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-jdk8/kotlin-stdlib-jdk8.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-js/kotlin-stdlib-js.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-js/kotlin-stdlib-js.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-wasm-js/kotlin-stdlib-wasm-js.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-wasm-js/kotlin-stdlib-wasm-js.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-wasm-wasi/kotlin-stdlib-wasm-wasi.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib-wasm-wasi/kotlin-stdlib-wasm-wasi.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib/kotlin-stdlib.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-stdlib/kotlin-stdlib.pom
@@ -15,7 +15,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-annotations-common/kotlin-test-annotations-common.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-annotations-common/kotlin-test-annotations-common.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-common/kotlin-test-common.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-common/kotlin-test-common.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-js/kotlin-test-js.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-js/kotlin-test-js.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-junit/kotlin-test-junit.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-junit/kotlin-test-junit.pom
@@ -15,7 +15,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-junit5/kotlin-test-junit5.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-junit5/kotlin-test-junit5.pom
@@ -15,7 +15,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-testng/kotlin-test-testng.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-testng/kotlin-test-testng.pom
@@ -15,7 +15,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-wasm-js/kotlin-test-wasm-js.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-wasm-js/kotlin-test-wasm-js.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-wasm-wasi/kotlin-test-wasm-wasi.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test-wasm-wasi/kotlin-test-wasm-wasi.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test/kotlin-test.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-test/kotlin-test.pom
@@ -15,7 +15,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-tooling-core/kotlin-tooling-core.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-tooling-core/kotlin-tooling-core.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-tooling-metadata/kotlin-tooling-metadata.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-tooling-metadata/kotlin-tooling-metadata.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-util-io/kotlin-util-io.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-util-io/kotlin-util-io.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-util-klib-metadata/kotlin-util-klib-metadata.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-util-klib-metadata/kotlin-util-klib-metadata.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-util-klib/kotlin-util-klib.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-util-klib/kotlin-util-klib.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlinx-atomicfu-runtime/kotlinx-atomicfu-runtime.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlinx-atomicfu-runtime/kotlinx-atomicfu-runtime.pom
@@ -16,7 +16,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlinx-js-plain-objects-compiler-plugin-embeddable/kotlinx-js-plain-objects-compiler-plugin-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlinx-js-plain-objects-compiler-plugin-embeddable/kotlinx-js-plain-objects-compiler-plugin-embeddable.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlinx-js-plain-objects-compiler-plugin/kotlinx-js-plain-objects-compiler-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlinx-js-plain-objects-compiler-plugin/kotlinx-js-plain-objects-compiler-plugin.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/multiplatform/org.jetbrains.kotlin.multiplatform.gradle.plugin/org.jetbrains.kotlin.multiplatform.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/multiplatform/org.jetbrains.kotlin.multiplatform.gradle.plugin/org.jetbrains.kotlin.multiplatform.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/native/cocoapods/org.jetbrains.kotlin.native.cocoapods.gradle.plugin/org.jetbrains.kotlin.native.cocoapods.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/native/cocoapods/org.jetbrains.kotlin.native.cocoapods.gradle.plugin/org.jetbrains.kotlin.native.cocoapods.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/allopen/org.jetbrains.kotlin.plugin.allopen.gradle.plugin/org.jetbrains.kotlin.plugin.allopen.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/allopen/org.jetbrains.kotlin.plugin.allopen.gradle.plugin/org.jetbrains.kotlin.plugin.allopen.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/assignment/org.jetbrains.kotlin.plugin.assignment.gradle.plugin/org.jetbrains.kotlin.plugin.assignment.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/assignment/org.jetbrains.kotlin.plugin.assignment.gradle.plugin/org.jetbrains.kotlin.plugin.assignment.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/atomicfu/org.jetbrains.kotlin.plugin.atomicfu.gradle.plugin/org.jetbrains.kotlin.plugin.atomicfu.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/atomicfu/org.jetbrains.kotlin.plugin.atomicfu.gradle.plugin/org.jetbrains.kotlin.plugin.atomicfu.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/compose/org.jetbrains.kotlin.plugin.compose.gradle.plugin/org.jetbrains.kotlin.plugin.compose.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/compose/org.jetbrains.kotlin.plugin.compose.gradle.plugin/org.jetbrains.kotlin.plugin.compose.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/dataframe/org.jetbrains.kotlin.plugin.dataframe.gradle.plugin/org.jetbrains.kotlin.plugin.dataframe.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/dataframe/org.jetbrains.kotlin.plugin.dataframe.gradle.plugin/org.jetbrains.kotlin.plugin.dataframe.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>APL-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/jpa/org.jetbrains.kotlin.plugin.jpa.gradle.plugin/org.jetbrains.kotlin.plugin.jpa.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/jpa/org.jetbrains.kotlin.plugin.jpa.gradle.plugin/org.jetbrains.kotlin.plugin.jpa.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/js-plain-objects/org.jetbrains.kotlin.plugin.js-plain-objects.gradle.plugin/org.jetbrains.kotlin.plugin.js-plain-objects.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/js-plain-objects/org.jetbrains.kotlin.plugin.js-plain-objects.gradle.plugin/org.jetbrains.kotlin.plugin.js-plain-objects.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/lombok/org.jetbrains.kotlin.plugin.lombok.gradle.plugin/org.jetbrains.kotlin.plugin.lombok.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/lombok/org.jetbrains.kotlin.plugin.lombok.gradle.plugin/org.jetbrains.kotlin.plugin.lombok.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/noarg/org.jetbrains.kotlin.plugin.noarg.gradle.plugin/org.jetbrains.kotlin.plugin.noarg.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/noarg/org.jetbrains.kotlin.plugin.noarg.gradle.plugin/org.jetbrains.kotlin.plugin.noarg.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/parcelize/org.jetbrains.kotlin.plugin.parcelize.gradle.plugin/org.jetbrains.kotlin.plugin.parcelize.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/parcelize/org.jetbrains.kotlin.plugin.parcelize.gradle.plugin/org.jetbrains.kotlin.plugin.parcelize.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/power-assert/org.jetbrains.kotlin.plugin.power-assert.gradle.plugin/org.jetbrains.kotlin.plugin.power-assert.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/power-assert/org.jetbrains.kotlin.plugin.power-assert.gradle.plugin/org.jetbrains.kotlin.plugin.power-assert.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/sam/with/receiver/org.jetbrains.kotlin.plugin.sam.with.receiver.gradle.plugin/org.jetbrains.kotlin.plugin.sam.with.receiver.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/sam/with/receiver/org.jetbrains.kotlin.plugin.sam.with.receiver.gradle.plugin/org.jetbrains.kotlin.plugin.sam.with.receiver.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/scripting/org.jetbrains.kotlin.plugin.scripting.gradle.plugin/org.jetbrains.kotlin.plugin.scripting.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/scripting/org.jetbrains.kotlin.plugin.scripting.gradle.plugin/org.jetbrains.kotlin.plugin.scripting.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/org.jetbrains.kotlin.plugin.serialization.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/org.jetbrains.kotlin.plugin.serialization.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/spring/org.jetbrains.kotlin.plugin.spring.gradle.plugin/org.jetbrains.kotlin.plugin.spring.gradle.plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/plugin/spring/org.jetbrains.kotlin.plugin.spring.gradle.plugin/org.jetbrains.kotlin.plugin.spring.gradle.plugin.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-compiler-bridge/sir-compiler-bridge.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-compiler-bridge/sir-compiler-bridge.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-light-classes/sir-light-classes.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-light-classes/sir-light-classes.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-printer/sir-printer.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-printer/sir-printer.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-providers/sir-providers.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir-providers/sir-providers.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir/sir.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/sir/sir.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-embeddable/swift-export-embeddable.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-embeddable/swift-export-embeddable.pom
@@ -10,7 +10,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-ide/swift-export-ide.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-ide/swift-export-ide.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-standalone/swift-export-standalone.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-standalone/swift-export-standalone.pom
@@ -9,7 +9,7 @@
   <url>https://kotlinlang.org/</url>
   <licenses>
     <license>
-      <name>The Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/plugins/KotlinBuildPublishingPlugin.kt
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/plugins/KotlinBuildPublishingPlugin.kt
@@ -123,7 +123,7 @@ fun MavenPublication.configureKotlinPomAttributes(
         url.set("https://kotlinlang.org/")
         licenses {
             license {
-                name.set("The Apache License, Version 2.0")
+                name.set("Apache-2.0")
                 url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
             }
         }


### PR DESCRIPTION
This replaces the custom name with an SPDX identifier to enable tooling to automatically detect the correct license. Using an SPDX identifier is recommended [by the official Maven documentation](https://maven.apache.org/pom.html#Licenses).

See https://spdx.org/licenses/Apache-2.0.html