### PR TITLE
use toArray instead of toTypedArray in ArrayDeque

### DIFF
--- a/libraries/stdlib/src/kotlin/collections/ArrayDeque.kt
+++ b/libraries/stdlib/src/kotlin/collections/ArrayDeque.kt
@@ -43,7 +43,7 @@ public class ArrayDeque<E> : AbstractMutableList<E> {
      * Constructs a deque that contains the same elements as the specified [elements] collection in the same order.
      */
     public constructor(elements: Collection<E>) {
-        elementData = elements.toTypedArray()
+        elementData = elements.toArray()
         size = elementData.size
         if (elementData.isEmpty()) elementData = emptyElementData
     }


### PR DESCRIPTION
`toArray` is much faster than `toTypedArray` on JVM. And we don't need a typed array here.