### PR TITLE
[Docs] Mark new kotlin.time types as new in 2.1.20

### DIFF
--- a/libraries/stdlib/src/kotlin/time/Clock.kt
+++ b/libraries/stdlib/src/kotlin/time/Clock.kt
@@ -15,7 +15,7 @@ package kotlin.time
  * This way, tests can be written deterministically by providing custom [Clock] implementations
  * to the system under test.
  */
-@SinceKotlin("2.1")
+@SinceKotlin("2.1.20")
 @ExperimentalTime
 public interface Clock {
     /**

--- a/libraries/stdlib/src/kotlin/time/Instant.kt
+++ b/libraries/stdlib/src/kotlin/time/Instant.kt
@@ -100,7 +100,7 @@ import kotlin.time.Duration.Companion.seconds
  * instant.toString() // 2023-01-02T21:35:01Z
  * ```
  */
-@SinceKotlin("2.1")
+@SinceKotlin("2.1.20")
 @ExperimentalTime
 public class Instant internal constructor(
     /**
@@ -426,7 +426,7 @@ public class Instant internal constructor(
  *
  * @sample samples.time.Instants.isDistantPast
  */
-@SinceKotlin("2.1")
+@SinceKotlin("2.1.20")
 @ExperimentalTime
 @kotlin.internal.InlineOnly
 public inline val Instant.isDistantPast: Boolean
@@ -437,7 +437,7 @@ public inline val Instant.isDistantPast: Boolean
  *
  * @sample samples.time.Instants.isDistantFuture
  */
-@SinceKotlin("2.1")
+@SinceKotlin("2.1.20")
 @ExperimentalTime
 @kotlin.internal.InlineOnly
 public inline val Instant.isDistantFuture: Boolean


### PR DESCRIPTION
The KotlinLang Docs for e.g.
[`Instant`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.time/-instant/) specify that Instant is available since Kotlin 2.1. However, it is only available from 2.1.20. The same applies for `Clock`.

When attempting to use these types in a Kotlin 2.1.10 project, I was left confused at the inability to import them. I eventually found the reason in the Kotlin 2.1.20 release changelog.

SinceKotlin's version field supports patch-level versions:
> `@property version The version in the following formats: `<major>.<minor>`
> or `<major>.<minor>.<patch>`, where major, minor and patch
> are non-negative integer numbers without leading zeros.

This PR includes the patch version for the Instant, Clock, and the relevant Instant top-level functions.