### PR TITLE
[WASM][Stdlib] fix regex matching N-category KT-80603

### DIFF
--- a/libraries/stdlib/native-wasm/src/kotlin/text/regex/AbstractCharClass.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/text/regex/AbstractCharClass.kt
@@ -602,7 +602,7 @@ internal abstract class AbstractCharClass : SpecialToken() {
             MN("Mn"),
             ME("Me"),
             MC("Mc"),
-            N("N"),
+            ISN("IsN"),
             ND("Nd"),
             NL("Nl"),
             NO("No"),
@@ -788,7 +788,7 @@ internal abstract class AbstractCharClass : SpecialToken() {
                 CharClasses.MN -> CachedCategory(CharCategory.NON_SPACING_MARK.value, true)
                 CharClasses.ME -> CachedCategory(CharCategory.ENCLOSING_MARK.value, false)
                 CharClasses.MC -> CachedCategory(CharCategory.COMBINING_SPACING_MARK.value, true)
-                CharClasses.N -> CachedCategoryScope(0xE00, true)
+                CharClasses.ISN -> CachedCategoryScope(0xE00, true)
                 CharClasses.ND -> CachedCategory(CharCategory.DECIMAL_DIGIT_NUMBER.value, true)
                 CharClasses.NL -> CachedCategory(CharCategory.LETTER_NUMBER.value, true)
                 CharClasses.NO -> CachedCategory(CharCategory.OTHER_NUMBER.value, true)

--- a/libraries/stdlib/native-wasm/test/harmony_regex/PatternTest2.kt
+++ b/libraries/stdlib/native-wasm/test/harmony_regex/PatternTest2.kt
@@ -682,12 +682,16 @@ class PatternTest2 {
         // One letter codes: L, M, N, P, S, Z, C
         // Two letter codes: Lu, Nd, Sc, Sm, ...
         // See java.lang.Character and Unicode standard for complete list
+
+        val regex = Regex("\\p{IsN}+")
+        assertEquals(listOf("٧٨٩", "०", "๙", "Ⅴ", "Ⅹ", "ⅻ", "123", "½", "¼", "¾", "²", "³", "456"),
+            regex.findAll("٧٨٩ ० ๙ Ⅴ Ⅹ ⅻ 123 ½ ¼ ¾ x² + y³ 中文 العربية456")
+                .map(MatchResult::value)
+                .toList()
+        )
+
         // TODO
         // Test \p{L}
-        // TODO
-
-        // Test \p{N}
-        // TODO
 
         // ... etc
 


### PR DESCRIPTION
single-letter groups are prepended with `Is` prefix during pattern lexing, all of them are supposed to be named accordingly. The `N` category violated this convention