### PR TITLE
Add samples for `removeSurrounding` functions of `String` and `CharSequence`

### DIFF
--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -814,4 +814,69 @@ class Strings {
         // list is converted to a String first and then concatenated with the "Numbers: " string
         assertEquals("Numbers: [1, 2, 3]", "Numbers: " + listOf(1, 2, 3))
     }
+
+    @Sample
+    fun removeSurroundingPrefixSuffixString() {
+        val textString = "[content]"
+        assertPrints(textString.removeSurrounding("[", "]"), "content")
+        // Does not start with prefix
+        assertPrints("content]".removeSurrounding("[", "]"), "content]")
+        // Does not end with suffix
+        assertPrints("[content".removeSurrounding("[", "]"), "[content")
+        // Does not start or end with prefix/suffix
+        assertPrints("content".removeSurrounding("[", "]"), "content")
+        // Empty content
+        assertPrints("[]".removeSurrounding("[", "]"), "")
+        // Different delimiters
+        assertPrints("<content>".removeSurrounding("[", "]"), "<content>")
+    }
+
+    @Sample
+    fun removeSurroundingPrefixSuffixCharSequence() {
+        val textCharSequence: CharSequence = StringBuilder("[content]")
+        assertPrints(textCharSequence.removeSurrounding("[", "]"), "content")
+        // Does not start with prefix
+        assertPrints(StringBuilder("content]").removeSurrounding("[", "]"), "content]")
+        // Does not end with suffix
+        assertPrints(StringBuilder("[content").removeSurrounding("[", "]"), "[content")
+        // Does not start or end with prefix/suffix
+        assertPrints(StringBuilder("content").removeSurrounding("[", "]"), "content")
+        // Empty content
+        assertPrints(StringBuilder("[]").removeSurrounding("[", "]"), "")
+        // Different delimiters
+        assertPrints(StringBuilder("<content>").removeSurrounding("[", "]"), "<content>")
+    }
+
+    @Sample
+    fun removeSurroundingDelimiterString() {
+        val textString = "***content***"
+        assertPrints(textString.removeSurrounding("***"), "content")
+        // Does not end with delimiter
+        assertPrints("##content".removeSurrounding("##"), "##content")
+        // Does not start with delimiter
+        assertPrints("content##".removeSurrounding("##"), "content##")
+        // No delimiters
+        assertPrints("content".removeSurrounding("##"), "content")
+        // Empty content
+        assertPrints("****".removeSurrounding("**"), "")
+        // Delimiter is single char, removes only one pair
+        assertPrints("!!!content!!!".removeSurrounding("!"), "!!content!!")
+    }
+
+    @Sample
+    fun removeSurroundingDelimiterCharSequence() {
+        val textCharSequence: CharSequence = StringBuilder("***content***")
+        assertPrints(textCharSequence.removeSurrounding("***"), "content")
+        // Does not end with delimiter
+        assertPrints(StringBuilder("##content").removeSurrounding("##"), "##content")
+        // Does not start with delimiter
+        assertPrints(StringBuilder("content##").removeSurrounding("##"), "content##")
+        // No delimiters
+        assertPrints(StringBuilder("content").removeSurrounding("##"), "content")
+        // Empty content
+        assertPrints(StringBuilder("****").removeSurrounding("**"), "")
+        // Delimiter is single char, removes only one pair
+        assertPrints(StringBuilder("!!!content!!!").removeSurrounding("!"), "!!content!!")
+    }
+
 }

--- a/libraries/stdlib/src/kotlin/text/Strings.kt
+++ b/libraries/stdlib/src/kotlin/text/Strings.kt
@@ -656,6 +656,8 @@ public fun String.removeSuffix(suffix: CharSequence): String {
  * When this char sequence starts with the given [prefix] and ends with the given [suffix],
  * returns a new char sequence having both the given [prefix] and [suffix] removed.
  * Otherwise, returns a new char sequence with the same characters.
+ *
+ * @sample samples.text.Strings.removeSurroundingPrefixSuffixCharSequence
  */
 public fun CharSequence.removeSurrounding(prefix: CharSequence, suffix: CharSequence): CharSequence {
     if ((length >= prefix.length + suffix.length) && startsWith(prefix) && endsWith(suffix)) {
@@ -668,6 +670,8 @@ public fun CharSequence.removeSurrounding(prefix: CharSequence, suffix: CharSequ
  * Removes from a string both the given [prefix] and [suffix] if and only if
  * it starts with the [prefix] and ends with the [suffix].
  * Otherwise, returns this string unchanged.
+ *
+ * @sample samples.text.Strings.removeSurroundingPrefixSuffixString
  */
 public fun String.removeSurrounding(prefix: CharSequence, suffix: CharSequence): String {
     if ((length >= prefix.length + suffix.length) && startsWith(prefix) && endsWith(suffix)) {
@@ -680,6 +684,8 @@ public fun String.removeSurrounding(prefix: CharSequence, suffix: CharSequence):
  * When this char sequence starts with and ends with the given [delimiter],
  * returns a new char sequence having this [delimiter] removed both from the start and end.
  * Otherwise, returns a new char sequence with the same characters.
+ *
+ * @sample samples.text.Strings.removeSurroundingDelimiterCharSequence
  */
 public fun CharSequence.removeSurrounding(delimiter: CharSequence): CharSequence = removeSurrounding(delimiter, delimiter)
 
@@ -687,6 +693,8 @@ public fun CharSequence.removeSurrounding(delimiter: CharSequence): CharSequence
  * Removes the given [delimiter] string from both the start and the end of this string
  * if and only if it starts with and ends with the [delimiter].
  * Otherwise, returns this string unchanged.
+ *
+ * @sample samples.text.Strings.removeSurroundingDelimiterString
  */
 public fun String.removeSurrounding(delimiter: CharSequence): String = removeSurrounding(delimiter, delimiter)
 


### PR DESCRIPTION
Add @sample documentation for the four `removeSurrounding` extension functions (String/CharSequence versions for both prefix/suffix and delimiter variants).

No specific YouTrack issue was linked to this change.