### PR TITLE
[JVM] Mark inner enum class 'abstract' when it is

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -123,7 +123,7 @@ fun IrClass.calculateInnerClassAccessFlags(context: JvmBackendContext): Int {
 private fun IrClass.innerAccessFlagsForModalityAndKind(): Int {
     when (kind) {
         ClassKind.INTERFACE -> return Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE
-        ClassKind.ENUM_CLASS -> return Opcodes.ACC_FINAL or Opcodes.ACC_ENUM
+        ClassKind.ENUM_CLASS -> return (if (modality == Modality.ABSTRACT) Opcodes.ACC_ABSTRACT else Opcodes.ACC_FINAL) or Opcodes.ACC_ENUM
         ClassKind.ANNOTATION_CLASS -> return Opcodes.ACC_ABSTRACT or Opcodes.ACC_ANNOTATION or Opcodes.ACC_INTERFACE
         else -> {
             if (modality === Modality.FINAL) {

--- a/compiler/testData/writeFlags/class/accessFlags/abstractInnerEnum.kt
+++ b/compiler/testData/writeFlags/class/accessFlags/abstractInnerEnum.kt
@@ -1,0 +1,10 @@
+interface I {
+    enum class E {
+        V { override fun go() { } };
+        abstract fun go()
+    }
+}
+
+// TESTED_OBJECT_KIND: innerClass
+// TESTED_OBJECTS: I, E
+// FLAGS: ACC_PUBLIC, ACC_STATIC, ACC_ABSTRACT, ACC_ENUM

--- a/compiler/testData/writeFlags/class/accessFlags/finalInnerEnum.kt
+++ b/compiler/testData/writeFlags/class/accessFlags/finalInnerEnum.kt
@@ -1,0 +1,9 @@
+interface I {
+    enum class E {
+        V { fun go() { } };
+    }
+}
+
+// TESTED_OBJECT_KIND: innerClass
+// TESTED_OBJECTS: I, E
+// FLAGS: ACC_PUBLIC, ACC_STATIC, ACC_FINAL, ACC_ENUM

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/fir/FirLightTreeWriteFlagsTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/fir/FirLightTreeWriteFlagsTestGenerated.java
@@ -106,6 +106,11 @@ public class FirLightTreeWriteFlagsTestGenerated extends AbstractFirLightTreeWri
         KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
       }
 
+      @TestMetadata("abstractInnerEnum.kt")
+      public void testAbstractInnerEnum() {
+        runTest("compiler/testData/writeFlags/class/accessFlags/abstractInnerEnum.kt");
+      }
+
       public void testAllFilesPresentInAccessFlags() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/writeFlags/class/accessFlags"), Pattern.compile("^(.+)\\.kt$"), null, true);
       }
@@ -113,6 +118,11 @@ public class FirLightTreeWriteFlagsTestGenerated extends AbstractFirLightTreeWri
       @TestMetadata("defaultImpls.kt")
       public void testDefaultImpls() {
         runTest("compiler/testData/writeFlags/class/accessFlags/defaultImpls.kt");
+      }
+
+      @TestMetadata("finalInnerEnum.kt")
+      public void testFinalInnerEnum() {
+        runTest("compiler/testData/writeFlags/class/accessFlags/finalInnerEnum.kt");
       }
 
       @TestMetadata("innerSealed.kt")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/fir/FirPsiWriteFlagsTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/fir/FirPsiWriteFlagsTestGenerated.java
@@ -106,6 +106,11 @@ public class FirPsiWriteFlagsTestGenerated extends AbstractFirPsiWriteFlagsTest 
         KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
       }
 
+      @TestMetadata("abstractInnerEnum.kt")
+      public void testAbstractInnerEnum() {
+        runTest("compiler/testData/writeFlags/class/accessFlags/abstractInnerEnum.kt");
+      }
+
       public void testAllFilesPresentInAccessFlags() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/writeFlags/class/accessFlags"), Pattern.compile("^(.+)\\.kt$"), null, true);
       }
@@ -113,6 +118,11 @@ public class FirPsiWriteFlagsTestGenerated extends AbstractFirPsiWriteFlagsTest 
       @TestMetadata("defaultImpls.kt")
       public void testDefaultImpls() {
         runTest("compiler/testData/writeFlags/class/accessFlags/defaultImpls.kt");
+      }
+
+      @TestMetadata("finalInnerEnum.kt")
+      public void testFinalInnerEnum() {
+        runTest("compiler/testData/writeFlags/class/accessFlags/finalInnerEnum.kt");
       }
 
       @TestMetadata("innerSealed.kt")

--- a/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrWriteFlagsTestGenerated.java
+++ b/compiler/tests-gen/org/jetbrains/kotlin/codegen/ir/IrWriteFlagsTestGenerated.java
@@ -106,6 +106,11 @@ public class IrWriteFlagsTestGenerated extends AbstractIrWriteFlagsTest {
         KotlinTestUtils.runTest(this::doTest, TargetBackend.JVM_IR, testDataFilePath);
       }
 
+      @TestMetadata("abstractInnerEnum.kt")
+      public void testAbstractInnerEnum() {
+        runTest("compiler/testData/writeFlags/class/accessFlags/abstractInnerEnum.kt");
+      }
+
       public void testAllFilesPresentInAccessFlags() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler/testData/writeFlags/class/accessFlags"), Pattern.compile("^(.+)\\.kt$"), null, true);
       }
@@ -113,6 +118,11 @@ public class IrWriteFlagsTestGenerated extends AbstractIrWriteFlagsTest {
       @TestMetadata("defaultImpls.kt")
       public void testDefaultImpls() {
         runTest("compiler/testData/writeFlags/class/accessFlags/defaultImpls.kt");
+      }
+
+      @TestMetadata("finalInnerEnum.kt")
+      public void testFinalInnerEnum() {
+        runTest("compiler/testData/writeFlags/class/accessFlags/finalInnerEnum.kt");
       }
 
       @TestMetadata("innerSealed.kt")


### PR DESCRIPTION
^[KT-79231](https://youtrack.jetbrains.com/issue/KT-79231) fixed


For Kotlin, version 2.2.10-release-430 (JRE 23.0.1+11-39)

```Kotlin
interface I {
    enum class E {
        V { override fun go() { } };
        abstract fun go()
    }
}
```
->  
InnerClasses in I:      `public static final #18= #20 of #2;     // E=class I$E of class I`    
InnerClasses in I\$E:   `public static final #81= #2 of #80;     // E=class I$E of class I`    
InnerClasses in I\$E\$V:`public static final #33= #4 of #32;     // E=class I$E of class I`    
   
``` Kotlin
interface I {
    enum class E {
        V { fun go() { } };
    }
} 
```
->
InnerClasses in I:      `public static final #18= #20 of #2;     // E=class I$E of class I`  
InnerClasses in I\$E:   `public static final #80= #2 of #79;     // E=class I$E of class I`  
InnerClasses in I\$E\$V:`public static final #33= #4 of #32;     // E=class I$E of class I`    

-----
for Java:  
openjdk version "23.0.1" 2024-10-15  
OpenJDK Runtime Environment (build 23.0.1+11-39)  
OpenJDK 64-Bit Server VM (build 23.0.1+11-39, mixed mode, sharing)  

```Java
public interface I {
    enum E {
        V { public void g() { } };
         abstract public void g();
    }
}
```
->
InnerClasses in I:      `public static abstract #13= #8 of #1;   // E=class I$E of class I`  
InnerClasses in I\$E:   `public static abstract #51= #1 of #47;  // E=class I$E of class I`  
InnerClasses in I\$E\$1:`public static abstract #21= #2 of #18;  // E=class I$E of class I`  

```Java
public interface I {
    enum E {
        V { public void g() { } }
    }
}
```
->
InnerClasses in I:      `public static #13= #8 of #1;            // E=class I$E of class I`  
InnerClasses in I\$E:   `public static #50= #1 of #46;           // E=class I$E of class I`  
InnerClasses in I\$E\$1:`public static #21= #2 of #18;           // E=class I$E of class I`  

--- 
So I suppose after KT-79231 is fixed, we get:
```Kotlin
interface I {
    enum class E {
        V { override fun go() { } };
        abstract fun go()
    }
}
```
->  
InnerClasses in I:      `public static abstract #19= #21 of #2;  // E=class I$E of class I`  
InnerClasses in I\$E:   `public static abstract #82= #2 of #81;  // E=class I$E of class I`  
InnerClasses in I\$E\$V:`public static abstract #34= #4 of #33;  // E=class I$E of class I`  


```Kotlin
interface I {
    enum class E {
        V { fun go() { } };
    }
}
```
->

InnerClasses in I:      `public static final #19= #21 of #2;     // E=class I$E of class I`  
InnerClasses in I\$E:   `public static final #81= #2 of #80;     // E=class I$E of class I`  
InnerClasses in I\$E\$V:`public static final #34= #4 of #33;     // E=class I$E of class I`  