### PR TITLE
[KT-57398] Fix missing projectId in compileJvm example

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/CompilationService.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/CompilationService.kt
@@ -20,9 +20,11 @@ import java.io.File
  *  val service = CompilationService.loadImplementation(ClassLoader.getSystemClassLoader())
  *  val executionConfig = service.makeCompilerExecutionStrategyConfiguration()
  *  val compilationConfig = service.makeJvmCompilationConfiguration()
- *  service.compileJvm(executionConfig, compilationConfig, listOf(File("src/a.kt")), listOf("-Xexplicit-api=strict"))
+ *  val id: ProjectId = ProjectId.ProjectUUID(UUID.randomUUID())
+ *  service.compileJvm(id, executionConfig, compilationConfig, listOf(File("src/a.kt")), listOf("-Xexplicit-api=strict"))
+ *  service.finishProjectCompilation(id)
  * ```
- *
+ * 
  * This interface is not intended to be implemented by the API consumers. An instance of [CompilationService] is expected to be obtained from [loadImplementation].
  */
 @ExperimentalBuildToolsApi


### PR DESCRIPTION
The projectId parameter was introduced in 175c00e as part of KT-57398,
but the example usage of compileJvm was not updated to reflect this
change.

This pull request adds the missing parameter to the example to align with
the current API.

#KT-57398