### PR TITLE
KT-72838: [Gradle] Support websockets in webpack devServer proxy

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -4686,21 +4686,23 @@ public final class org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackC
 }
 
 public final class org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig$DevServer$Proxy : java/io/Serializable {
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/Map;
 	public final fun component4 ()Ljava/lang/Boolean;
 	public final fun component5 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lorg/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig$DevServer$Proxy;
-	public static synthetic fun copy$default (Lorg/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig$DevServer$Proxy;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig$DevServer$Proxy;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lorg/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig$DevServer$Proxy;
+	public static synthetic fun copy$default (Lorg/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig$DevServer$Proxy;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig$DevServer$Proxy;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChangeOrigin ()Ljava/lang/Boolean;
 	public final fun getContext ()Ljava/util/List;
 	public final fun getPathRewrite ()Ljava/util/Map;
 	public final fun getSecure ()Ljava/lang/Boolean;
 	public final fun getTarget ()Ljava/lang/String;
+	public final fun getWs ()Ljava/lang/Boolean;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
@@ -112,6 +112,7 @@ data class KotlinWebpackConfig(
             val pathRewrite: MutableMap<String, String>? = null,
             val secure: Boolean? = null,
             val changeOrigin: Boolean? = null,
+            val ws: Boolean? = null,
         ) : Serializable
     }
 


### PR DESCRIPTION
Fixes KT-72838

Add `ws` parameter to webpack devServer proxy DSL in gradle plugin so that it is passed through to the generated webpack config.

The parameter is not listed in the [webpack docs](https://webpack.js.org/configuration/dev-server/#devserverproxy), but it's described in the underlying library's docs [here](https://github.com/chimurai/http-proxy-middleware?tab=readme-ov-file#http-proxy-options):
> option.ws: true/false: if you want to proxy websockets