### PR TITLE
[JS] Expose console.debug

### DIFF
--- a/libraries/stdlib/js/src/kotlin/debug.kt
+++ b/libraries/stdlib/js/src/kotlin/debug.kt
@@ -10,6 +10,7 @@ package kotlin.js
  */
 @Suppress("NOT_DOCUMENTED")
 public external interface Console {
+    public fun debug(vararg o: Any?): Unit
     public fun dir(o: Any): Unit
     public fun error(vararg o: Any?): Unit
     public fun info(vararg o: Any?): Unit

--- a/libraries/tools/binary-compatibility-validator/klib-public-api/kotlin-stdlib.api
+++ b/libraries/tools/binary-compatibility-validator/klib-public-api/kotlin-stdlib.api
@@ -14236,6 +14236,7 @@ abstract interface <#A: out kotlin/Any?> kotlin.js.collections/JsReadonlySet // 
 
 // Targets: [js]
 abstract interface kotlin.js/Console { // kotlin.js/Console|null[0]
+    abstract fun debug(kotlin/Array<out kotlin/Any?>...) // kotlin.js/Console.debug|debug(kotlin.Array<out|kotlin.Any?>...){}[0]
     abstract fun dir(kotlin/Any) // kotlin.js/Console.dir|dir(kotlin.Any){}[0]
     abstract fun error(kotlin/Array<out kotlin/Any?>...) // kotlin.js/Console.error|error(kotlin.Array<out|kotlin.Any?>...){}[0]
     abstract fun info(kotlin/Array<out kotlin/Any?>...) // kotlin.js/Console.info|info(kotlin.Array<out|kotlin.Any?>...){}[0]


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/console/debug_static

Will be useful for KMP logging libraries

_I would very much love some pointers on test for this if it's required_