### PR TITLE
[Gradle] Support for new Android multiplatform compilation in Kotlin parcelize

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/android/internal/ParcelizeSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/android/internal/ParcelizeSubplugin.kt
@@ -6,35 +6,27 @@
 @file:Suppress("PackageDirectoryMismatch") // Old package for compatibility
 package org.jetbrains.kotlin.gradle.internal
 
-import com.android.build.gradle.BaseExtension
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.*
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
-import org.jetbrains.kotlin.gradle.utils.forAllAndroidVariants
+import org.jetbrains.kotlin.gradle.utils.configureAndroidVariants
 
 // Use apply plugin: 'kotlin-parcelize' to enable Android Extensions in an Android project.
 class ParcelizeSubplugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         val kotlinPluginVersion = target.getKotlinPluginVersion()
         val dependency = target.dependencies.create("org.jetbrains.kotlin:kotlin-parcelize-runtime:$kotlinPluginVersion")
-        target.forAllAndroidVariants {
+        target.configureAndroidVariants {
             it.runtimeConfiguration.dependencies.add(dependency)
             it.compileConfiguration.dependencies.add(dependency)
         }
     }
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean {
-        if (kotlinCompilation !is KotlinJvmAndroidCompilation) {
-            return false
+        return when (kotlinCompilation.platformType) {
+            KotlinPlatformType.jvm, KotlinPlatformType.androidJvm -> true
+            else -> false
         }
-
-        val project = kotlinCompilation.target.project
-        if (project.extensions.findByName("android") !is BaseExtension) {
-            return false
-        }
-
-        return true
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/forEachAndroidVariant.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/forEachAndroidVariant.kt
@@ -5,9 +5,14 @@
 
 package org.jetbrains.kotlin.gradle.utils
 
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Component
 import com.android.build.gradle.*
 import org.gradle.api.Project
 
+/**
+ * Uses the legacy Variant API
+ */
 internal fun Project.forAllAndroidVariants(
     @Suppress("TYPEALIAS_EXPANSION_DEPRECATION") action: (DeprecatedAndroidBaseVariant) -> Unit,
 ) {
@@ -23,5 +28,16 @@ internal fun Project.forAllAndroidVariants(
     if (androidExtension is TestedExtension) {
         androidExtension.testVariants.all(action)
         androidExtension.unitTestVariants.all(action)
+    }
+}
+
+/**
+ * Uses the new Variant API
+ */
+internal fun Project.configureAndroidVariants(action: (Component) -> Unit) {
+    val androidComponentsExtension = this.extensions.getByType(AndroidComponentsExtension::class.java)
+    androidComponentsExtension.onVariants { variant ->
+        action(variant)
+        variant.nestedComponents.forEach { action(it) }
     }
 }


### PR DESCRIPTION
This change also migrates to using the new Variant API
For consistency it applies the same action to the main variant as well as all nested components (unit test, device test and test fixtures)

^KT-62294
^KT-74420