### PR TITLE
Make toList() safer on Collections with size 1

### DIFF
--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -1343,7 +1343,7 @@ public fun <T> Iterable<T>.toList(): List<T> {
     if (this is Collection) {
         return when (size) {
             0 -> emptyList()
-            1 -> listOf(if (this is List) get(0) else iterator().next())
+            1 -> if (this is List) listOf(get(0)) else (iterator().takeIf { it.hasNext() }?.next()?.let(::listOf) ?: emptyList())
             else -> this.toMutableList()
         }
     }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Snapshots.kt
@@ -167,7 +167,7 @@ object Snapshots : TemplateGroupBase() {
             if (this is Collection) {
                 return when (size) {
                     0 -> emptyList()
-                    1 -> listOf(if (this is List) get(0) else iterator().next())
+                    1 -> if (this is List) listOf(get(0)) else (iterator().takeIf { it.hasNext() }?.next()?.let(::listOf) ?: emptyList())
                     else -> this.toMutableList()
                 }
             }


### PR DESCRIPTION
It's possible for library code to define a Collection whose size property is one, but producing an iterator without any next element. This is probably some kind of mistake, but it's also very hard for a user of that library to deal with the error that toList() generates under those circumstances.  If size is 1, conditionally generate an empty list if the initial iterator has no next element, consistently with other collection snapshotters.