### PR TITLE
Fix mixing relative friend paths and absolute classpaths with symlinks

### DIFF
--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
@@ -75,11 +75,11 @@ abstract class LibraryPathFilter {
         override fun accepts(path: Path?): Boolean {
             if (path == null) return false
             val isPathAbsolute = path.isAbsolute
-            val realPath by lazy(LazyThreadSafetyMode.NONE) { path.toRealPath() }
+            val absolutePath by lazy(LazyThreadSafetyMode.NONE) { path.toAbsolutePath().normalize() }
             return libs.any {
                 when {
-                    it.isAbsolute && !isPathAbsolute -> realPath.startsWith(it)
-                    !it.isAbsolute && isPathAbsolute && it.exists() -> path.startsWith(it.toRealPath())
+                    it.isAbsolute && !isPathAbsolute -> absolutePath.startsWith(it.normalize())
+                    !it.isAbsolute && isPathAbsolute -> absolutePath.startsWith(it.toAbsolutePath().normalize())
                     else -> path.startsWith(it)
                 }
             }

--- a/compiler/tests-integration/tests/org/jetbrains/kotlin/cli/FriendPathsTest.kt
+++ b/compiler/tests-integration/tests/org/jetbrains/kotlin/cli/FriendPathsTest.kt
@@ -21,26 +21,61 @@ import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import org.jetbrains.kotlin.test.CompilerTestUtil
 import org.jetbrains.kotlin.test.TestCaseWithTmpdir
 import java.io.File
+import kotlin.io.path.createSymbolicLinkPointingTo
 
 class FriendPathsTest : TestCaseWithTmpdir() {
     private fun getTestDataDirectory(): File = File("compiler/testData/friendPaths/")
 
+    private val absoluteArchive by lazy { File(tmpdir, "lib.jar") }
+    private val relativeArchive by lazy { absoluteArchive.relativeTo(File("").absoluteFile) }
+
+    private val absoluteDir by lazy { File(tmpdir, "lib") }
+    private val relativeDir by lazy { absoluteDir.relativeTo(File("").absoluteFile) }
+
     fun testArchive() {
-        doTestFriendPaths(File(tmpdir, "lib.jar"))
+        doTestFriendPaths(absoluteArchive, absoluteArchive)
     }
 
     /** Regression test for KT-29933. */
     fun testArchiveWithRelativePath() {
-        doTestFriendPaths(File(tmpdir, "lib.jar").relativeTo(File("").absoluteFile))
+        doTestFriendPaths(relativeArchive, relativeArchive)
     }
 
     fun testDirectory() {
-        doTestFriendPaths(File(tmpdir, "lib"))
+        doTestFriendPaths(absoluteDir, absoluteDir)
     }
 
     /** Regression test for KT-29933. */
     fun testDirectoryWithRelativePath() {
-        doTestFriendPaths(File(tmpdir, "lib").relativeTo(File("").absoluteFile))
+        doTestFriendPaths(relativeDir, relativeDir)
+    }
+
+    fun testArchiveWithRelativeFriendPath() {
+        doTestFriendPaths(absoluteArchive, relativeArchive)
+    }
+
+    fun testArchiveWithRelativeClasspath() {
+        doTestFriendPaths(relativeArchive, absoluteArchive)
+    }
+
+    fun testArchiveWithRelativeFriendPathThroughSymlink() {
+        val dir = File(tmpdir, "dir")
+        dir.mkdir()
+        val symlink = File(tmpdir, "symlink")
+        symlink.toPath().createSymbolicLinkPointingTo(dir.toPath())
+        val libDest = File(symlink, "lib.jar")
+        val relativeLibDest = libDest.relativeTo(File("").absoluteFile)
+        doTestFriendPaths(libDest, relativeLibDest)
+    }
+
+    fun testArchiveWithRelativeClasspathThroughSymlink() {
+        val dir = File(tmpdir, "dir")
+        dir.mkdir()
+        val symlink = File(tmpdir, "symlink")
+        symlink.toPath().createSymbolicLinkPointingTo(dir.toPath())
+        val libDest = File(symlink, "lib.jar")
+        val relativeLibDest = libDest.relativeTo(File("").absoluteFile)
+        doTestFriendPaths(relativeLibDest, libDest)
     }
 
     // This is a regression test for KT-70991.
@@ -60,7 +95,7 @@ class FriendPathsTest : TestCaseWithTmpdir() {
         )
     }
 
-    private fun doTestFriendPaths(libDest: File) {
+    private fun doTestFriendPaths(libDest: File, friendPath: File) {
         val libSrc = File(getTestDataDirectory(), "lib.kt")
         CompilerTestUtil.executeCompilerAssertSuccessful(K2JVMCompiler(), listOf("-d", libDest.path, libSrc.path))
 
@@ -68,7 +103,7 @@ class FriendPathsTest : TestCaseWithTmpdir() {
             K2JVMCompiler(),
             listOf(
                 "-d", tmpdir.path, "-cp", libDest.path, File(getTestDataDirectory(), "usage.kt").path,
-                "-Xfriend-paths=${libDest.path}"
+                "-Xfriend-paths=${friendPath.path}"
             ),
         )
     }


### PR DESCRIPTION
The fix for KT-60886 (a5b530d5) converted calls to toAbsolutePath() to toRealPath() to fix the testDirectoryWithRelativePath test, which was failing due to comparing a normalized path to an unnormalized path (with ../../.. in it).

Calling toRealPath() instead of toAbsolutePath() to get a normalized path also resolves any symlinks in the path to their targets.  Since toRealPath() is not called on the absolute path it is being compared to it results in different absolute paths and the match check always fails.

Use toAbsolutePath().normalize() to produce a normalize absolute path instead.

Fixes https://youtrack.jetbrains.com/issue/KT-80039