### PR TITLE
Support for non-denotable union types

### DIFF
--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/evaluate/FirCompileTimeConstantEvaluator.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/evaluate/FirCompileTimeConstantEvaluator.kt
@@ -308,6 +308,7 @@ internal object FirCompileTimeConstantEvaluator {
             is ConeCapturedType -> lowerType?.toConstantValueKind() ?: constructor.supertypes!!.first().toConstantValueKind()
             is ConeDefinitelyNotNullType -> original.toConstantValueKind()
             is ConeIntersectionType -> intersectedTypes.first().toConstantValueKind()
+            is ConeUnionType -> null
             is ConeStubType, is ConeIntegerLiteralType, is ConeTypeVariableType -> null
         }
 

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
@@ -855,4 +855,16 @@ default: 'first-only-warn' in language version 2.2+, 'first-only' in version 2.1
 
         stubLifecycle()
     }
+
+    compilerArgument {
+        name = "Xunion-types"
+        description = "Enable experimental language support for union types".asReleaseDependent()
+        valueType = BooleanType.defaultFalse
+
+        additionalAnnotations(
+            Enables(LanguageFeature.UnionTypes)
+        )
+
+        stubLifecycle()
+    }
 }

--- a/compiler/cli/cli-common/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
+++ b/compiler/cli/cli-common/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
@@ -896,6 +896,17 @@ default: 'first-only-warn' in language version 2.2+, 'first-only' in version 2.1
             field = value
         }
 
+    @Argument(
+        value = "-Xunion-types",
+        description = "Enable experimental language support for union types",
+    )
+    @Enables(LanguageFeature.UnionTypes)
+    var unionTypes: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
     @get:Transient
     abstract val configurator: CommonCompilerArgumentsConfigurator
 

--- a/compiler/cli/cli-common/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-common/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
@@ -80,6 +80,7 @@ fun copyCommonCompilerArguments(from: CommonCompilerArguments, to: CommonCompile
     to.suppressApiVersionGreaterThanLanguageVersionError = from.suppressApiVersionGreaterThanLanguageVersionError
     to.suppressVersionWarnings = from.suppressVersionWarnings
     to.suppressedDiagnostics = from.suppressedDiagnostics?.copyOf()
+    to.unionTypes = from.unionTypes
     to.unrestrictedBuilderInference = from.unrestrictedBuilderInference
     to.useFirExperimentalCheckers = from.useFirExperimentalCheckers
     to.useFirIC = from.useFirIC

--- a/compiler/cli/cli-common/gen/org/jetbrains/kotlin/cli/common/arguments/ConfigureCommonLanguageFeatures.kt
+++ b/compiler/cli/cli-common/gen/org/jetbrains/kotlin/cli/common/arguments/ConfigureCommonLanguageFeatures.kt
@@ -73,4 +73,8 @@ internal fun HashMap<LanguageFeature, LanguageFeature.State>.configureCommonLang
     if (arguments.annotationTargetAll) {
         put(LanguageFeature.AnnotationAllUseSiteTarget, LanguageFeature.State.ENABLED)
     }
+
+    if (arguments.unionTypes) {
+        put(LanguageFeature.UnionTypes, LanguageFeature.State.ENABLED)
+    }
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/ConeTypeCompatibilityChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/ConeTypeCompatibilityChecker.kt
@@ -247,6 +247,7 @@ object ConeTypeCompatibilityChecker {
             is ConeTypeVariableType -> emptySet()
             is ConeDefinitelyNotNullType -> original.collectLowerBounds()
             is ConeIntersectionType -> intersectedTypes.flatMap { it.collectLowerBounds() }.toSet()
+            is ConeUnionType -> TODO()
             is ConeFlexibleType -> lowerBound.collectLowerBounds()
             is ConeCapturedType -> constructor.supertypes?.flatMap { it.collectLowerBounds() }?.toSet().orEmpty()
             is ConeIntegerConstantOperatorType -> setOf(getApproximatedType())

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirPrivateToThisAccessChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/expression/FirPrivateToThisAccessChecker.kt
@@ -141,6 +141,9 @@ object FirPrivateToThisAccessChecker : FirQualifiedAccessExpressionChecker(MppCh
             is ConeIntersectionType -> {
                 return this.intersectedTypes.any { it.contradictsWith(requiredVariance, session) }
             }
+            is ConeUnionType -> {
+                return this.unionTypes.all { it.contradictsWith(requiredVariance, session) }
+            }
             is ConeCapturedType -> {
                 // Looks like not possible here
                 return false

--- a/compiler/fir/cones/src/org/jetbrains/kotlin/fir/renderer/ConeTypeRenderer.kt
+++ b/compiler/fir/cones/src/org/jetbrains/kotlin/fir/renderer/ConeTypeRenderer.kt
@@ -130,6 +130,10 @@ open class ConeTypeRenderer(
                 "`renderConstructor` mustn't be called with an intersection type argument. " +
                         "Call `render` to simply render the type or filter out intersection types on the call-site."
             )
+            is ConeUnionType -> error(
+                "`renderConstructor` mustn't be called with an union type argument. " +
+                        "Call `render` to simply render the type or filter out union types on the call-site."
+            )
         }
         builder.append(nullabilityMarker)
     }

--- a/compiler/fir/cones/src/org/jetbrains/kotlin/fir/renderer/ConeTypeRenderer.kt
+++ b/compiler/fir/cones/src/org/jetbrains/kotlin/fir/renderer/ConeTypeRenderer.kt
@@ -82,6 +82,10 @@ open class ConeTypeRenderer(
                 render(type)
             }
 
+            is ConeUnionType -> {
+                render(type)
+            }
+
             is ConeDynamicType -> {
                 builder.append("dynamic")
             }
@@ -237,6 +241,17 @@ open class ConeTypeRenderer(
         for ((index, intersected) in type.intersectedTypes.withIndex()) {
             if (index > 0) {
                 builder.append(" & ")
+            }
+            this.render(intersected)
+        }
+        builder.append(")")
+    }
+
+    protected open fun render(type: ConeUnionType) {
+        builder.append("ut(")
+        for ((index, intersected) in type.unionTypes.withIndex()) {
+            if (index > 0) {
+                builder.append(" | ")
             }
             this.render(intersected)
         }

--- a/compiler/fir/cones/src/org/jetbrains/kotlin/fir/types/ConeTypeUtils.kt
+++ b/compiler/fir/cones/src/org/jetbrains/kotlin/fir/types/ConeTypeUtils.kt
@@ -51,6 +51,7 @@ val ConeKotlinType.isMarkedNullable: Boolean
         is ConeDefinitelyNotNullType -> false
         is ConeIntersectionType -> false
         is ConeStubType -> isMarkedNullable
+        is ConeUnionType -> false
     }
 
 val ConeKotlinType.hasFlexibleMarkedNullability: Boolean
@@ -144,6 +145,10 @@ inline fun ConeIntersectionType.mapTypes(func: (ConeKotlinType) -> ConeKotlinTyp
     return ConeIntersectionType(intersectedTypes.map(func), upperBoundForApproximation?.let(func))
 }
 
+inline fun ConeUnionType.mapTypes(func: (ConeKotlinType) -> ConeKotlinType): ConeUnionType {
+    return ConeUnionType(unionTypes.map(func), upperBoundForApproximation?.let(func))
+}
+
 fun ConeClassLikeType.withArguments(typeArguments: Array<out ConeTypeProjection>): ConeClassLikeType = when (this) {
     is ConeClassLikeTypeImpl -> ConeClassLikeTypeImpl(lookupTag, typeArguments, isMarkedNullable, attributes)
     is ConeErrorType -> this
@@ -200,6 +205,7 @@ fun ConeRigidType.getConstructor(): TypeConstructorMarker {
         is ConeCapturedType -> this.constructor
         is ConeTypeVariableType -> this.typeConstructor
         is ConeIntersectionType -> this
+        is ConeUnionType -> this
         is ConeStubType -> this.constructor
         is ConeDefinitelyNotNullType -> original.getConstructor()
         is ConeIntegerLiteralType -> this

--- a/compiler/fir/cones/src/org/jetbrains/kotlin/fir/types/ConeTypes.kt
+++ b/compiler/fir/cones/src/org/jetbrains/kotlin/fir/types/ConeTypes.kt
@@ -325,3 +325,34 @@ class ConeIntersectionType(
         return intersectedTypes.hashCode().also { hashCode = it }
     }
 }
+
+class ConeUnionType(
+    val unionTypes: Collection<ConeKotlinType>,
+    val upperBoundForApproximation: ConeKotlinType? = null,
+) : ConeSimpleKotlinType(), UnionTypeConstructorMarker, ConeTypeConstructorMarker {
+    override val typeArguments: Array<out ConeTypeProjection>
+        get() = EMPTY_ARRAY
+
+    override val attributes: ConeAttributes = unionTypes.foldMap(
+        { it.attributes },
+        { a, b -> a.union(b) }
+    )
+
+    private var hashCode = 0
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ConeIntersectionType
+
+        if (unionTypes != other.intersectedTypes) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        if (hashCode != 0) return hashCode
+        return unionTypes.hashCode().also { hashCode = it }
+    }
+}

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/FirJavaElementFinder.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/FirJavaElementFinder.kt
@@ -399,7 +399,7 @@ private fun ConeKotlinType.mapToCanonicalString(session: FirSession): String {
     return when (this) {
         is ConeClassLikeType -> mapToCanonicalString(session)
         is ConeTypeVariableType, is ConeFlexibleType, is ConeCapturedType,
-        is ConeDefinitelyNotNullType, is ConeIntersectionType, is ConeStubType, is ConeIntegerLiteralType ->
+        is ConeDefinitelyNotNullType, is ConeIntersectionType, is ConeStubType, is ConeIntegerLiteralType, is ConeUnionType ->
             errorWithAttachment("Unexpected type: ${this::class.java}") {
                 withConeTypeEntry("type", this@mapToCanonicalString)
             }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrTypeConverter.kt
@@ -249,7 +249,7 @@ class Fir2IrTypeConverter(
             is ConeDefinitelyNotNullType -> {
                 original.toIrType(c, typeOrigin).makeNotNull()
             }
-            is ConeIntersectionType -> {
+            is ConeIntersectionType, is ConeUnionType -> {
                 val approximated = approximateForIrOrNull(c)!!
                 approximated.toIrType(c, typeOrigin)
             }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/expressions/FirExpressionEvaluator.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/expressions/FirExpressionEvaluator.kt
@@ -495,6 +495,7 @@ private fun ConeKotlinType.toConstantValueKind(): ConstantValueKind? =
         is ConeCapturedType -> lowerType?.toConstantValueKind() ?: constructor.supertypes!!.first().toConstantValueKind()
         is ConeDefinitelyNotNullType -> original.toConstantValueKind()
         is ConeIntersectionType -> intersectedTypes.first().toConstantValueKind()
+        is ConeUnionType -> unionTypes.first().toConstantValueKind()
         is ConeStubType, is ConeIntegerLiteralType, is ConeTypeVariableType -> null
     }
 

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/LookupTagUtils.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/LookupTagUtils.kt
@@ -86,6 +86,7 @@ fun ConeKotlinType.findClassRepresentation(
         is ConeDefinitelyNotNullType -> original.findClassRepresentation(dispatchReceiverParameterType, session)
         is ConeIntegerLiteralType -> possibleTypes.findClassRepresentationThatIsSubtypeOf(dispatchReceiverParameterType, session)
         is ConeIntersectionType -> intersectedTypes.findClassRepresentationThatIsSubtypeOf(dispatchReceiverParameterType, session)
+        is ConeUnionType -> unionTypes.findClassRepresentationThatIsSubtypeOf(dispatchReceiverParameterType, session)
         is ConeTypeParameterType -> lookupTag.findClassRepresentationThatIsSubtypeOf(dispatchReceiverParameterType, session)
         is ConeTypeVariableType -> (this.typeConstructor.originalTypeParameter as? ConeTypeParameterLookupTag)
             ?.findClassRepresentationThatIsSubtypeOf(dispatchReceiverParameterType, session)

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/substitution/AbstractConeSubstitutor.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/substitution/AbstractConeSubstitutor.kt
@@ -73,6 +73,7 @@ abstract class AbstractConeSubstitutor(protected val typeContext: ConeTypeContex
             is ConeCapturedType -> return this.substitute(::substituteOrNull)
             is ConeDefinitelyNotNullType -> this.substituteOriginal()
             is ConeIntersectionType -> this.substituteIntersectedTypes()
+            is ConeUnionType -> TODO()
             is ConeStubType -> return null
             is ConeIntegerLiteralType -> return null
         }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeInferenceContext.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeInferenceContext.kt
@@ -137,12 +137,20 @@ interface ConeInferenceContext : TypeSystemInferenceExtensionContext, ConeTypeCo
                     constructor.upperBoundForApproximation?.withAttributes(coneAttributes)
                 )
             }
+            is ConeUnionType -> if (coneAttributes === constructor.attributes) {
+                constructor
+            } else {
+                ConeUnionType(
+                    constructor.unionTypes.map { it.withAttributes(coneAttributes) },
+                    constructor.upperBoundForApproximation?.withAttributes(coneAttributes)
+                )
+            }
             is ConeCapturedTypeConstructor,
             is ConeIntegerLiteralType,
             is ConeStubTypeConstructor,
             is ConeTypeVariableTypeConstructor,
                 -> error("Unsupported type constructor: ${constructor::class}")
-            is ConeClassifierLookupTag
+            is ConeClassifierLookupTag,
                 -> error("Unexpected /* sealed */ ConeClassifierLookupTag inheritor: ${constructor::class}")
         }
     }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeInferenceContext.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeInferenceContext.kt
@@ -266,6 +266,10 @@ interface ConeInferenceContext : TypeSystemInferenceExtensionContext, ConeTypeCo
             return this.intersectedTypes.any { it.containsInternal(predicate) }
         }
 
+        if (this is ConeUnionType) {
+            return this.unionTypes.any { it.containsInternal(predicate) }
+        }
+
         if (this is ConeCapturedType) {
             return this.constructor.projection.type?.containsInternal(predicate) == true
         }

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeTypeUnioner.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/ConeTypeUnioner.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.types
+
+import org.jetbrains.kotlin.types.AbstractTypeChecker
+
+object ConeTypeUnion {
+    fun unionTypes(
+        context: ConeInferenceContext,
+        types: Collection<ConeKotlinType>
+    ): ConeKotlinType {
+        when (types.size) {
+            0 -> error("Expected some types")
+            1 -> return types.single()
+        }
+
+        val inputTypes = mutableListOf<ConeKotlinType>().apply {
+            for (inputType in types) {
+                if (inputType is ConeUnionType) {
+                    addAll(inputType.unionTypes)
+                } else {
+                    add(inputType)
+                }
+            }
+        }
+
+        if (inputTypes.any { it is ConeFlexibleType } && inputTypes.none { it.isRaw() || it is ConeDynamicType }) {
+            TODO()
+        }
+
+        val isResultNotNullable = with(context) {
+            inputTypes.any { !it.isNullableType() }
+        }
+        val inputTypesMadeNotNullIfNeeded = inputTypes.mapTo(LinkedHashSet()) {
+            if (isResultNotNullable) it.makeConeTypeDefinitelyNotNullOrNotNull(context) else it
+        }
+        if (inputTypesMadeNotNullIfNeeded.size == 1) return inputTypesMadeNotNullIfNeeded.single()
+
+        /*
+         * Here we drop types from intersection set for cases like that:
+         *
+         * interface A
+         * interface B : A
+         *
+         * type = (A & B & ...)
+         *
+         * We want to drop A from that set, because it's useless for type checking. But in case if
+         *   A came from inference and B came from smartcast we want to save both types in intersection
+         */
+        val resultList = inputTypesMadeNotNullIfNeeded.toMutableList()
+        resultList.removeIfNonSingleErrorOrInRelation { candidate, other -> other.isStrictSubtypeOf(context, candidate) }
+        assert(resultList.isNotEmpty()) { "no types left after removing strict supertypes: ${inputTypes.joinToString()}" }
+        return resultList.singleOrNull() ?: ConeUnionType(resultList)
+
+        ConeIntegerLiteralIntersector.findCommonIntersectionType(resultList)?.let { return it }
+
+        resultList.removeIfNonSingleErrorOrInRelation { candidate, other -> AbstractTypeChecker.equalTypes(context, candidate, other) }
+        assert(resultList.isNotEmpty()) { "no types left after removing equal types: ${inputTypes.joinToString()}" }
+        return resultList.singleOrNull() ?: ConeIntersectionType(resultList)
+    }
+
+    private fun MutableCollection<ConeKotlinType>.removeIfNonSingleErrorOrInRelation(
+        predicate: (candidate: ConeKotlinType, other: ConeKotlinType) -> Boolean
+    ) {
+        val iterator = iterator()
+        while (iterator.hasNext()) {
+            val candidate = iterator.next()
+            if (candidate is ConeErrorType && size > 1 ||
+                any { other -> other !== candidate && predicate(candidate, other) }
+            ) {
+                iterator.remove()
+            }
+        }
+    }
+
+    private fun ConeKotlinType.isStrictSubtypeOf(context: ConeTypeContext, supertype: ConeKotlinType): Boolean =
+        AbstractTypeChecker.isSubtypeOf(context, this, supertype) && !AbstractTypeChecker.isSubtypeOf(context, supertype, this)
+}

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ContextSensitiveResolutionUtils.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/ContextSensitiveResolutionUtils.kt
@@ -53,6 +53,8 @@ fun ConeKotlinType.getClassRepresentativeForContextSensitiveResolution(session: 
             }
         }
 
+        is ConeUnionType -> TODO()
+
         is ConeLookupTagBasedType ->
             when (val symbol = lookupTag.toSymbol(session)) {
                 is FirRegularClassSymbol -> symbol

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/SamResolution.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/SamResolution.kt
@@ -113,8 +113,8 @@ class FirSamResolver(
             }
 
             is ConeStubType, is ConeTypeParameterType, is ConeTypeVariableType,
-            is ConeDefinitelyNotNullType, is ConeIntersectionType, is ConeIntegerLiteralType,
-            -> null
+            is ConeDefinitelyNotNullType, is ConeIntersectionType, is ConeIntegerLiteralType, is ConeUnionType
+                -> null
 
             is ConeCapturedType -> type.lowerType?.let { getSamInfoForPossibleSamType(it) }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirWhenExhaustivenessTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirWhenExhaustivenessTransformer.kt
@@ -569,6 +569,9 @@ private data object WhenSelfTypeExhaustivenessChecker : WhenExhaustivenessChecke
 
         val checkedTypes = mutableSetOf<ConeKotlinType>()
         whenExpression.accept(ConditionChecker, checkedTypes)
+        if (session.languageVersionSettings.supportsFeature(LanguageFeature.UnionTypes)) {
+            return convertedSubjectType.isSubtypeOf(ConeTypeUnion.unionTypes(session.typeContext, checkedTypes), session)
+        }
 
         // If there are no cases that check for self-type or super-type, report an Unknown missing case,
         // since we do not want to suggest this sort of check.

--- a/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/TypeUtils.kt
+++ b/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/TypeUtils.kt
@@ -35,6 +35,7 @@ fun ConeKotlinType?.collectUpperBounds(): Set<ConeClassLikeType> {
             }
             is ConeDefinitelyNotNullType -> collect(type.original)
             is ConeIntersectionType -> type.intersectedTypes.forEach(::collect)
+            is ConeUnionType -> type.unionTypes.forEach(::collect)
             is ConeFlexibleType -> collect(type.upperBound)
             is ConeCapturedType -> type.constructor.supertypes?.forEach(::collect)
             is ConeIntegerConstantOperatorType -> upperBounds.add(type.getApproximatedType())

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
@@ -174,6 +174,7 @@ interface IrTypeSystemContext : TypeSystemContext, TypeSystemCommonSuperTypesCon
 
     override fun TypeConstructorMarker.isIntersection() = false
     override fun TypeConstructorMarker.isUnion() = false
+    override fun TypeConstructorMarker.unionTypes(): Collection<KotlinTypeMarker> = emptySet()
 
     override fun TypeConstructorMarker.isClassTypeConstructor() = this is IrClassSymbol
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSystemContext.kt
@@ -173,6 +173,7 @@ interface IrTypeSystemContext : TypeSystemContext, TypeSystemCommonSuperTypesCon
     }
 
     override fun TypeConstructorMarker.isIntersection() = false
+    override fun TypeConstructorMarker.isUnion() = false
 
     override fun TypeConstructorMarker.isClassTypeConstructor() = this is IrClassSymbol
 
@@ -404,6 +405,14 @@ interface IrTypeSystemContext : TypeSystemContext, TypeSystemCommonSuperTypesCon
     @Suppress("UNCHECKED_CAST")
     override fun intersectTypes(types: Collection<KotlinTypeMarker>): KotlinTypeMarker =
         makeTypeIntersection(types as Collection<IrType>)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun unionTypes(types: Collection<SimpleTypeMarker>): SimpleTypeMarker =
+        TODO()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun unionTypes(types: Collection<KotlinTypeMarker>): KotlinTypeMarker =
+        TODO()
 
     override fun SimpleTypeMarker.isPrimitiveType(): Boolean =
         this is IrSimpleType && irTypePredicates_isPrimitiveType()

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt
@@ -460,6 +460,12 @@ class ResultTypeResolver(
     }
 
     private fun Context.findSuperType(variableWithConstraints: VariableWithConstraints): KotlinTypeMarker? {
+        if (languageVersionSettings.supportsFeature(LanguageFeature.UnionTypes)) {
+            val lowerConstraintTypes = prepareLowerConstraints(variableWithConstraints.constraints)
+            if (lowerConstraintTypes.isNotEmpty()) {
+                return unionTypes(lowerConstraintTypes)
+            }
+        }
         val upperConstraints = variableWithConstraints.constraints.filter {
             it.kind == ConstraintKind.UPPER && this@findSuperType.isProperTypeForFixation(it.type)
         }

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/ResultTypeResolver.kt
@@ -352,6 +352,11 @@ class ResultTypeResolver(
 
         if (lowerConstraintTypes.isNotEmpty()) {
             val types = sinkIntegerLiteralTypes(lowerConstraintTypes)
+
+            if (languageVersionSettings.supportsFeature(LanguageFeature.UnionTypes)) {
+                return unionTypes(types)
+            }
+
             var commonSuperType = computeCommonSuperType(types)
 
             if (commonSuperType.contains { it.asRigidType()?.isStubTypeForVariableInSubtyping() == true }) {
@@ -460,12 +465,6 @@ class ResultTypeResolver(
     }
 
     private fun Context.findSuperType(variableWithConstraints: VariableWithConstraints): KotlinTypeMarker? {
-        if (languageVersionSettings.supportsFeature(LanguageFeature.UnionTypes)) {
-            val lowerConstraintTypes = prepareLowerConstraints(variableWithConstraints.constraints)
-            if (lowerConstraintTypes.isNotEmpty()) {
-                return unionTypes(lowerConstraintTypes)
-            }
-        }
         val upperConstraints = variableWithConstraints.constraints.filter {
             it.kind == ConstraintKind.UPPER && this@findSuperType.isProperTypeForFixation(it.type)
         }

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerStateForConstraintSystem.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerStateForConstraintSystem.kt
@@ -504,14 +504,14 @@ abstract class TypeCheckerStateForConstraintSystem(
 
         fun correctSuperType(superType: RigidTypeMarker) =
             superType.isSingleClassifierType() || superType.typeConstructor()
-                .isIntersection() || subType.typeConstructor().isUnion() || isMyTypeVariable(superType) || superType.isError()
+                .isIntersection() || superType.typeConstructor().isUnion() || isMyTypeVariable(superType) || superType.isError()
                     || superType.isIntegerLiteralType()
 
         assert(subType.bothBounds(::correctSubType)) {
-            "Not singleClassifierType and not intersection subType: $subType"
+            "Not singleClassifierType and not intersection or union subType: $subType"
         }
         assert(superType.bothBounds(::correctSuperType)) {
-            "Not singleClassifierType superType and not union superType: $superType"
+            "Not singleClassifierType superType: $superType"
         }
     }
 

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerStateForConstraintSystem.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/TypeCheckerStateForConstraintSystem.kt
@@ -499,17 +499,19 @@ abstract class TypeCheckerStateForConstraintSystem(
         if (!AbstractTypeChecker.RUN_SLOW_ASSERTIONS) return
         fun correctSubType(subType: RigidTypeMarker) =
             subType.isSingleClassifierType() || subType.typeConstructor()
-                .isIntersection() || isMyTypeVariable(subType) || subType.isError() || subType.isIntegerLiteralType()
+                .isIntersection() || subType.typeConstructor().isUnion() || isMyTypeVariable(subType) || subType.isError()
+                    || subType.isIntegerLiteralType()
 
         fun correctSuperType(superType: RigidTypeMarker) =
             superType.isSingleClassifierType() || superType.typeConstructor()
-                .isIntersection() || isMyTypeVariable(superType) || superType.isError() || superType.isIntegerLiteralType()
+                .isIntersection() || subType.typeConstructor().isUnion() || isMyTypeVariable(superType) || superType.isError()
+                    || superType.isIntegerLiteralType()
 
         assert(subType.bothBounds(::correctSubType)) {
             "Not singleClassifierType and not intersection subType: $subType"
         }
         assert(superType.bothBounds(::correctSuperType)) {
-            "Not singleClassifierType superType: $superType"
+            "Not singleClassifierType superType and not union superType: $superType"
         }
     }
 

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/types/AbstractTypeApproximator.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/types/AbstractTypeApproximator.kt
@@ -364,6 +364,63 @@ abstract class AbstractTypeApproximator(
         return createTypeWithUpperBoundForIntersectionResult(intersectionType, alternativeTypeApproximated)
     }
 
+    private fun approximateUnionType(
+        type: RigidTypeMarker,
+        conf: TypeApproximatorConfiguration,
+        toSuper: Boolean,
+        depth: Int
+    ): KotlinTypeMarker? {
+        val typeConstructor = type.typeConstructor()
+        assert(typeConstructor.isUnion()) {
+            "Should be union type: $type, typeConstructor class: ${typeConstructor::class.java.canonicalName}"
+        }
+        assert(typeConstructor.supertypes().isNotEmpty()) {
+            "Supertypes for union type should not be empty: $type"
+        }
+
+        val upperBoundForApproximation = type.getUpperBoundForApproximationOfIntersectionType()
+
+        if (toSuper && upperBoundForApproximation != null &&
+            (conf.intersectionStrategy == TypeApproximatorConfiguration.IntersectionStrategy.TO_COMMON_SUPERTYPE ||
+                    conf.intersectionStrategy == TypeApproximatorConfiguration.IntersectionStrategy.TO_UPPER_BOUND_IF_SUPERTYPE)
+        ) {
+            return approximateToSuperType(upperBoundForApproximation, conf, depth) ?: upperBoundForApproximation
+        }
+
+        var thereIsApproximation = false
+        val newTypes = typeConstructor.supertypes().map {
+            val newType = if (toSuper) approximateToSuperType(it, conf, depth) else approximateToSubType(it, conf, depth)
+            if (newType != null) {
+                thereIsApproximation = true
+                newType
+            } else it
+        }
+
+        /**
+         * For case ALLOWED:
+         * A <: A', B <: B' => A & B <: A' & B'
+         *
+         * For other case -- it's impossible to find some type except Nothing as subType for intersection type.
+         */
+        val baseResult = when (conf.intersectionStrategy) {
+            TypeApproximatorConfiguration.IntersectionStrategy.ALLOWED -> if (!thereIsApproximation) {
+                return null
+            } else {
+                intersectTypes(newTypes, upperBoundForApproximation, toSuper, conf, depth)
+            }
+            TypeApproximatorConfiguration.IntersectionStrategy.TO_FIRST -> if (toSuper) newTypes.first() else return type.defaultResult(toSuper = false)
+            // commonSupertypeCalculator should handle flexible types correctly
+            TypeApproximatorConfiguration.IntersectionStrategy.TO_COMMON_SUPERTYPE,
+            TypeApproximatorConfiguration.IntersectionStrategy.TO_UPPER_BOUND_IF_SUPERTYPE -> {
+                if (!toSuper) return type.defaultResult(toSuper = false)
+                val resultType = commonSuperType(newTypes)
+                approximateToSuperType(resultType, conf) ?: resultType
+            }
+        }
+
+        return if (type.isMarkedNullable()) baseResult.withNullability(true) else baseResult
+    }
+
     private fun approximateCapturedType(
         capturedType: CapturedTypeMarker,
         conf: TypeApproximatorConfiguration,
@@ -515,6 +572,10 @@ abstract class AbstractTypeApproximator(
 
         if (typeConstructor.isIntersection()) {
             return approximateIntersectionType(type, conf, toSuper, depth)
+        }
+
+        if (typeConstructor.isUnion()) {
+            return approximateUnionType(type, conf, toSuper, depth)
         }
 
         if (typeConstructor is TypeVariableTypeConstructorMarker) {

--- a/compiler/util/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
@@ -448,6 +448,7 @@ enum class LanguageFeature(
     PropertyParamAnnotationDefaultTargetMode(sinceVersion = null, kind = OTHER), // KT-73255
     AnnotationAllUseSiteTarget(sinceVersion = null, kind = OTHER), // KT-73256
     ImplicitJvmExposeBoxed(sinceVersion = null, kind = UNSTABLE_FEATURE), // KT-73466
+    UnionTypes(sinceVersion = null, kind = OTHER),
 
     // K1 support only. We keep it, as we may want to support it also in K2
     UnitConversionsOnArbitraryExpressions(sinceVersion = null),

--- a/core/compiler.common/src/org/jetbrains/kotlin/types/AbstractTypeChecker.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/types/AbstractTypeChecker.kt
@@ -398,7 +398,7 @@ object AbstractTypeChecker {
             assert(subType.isSingleClassifierType() || subType.typeConstructor().isIntersection() || state.isAllowedTypeVariable(subType)) {
                 "Not singleClassifierType and not intersection subType: $subType"
             }
-            assert(superType.isSingleClassifierType() || state.isAllowedTypeVariable(superType)) {
+            assert(superType.isSingleClassifierType() || superType.typeConstructor().isUnion() || state.isAllowedTypeVariable(superType)) {
                 "Not singleClassifierType superType: $superType"
             }
         }
@@ -782,8 +782,8 @@ object AbstractNullabilityChecker {
                 ) {
                     "Not singleClassifierType and not intersection subType: $subType"
                 }
-                assert(superType.isSingleClassifierType() || state.isAllowedTypeVariable(superType)) {
-                    "Not singleClassifierType superType: $superType"
+                assert(superType.isSingleClassifierType() || superType.typeConstructor().isUnion() || state.isAllowedTypeVariable(superType)) {
+                    "Not singleClassifierType superType and not union superType: $superType"
                 }
             }
 

--- a/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
@@ -37,6 +37,8 @@ interface CapturedTypeConstructorMarker : TypeConstructorMarker
 
 interface IntersectionTypeConstructorMarker : TypeConstructorMarker
 
+interface UnionTypeConstructorMarker : TypeConstructorMarker
+
 interface TypeSubstitutorMarker
 
 interface AnnotationMarker
@@ -475,6 +477,7 @@ interface TypeSystemContext : TypeSystemOptimizationContext {
     fun TypeConstructorMarker.getParameters(): List<TypeParameterMarker>
     fun TypeConstructorMarker.supertypes(): Collection<KotlinTypeMarker>
     fun TypeConstructorMarker.isIntersection(): Boolean
+    fun TypeConstructorMarker.isUnion(): Boolean
     fun TypeConstructorMarker.isClassTypeConstructor(): Boolean
     fun TypeConstructorMarker.isInterface(): Boolean
     fun TypeConstructorMarker.isIntegerLiteralTypeConstructor(): Boolean
@@ -602,6 +605,9 @@ interface TypeSystemContext : TypeSystemOptimizationContext {
 
     fun intersectTypes(types: Collection<KotlinTypeMarker>): KotlinTypeMarker
     fun intersectTypes(types: Collection<SimpleTypeMarker>): SimpleTypeMarker
+
+    fun unionTypes(types: Collection<KotlinTypeMarker>): KotlinTypeMarker
+    fun unionTypes(types: Collection<SimpleTypeMarker>): SimpleTypeMarker
 
     fun KotlinTypeMarker.isRigidType(): Boolean = asRigidType() != null
 

--- a/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/types/model/TypeSystemContext.kt
@@ -478,6 +478,7 @@ interface TypeSystemContext : TypeSystemOptimizationContext {
     fun TypeConstructorMarker.supertypes(): Collection<KotlinTypeMarker>
     fun TypeConstructorMarker.isIntersection(): Boolean
     fun TypeConstructorMarker.isUnion(): Boolean
+    fun TypeConstructorMarker.unionTypes(): Collection<KotlinTypeMarker>
     fun TypeConstructorMarker.isClassTypeConstructor(): Boolean
     fun TypeConstructorMarker.isInterface(): Boolean
     fun TypeConstructorMarker.isIntegerLiteralTypeConstructor(): Boolean

--- a/core/descriptors/src/org/jetbrains/kotlin/types/UnionTypeConstructor.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/UnionTypeConstructor.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.types
+
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
+import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
+import org.jetbrains.kotlin.types.checker.KotlinTypeRefiner
+import org.jetbrains.kotlin.types.model.UnionTypeConstructorMarker
+
+class UnionTypeConstructor(typesToUnion: Collection<KotlinType>) : TypeConstructor, UnionTypeConstructorMarker {
+    private var alternative: KotlinType? = null
+
+    private constructor(
+        typesToUnion: Collection<KotlinType>,
+        alternative: KotlinType?,
+    ) : this(typesToUnion) {
+        this.alternative = alternative
+    }
+
+    init {
+        assert(!typesToUnion.isEmpty()) { "Attempt to create an empty intersection" }
+    }
+
+    private val unionTypes = LinkedHashSet(typesToUnion)
+    private val hashCode = unionTypes.hashCode()
+
+    override fun getParameters(): List<TypeParameterDescriptor> = emptyList()
+
+    override fun getSupertypes(): Collection<KotlinType> = TODO()
+
+    // Type should not be rendered in scope's debug name. This may cause performance issues in case of complicated intersection types.
+    fun createScopeForKotlinType(): MemberScope = TODO()
+//        TypeIntersectionScope.create("member scope for intersection type", unionTypes)
+
+    override fun isFinal(): Boolean = false
+
+    override fun isDenotable(): Boolean = false
+
+    override fun getDeclarationDescriptor(): ClassifierDescriptor? = null
+
+    override fun getBuiltIns(): KotlinBuiltIns =
+        unionTypes.iterator().next().constructor.builtIns
+
+    override fun toString(): String = makeDebugNameForIntersectionType()
+
+    fun makeDebugNameForIntersectionType(getProperTypeRelatedToStringify: (KotlinType) -> Any = { it.toString() }): String {
+        return unionTypes.sortedBy { getProperTypeRelatedToStringify(it).toString() }
+            .joinToString(separator = " & ", prefix = "{", postfix = "}") { getProperTypeRelatedToStringify(it).toString() }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is UnionTypeConstructor) return false
+
+        return unionTypes == other.unionTypes
+    }
+
+    @OptIn(TypeRefinement::class)
+    fun createType(): SimpleType =
+        KotlinTypeFactory.simpleTypeWithNonTrivialMemberScope(
+            TypeAttributes.Empty, this, listOf(), false, this.createScopeForKotlinType()
+        ) { kotlinTypeRefiner ->
+            TODO()
+            // this.refine(kotlinTypeRefiner).createType()
+        }
+
+    override fun hashCode(): Int = hashCode
+
+    @TypeRefinement
+    override fun refine(kotlinTypeRefiner: KotlinTypeRefiner) = TODO()
+        // transformComponents { it.refine(kotlinTypeRefiner) } ?: this
+
+    /*fun setAlternative(alternative: KotlinType?): IntersectionTypeConstructor {
+        return IntersectionTypeConstructor(unionTypes, alternative)
+    }*/
+
+    fun getAlternativeType(): KotlinType? = alternative
+}

--- a/core/descriptors/src/org/jetbrains/kotlin/types/UnionTypeConstructor.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/UnionTypeConstructor.kt
@@ -26,7 +26,7 @@ class UnionTypeConstructor(typesToUnion: Collection<KotlinType>) : TypeConstruct
         assert(!typesToUnion.isEmpty()) { "Attempt to create an empty intersection" }
     }
 
-    private val unionTypes = LinkedHashSet(typesToUnion)
+    val unionTypes = LinkedHashSet(typesToUnion)
     private val hashCode = unionTypes.hashCode()
 
     override fun getParameters(): List<TypeParameterDescriptor> = emptyList()

--- a/core/descriptors/src/org/jetbrains/kotlin/types/checker/ClassicTypeSystemContext.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/checker/ClassicTypeSystemContext.kt
@@ -134,7 +134,12 @@ interface ClassicTypeSystemContext : TypeSystemInferenceExtensionContext, TypeSy
 
     override fun TypeConstructorMarker.isUnion(): Boolean {
         require(this is TypeConstructor, this::errorMessage)
-        return this is IntersectionTypeConstructor
+        return this is UnionTypeConstructor
+    }
+
+    override fun TypeConstructorMarker.unionTypes(): Collection<KotlinTypeMarker> {
+        require(this is UnionTypeConstructor, this::errorMessage)
+        return this.unionTypes
     }
 
     override fun identicalArguments(a: RigidTypeMarker, b: RigidTypeMarker): Boolean {

--- a/core/descriptors/src/org/jetbrains/kotlin/types/checker/ClassicTypeSystemContext.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/types/checker/ClassicTypeSystemContext.kt
@@ -132,6 +132,11 @@ interface ClassicTypeSystemContext : TypeSystemInferenceExtensionContext, TypeSy
         return this is IntersectionTypeConstructor
     }
 
+    override fun TypeConstructorMarker.isUnion(): Boolean {
+        require(this is TypeConstructor, this::errorMessage)
+        return this is IntersectionTypeConstructor
+    }
+
     override fun identicalArguments(a: RigidTypeMarker, b: RigidTypeMarker): Boolean {
         require(a is SimpleType, a::errorMessage)
         require(b is SimpleType, b::errorMessage)
@@ -406,6 +411,18 @@ interface ClassicTypeSystemContext : TypeSystemInferenceExtensionContext, TypeSy
     }
 
     override fun intersectTypes(types: Collection<SimpleTypeMarker>): SimpleTypeMarker {
+        @Suppress("UNCHECKED_CAST")
+        return org.jetbrains.kotlin.types.checker.intersectTypes(types as Collection<SimpleType>)
+    }
+
+    override fun unionTypes(types: Collection<KotlinTypeMarker>): KotlinTypeMarker {
+        TODO()
+        @Suppress("UNCHECKED_CAST")
+        return org.jetbrains.kotlin.types.checker.intersectTypes(types as Collection<UnwrappedType>)
+    }
+
+    override fun unionTypes(types: Collection<SimpleTypeMarker>): SimpleTypeMarker {
+        TODO()
         @Suppress("UNCHECKED_CAST")
         return org.jetbrains.kotlin.types.checker.intersectTypes(types as Collection<SimpleType>)
     }


### PR DESCRIPTION
This PR adds a language features: "union types" for non-denotable union types.
Currently, with "LANGUAGE: +UnionTypes" we can do this:
```kotlin
// LANGUAGE: +UnionTypes

var b = false

fun box(): String {
    val x = if (b) { // infered type Long | String
        11L
    } else {
        "OK"
    }
    return when (x) {
        is Long -> "Fail"
        is String -> x
    }
}
```
