### PR TITLE
Check resolution scope membership using non-null virtual file via view provider

### DIFF
--- a/analysis/analysis-api-impl-base/src/org/jetbrains/kotlin/analysis/api/impl/base/projectStructure/KaBaseResolutionScope.kt
+++ b/analysis/analysis-api-impl-base/src/org/jetbrains/kotlin/analysis/api/impl/base/projectStructure/KaBaseResolutionScope.kt
@@ -68,8 +68,8 @@ internal class KaBaseResolutionScope(
          * analyzable in its context module's session.
          */
         val psiFile = element.containingFile
-        val virtualFile = psiFile.virtualFile
-        return virtualFile != null && cachedSearchScopeContains(virtualFile) || isAccessibleDanglingFile(psiFile)
+        val virtualFile = psiFile.viewProvider.virtualFile
+        return cachedSearchScopeContains(virtualFile) || isAccessibleDanglingFile(psiFile)
     }
 
     private fun cachedSearchScopeContains(virtualFile: VirtualFile): Boolean {


### PR DESCRIPTION
This fixes membership results for light classes, e.g. for synthetic R.java classes generated by the Android IDE plugin.

Issue link: https://youtrack.jetbrains.com/issue/KT-80352

cc @marcopennekamp 