### PR TITLE
Change getDefaultProguardFile in test project to use proguard-android-optimize.txt

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalSingleModuleProject/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/AndroidIncrementalSingleModuleProject/app/build.gradle
@@ -29,7 +29,7 @@ android {
     buildTypes {
         release {
             minifyEnabled = false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 


### PR DESCRIPTION
This is a noop change since minifyEnabled is false.

Prep for change to remove support for proguard-android.txt in AGP 9 (since it's surprising that it disables all R8 optimization)

https://issuetracker.google.com/issues/438784515