### PR TITLE
Make docs of String to number funs a little more clear about digits

### DIFF
--- a/kotlin-native/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
@@ -67,7 +67,7 @@ public actual inline fun String?.toBoolean(): Boolean = this.equals("true", igno
 /**
  * Parses the string to a [Byte] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Byte] value range (within `Byte.MIN_VALUE..Byte.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -89,7 +89,7 @@ public actual inline fun String.toByte(radix: Int): Byte = toByteOrNull(radix) ?
 /**
  * Parses the string to a [Short] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Short] value range (within `Short.MIN_VALUE..Short.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -111,7 +111,7 @@ public actual inline fun String.toShort(radix: Int): Short = toShortOrNull(radix
 /**
  * Parses the string to an [Int] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Int] value range (within `Int.MIN_VALUE..Int.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -133,7 +133,7 @@ public actual inline fun String.toInt(radix: Int): Int = toIntOrNull(radix) ?: t
 /**
  * Parses the string to a [Long] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Long] value range (within `Long.MIN_VALUE..Long.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *

--- a/libraries/stdlib/common/src/kotlin/TextH.kt
+++ b/libraries/stdlib/common/src/kotlin/TextH.kt
@@ -551,7 +551,7 @@ public expect fun String?.toBoolean(): Boolean
 /**
  * Parses the string to a [Byte] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Byte] value range (within `Byte.MIN_VALUE..Byte.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -570,7 +570,7 @@ public expect fun String.toByte(radix: Int): Byte
 /**
  * Parses the string to a [Short] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Short] value range (within `Short.MIN_VALUE..Short.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -589,7 +589,7 @@ public expect fun String.toShort(radix: Int): Short
 /**
  * Parses the string to an [Int] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Int] value range (within `Int.MIN_VALUE..Int.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -608,7 +608,7 @@ public expect fun String.toInt(radix: Int): Int
 /**
  * Parses the string to a [Long] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Long] value range (within `Long.MIN_VALUE..Long.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *

--- a/libraries/stdlib/js/src/kotlin/text/numberConversions.kt
+++ b/libraries/stdlib/js/src/kotlin/text/numberConversions.kt
@@ -20,7 +20,7 @@ public actual fun String?.toBoolean(): Boolean = this != null && this.lowercase(
 /**
  * Parses the string to a [Byte] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Byte] value range (within `Byte.MIN_VALUE..Byte.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -40,7 +40,7 @@ public actual fun String.toByte(radix: Int): Byte = toByteOrNull(radix) ?: numbe
 /**
  * Parses the string to a [Short] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Short] value range (within `Short.MIN_VALUE..Short.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -59,7 +59,7 @@ public actual fun String.toShort(radix: Int): Short = toShortOrNull(radix) ?: nu
 /**
  * Parses the string to an [Int] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Int] value range (within `Int.MIN_VALUE..Int.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -78,7 +78,7 @@ public actual fun String.toInt(radix: Int): Int = toIntOrNull(radix) ?: numberFo
 /**
  * Parses the string to a [Long] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Long] value range (within `Long.MIN_VALUE..Long.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *

--- a/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/text/StringNumberConversionsJVM.kt
@@ -57,7 +57,7 @@ public actual inline fun String?.toBoolean(): Boolean = java.lang.Boolean.parseB
 /**
  * Parses the string to a [Byte] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Byte] value range (within `Byte.MIN_VALUE..Byte.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -80,7 +80,7 @@ public actual inline fun String.toByte(radix: Int): Byte = java.lang.Byte.parseB
 /**
  * Parses the string to a [Short] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Short] value range (within `Short.MIN_VALUE..Short.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -102,7 +102,7 @@ public actual inline fun String.toShort(radix: Int): Short = java.lang.Short.par
 /**
  * Parses the string to an [Int] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Int] value range (within `Int.MIN_VALUE..Int.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -124,7 +124,7 @@ public actual inline fun String.toInt(radix: Int): Int = java.lang.Integer.parse
 /**
  * Parses the string to a [Long] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Long] value range (within `Long.MIN_VALUE..Long.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *

--- a/libraries/stdlib/src/kotlin/text/StringNumberConversions.kt
+++ b/libraries/stdlib/src/kotlin/text/StringNumberConversions.kt
@@ -12,7 +12,7 @@ package kotlin.text
 /**
  * Parses the string to a [Byte] number or returns `null` if the string is not a valid representation of a [Byte].
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Byte] value range (within `Byte.MIN_VALUE..Byte.MAX_VALUE`),
  * otherwise `null` is returned.
  *
@@ -37,7 +37,7 @@ public fun String.toByteOrNull(radix: Int): Byte? {
 /**
  * Parses the string to a [Short] number or returns `null` if the string is not a valid representation of a [Short].
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Short] value range (within `Short.MIN_VALUE..Short.MAX_VALUE`),
  * otherwise `null` is returned.
  *
@@ -62,7 +62,7 @@ public fun String.toShortOrNull(radix: Int): Short? {
 /**
  * Parses the string to an [Int] number or returns `null` if the string is not a valid representation of an [Int].
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Int] value range (within `Int.MIN_VALUE..Int.MAX_VALUE`),
  * otherwise `null` is returned.
  *
@@ -142,7 +142,7 @@ public fun String.toIntOrNull(radix: Int): Int? {
 /**
  * Parses the string to a [Long] number or returns `null` if the string is not a valid representation of a [Long].
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Long] value range (within `Long.MIN_VALUE..Long.MAX_VALUE`),
  * otherwise `null` is returned.
  *

--- a/libraries/stdlib/wasm/src/kotlin/text/StringNumberConversionsWasm.kt
+++ b/libraries/stdlib/wasm/src/kotlin/text/StringNumberConversionsWasm.kt
@@ -17,7 +17,7 @@ public actual fun String?.toBoolean(): Boolean = this != null && this.lowercase(
 /**
  * Parses the string to a [Byte] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Byte] value range (within `Byte.MIN_VALUE..Byte.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -36,7 +36,7 @@ public actual fun String.toByte(radix: Int): Byte = toByteOrNull(radix) ?: numbe
 /**
  * Parses the string to a [Short] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Short] value range (within `Short.MIN_VALUE..Short.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -55,7 +55,7 @@ public actual fun String.toShort(radix: Int): Short = toShortOrNull(radix) ?: nu
 /**
  * Parses the string to an [Int] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Int] value range (within `Int.MIN_VALUE..Int.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *
@@ -74,7 +74,7 @@ public actual fun String.toInt(radix: Int): Int = toIntOrNull(radix) ?: numberFo
 /**
  * Parses the string to a [Long] number.
  *
- * The string must consist of an optional leading `+` or `-` sign and decimal digits (`0-9`),
+ * The string must consist of an optional leading `+` or `-` sign and decimal digits (like `0-9`),
  * and fit the valid [Long] value range (within `Long.MIN_VALUE..Long.MAX_VALUE`),
  * otherwise a [NumberFormatException] will be thrown.
  *


### PR DESCRIPTION
Java [`Integer::parseInt`](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/lang/Integer.html#parseInt(java.lang.String)) and Kotlin [`String.toInt`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/to-int.html) and other String to non-float functions accept non-ASCII (aka non-English aka non-[Western-Arabic](https://en.wikipedia.org/wiki/Arabic_numerals)) digits in a String too. For example, [Eastern Arabic digits](https://en.wikipedia.org/wiki/Eastern_Arabic_numerals):

```kotlin
println("12۳".toByte())        // 123
println("12۳۴".toShort())      // 1234
println("12۳۴۵".toIntOrNull()) // 12345
println("12۳۴۵6".toUInt())     // 123456
println("12۳۴۵67".toLong())    // 1234567
```

This is a good and expected behavior in my opinion. I don't know if Kotlin implementation of these functions for non-JVM targets also behave the same way.

Alos, Java [`Character::isDigit`](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/lang/Character.html#isDigit(char)) and Kotlin [`Char.isDigit`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/is-digit.html) return true for non-ASCII numerals too. Same for `"\\p{javaDigit}"` or `"\\p{Nd}"` regexes in both Java and Kotlin. See [this code snippet](https://www.mycompiler.io/view/K2umL41XEbM). They all match a few hundred types of digit chars in JDK 24.

I have updated the docs to hopefully make it just a bit more clear that `0-9` are just one set of chars that are valid as digits. I don't know whether all those functions updated in this commit (especially non-JVM or `expect` ones) accept non-English digits too. If not, then my update for docs of those should be reverted and I hope their implementations is updated to make them behave the same way as on JVM implementation.

Another thing is, it seems most of those functions lack unit tests for non-ASCII digits to clarify their behavior. Found a weird bug:

```kotlin
println("123۴۵۶.789۳۲۱".toBigDecimal())       // 123456.789321
// Exactly the same string as above
println("123۴۵۶.789۳۲۱".toBigDecimalOrNull()) // null
```

And, `BigDecimal` allows non-ASCII digits in the string, but `String.toDouble` and variants throw exception.

Related:
- [Convert String to double in Java](https://stackoverflow.com/a/79763346/8583692)
- [String.toDouble does not parse non-English digits](https://youtrack.jetbrains.com/issue/KT-58122)
