### PR TITLE
[K/JS]: KT-76027: Introduce an additional enum test step to cover incremental compilation bug with `@JsExport`

### DIFF
--- a/js/js.translator/testData/incremental/invalidation/enum/lib1/l1.4.kt
+++ b/js/js.translator/testData/incremental/invalidation/enum/lib1/l1.4.kt
@@ -1,0 +1,4 @@
+@JsExport
+enum class TestEnum {
+    A, B
+}

--- a/js/js.translator/testData/incremental/invalidation/enum/lib1/module.info
+++ b/js/js.translator/testData/incremental/invalidation/enum/lib1/module.info
@@ -10,3 +10,8 @@ STEP 2:
     added file: l1.kt
 STEP 3:
     updated exports: l1.kt
+STEP 4:
+    modifications:
+        U : l1.4.kt -> l1.kt
+    modified ir: l1.kt
+STEP 5:

--- a/js/js.translator/testData/incremental/invalidation/enum/main/module.info
+++ b/js/js.translator/testData/incremental/invalidation/enum/main/module.info
@@ -14,3 +14,11 @@ STEP 3:
         U : testEnumEntries.3.kt -> testEnumEntries.kt
     dependencies: lib1
     modified ir: testEnumEntries.kt
+STEP 4:
+    dependencies: lib1
+    updated imports: testEnumValues.kt, testEnumEntries.kt
+STEP 5:
+    modifications:
+        U : testEnumEntries.5.kt -> testEnumEntries.kt
+    dependencies: lib1
+    modified ir: testEnumEntries.kt

--- a/js/js.translator/testData/incremental/invalidation/enum/main/testEnumEntries.0.kt
+++ b/js/js.translator/testData/incremental/invalidation/enum/main/testEnumEntries.0.kt
@@ -1,7 +1,7 @@
 @kotlin.ExperimentalStdlibApi
 fun testEnumEntries(stepId: Int): Boolean {
     when (stepId) {
-        0, 1, 2, 3 -> return true
+        0, 1, 2, 3, 4, 5 -> return true
         else -> return false
     }
     return true

--- a/js/js.translator/testData/incremental/invalidation/enum/main/testEnumEntries.5.kt
+++ b/js/js.translator/testData/incremental/invalidation/enum/main/testEnumEntries.5.kt
@@ -2,7 +2,7 @@
 fun testEnumEntries(stepId: Int): Boolean {
     val entries = TestEnum.entries
 
-    if (entries.contains((object {}) as Any?)) return false
+//    if (entries.contains((object {}) as Any?)) return false
 
     when (stepId) {
         0 -> if (entries.isNotEmpty()) return false

--- a/js/js.translator/testData/incremental/invalidation/enum/main/testEnumValues.kt
+++ b/js/js.translator/testData/incremental/invalidation/enum/main/testEnumValues.kt
@@ -2,7 +2,7 @@ fun testEnumValues(stepId: Int): Boolean {
     val values = enumValues<TestEnum>().map { it.ordinal to it.name }
     when (stepId) {
         0 -> if (values.isEmpty()) return true
-        1, 2, 3 -> if (values == listOf(0 to "A", 1 to "B")) return true
+        1, 2, 3, 4, 5 -> if (values == listOf(0 to "A", 1 to "B")) return true
         else -> return false
     }
     return false

--- a/js/js.translator/testData/incremental/invalidation/enum/project.info
+++ b/js/js.translator/testData/incremental/invalidation/enum/project.info
@@ -22,7 +22,7 @@ STEP 4:
     language: +EnumEntries
     libs: lib1, main
     dirty js modules: lib1, main
-    dirty js files:   lib1/l1
+    dirty js files:   lib1/l1, lib1/l1.export, main/testEnumEntries, main/testEnumValues, lib1
 STEP 5:
     language: +EnumEntries
     libs: lib1, main

--- a/js/js.translator/testData/incremental/invalidation/enum/project.info
+++ b/js/js.translator/testData/incremental/invalidation/enum/project.info
@@ -18,3 +18,13 @@ STEP 3:
     libs: lib1, main
     dirty js modules: main, lib1
     dirty js files:   lib1/l1, main/testEnumEntries
+STEP 4:
+    language: +EnumEntries
+    libs: lib1, main
+    dirty js modules: lib1, main
+    dirty js files:   lib1/l1
+STEP 5:
+    language: +EnumEntries
+    libs: lib1, main
+    dirty js modules: main
+    dirty js files:   main/testEnumEntries


### PR DESCRIPTION
Kotlin/JS compiler prior to 2.2.0 version produced `ReferenceError` while accessing the synthetic property of the enum class after consumer code modification ([KT-76027](https://youtrack.jetbrains.com/issue/KT-76027)).

This updated enum test adds necessary incremental compilation check for such a case.