### PR TITLE
[Docs] Improve grammar in "lazy" documentation

### DIFF
--- a/libraries/stdlib/samples/test/samples/lazy/LazySamples.kt
+++ b/libraries/stdlib/samples/test/samples/lazy/LazySamples.kt
@@ -58,7 +58,7 @@ class LazySamples {
             println("Thread 2: $answer")
         }
 
-        // It is guaranteed that 'Computing' message will be printed once, but both threads will see 42 as an answer
+        // It is guaranteed that 'Computing' message will be printed once, and both threads will see 42 as an answer
         t1.join()
         t2.join()
     }


### PR DESCRIPTION
Current version: 
`// It is guaranteed that 'Computing' message will be printed once, **but** both threads will see 42 as an answer`

Proposed version:
`// It is guaranteed that 'Computing' message will be printed once, **and** both threads will see 42 as an answer`


- This change make documentation more clear and less contradictory
- No functional behaviour is affected - just a doc/grammar improvement