### PR TITLE
Fix equals methods when comparing primitive range with ComparableRange

### DIFF
--- a/generators/builtins/ReadMe.md
+++ b/generators/builtins/ReadMe.md
@@ -1,0 +1,1 @@
+To run these generators, open generateBuiltIns.kt and run the `main` function in the IDE

--- a/generators/builtins/ranges.kt
+++ b/generators/builtins/ranges.kt
@@ -64,9 +64,11 @@ public class $range(start: $t, endInclusive: $t) : ${t}Progression(start, endInc
      */
     override fun isEmpty(): Boolean = first > last
 
-    override fun equals(other: Any?): Boolean =
-        other is $range && (isEmpty() && other.isEmpty() ||
-        ${compare("first")} && ${compare("last")})
+    override fun equals(other: Any?): Boolean = when (other) {
+        is $range -> (isEmpty() && other.isEmpty()) || (${compare("first")} && ${compare("last")})
+        is ClosedRange<*> -> (isEmpty() && other.isEmpty()) || (${compare("start")} && ${compare("endInclusive")})
+        else -> false
+    }
 
     override fun hashCode(): Int $hashCode
 

--- a/libraries/stdlib/src/kotlin/ranges/PrimitiveRanges.kt
+++ b/libraries/stdlib/src/kotlin/ranges/PrimitiveRanges.kt
@@ -33,9 +33,11 @@ public class CharRange(start: Char, endInclusive: Char) : CharProgression(start,
      */
     override fun isEmpty(): Boolean = first > last
 
-    override fun equals(other: Any?): Boolean =
-        other is CharRange && (isEmpty() && other.isEmpty() ||
-        first == other.first && last == other.last)
+    override fun equals(other: Any?): Boolean = when (other) {
+        is CharRange -> (isEmpty() && other.isEmpty()) || (first == other.first && last == other.last)
+        is ClosedRange<*> -> (isEmpty() && other.isEmpty()) || (start == other.start && endInclusive == other.endInclusive)
+        else -> false
+    }
 
     override fun hashCode(): Int =
         if (isEmpty()) -1 else (31 * first.code + last.code)
@@ -72,9 +74,11 @@ public class IntRange(start: Int, endInclusive: Int) : IntProgression(start, end
      */
     override fun isEmpty(): Boolean = first > last
 
-    override fun equals(other: Any?): Boolean =
-        other is IntRange && (isEmpty() && other.isEmpty() ||
-        first == other.first && last == other.last)
+    override fun equals(other: Any?): Boolean = when (other) {
+        is IntRange -> (isEmpty() && other.isEmpty()) || (first == other.first && last == other.last)
+        is ClosedRange<*> -> (isEmpty() && other.isEmpty()) || (start == other.start && endInclusive == other.endInclusive)
+        else -> false
+    }
 
     override fun hashCode(): Int =
         if (isEmpty()) -1 else (31 * first + last)
@@ -111,9 +115,11 @@ public class LongRange(start: Long, endInclusive: Long) : LongProgression(start,
      */
     override fun isEmpty(): Boolean = first > last
 
-    override fun equals(other: Any?): Boolean =
-        other is LongRange && (isEmpty() && other.isEmpty() ||
-        first == other.first && last == other.last)
+    override fun equals(other: Any?): Boolean = when (other) {
+        is LongRange -> (isEmpty() && other.isEmpty()) || (first == other.first && last == other.last)
+        is ClosedRange<*> -> (isEmpty() && other.isEmpty()) || (start == other.start && endInclusive == other.endInclusive)
+        else -> false
+    }
 
     override fun hashCode(): Int =
         if (isEmpty()) -1 else (31 * (first xor (first ushr 32)) + (last xor (last ushr 32))).toInt()

--- a/libraries/stdlib/src/kotlin/ranges/Ranges.kt
+++ b/libraries/stdlib/src/kotlin/ranges/Ranges.kt
@@ -17,7 +17,7 @@ private open class ComparableRange<T : Comparable<T>>(
 ) : ClosedRange<T> {
 
     override fun equals(other: Any?): Boolean {
-        return other is ComparableRange<*> && (isEmpty() && other.isEmpty() ||
+        return other is ClosedRange<*> && (isEmpty() && other.isEmpty() ||
                 start == other.start && endInclusive == other.endInclusive)
     }
 
@@ -95,8 +95,8 @@ private class ClosedDoubleRange(
     start: Double,
     endInclusive: Double
 ) : ClosedFloatingPointRange<Double> {
-    private val _start = start
-    private val _endInclusive = endInclusive
+    private val _start: Double = start
+    private val _endInclusive: Double = endInclusive
     override val start: Double get() = _start
     override val endInclusive: Double get() = _endInclusive
 
@@ -106,8 +106,9 @@ private class ClosedDoubleRange(
     override fun isEmpty(): Boolean = !(_start <= _endInclusive)
 
     override fun equals(other: Any?): Boolean {
-        return other is ClosedDoubleRange && (isEmpty() && other.isEmpty() ||
-                _start == other._start && _endInclusive == other._endInclusive)
+        // Casting to a Double is necessary because ClosedRange.start/endInclusive are Any (boxed) here, and those don't respect -0.0==0.0
+        return other is ClosedRange<*> && ((isEmpty() && other.isEmpty()) ||
+                (other.start as? Double == _start && other.endInclusive as? Double == _endInclusive))
     }
 
     override fun hashCode(): Int {
@@ -187,8 +188,9 @@ private class ClosedFloatRange(
     override fun isEmpty(): Boolean = !(_start <= _endInclusive)
 
     override fun equals(other: Any?): Boolean {
-        return other is ClosedFloatRange && (isEmpty() && other.isEmpty() ||
-                _start == other._start && _endInclusive == other._endInclusive)
+        // Casting to a Float is necessary because ClosedRange.start/endInclusive are Any (boxed) here, and those don't respect -0f==0f
+        return other is ClosedRange<*> && ((isEmpty() && other.isEmpty()) ||
+                (other.start as? Float == _start && other.endInclusive as? Float == _endInclusive))
     }
 
     override fun hashCode(): Int {

--- a/libraries/stdlib/test/ranges/RangeTest.kt
+++ b/libraries/stdlib/test/ranges/RangeTest.kt
@@ -48,6 +48,10 @@ public class RangeTest {
         assertEquals(closedRange, openRange2)
 
         assertTrue((1 until Int.MIN_VALUE).isEmpty())
+
+        val comparableRange = 1.comparableRangeTo(2)
+        assertTrue(1..2 == comparableRange)
+        assertTrue(comparableRange == 1..2)
     }
 
     @Test fun byteRange() {
@@ -83,6 +87,13 @@ public class RangeTest {
         // byte arguments now construct IntRange so no overflow here
         assertTrue((0.toByte() until Byte.MIN_VALUE).isEmpty())
         assertTrue((0.toByte() until Int.MIN_VALUE).isEmpty())
+
+        // TODO is this fixable? Byte.rangeTo gives us an IntRange
+//        val comparableRange: ClosedRange<Byte> = 1.toByte().comparableRangeTo(2.toByte())
+//        val byteRange: IntRange = 1.toByte()..2.toByte()
+//
+//        assertTrue(byteRange.equals(comparableRange))
+//        assertTrue(comparableRange.equals(byteRange))
     }
 
     @Test fun shortRange() {
@@ -116,6 +127,12 @@ public class RangeTest {
 
         assertTrue((0.toShort() until Short.MIN_VALUE).isEmpty())
         assertTrue((0.toShort() until Int.MIN_VALUE).isEmpty())
+
+        // TODO is this fixable? Short.rangeTo gives us an IntRange
+//        val comparableRange: ClosedRange<Short> = 1.toShort().comparableRangeTo(2.toShort())
+//        val shortRange: IntRange = 1.toShort()..2.toShort()
+//        assertTrue(shortRange.equals(comparableRange))
+//        assertTrue(comparableRange.equals(shortRange))
     }
 
     @Test fun longRange() {
@@ -157,6 +174,10 @@ public class RangeTest {
 
         assertTrue((0 until Long.MIN_VALUE).isEmpty())
         assertTrue((0L until Long.MIN_VALUE).isEmpty())
+
+        val comparableRange = 1L.comparableRangeTo(2L)
+        assertTrue(1L..2L == comparableRange)
+        assertTrue(comparableRange == 1L..2L)
     }
 
     @Test fun charRange() {
@@ -193,6 +214,10 @@ public class RangeTest {
         assertEquals(closedRange, openRange2)
 
         assertTrue(('A' until Char.MIN_VALUE).isEmpty())
+
+        val comparableRange = 'A'.comparableRangeTo('Z')
+        assertTrue('A'..'Z' == comparableRange)
+        assertTrue(comparableRange == 'A'..'Z')
     }
 
     @Test fun doubleRange() {
@@ -248,6 +273,10 @@ public class RangeTest {
         assertFalse(Double.NaN in openNanRange)
         assertFalse(Float.NaN in openNanRange)
         assertTrue(openNanRange.isEmpty())
+
+        val comparableRange = 0.0.comparableRangeTo(1.0)
+        assertTrue(0.0..1.0 == comparableRange)
+        assertTrue(comparableRange == 0.0..1.0)
     }
 
     @Test fun floatRange() {
@@ -302,6 +331,10 @@ public class RangeTest {
         assertFalse(1.0F in openNanRange)
         assertFalse(Float.NaN in openNanRange)
         assertTrue(openNanRange.isEmpty())
+
+        val comparableRange = 0f.comparableRangeTo(1f)
+        assertTrue(0f..1f == comparableRange)
+        assertTrue(comparableRange == 0f..1f)
     }
 
     @Test
@@ -413,7 +446,7 @@ public class RangeTest {
     @Test fun comparableRange() {
         val range = "island".."isle"
         assertEquals("island..isle", range.toString())
-        assertEquals(range, range.start..range.endInclusive)
+        assertEquals(range, range.start.comparableRangeTo(range.endInclusive))
 
         assertFalse("apple" in range)
         assertFalse("icicle" in range)
@@ -528,3 +561,6 @@ public class RangeTest {
         assertNull(IntProgression.fromClosedRange(0, 3, -2).lastOrNull())
     }
 }
+
+// Helper method to create a ComparableRange<T>
+private fun <T : Comparable<T>> T.comparableRangeTo(that: T): ClosedRange<T> = this .. that


### PR DESCRIPTION
In my codebase I added a helper method for working with Comparable<T> that creates a range using T..T and I was surprised to see that my tests failed when I was asserting the values against a literal 1L..2L.

This PR fixes that behavior by checking if the other object is of type ClosedRange and then compares the interface fields directly.  I couldn't get this to work for Short/Byte because the operator functions for those types return an IntRange (which cannot easily be coerced to/from a ComparableRange<Byte>, etc).  Open to suggestions on how/whether this can be fixed!

Also added a ReadMe to the generators/builtins folder because I couldn't figure out how to run those generators from the other ReadMe files.

Fixes KT-79598