### PR TITLE
Update pi.c: improve the performance of `is_prime`

### DIFF
--- a/kotlin-native/performance/numerical/src/nativeInterop/cinterop/pi.c
+++ b/kotlin-native/performance/numerical/src/nativeInterop/cinterop/pi.c
@@ -74,12 +74,12 @@ static int pow_mod(int a, int b, int m)
 static int is_prime(int n)
 {
     int r, i;
-    if ((n % 2) == 0)
+    if ((n % 2) == 0 || (n % 3) == 0)
         return 0;
 
     r = (int) (sqrt(n));
-    for (i = 3; i <= r; i += 2)
-        if ((n % i) == 0)
+    for (i = 5; i <= r; i += 6)
+        if ((n % i) == 0 || (n % (i + 2)) == 0)
             return 0;
     return 1;
 }


### PR DESCRIPTION
Checking the remainder of division by 3 at the beginning lets us do less checks in the loop overall.