### PR TITLE
Tweak a bit the NOTHING_TO_INLINE warning message to make it OK on hot paths

### DIFF
--- a/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
+++ b/compiler/frontend/src/org/jetbrains/kotlin/diagnostics/rendering/DefaultErrorMessages.java
@@ -1260,7 +1260,7 @@ public class DefaultErrorMessages {
         MAP.put(DECLARATION_CANT_BE_INLINED_WARNING, "'inline' modifier is not allowed on virtual enum members. Only private or final members can be inlined. This warning will become an error in K2");
         MAP.put(OVERRIDE_BY_INLINE, "Override by an inline function");
         MAP.put(REIFIED_TYPE_PARAMETER_IN_OVERRIDE, "Override by a function with reified type parameter");
-        MAP.put(NOTHING_TO_INLINE, "Expected performance impact from inlining is insignificant. Inlining works best for functions with parameters of functional types");
+        MAP.put(NOTHING_TO_INLINE, "Unless on a hot path, the expected performance impact from inlining is often insignificant. Inlining works best for functions with parameters of functional types");
         MAP.put(USAGE_IS_NOT_INLINABLE, "Illegal usage of inline-parameter ''{0}'' in ''{1}''. Add ''noinline'' modifier to the parameter declaration", ELEMENT_TEXT, SHORT_NAMES_IN_TYPES);
         MAP.put(USAGE_IS_NOT_INLINABLE_WARNING, "Deprecated usage of inline-parameter ''{0}'' in ''{1}''. Add ''noinline'' modifier to the parameter declaration. See https://youtrack.jetbrains.com/issue/KT-52502", ELEMENT_TEXT, SHORT_NAMES_IN_TYPES);
         MAP.put(NULLABLE_INLINE_PARAMETER, "Inline-parameter ''{0}'' of ''{1}'' must not be nullable. Add ''noinline'' modifier to the parameter declaration or make its type not nullable", ELEMENT_TEXT, SHORT_NAMES_IN_TYPES);


### PR DESCRIPTION
This is coming from https://github.com/apollographql/apollo-kotlin/pull/6688/files#diff-03dfe02d86c735a5b0cb0bb2a50cffc7ba274e18567ea19d0cd3c086a0f3ad03R68

[Looking for `@Suppress("NOTHING_TO_INLINE")` on GitHub](https://github.com/search?q=%40Suppress%28%22NOTHING_TO_INLINE%22%29+language%3AKotlin+&type=code) finds 11k occurences, some of them in the stdlib. Can we soften the language to make it more acceptable to use?