### PR TITLE
Adapt PluginStructureProvider to 2025.2 ahead

### DIFF
--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/PluginStructureProvider.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/PluginStructureProvider.kt
@@ -15,9 +15,7 @@ import com.intellij.mock.MockApplication
 import com.intellij.mock.MockComponentManager
 import com.intellij.mock.MockProject
 import com.intellij.openapi.extensions.DefaultPluginDescriptor
-import com.intellij.openapi.extensions.PluginDescriptor
 import com.intellij.util.containers.ContainerUtil
-import com.intellij.util.lang.ZipFilePool
 import com.intellij.util.messages.ListenerDescriptor
 import com.intellij.util.messages.impl.MessageBusEx
 import com.intellij.util.xml.dom.NoOpXmlInterner
@@ -60,15 +58,12 @@ object PluginStructureProvider {
     private fun getOrCalculatePluginDescriptor(
         designation: PluginDesignation,
     ): RawPluginDescriptor = pluginDescriptorsCache.computeIfAbsent(designation) {
-        val descriptor = RawPluginDescriptor()
         PluginXmlPathResolver.DEFAULT_PATH_RESOLVER.resolvePath(
             readContext = ReadContext,
             dataLoader = ResourceDataLoader(designation.classLoader),
             relativePath = designation.relativePath,
-            readInto = descriptor,
-        )
-
-        descriptor
+            readInto = null,
+        ) ?: RawPluginDescriptor()
     }
 
     fun registerProjectExtensionPoints(project: MockProject, pluginRelativePath: String) {


### PR DESCRIPTION
In 252, PathResolver#resolvePath dropped readInto parameter, mentioning that it's not used. Indeed, even with 241 for now, passing a default RawPluginDescriptor instance is no-op (or same as passing null).

In addition, the return value of resolvePath call is not used at the moment (violating check-return-value). In 252, that read XML content isn't quite used if we return the default RawPluginDescriptor instance again. Instead, the original intention is supposed to be elvis, i.e., try resolvePath or use a default instance.

^KT-79870