### PR TITLE
[FIR] Don't unescape twice when processing ESCAPE_STRING_TEMPLATE_ENTRY

### DIFF
--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/AbstractLightTreeRawFirBuilder.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/AbstractLightTreeRawFirBuilder.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.ElementTypeUtils.isExpression
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.builder.AbstractRawFirBuilder
 import org.jetbrains.kotlin.fir.builder.Context
-import org.jetbrains.kotlin.fir.builder.escapedStringToCharacter
 import org.jetbrains.kotlin.fir.types.FirImplicitTypeRef
 import org.jetbrains.kotlin.fir.types.impl.FirImplicitTypeRefImplWithoutSource
 import org.jetbrains.kotlin.lexer.KtTokens.*
@@ -48,13 +47,6 @@ abstract class AbstractLightTreeRawFirBuilder(
 
     override val LighterASTNode.asText: String
         get() = this.toString()
-
-    override val LighterASTNode.unescapedValue: String
-        get() {
-            val escape = this.asText
-            return escapedStringToCharacter(escape).value?.toString()
-                ?: escape.replace("\\", "").replace("u", "\\u")
-        }
 
     override fun LighterASTNode.getReferencedNameAsName(): Name {
         return this.asText.nameAsSafeName()

--- a/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/PsiRawFirBuilder.kt
+++ b/compiler/fir/raw-fir/psi2fir/src/org/jetbrains/kotlin/fir/builder/PsiRawFirBuilder.kt
@@ -106,9 +106,6 @@ open class PsiRawFirBuilder(
     override val PsiElement.asText: String
         get() = text
 
-    override val PsiElement.unescapedValue: String
-        get() = (this as KtEscapeStringTemplateEntry).unescapedValue
-
     override fun PsiElement.getChildNodeByType(type: IElementType): PsiElement? {
         return children.firstOrNull { it.node.elementType == type }
     }

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/AbstractRawFirBuilder.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/AbstractRawFirBuilder.kt
@@ -68,7 +68,6 @@ abstract class AbstractRawFirBuilder<T : Any>(val baseSession: FirSession, val c
 
     abstract val T.elementType: IElementType
     abstract val T.asText: String
-    abstract val T.unescapedValue: String
     abstract fun T.getReferencedNameAsName(): Name
     abstract fun T.getLabelName(): String?
     abstract fun T.getExpressionInParentheses(): T?

--- a/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/AbstractRawFirBuilder.kt
+++ b/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/AbstractRawFirBuilder.kt
@@ -587,12 +587,16 @@ abstract class AbstractRawFirBuilder<T : Any>(val baseSession: FirSession, val c
                             )
                         }
                         ESCAPE_STRING_TEMPLATE_ENTRY -> {
-                            sb.append(entry.unescapedValue)
                             val characterWithDiagnostic = escapedStringToCharacter(entry.asText)
+                            val unescapedCharacter = characterWithDiagnostic.value
+                            if (unescapedCharacter != null) {
+                                sb.append(unescapedCharacter)
+                            }
+
                             arguments += buildConstOrErrorExpression(
                                 entry.toFirSourceElement(),
                                 ConstantValueKind.String,
-                                characterWithDiagnostic.value?.toString(),
+                                unescapedCharacter?.toString(),
                                 ConeSimpleDiagnostic(
                                     "Incorrect character: ${entry.asText}",
                                     characterWithDiagnostic.getDiagnostic() ?: DiagnosticKind.IllegalConstExpression


### PR DESCRIPTION
This change avoids needlessly unescaping a character escape sequence in a string twice.

In the psi2fir case, different unescaping implementations were used for the path with template expressions and the path without any template expressions ("fast-pass"); [`ConversionUtils.escapedStringToCharacter`](https://github.com/JetBrains/kotlin/blob/bc0801e5de83f80756816a6428d66a802e2f9f18/compiler/fir/raw-fir/raw-fir.common/src/org/jetbrains/kotlin/fir/builder/ConversionUtils.kt#L73) vs. [`StringUtil.unescapeStringCharacters`](https://github.com/JetBrains/intellij-community/blob/ab84f20f89d0b9131ca697478c1ce73836450b68/platform/util/src/com/intellij/openapi/util/text/StringUtil.java#L620). The latter supports all of Java's escape sequences instead of just the ones supported by Kotlin. This was not a problem in practice, because when `ConversionUtils.escapedStringToCharacter` returned an error, the potentially wrongly unescaped value in `sb` was not used. So this PR does not change the output of `AbstractRawFirBuilder.toInterpolatingCall`. 