### PR TITLE
Add multi-thread to ObjcExportHeaderGenerator when processing packageFragments

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.objcexport.ObjCExportCodeGenerato
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageUtil
 import org.jetbrains.kotlin.config.nativeBinaryOptions.BinaryOptions
+import org.jetbrains.kotlin.config.parallelBackendThreads
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.konan.exec.Command
 import org.jetbrains.kotlin.konan.file.File
@@ -85,7 +86,7 @@ internal fun produceObjCExportInterface(
     val additionalImports = context.config.configuration.getNotNull(KonanConfigKeys.FRAMEWORK_IMPORT_HEADERS)
     val headerGenerator = ObjCExportHeaderGenerator.createInstance(
             moduleDescriptors, mapper, namer, problemCollector, objcGenerics, objcExportBlockExplicitParameterNames, shouldExportKDoc = shouldExportKDoc,
-            additionalImports = additionalImports)
+            additionalImports = additionalImports, config.threadsCount)
     headerGenerator.translateModule()
     return headerGenerator.buildInterface()
 }

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
@@ -16,7 +16,16 @@ internal class ObjCExportHeaderGeneratorImpl(
     objcExportBlockExplicitParameterNames: Boolean,
     override val shouldExportKDoc: Boolean,
     private val additionalImports: List<String>,
-) : ObjCExportHeaderGenerator(moduleDescriptors, mapper, namer, objcGenerics, objcExportBlockExplicitParameterNames, problemCollector) {
+    threadsCount: Int,
+) : ObjCExportHeaderGenerator(
+    moduleDescriptors,
+    mapper,
+    namer,
+    objcGenerics,
+    objcExportBlockExplicitParameterNames,
+    problemCollector,
+    threadsCount
+) {
     override fun getAdditionalImports(): List<String> =
         additionalImports
 }

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjcExportHeaderGeneratorMobile.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjcExportHeaderGeneratorMobile.kt
@@ -19,7 +19,16 @@ class ObjcExportHeaderGeneratorMobile internal constructor(
     objcGenerics: Boolean,
     objcExportBlockExplicitParameterNames: Boolean,
     private val restrictToLocalModules: Boolean,
-) : ObjCExportHeaderGenerator(moduleDescriptors, mapper, namer, objcGenerics, objcExportBlockExplicitParameterNames, problemCollector) {
+    threadsCount: Int,
+) : ObjCExportHeaderGenerator(
+    moduleDescriptors,
+    mapper,
+    namer,
+    objcGenerics,
+    objcExportBlockExplicitParameterNames,
+    problemCollector,
+    threadsCount
+) {
 
     companion object {
         fun createInstance(
@@ -30,6 +39,7 @@ class ObjcExportHeaderGeneratorMobile internal constructor(
             deprecationResolver: DeprecationResolver? = null,
             local: Boolean = false,
             restrictToLocalModules: Boolean = false,
+            threadsCount: Int = Runtime.getRuntime().availableProcessors(),
         ): ObjCExportHeaderGenerator {
             val mapper = ObjCExportMapper(deprecationResolver, local, configuration.unitSuspendFunctionExport, configuration.entryPoints)
             val namerConfiguration = createNamerConfiguration(configuration)
@@ -42,7 +52,8 @@ class ObjcExportHeaderGeneratorMobile internal constructor(
                 problemCollector,
                 configuration.objcGenerics,
                 configuration.objcExportBlockExplicitParameterNames,
-                restrictToLocalModules
+                restrictToLocalModules,
+                threadsCount,
             )
         }
     }


### PR DESCRIPTION
After looking at the profile I found some sections that can be process in parallel to improve framework generation speeds

<img width="589" height="584" alt="Screenshot 2025-11-13 at 10 59 57 a m" src="https://github.com/user-attachments/assets/4847517c-eb4f-438c-a585-4bc5b16e612a" />

KT-82436
