### PR TITLE
[KT-80003][K/N] deprecate eager GlobalData initialization

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -291,9 +291,12 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
         }
     } ?: false // Disabled by default because of KT-68928
 
-    val globalDataLazyInit: Boolean by lazy {
-        configuration.get(BinaryOptions.globalDataLazyInit) ?: true
-    }
+    val globalDataLazyInit: Boolean
+        get() = configuration.get(BinaryOptions.globalDataLazyInit)?.also {
+            if (!it) {
+                configuration.report(CompilerMessageSeverity.STRONG_WARNING, "Eager Global Data initialization is deprecated")
+            }
+        } ?: true
 
     val genericSafeCasts: Boolean by lazy {
         configuration.get(BinaryOptions.genericSafeCasts)


### PR DESCRIPTION
related issue: [KT-80003](https://youtrack.jetbrains.com/issue/KT-80003/Kotlin-Native-deprecate-eager-GlobalData-initialization)

Emit compilation warning, when eager GlobalData initialization is used (globalDataLazyInit=false binary option)