### PR TITLE
KT-80186 Remove use of deprecated Gradle Project.container

### DIFF
--- a/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/CompileBenchmarkingPlugin.kt
+++ b/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/CompileBenchmarkingPlugin.kt
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.Exec
 import org.jetbrains.kotlin.*
 import javax.inject.Inject
 
-class BuildStep (private val _name: String): Named  {
+open class BuildStep @Inject constructor(private val _name: String): Named  {
     override fun getName(): String = _name
     lateinit var command: List<String>
 
@@ -16,7 +16,7 @@ class BuildStep (private val _name: String): Named  {
     }
 }
 
-class BuildStepContainer(val project: Project): NamedDomainObjectContainer<BuildStep> by project.container(BuildStep::class.java) {
+class BuildStepContainer(val project: Project): NamedDomainObjectContainer<BuildStep> by project.objects.domainObjectContainer(BuildStep::class.java) {
     fun step(name: String, configure: Action<BuildStep>) =
         maybeCreate(name).apply { configure.execute(this) }
     

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinNativeBinaryContainer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinNativeBinaryContainer.kt
@@ -39,7 +39,7 @@ abstract class KotlinNativeBinaryContainer @Inject constructor(
         get() = target.compilations.getByName(KotlinCompilation.TEST_COMPILATION_NAME)
 
     private val nameToBinary = mutableMapOf<String, NativeBinary>()
-    internal val prefixGroups: NamedDomainObjectSet<PrefixGroup> = project.container(PrefixGroup::class.java)
+    internal val prefixGroups: NamedDomainObjectSet<PrefixGroup> = project.objects.domainObjectContainer(PrefixGroup::class.java)
 
     // region DSL getters.
     private inline fun <reified T : NativeBinary> getBinary(
@@ -159,7 +159,7 @@ abstract class KotlinNativeBinaryContainer @Inject constructor(
     }
     // endregion.
 
-    internal inner class PrefixGroup(
+    internal open inner class PrefixGroup @Inject constructor(
         private val name: String
     ) : Named {
         override fun getName(): String = name

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
@@ -297,7 +297,7 @@ abstract class KotlinJsProjectExtension(project: Project) :
     )
     fun getTargets(): NamedDomainObjectContainer<KotlinTarget>? =
         targetFuture.lenient.getOrNull()?.let { target ->
-            target.project.container(KotlinTarget::class.java)
+            target.project.objects.domainObjectContainer(KotlinTarget::class.java)
                 .apply { add(target) }
         }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/external/ExternalKotlinTargetImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/external/ExternalKotlinTargetImpl.kt
@@ -90,7 +90,7 @@ internal class ExternalKotlinTargetImpl internal constructor(
     }
 
     override val compilations: NamedDomainObjectContainer<DecoratedExternalKotlinCompilation> by lazy {
-        project.container(DecoratedExternalKotlinCompilation::class.java)
+        project.objects.domainObjectContainer(DecoratedExternalKotlinCompilation::class.java)
     }
 
     @Suppress("unchecked_cast")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinTargetPresets.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinTargetPresets.kt
@@ -27,7 +27,7 @@ internal abstract class KotlinOnlyTargetPreset<R : KotlinOnlyTarget<T>, T : Kotl
             targetPreset = this@KotlinOnlyTargetPreset
 
             val compilationFactory = createCompilationFactory(this)
-            compilations = project.container(compilationFactory.itemClass, compilationFactory)
+            compilations = project.objects.domainObjectContainer(compilationFactory.itemClass, compilationFactory)
         }
 
         createKotlinTargetConfigurator().configureTarget(result)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/android/KotlinAndroidTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/android/KotlinAndroidTarget.kt
@@ -48,7 +48,7 @@ abstract class KotlinAndroidTarget @Inject constructor(
         get() = KotlinPlatformType.androidJvm
 
     override val compilations: NamedDomainObjectContainer<out KotlinJvmAndroidCompilation> =
-        project.container(KotlinJvmAndroidCompilation::class.java)
+        project.objects.domainObjectContainer(KotlinJvmAndroidCompilation::class.java)
 
 
     @ExperimentalKotlinGradlePluginApi

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/KotlinJsPlatformTestRun.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/KotlinJsPlatformTestRun.kt
@@ -24,7 +24,7 @@ import kotlin.properties.Delegates
 class JsCompilationExecutionSource(override val compilation: KotlinJsIrCompilation) :
     CompilationExecutionSource<KotlinJsIrCompilation>
 
-open class KotlinJsPlatformTestRun(testRunName: String, target: KotlinTarget) :
+open class KotlinJsPlatformTestRun @Inject constructor(testRunName: String, target: KotlinTarget) :
     KotlinTaskTestRun<JsCompilationExecutionSource, KotlinJsTest>(testRunName, target),
     CompilationExecutionSourceSupport<KotlinJsIrCompilation> {
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrSubTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrSubTarget.kt
@@ -89,7 +89,7 @@ abstract class KotlinJsIrSubTarget(
         lowerCamelCaseName(target.disambiguationClassifier, disambiguationClassifier, *names)
 
     private fun configureTests() {
-        testRuns = project.container(KotlinJsPlatformTestRun::class.java) { name -> KotlinJsPlatformTestRun(name, target) }.also {
+        testRuns = project.objects.domainObjectContainer(KotlinJsPlatformTestRun::class.java) { name -> KotlinJsPlatformTestRun(name, target) }.also {
             (this as ExtensionAware).extensions.add(this::testRuns.name, it)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -67,12 +67,12 @@ constructor(
     private val propertiesProvider = PropertiesProvider(project)
     internal val shouldGenerateTypeScriptDefinitions: Property<Boolean> = project.objects.property<Boolean>(false)
 
-    override val subTargets: NamedDomainObjectContainer<KotlinJsIrSubTargetWithBinary> = project.container(
+    override val subTargets: NamedDomainObjectContainer<KotlinJsIrSubTargetWithBinary> = project.objects.domainObjectContainer(
         KotlinJsIrSubTargetWithBinary::class.java
     )
 
     override val testRuns: NamedDomainObjectContainer<KotlinJsReportAggregatingTestRun> by lazy {
-        project.container(KotlinJsReportAggregatingTestRun::class.java, KotlinJsTestRunFactory(this))
+        project.objects.domainObjectContainer(KotlinJsReportAggregatingTestRun::class.java, KotlinJsTestRunFactory(this))
     }
 
     override var wasmTargetType: KotlinWasmTargetType? = null

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/KotlinJvmTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/KotlinJvmTarget.kt
@@ -48,7 +48,7 @@ abstract class KotlinJvmTarget @Inject constructor(
     KotlinTargetWithTests<JvmClasspathTestRunSource, KotlinJvmTestRun> {
 
     override val testRuns: NamedDomainObjectContainer<KotlinJvmTestRun> by lazy {
-        project.container(KotlinJvmTestRun::class.java, KotlinJvmTestRunFactory(this))
+        project.objects.domainObjectContainer(KotlinJvmTestRun::class.java, KotlinJvmTestRunFactory(this))
     }
 
     internal val mainRun: Future<KotlinJvmRunDslImpl?> = project.future { registerMainRunTask() }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/KotlinWithJavaTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/KotlinWithJavaTarget.kt
@@ -71,7 +71,7 @@ abstract class KotlinWithJavaTarget<KotlinOptionsType : Any, CO : KotlinCommonCo
 
     override val compilations: NamedDomainObjectContainer<KotlinWithJavaCompilation<KotlinOptionsType, CO>> =
         @Suppress("UNCHECKED_CAST")
-        project.container(
+        project.objects.domainObjectContainer(
             KotlinWithJavaCompilation::class.java as Class<KotlinWithJavaCompilation<KotlinOptionsType, CO>>,
             KotlinWithJavaCompilationFactory(this, compilerOptionsFactory, kotlinOptionsFactory)
         )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeCompilation.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeCompilation.kt
@@ -72,7 +72,7 @@ open class KotlinNativeCompilation @Inject internal constructor(
         get() = super.compilerOptions as NativeCompilerOptions
 
     // Interop DSL.
-    val cinterops = compilation.project.container(DefaultCInteropSettings::class.java, DefaultCInteropSettingsFactory(compilation))
+    val cinterops = compilation.project.objects.domainObjectContainer(DefaultCInteropSettings::class.java, DefaultCInteropSettingsFactory(compilation))
 
     fun cinterops(action: Action<NamedDomainObjectContainer<DefaultCInteropSettings>>) = action.execute(cinterops)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeTarget.kt
@@ -204,13 +204,13 @@ abstract class KotlinNativeTargetWithTests<T : KotlinNativeBinaryTestRun>(
 abstract class KotlinNativeTargetWithHostTests @Inject constructor(project: Project, konanTarget: KonanTarget) :
     KotlinNativeTargetWithTests<KotlinNativeHostTestRun>(project, konanTarget) {
     override val testRuns: NamedDomainObjectContainer<KotlinNativeHostTestRun> by lazy {
-        project.container(KotlinNativeHostTestRun::class.java, KotlinNativeHostTestRunFactory(this))
+        project.objects.domainObjectContainer(KotlinNativeHostTestRun::class.java, KotlinNativeHostTestRunFactory(this))
     }
 }
 
 abstract class KotlinNativeTargetWithSimulatorTests @Inject constructor(project: Project, konanTarget: KonanTarget) :
     KotlinNativeTargetWithTests<KotlinNativeSimulatorTestRun>(project, konanTarget) {
     override val testRuns: NamedDomainObjectContainer<KotlinNativeSimulatorTestRun> by lazy {
-        project.container(KotlinNativeSimulatorTestRun::class.java, KotlinNativeSimulatorTestRunFactory(this))
+        project.objects.domainObjectContainer(KotlinNativeSimulatorTestRun::class.java, KotlinNativeSimulatorTestRunFactory(this))
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeTargetPreset.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/KotlinNativeTargetPreset.kt
@@ -59,7 +59,7 @@ internal abstract class AbstractKotlinNativeTargetPreset<T : KotlinNativeTarget>
             targetPreset = this@AbstractKotlinNativeTargetPreset
 
             val compilationFactory = KotlinNativeCompilationFactory(this)
-            compilations = project.container(compilationFactory.itemClass, compilationFactory)
+            compilations = project.objects.domainObjectContainer(compilationFactory.itemClass, compilationFactory)
         }
 
         createTargetConfigurator().configureTarget(result)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
@@ -131,7 +131,7 @@ abstract class CocoapodsExtension @Inject constructor(private val project: Proje
 
     internal val specRepos = SpecRepos()
 
-    private val _pods = project.container(CocoapodsDependency::class.java)
+    private val _pods = project.objects.domainObjectContainer(CocoapodsDependency::class.java)
 
     val podsAsTaskInput: List<CocoapodsDependency>
         get() = _pods.toList()


### PR DESCRIPTION
Project.container is being deprecated in 9.2.0.

The replacement has existed since 5.5.