### PR TITLE
Docs: Replace "Twitter" with "X" in ReadMe

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ Some handy links:
  * [Forum](https://discuss.kotlinlang.org/)
  * [Kotlin Blog](https://blog.jetbrains.com/kotlin/)
  * [Subscribe to Kotlin YouTube channel](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
- * [Follow Kotlin on Twitter](https://twitter.com/kotlin)
+ * [Follow Kotlin on X (Previously Twitter)](https://x.com/kotlin)
  * [Public Slack channel](https://slack.kotlinlang.org/)
  * [TeamCity CI build](https://teamcity.jetbrains.com/project.html?tab=projectOverview&projectId=Kotlin)
  * [Kotlin Foundation](https://kotlinfoundation.org/)


### PR DESCRIPTION
#### **What**  
This pull request updates the documentation by replacing all instances of "Twitter" with "X" in the `ReadMe` file to align with the platform's rebranding.  

#### **Why**  
Elon Musk's acquisition of Twitter led to its official rebranding as "X." To maintain consistency and accuracy across our documentation, this change ensures that references to the platform reflect its current name.   