### PR TITLE
[KT-75801]: minor optimization on object array to list conversion functions

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -4806,14 +4806,7 @@ public fun <T> Array<out T>.take(n: Int): List<T> {
     if (n == 0) return emptyList()
     if (n >= size) return toList()
     if (n == 1) return listOf(this[0])
-    var count = 0
-    val list = ArrayList<T>(n)
-    for (item in this) {
-        list.add(item)
-        if (++count == n)
-            break
-    }
-    return list
+    return copyOfRange(0, n).asList()
 }
 
 /**
@@ -5005,10 +4998,7 @@ public fun <T> Array<out T>.takeLast(n: Int): List<T> {
     val size = size
     if (n >= size) return toList()
     if (n == 1) return listOf(this[size - 1])
-    val list = ArrayList<T>(n)
-    for (index in size - n until size)
-        list.add(this[index])
-    return list
+    return copyOfRange(size - n, size).asList()
 }
 
 /**
@@ -5295,13 +5285,16 @@ public inline fun CharArray.takeLastWhile(predicate: (Char) -> Boolean): List<Ch
  * @sample samples.collections.Collections.Transformations.take
  */
 public inline fun <T> Array<out T>.takeWhile(predicate: (T) -> Boolean): List<T> {
-    val list = ArrayList<T>()
-    for (item in this) {
-        if (!predicate(item))
-            break
-        list.add(item)
+    val size = size
+    return when (size) {
+        0 -> emptyList()
+        1 -> if (predicate(this[0])) listOf(this[0]) else emptyList()
+        else -> {
+            var i = 0
+            while (i < size && predicate(this[i])) i++
+            return if (i == 0) emptyList() else copyOfRange(0, i).asList()
+        }
     }
-    return list
 }
 
 /**

--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -9831,7 +9831,7 @@ public fun <T> Array<out T>.toList(): List<T> {
     return when (size) {
         0 -> emptyList()
         1 -> listOf(this[0])
-        else -> this.toMutableList()
+        else -> copyOf().asList()
     }
 }
 

--- a/libraries/stdlib/src/kotlin/collections/Arrays.kt
+++ b/libraries/stdlib/src/kotlin/collections/Arrays.kt
@@ -17,11 +17,26 @@ import kotlin.contracts.*
  * @sample samples.collections.Arrays.Transformations.flattenArray
  */
 public fun <T> Array<out Array<out T>>.flatten(): List<T> {
-    val result = ArrayList<T>(sumOf { it.size })
-    for (element in this) {
-        result.addAll(element)
+    return when (size) {
+        0 -> emptyList()
+        1 -> this[0].toList()
+        else -> {
+            val totalSizeLong = sumOf { it.size.toLong() }
+            if (totalSizeLong < 1L) return emptyList()
+            require(totalSizeLong <= Int.MAX_VALUE.toLong()) {
+                "Sum of all arrays overflow maximum array capacity (of Int.MAX_VALUE)"
+            }
+            var outputArray = arrayOfNulls<Any?>(totalSizeLong.toInt())
+            var offset = 0
+            for (innerArray in this) {
+                innerArray.copyInto(outputArray, offset)
+                offset += innerArray.size
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            return outputArray.asList() as List<T>
+        }
     }
-    return result
 }
 
 /**

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
@@ -192,7 +192,7 @@ object Filtering : TemplateGroupBase() {
             """
         }
 
-        body(ArraysOfObjects, ArraysOfPrimitives, ArraysOfUnsigned) {
+        body(ArraysOfPrimitives, ArraysOfUnsigned) {
             """
             require(n >= 0) { "Requested element count $n is less than zero." }
             if (n == 0) return emptyList()
@@ -206,6 +206,17 @@ object Filtering : TemplateGroupBase() {
                     break
             }
             return list
+            """
+        }
+
+        // For object arrays, ensure a single array copy instead of copying using a loop (see KT-75801)
+        body(ArraysOfObjects) {
+            """
+            require(n >= 0) { "Requested element count $n is less than zero." }
+            if (n == 0) return emptyList()
+            if (n >= size) return toList()
+            if (n == 1) return listOf(this[0])
+            return copyOfRange(0, n).asList()
             """
         }
     }
@@ -270,7 +281,7 @@ object Filtering : TemplateGroupBase() {
             """
         }
 
-        body(ArraysOfObjects, ArraysOfPrimitives, ArraysOfUnsigned) {
+        body(ArraysOfPrimitives, ArraysOfUnsigned) {
             """
             require(n >= 0) { "Requested element count $n is less than zero." }
             if (n == 0) return emptyList()
@@ -284,6 +295,19 @@ object Filtering : TemplateGroupBase() {
             return list
             """
         }
+
+        // For object arrays, ensure a single array copy instead of copying using a loop (see KT-75801)
+        body(ArraysOfObjects) {
+            """
+            require(n >= 0) { "Requested element count $n is less than zero." }
+            if (n == 0) return emptyList()
+            val size = size
+            if (n >= size) return toList()
+            if (n == 1) return listOf(this[size - 1])
+            return copyOfRange(size - n, size).asList()
+            """
+        }
+
         body(Lists) {
             """
             require(n >= 0) { "Requested element count $n is less than zero." }
@@ -412,6 +436,22 @@ object Filtering : TemplateGroupBase() {
             doc { "Returns a sequence containing first elements satisfying the given [predicate]." }
             returns("Sequence<T>")
             body { """return TakeWhileSequence(this, predicate)""" }
+        }
+
+        // For object arrays, ensure a single array copy instead of copying using a loop (see KT-75801)
+        body(ArraysOfObjects) {
+            """
+            val size = ${f.code.size}
+            return when (size) {
+                0 -> emptyList()
+                1 -> if (predicate(this[0])) listOf(this[0]) else emptyList()
+                else -> {
+                    var i = 0
+                    while (i < size && predicate(this[i])) i++
+                    return if (i == 0) emptyList() else copyOfRange(0, i).asList()
+                }
+            }
+            """
         }
     }
 

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
@@ -173,12 +173,22 @@ object Snapshots : TemplateGroupBase() {
             return this.toMutableList().optimizeReadOnlyList()
             """
         }
-        body(CharSequences, ArraysOfPrimitives, ArraysOfObjects) {
+        body(CharSequences, ArraysOfPrimitives) {
             """
             return when (${f.code.size}) {
                 0 -> emptyList()
                 1 -> listOf(this[0])
                 else -> this.toMutableList()
+            }
+            """
+        }
+        // For object array, ensure a single array copy instead of delegating to `toMutableList`, which can cause two copies (see KT-75801)
+        body(ArraysOfObjects) {
+            """
+            return when (${f.code.size}) {
+                0 -> emptyList()
+                1 -> listOf(this[0])
+                else -> copyOf().asList()
             }
             """
         }


### PR DESCRIPTION
Related issue: [KT-75801](https://youtrack.jetbrains.com/issue/KT-75801)
[Related benchmark project](https://github.com/alexismanin/kt-benchmark-array-to-list)

This contains two different cases of optimization:

 * `Array<T>.(take|takeLast|takeWhile)` functions : replace loop copy with `copyOfRange().asList()`
 * `Array<T>.toList()` and `Array<Array<T>>.flatten()` : force using direct array copy instead of delegating to mutable list. 
    This is done because at least OpenJDK implementation causes two array copies to happen instead of a single one.

I've not modified any primitive array function, because of unboxing. If I'd applied the same logic to primitive arrays, the initial copy might indeed get faster, but then, unboxing would be delayed on  `List.get()` calls, therefore adding performance penalty on the consumer side.

I tested using ` ./gradlew coreLibsTest` (success). I'm still trying to run a full `./gradlew build`, but I've got configuration issues to investigate:

> Task with path ':plugins:plugin-sandbox:plugin-annotations:jar' not found in project ':analysis:analysis-test-framework

It is my first contribution here, so if I've missed a point or done something wrong (formatting, doc, testing, etc.), any insight is appreciated. 