### PR TITLE
Don't create unnecessary array copies in `sortedDescending()`

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -6699,49 +6699,49 @@ public fun <T : Comparable<T>> Array<out T>.sortedDescending(): List<T> {
  * Returns a list of all elements sorted descending according to their natural sort order.
  */
 public fun ByteArray.sortedDescending(): List<Byte> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
  * Returns a list of all elements sorted descending according to their natural sort order.
  */
 public fun ShortArray.sortedDescending(): List<Short> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
  * Returns a list of all elements sorted descending according to their natural sort order.
  */
 public fun IntArray.sortedDescending(): List<Int> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
  * Returns a list of all elements sorted descending according to their natural sort order.
  */
 public fun LongArray.sortedDescending(): List<Long> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
  * Returns a list of all elements sorted descending according to their natural sort order.
  */
 public fun FloatArray.sortedDescending(): List<Float> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
  * Returns a list of all elements sorted descending according to their natural sort order.
  */
 public fun DoubleArray.sortedDescending(): List<Double> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
  * Returns a list of all elements sorted descending according to their natural sort order.
  */
 public fun CharArray.sortedDescending(): List<Char> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -3155,7 +3155,7 @@ public fun UShortArray.sortedArrayDescending(): UShortArray {
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 public fun UIntArray.sortedDescending(): List<UInt> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
@@ -3166,7 +3166,7 @@ public fun UIntArray.sortedDescending(): List<UInt> {
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 public fun ULongArray.sortedDescending(): List<ULong> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
@@ -3177,7 +3177,7 @@ public fun ULongArray.sortedDescending(): List<ULong> {
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 public fun UByteArray.sortedDescending(): List<UByte> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**
@@ -3188,7 +3188,7 @@ public fun UByteArray.sortedDescending(): List<UByte> {
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 public fun UShortArray.sortedDescending(): List<UShort> {
-    return copyOf().apply { sort() }.reversed()
+    return sortedArrayDescending().asList()
 }
 
 /**

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
@@ -305,7 +305,7 @@ object Ordering : TemplateGroupBase() {
         }
         body(ArraysOfPrimitives, ArraysOfUnsigned) {
             """
-            return copyOf().apply { sort() }.reversed()
+            return sortedArrayDescending().asList()
             """
         }
 


### PR DESCRIPTION
See [KT-76458](https://youtrack.jetbrains.com/issue/KT-76458/Dont-create-unnecessary-array-copies-in-sortedDescending)