### PR TITLE
Cross Compile macOS paltformLib Caches KT-80973

### DIFF
--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -79,6 +79,8 @@ cacheableTargets.mingw_x64 =
 
 cacheableTargets.macos_arm64 = \
   macos_arm64 \
+  macos_x64 \
+  ios_x64 \
   ios_simulator_arm64 \
   ios_arm64
 


### PR DESCRIPTION
Currently using an apple silicone Mac, you can't cross-compile x86_64 platformLib caches. This is not a technical limitation and is completely possible. I think it doesn't go  against any license terms.