### PR TITLE
Cache NameResolver and KlibMetadataClassDataFinder

### DIFF
--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataClassDataFinder.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataClassDataFinder.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.serialization.deserialization.ClassData
 import org.jetbrains.kotlin.serialization.deserialization.ClassDataFinder
 import org.jetbrains.kotlin.serialization.deserialization.getClassId
+import java.util.HashMap
 
 class KlibMetadataClassDataFinder(
     private val fragment: PackageFragment,
@@ -22,12 +23,13 @@ class KlibMetadataClassDataFinder(
 ) : ClassDataFinder {
     val nameList = fragment.getExtension(KlibMetadataProtoBuf.className).orEmpty()
 
+    val classIdToIndex: Map<ClassId, Int> = buildMap {
+        nameList.forEachIndexed { index, value -> this[nameResolver.getClassId(value)] = index }
+    }
+
     override fun findClassData(classId: ClassId): ClassData? {
 
-        val index = nameList.indexOfFirst { nameResolver.getClassId(it) == classId }
-        if (index == -1) {
-            return null
-        }
+        val index = classIdToIndex[classId] ?: return null
 
         val foundClass = fragment.getClass_(index) ?: error("Could not find data for serialized class $classId")
 


### PR DESCRIPTION
Enable caching of NameResolver and KlibMetadataClassDataFinder for each fragment in MetadataLibraryBasedSymbolProvider.

Closes: https://youtrack.jetbrains.com/issue/KT-80438/Uncached-KlibMetadataClassDataFinder.findClassData