### PR TITLE
K/N Pass cacheable zipFileSystemAccessor to missing sections KT-81670

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.nativeBinaryOptions.BinaryOptions
+import org.jetbrains.kotlin.config.zipFileSystemAccessor
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.library.impl.createKonanLibrary
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind
@@ -74,7 +75,13 @@ class KonanDriver(
             when {
                 !filesToCache.isNullOrEmpty() -> filesToCache
                 configuration.get(KonanConfigKeys.MAKE_PER_FILE_CACHE) == true -> {
-                    val lib = createKonanLibrary(File(libPath), "default", null, true)
+                    val lib = createKonanLibrary(
+                            File(libPath),
+                            "default",
+                            null,
+                            true,
+                            configuration.zipFileSystemAccessor
+                    )
                     val mainIr = lib.mainIr
                     (0 until mainIr.fileCount()).map { fileIndex ->
                         val fileReader = IrLibraryFileFromBytes(IrKlibBytesSource(mainIr, fileIndex))

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLibrariesResolveSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLibrariesResolveSupport.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.cli.common.messages.getLogger
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.DuplicatedUniqueNameStrategy
 import org.jetbrains.kotlin.config.KlibConfigurationKeys
+import org.jetbrains.kotlin.config.zipFileSystemAccessor
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.library.defaultResolver
 import org.jetbrains.kotlin.konan.target.Distribution
@@ -35,10 +36,12 @@ class KonanLibrariesResolveSupport(
     private val unresolvedLibraries = libraryPaths.toUnresolvedLibraries
 
     private val resolver = defaultResolver(
-        libraryPaths + includedLibraryFiles.map { it.absolutePath },
-        target,
-        distribution,
-        configuration.getLogger()
+            libraryPaths + includedLibraryFiles.map { it.absolutePath },
+            target,
+            distribution,
+            configuration.getLogger(),
+            false,
+            configuration.zipFileSystemAccessor
     ).libraryResolver(resolveManifestDependenciesLenient)
 
     // We pass included libraries by absolute paths to avoid repository-based resolution for them.

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlin.konan.library
 
 import org.jetbrains.kotlin.konan.file.File
+import org.jetbrains.kotlin.konan.file.ZipFileSystemAccessor
 import org.jetbrains.kotlin.konan.library.impl.createKonanLibraryComponents
 import org.jetbrains.kotlin.konan.target.Distribution
 import org.jetbrains.kotlin.konan.target.KonanTarget
@@ -17,13 +18,15 @@ fun defaultResolver(
     target: KonanTarget,
     distribution: Distribution,
     logger: Logger = DummyLogger,
-    skipCurrentDir: Boolean = false
+    skipCurrentDir: Boolean = false,
+    zipFileSystemAccessor: ZipFileSystemAccessor? = null,
 ): SearchPathResolverWithTarget<KonanLibrary> = KonanLibraryProperResolver(
     directLibs = directLibs,
     target = target,
     distributionKlib = distribution.klib,
     skipCurrentDir = skipCurrentDir,
-    logger = logger
+    logger = logger,
+    zipFileSystemAccessor,
 )
 
 class KonanLibraryProperResolver(
@@ -31,7 +34,8 @@ class KonanLibraryProperResolver(
     override val target: KonanTarget,
     distributionKlib: String?,
     skipCurrentDir: Boolean,
-    override val logger: Logger
+    override val logger: Logger,
+    val zipFileSystemAccessor: ZipFileSystemAccessor? = null,
 ) : KotlinLibraryProperResolverWithAttributes<KonanLibrary>(
     directLibs = directLibs,
     distributionKlib = distributionKlib,
@@ -39,7 +43,8 @@ class KonanLibraryProperResolver(
     logger = logger,
     knownIrProviders = listOf(KLIB_INTEROP_IR_PROVIDER_IDENTIFIER)
 ), SearchPathResolverWithTarget<KonanLibrary> {
-    override fun libraryComponentBuilder(file: File, isDefault: Boolean) = createKonanLibraryComponents(file, target, isDefault)
+    override fun libraryComponentBuilder(file: File, isDefault: Boolean) =
+        createKonanLibraryComponents(file, target, isDefault, zipFileSystemAccessor)
 
     override val distPlatformHead: File?
         get() = distributionKlib?.File()?.child("platform")?.child(target.visibleName)

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.konan.library.impl
 
 import org.jetbrains.kotlin.konan.file.File
+import org.jetbrains.kotlin.konan.file.ZipFileSystemAccessor
 import org.jetbrains.kotlin.konan.library.*
 import org.jetbrains.kotlin.konan.properties.Properties
 import org.jetbrains.kotlin.konan.properties.propertyList
@@ -84,15 +85,16 @@ fun createKonanLibrary(
     libraryFilePossiblyDenormalized: File,
     component: String,
     target: KonanTarget? = null,
-    isDefault: Boolean = false
+    isDefault: Boolean = false,
+    zipFileSystemAccessor: ZipFileSystemAccessor? = null,
 ): KonanLibrary {
     // KT-58979: The following access classes need normalized klib path to correctly provide symbols from resolved klibs
     val libraryFile = Paths.get(libraryFilePossiblyDenormalized.absolutePath).normalize().File()
-    val baseAccess = BaseLibraryAccess<KotlinLibraryLayout>(libraryFile, component)
-    val targetedAccess = TargetedLibraryAccess<TargetedKotlinLibraryLayout>(libraryFile, component, target)
-    val metadataAccess = MetadataLibraryAccess<MetadataKotlinLibraryLayout>(libraryFile, component)
-    val irAccess = IrLibraryAccess<IrKotlinLibraryLayout>(libraryFile, component)
-    val bitcodeAccess = BitcodeLibraryAccess<BitcodeKotlinLibraryLayout>(libraryFile, component, target)
+    val baseAccess = BaseLibraryAccess<KotlinLibraryLayout>(libraryFile, component, zipFileSystemAccessor)
+    val targetedAccess = TargetedLibraryAccess<TargetedKotlinLibraryLayout>(libraryFile, component, target, zipFileSystemAccessor)
+    val metadataAccess = MetadataLibraryAccess<MetadataKotlinLibraryLayout>(libraryFile, component, zipFileSystemAccessor)
+    val irAccess = IrLibraryAccess<IrKotlinLibraryLayout>(libraryFile, component, zipFileSystemAccessor)
+    val bitcodeAccess = BitcodeLibraryAccess<BitcodeKotlinLibraryLayout>(libraryFile, component, target, zipFileSystemAccessor)
 
     val base = BaseKotlinLibraryImpl(baseAccess, isDefault)
     val targeted = TargetedLibraryImpl(targetedAccess, base)
@@ -106,11 +108,12 @@ fun createKonanLibrary(
 fun createKonanLibraryComponents(
     libraryFile: File,
     target: KonanTarget? = null,
-    isDefault: Boolean = true
+    isDefault: Boolean = true,
+    zipFileSystemAccessor: ZipFileSystemAccessor? = null,
 ) : List<KonanLibrary> {
     val baseAccess = BaseLibraryAccess<KotlinLibraryLayout>(libraryFile, null)
     val base = BaseKotlinLibraryImpl(baseAccess, isDefault)
     return base.componentList.map {
-        createKonanLibrary(libraryFile, it, target, isDefault)
+        createKonanLibrary(libraryFile, it, target, isDefault, zipFileSystemAccessor)
     }
 }

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryLayoutImpl.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryLayoutImpl.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlin.konan.library.impl
 
 import org.jetbrains.kotlin.konan.file.File
+import org.jetbrains.kotlin.konan.file.ZipFileSystemAccessor
 import org.jetbrains.kotlin.konan.file.createTempDir
 import org.jetbrains.kotlin.konan.file.file
 import org.jetbrains.kotlin.konan.file.unzipTo
@@ -26,8 +27,8 @@ class BitcodeLibraryLayoutImpl(klib: File, component: String, target: KonanTarge
 
 }
 
-open class TargetedLibraryAccess<L : TargetedKotlinLibraryLayout>(klib: File, component: String, val target: KonanTarget?) :
-    BaseLibraryAccess<L>(klib, component) {
+open class TargetedLibraryAccess<L : TargetedKotlinLibraryLayout>(klib: File, component: String, val target: KonanTarget?, zipFileSystemAccessor: ZipFileSystemAccessor?) :
+    BaseLibraryAccess<L>(klib, component, zipFileSystemAccessor) {
 
     override val layout = TargetedLibraryLayoutImpl(klib, component, target)
     protected open val extractingLayout: TargetedKotlinLibraryLayout by lazy { ExtractingTargetedLibraryImpl(layout) }
@@ -40,8 +41,8 @@ open class TargetedLibraryAccess<L : TargetedKotlinLibraryLayout>(klib: File, co
             action(layout as L)
 }
 
-open class BitcodeLibraryAccess<L : BitcodeKotlinLibraryLayout>(klib: File, component: String, target: KonanTarget?) :
-    TargetedLibraryAccess<L>(klib, component, target) {
+open class BitcodeLibraryAccess<L : BitcodeKotlinLibraryLayout>(klib: File, component: String, target: KonanTarget?, zipFileSystemAccessor: ZipFileSystemAccessor?) :
+    TargetedLibraryAccess<L>(klib, component, target, zipFileSystemAccessor) {
 
     override val layout = BitcodeLibraryLayoutImpl(klib, component, target)
     override val extractingLayout: BitcodeKotlinLibraryLayout by lazy { ExtractingBitcodeLibraryImpl(layout) }


### PR DESCRIPTION
Internally at google we have a patch for [KotlinLibraryLayoutImpl.kt](https://github.com/JetBrains/kotlin/blob/ffc04e497bb5daba44dda5defe8b361e113dc083/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KotlinLibraryLayoutImpl.kt#L41) that changes the else value of klibZipAccessor to ZipFileSystemCacheableAccessor with 100 limit, after updating to 2.3.0-dev-7988 we removed the patch since it was no longer required. This resulted in a regression of ~24%.

This doesn't fix all the issues (because theres a lot of different usages of KotlinLibraryLayoutImpl) but it fixes our internal regression.