### PR TITLE
Support `-Xwarning-level` for Opt-in CLI diagnostics

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.*
-import org.jetbrains.kotlin.fir.cli.CliDiagnostics
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics
 import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.progress.CompilationCanceledException

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/fir/FirDiagnosticsCompilerResultsReporter.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/fir/FirDiagnosticsCompilerResultsReporter.kt
@@ -112,7 +112,7 @@ object FirDiagnosticsCompilerResultsReporter {
         reporter: MessageCollector,
         renderDiagnosticName: Boolean
     ) {
-        val severity = AnalyzerWithCompilerReport.convertSeverity(diagnostic.severity)
+        val severity = diagnostic.severity.toCompilerMessageSeverity()
         val message = diagnostic.renderMessage()
         val textToRender = when (renderDiagnosticName) {
             true -> "[${diagnostic.factoryName}] $message"
@@ -128,7 +128,7 @@ object FirDiagnosticsCompilerResultsReporter {
         messageRenderer: MessageRenderer
     ) {
         if (diagnostic.severity == Severity.ERROR) {
-            val severity = AnalyzerWithCompilerReport.convertSeverity(diagnostic.severity)
+            val severity = diagnostic.severity.toCompilerMessageSeverity()
             val message = diagnostic.renderMessage()
             val diagnosticText = messageRenderer.render(severity, message, location)
             throw IllegalStateException("${diagnostic.factory.name}: $diagnosticText")

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/AnalyzerWithCompilerReport.kt
@@ -131,14 +131,6 @@ class AnalyzerWithCompilerReport(
     }
 
     companion object {
-
-        fun convertSeverity(severity: Severity): CompilerMessageSeverity = when (severity) {
-            Severity.INFO -> INFO
-            Severity.ERROR -> ERROR
-            Severity.WARNING -> WARNING
-            Severity.FIXED_WARNING -> FIXED_WARNING
-        }
-
         private val SYNTAX_ERROR_FACTORY = DiagnosticFactory0.create<PsiErrorElement>(Severity.ERROR)
 
         private fun reportDiagnostic(diagnostic: Diagnostic, reporter: DiagnosticMessageReporter, renderDiagnosticName: Boolean): Boolean {

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/DefaultDiagnosticReporter.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/messages/DefaultDiagnosticReporter.kt
@@ -29,7 +29,7 @@ interface MessageCollectorBasedReporter : DiagnosticMessageReporter {
     val messageCollector: MessageCollector
 
     override fun report(diagnostic: Diagnostic, file: PsiFile, render: String) = messageCollector.report(
-        AnalyzerWithCompilerReport.convertSeverity(diagnostic.severity),
+        diagnostic.severity.toCompilerMessageSeverity(),
         render,
         MessageUtil.psiFileToMessageLocation(file, file.name, DiagnosticUtils.getLineAndColumnRange(diagnostic))
     )

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/utils.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/utils.kt
@@ -162,5 +162,5 @@ fun CompilerConfiguration.reportIfNeeded(factory: KtSourcelessDiagnosticFactory,
             get() = this@reportIfNeeded.languageVersionSettings
 
     }) ?: return
-    messageCollector.report(AnalyzerWithCompilerReport.convertSeverity(diagnostic.severity), message)
+    messageCollector.report(diagnostic.severity.toCompilerMessageSeverity(), message)
 }

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/utils.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/utils.kt
@@ -26,10 +26,8 @@ import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.*
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.IncrementalCompilation
-import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.config.messageCollector
-import org.jetbrains.kotlin.diagnostics.DiagnosticBaseContext
 import org.jetbrains.kotlin.diagnostics.KtSourcelessDiagnosticFactory
 import org.jetbrains.kotlin.fir.declarations.FirFile
 import org.jetbrains.kotlin.fir.packageFqName
@@ -157,10 +155,6 @@ fun disposeRootInWriteAction(disposable: Disposable) {
 }
 
 fun CompilerConfiguration.reportIfNeeded(factory: KtSourcelessDiagnosticFactory, message: String) {
-    val diagnostic = factory.create(message, object : DiagnosticBaseContext {
-        override val languageVersionSettings: LanguageVersionSettings
-            get() = this@reportIfNeeded.languageVersionSettings
-
-    }) ?: return
-    messageCollector.report(diagnostic.severity.toCompilerMessageSeverity(), message)
+    val effectiveSeverity = factory.getEffectiveSeverity(this@reportIfNeeded.languageVersionSettings) ?: return
+    messageCollector.report(effectiveSeverity.toCompilerMessageSeverity(), message)
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/CliDiagnostics.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/CliDiagnostics.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.fir.cli
+package org.jetbrains.kotlin.fir.analysis.diagnostics
 
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.diagnostics.KtSourcelessDiagnosticFactory
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.BaseSourcelessDiagnosticFactory
 import org.jetbrains.kotlin.diagnostics.warningWithoutSource
-import org.jetbrains.kotlin.fir.cli.CliDiagnostics.CLI_COMPILER_PLUGIN_IS_EXPERIMENTAL
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics.CLI_COMPILER_PLUGIN_IS_EXPERIMENTAL
 import kotlin.getValue
 
 object CliDiagnostics : KtDiagnosticsContainer() {

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/CliDiagnostics.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/CliDiagnostics.kt
@@ -8,14 +8,23 @@ package org.jetbrains.kotlin.fir.analysis.diagnostics
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
 import org.jetbrains.kotlin.diagnostics.KtSourcelessDiagnosticFactory
+import org.jetbrains.kotlin.diagnostics.errorWithoutSource
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.BaseSourcelessDiagnosticFactory
 import org.jetbrains.kotlin.diagnostics.warningWithoutSource
 import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics.CLI_COMPILER_PLUGIN_IS_EXPERIMENTAL
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics.CLI_NOT_AN_OPT_IN_REQUIREMENT_MARKER
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics.CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics.CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED_ERROR
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics.CLI_OPT_IN_REQUIREMENT_MARKER_IS_UNRESOLVED
 import kotlin.getValue
 
 object CliDiagnostics : KtDiagnosticsContainer() {
     val CLI_COMPILER_PLUGIN_IS_EXPERIMENTAL: KtSourcelessDiagnosticFactory by warningWithoutSource()
+    val CLI_OPT_IN_REQUIREMENT_MARKER_IS_UNRESOLVED: KtSourcelessDiagnosticFactory by warningWithoutSource()
+    val CLI_NOT_AN_OPT_IN_REQUIREMENT_MARKER: KtSourcelessDiagnosticFactory by warningWithoutSource()
+    val CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED: KtSourcelessDiagnosticFactory by warningWithoutSource()
+    val CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED_ERROR: KtSourcelessDiagnosticFactory by errorWithoutSource()
 
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = KtDiagnosticMessagesCli
 }
@@ -23,5 +32,9 @@ object CliDiagnostics : KtDiagnosticsContainer() {
 object KtDiagnosticMessagesCli : BaseSourcelessDiagnosticFactory() {
     override val MAP: KtDiagnosticFactoryToRendererMap by KtDiagnosticFactoryToRendererMap("CLI") { map ->
         map.put(CLI_COMPILER_PLUGIN_IS_EXPERIMENTAL, MESSAGE_PLACEHOLDER)
+        map.put(CLI_OPT_IN_REQUIREMENT_MARKER_IS_UNRESOLVED, MESSAGE_PLACEHOLDER)
+        map.put(CLI_NOT_AN_OPT_IN_REQUIREMENT_MARKER, MESSAGE_PLACEHOLDER)
+        map.put(CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED, MESSAGE_PLACEHOLDER)
+        map.put(CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED_ERROR, MESSAGE_PLACEHOLDER)
     }
 }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/ComponentsContainers.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/ComponentsContainers.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.fir.analysis.checkers.FirInlineCheckerPlatformSpecif
 import org.jetbrains.kotlin.fir.analysis.checkers.FirPrimaryConstructorSuperTypeCheckerPlatformComponent
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNameConflictsTrackerImpl
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirGenericArrayClassLiteralSupport
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirComposedDiagnosticRendererFactory
 import org.jetbrains.kotlin.fir.analysis.diagnostics.diagnosticRendererFactory
 import org.jetbrains.kotlin.fir.analysis.jvm.FirJvmOverridesBackwardCompatibilityHelper
@@ -24,7 +25,6 @@ import org.jetbrains.kotlin.fir.analysis.jvm.checkers.FirJvmInlineCheckerCompone
 import org.jetbrains.kotlin.fir.analysis.jvm.checkers.FirJvmPrimaryConstructorSuperTypeCheckerPlatformComponent
 import org.jetbrains.kotlin.fir.caches.FirCachesFactory
 import org.jetbrains.kotlin.fir.caches.FirThreadUnsafeCachesFactory
-import org.jetbrains.kotlin.fir.cli.CliDiagnostics
 import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.extensions.*
 import org.jetbrains.kotlin.fir.java.FirJavaVisibilityChecker

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/KtDiagnosticFactory.kt
@@ -29,7 +29,7 @@ sealed class AbstractKtDiagnosticFactory(
         get() = rendererFactory.MAP[this]
             ?: error("Renderer is not found for factory $this inside ${rendererFactory.MAP.name} renderer map")
 
-    protected fun getEffectiveSeverity(languageVersionSettings: LanguageVersionSettings): Severity? {
+    fun getEffectiveSeverity(languageVersionSettings: LanguageVersionSettings): Severity? {
         return when (languageVersionSettings.getFlag(AnalysisFlags.warningLevels)[name]) {
             WarningLevel.Error -> Severity.ERROR
             WarningLevel.Warning -> Severity.FIXED_WARNING

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/Severity.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/Severity.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlin.diagnostics
 
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+
 enum class Severity {
     INFO,
     ERROR,
@@ -13,5 +15,12 @@ enum class Severity {
     /**
      * see [org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.FIXED_WARNING]
      */
-    FIXED_WARNING,
+    FIXED_WARNING;
+
+    fun toCompilerMessageSeverity(): CompilerMessageSeverity = when (this) {
+        INFO -> CompilerMessageSeverity.INFO
+        ERROR -> CompilerMessageSeverity.ERROR
+        WARNING -> CompilerMessageSeverity.WARNING
+        FIXED_WARNING -> CompilerMessageSeverity.FIXED_WARNING
+    }
 }

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/impl/BaseDiagnosticsCollector.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/impl/BaseDiagnosticsCollector.kt
@@ -6,8 +6,10 @@
 package org.jetbrains.kotlin.diagnostics.impl
 
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.diagnostics.DiagnosticBaseContext
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.KtDiagnostic
+import org.jetbrains.kotlin.diagnostics.KtSourcelessDiagnosticFactory
 
 abstract class BaseDiagnosticsCollector : DiagnosticReporter() {
     abstract val diagnostics: List<KtDiagnostic>
@@ -28,6 +30,15 @@ abstract class BaseDiagnosticsCollector : DiagnosticReporter() {
 
         fun reportError(message: String) {
             report(message, CompilerMessageSeverity.ERROR)
+        }
+
+        fun reportIfNeeded(
+            factory: KtSourcelessDiagnosticFactory,
+            message: String,
+            context: DiagnosticBaseContext,
+        ) {
+            val refinedSeverity = factory.getEffectiveSeverity(context.languageVersionSettings)?.toCompilerMessageSeverity() ?: return
+            report(message, refinedSeverity)
         }
     }
 }

--- a/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/impl/BaseDiagnosticsCollector.kt
+++ b/compiler/frontend.common/src/org/jetbrains/kotlin/diagnostics/impl/BaseDiagnosticsCollector.kt
@@ -24,10 +24,6 @@ abstract class BaseDiagnosticsCollector : DiagnosticReporter() {
 
         fun report(message: String, severity: CompilerMessageSeverity)
 
-        fun reportWarning(message: String) {
-            report(message, CompilerMessageSeverity.WARNING)
-        }
-
         fun reportError(message: String) {
             report(message, CompilerMessageSeverity.ERROR)
         }

--- a/compiler/testData/cli/metadata/optInDiagnostics.kt
+++ b/compiler/testData/cli/metadata/optInDiagnostics.kt
@@ -1,0 +1,10 @@
+interface NotAnAnnotation
+
+@Deprecated("Warning", level = DeprecationLevel.WARNING)
+@RequiresOptIn
+@Retention(AnnotationRetention.BINARY)
+annotation class Warning
+
+@Deprecated("Error", level = DeprecationLevel.ERROR)
+@RequiresOptIn
+annotation class Error

--- a/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.args
+++ b/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.args
@@ -5,3 +5,4 @@ $TEMP_DIR$
 $TESTDATA_DIR$/../../../../dist/common/kotlin-stdlib-common.klib
 -Xtarget-platform=JVM,JS,WasmJs,WasmWasi,Native
 -opt-in=Error
+-Xwarning-level=CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED_ERROR\:disabled

--- a/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.args
+++ b/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.args
@@ -1,0 +1,7 @@
+$TESTDATA_DIR$/optInDiagnostics.kt
+-d
+$TEMP_DIR$
+-cp
+$TESTDATA_DIR$/../../../../dist/common/kotlin-stdlib-common.klib
+-Xtarget-platform=JVM,JS,WasmJs,WasmWasi,Native
+-opt-in=Error

--- a/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.out
+++ b/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.out
@@ -1,2 +1,2 @@
-error: opt-in requirement marker Error is deprecated. Error
+error: diagnostic "CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED_ERROR" is an error. Changing the severity of errors is prohibited
 COMPILATION_ERROR

--- a/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.out
+++ b/compiler/testData/cli/metadata/optInErrorIsNotSuppressible.out
@@ -1,0 +1,2 @@
+error: opt-in requirement marker Error is deprecated. Error
+COMPILATION_ERROR

--- a/compiler/testData/cli/metadata/optInWarningsAreDisabled.args
+++ b/compiler/testData/cli/metadata/optInWarningsAreDisabled.args
@@ -1,0 +1,11 @@
+$TESTDATA_DIR$/optInDiagnostics.kt
+-d
+$TEMP_DIR$
+-cp
+$TESTDATA_DIR$/../../../../dist/common/kotlin-stdlib-common.klib
+-Xtarget-platform=JVM,JS,WasmJs,WasmWasi,Native
+-opt-in=Unresolved
+-opt-in=NotAnAnnotation
+-opt-in=kotlin.RequiresOptIn
+-opt-in=Warning
+-Werror

--- a/compiler/testData/cli/metadata/optInWarningsAreDisabled.args
+++ b/compiler/testData/cli/metadata/optInWarningsAreDisabled.args
@@ -9,3 +9,6 @@ $TESTDATA_DIR$/../../../../dist/common/kotlin-stdlib-common.klib
 -opt-in=kotlin.RequiresOptIn
 -opt-in=Warning
 -Werror
+-Xwarning-level=CLI_OPT_IN_REQUIREMENT_MARKER_IS_UNRESOLVED\:disabled
+-Xwarning-level=CLI_NOT_AN_OPT_IN_REQUIREMENT_MARKER\:disabled
+-Xwarning-level=CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED\:disabled

--- a/compiler/testData/cli/metadata/optInWarningsAreDisabled.out
+++ b/compiler/testData/cli/metadata/optInWarningsAreDisabled.out
@@ -1,5 +1,1 @@
-warning: opt-in requirement marker Unresolved is unresolved. Please make sure it's present in the module dependencies
-warning: class NotAnAnnotation is not an opt-in requirement marker
-warning: opt-in requirement marker Warning is deprecated. Warning
-error: warnings found and -Werror specified
-COMPILATION_ERROR
+OK

--- a/compiler/testData/cli/metadata/optInWarningsAreDisabled.out
+++ b/compiler/testData/cli/metadata/optInWarningsAreDisabled.out
@@ -1,0 +1,5 @@
+warning: opt-in requirement marker Unresolved is unresolved. Please make sure it's present in the module dependencies
+warning: class NotAnAnnotation is not an opt-in requirement marker
+warning: opt-in requirement marker Warning is deprecated. Warning
+error: warnings found and -Werror specified
+COMPILATION_ERROR

--- a/compiler/testData/cli/metadata/optInWarningsAsErrors.args
+++ b/compiler/testData/cli/metadata/optInWarningsAsErrors.args
@@ -8,3 +8,6 @@ $TESTDATA_DIR$/../../../../dist/common/kotlin-stdlib-common.klib
 -opt-in=NotAnAnnotation
 -opt-in=kotlin.RequiresOptIn
 -opt-in=Warning
+-Xwarning-level=CLI_OPT_IN_REQUIREMENT_MARKER_IS_UNRESOLVED\:error
+-Xwarning-level=CLI_NOT_AN_OPT_IN_REQUIREMENT_MARKER\:error
+-Xwarning-level=CLI_OPT_IN_REQUIREMENT_MARKER_IS_DEPRECATED\:error

--- a/compiler/testData/cli/metadata/optInWarningsAsErrors.args
+++ b/compiler/testData/cli/metadata/optInWarningsAsErrors.args
@@ -1,0 +1,10 @@
+$TESTDATA_DIR$/optInDiagnostics.kt
+-d
+$TEMP_DIR$
+-cp
+$TESTDATA_DIR$/../../../../dist/common/kotlin-stdlib-common.klib
+-Xtarget-platform=JVM,JS,WasmJs,WasmWasi,Native
+-opt-in=Unresolved
+-opt-in=NotAnAnnotation
+-opt-in=kotlin.RequiresOptIn
+-opt-in=Warning

--- a/compiler/testData/cli/metadata/optInWarningsAsErrors.out
+++ b/compiler/testData/cli/metadata/optInWarningsAsErrors.out
@@ -1,4 +1,4 @@
-warning: opt-in requirement marker Unresolved is unresolved. Please make sure it's present in the module dependencies
-warning: class NotAnAnnotation is not an opt-in requirement marker
-warning: opt-in requirement marker Warning is deprecated. Warning
-OK
+error: opt-in requirement marker Unresolved is unresolved. Please make sure it's present in the module dependencies
+error: class NotAnAnnotation is not an opt-in requirement marker
+error: opt-in requirement marker Warning is deprecated. Warning
+COMPILATION_ERROR

--- a/compiler/testData/cli/metadata/optInWarningsAsErrors.out
+++ b/compiler/testData/cli/metadata/optInWarningsAsErrors.out
@@ -1,0 +1,4 @@
+warning: opt-in requirement marker Unresolved is unresolved. Please make sure it's present in the module dependencies
+warning: class NotAnAnnotation is not an opt-in requirement marker
+warning: opt-in requirement marker Warning is deprecated. Warning
+OK

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/HandlerUtils.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/HandlerUtils.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.test.backend.handlers
 
 import com.intellij.openapi.util.io.FileUtil
 import org.jetbrains.kotlin.cli.common.fir.SequentialPositionFinder
-import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.codeMetaInfo.model.DiagnosticCodeMetaInfo
 import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.diagnostics.Severity
@@ -115,7 +114,7 @@ fun BinaryArtifactHandler<*>.checkFullDiagnosticRender() {
 }
 
 private fun renderDiagnosticMessage(fileName: String, severity: Severity, message: String?, line: Int, column: Int): String {
-    val severityString = AnalyzerWithCompilerReport.convertSeverity(severity).toString().toLowerCaseAsciiOnly()
+    val severityString = severity.toCompilerMessageSeverity().toString().toLowerCaseAsciiOnly()
     return "/${fileName}:$line:$column: $severityString: $message"
 }
 

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/NoIrCompilationErrorsHandler.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/NoIrCompilationErrorsHandler.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.test.backend.handlers
 
-import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.diagnostics.Severity
 import org.jetbrains.kotlin.test.backend.ir.IrBackendInput
 import org.jetbrains.kotlin.test.model.BackendInputHandler
@@ -39,7 +38,7 @@ class NoIrCompilationErrorsHandler(testServices: TestServices) : BackendInputHan
                     diagnostic.severity == Severity.ERROR &&
                     diagnosticsService.shouldRenderDiagnostic(module, diagnostic.factoryName, diagnostic.severity)
                 ) {
-                    val severity = AnalyzerWithCompilerReport.convertSeverity(diagnostic.severity).toString().toLowerCaseAsciiOnly()
+                    val severity = diagnostic.severity.toCompilerMessageSeverity().toString().toLowerCaseAsciiOnly()
                     val message = diagnostic.renderMessage()
                     error("/$file:${diagnostic.firstRange}: $severity: $message")
                 }

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/handlers/FirDiagnosticsHandler.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.test.frontend.fir.handlers
 import com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.*
 import org.jetbrains.kotlin.checkers.utils.TypeOfCall
-import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.pipeline.metadata.MetadataFrontendPipelineArtifact
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.diagnostics.*
@@ -116,7 +115,7 @@ class FullDiagnosticsRenderer(private val directive: SimpleDirective) {
                         is KtDiagnosticWithSource -> it.textRanges
                         is KtDiagnosticWithoutSource -> listOf(it.firstRange)
                     },
-                    severity = AnalyzerWithCompilerReport.convertSeverity(it.severity).toString().toLowerCaseAsciiOnly(),
+                    severity = it.severity.toCompilerMessageSeverity().toString().toLowerCaseAsciiOnly(),
                     message = it.renderMessage()
                 )
             }

--- a/compiler/tests-integration/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
+++ b/compiler/tests-integration/tests-gen/org/jetbrains/kotlin/cli/CliTestGenerated.java
@@ -2315,6 +2315,21 @@ public class CliTestGenerated extends AbstractCliTest {
       runTest("compiler/testData/cli/metadata/noVirtualFileHiddenForMemberWithPlatformDependentAnnotation.args");
     }
 
+    @TestMetadata("optInErrorIsNotSuppressible.args")
+    public void testOptInErrorIsNotSuppressible() {
+      runTest("compiler/testData/cli/metadata/optInErrorIsNotSuppressible.args");
+    }
+
+    @TestMetadata("optInWarningsAreDisabled.args")
+    public void testOptInWarningsAreDisabled() {
+      runTest("compiler/testData/cli/metadata/optInWarningsAreDisabled.args");
+    }
+
+    @TestMetadata("optInWarningsAsErrors.args")
+    public void testOptInWarningsAsErrors() {
+      runTest("compiler/testData/cli/metadata/optInWarningsAsErrors.args");
+    }
+
     @TestMetadata("optionalAnnotationsFromMetadata.args")
     public void testOptionalAnnotationsFromMetadata() {
       runTest("compiler/testData/cli/metadata/optionalAnnotationsFromMetadata.args");

--- a/compiler/tests/org/jetbrains/kotlin/checkers/DefaultMessagesTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/checkers/DefaultMessagesTest.kt
@@ -5,8 +5,10 @@
 
 package org.jetbrains.kotlin.checkers
 
+import org.jetbrains.kotlin.fir.analysis.diagnostics.CliDiagnostics
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrorsDefaultMessages
+import org.jetbrains.kotlin.fir.analysis.diagnostics.KtDiagnosticMessagesCli
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrors
 import org.jetbrains.kotlin.fir.analysis.diagnostics.js.FirJsErrorsDefaultMessages
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors
@@ -19,8 +21,6 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.web.common.FirWebCommonErro
 import org.jetbrains.kotlin.fir.analysis.diagnostics.web.common.FirWebCommonErrorsDefaultMessages
 import org.jetbrains.kotlin.fir.builder.FirSyntaxErrors
 import org.jetbrains.kotlin.fir.builder.FirSyntaxErrorsDefaultMessages
-import org.jetbrains.kotlin.fir.cli.CliDiagnostics
-import org.jetbrains.kotlin.fir.cli.KtDiagnosticMessagesCli
 import org.jetbrains.kotlin.test.utils.verifyMessages
 import org.junit.Test
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-48419/Using-a-RequiresOptIn-API-that-does-not-exist-should-have-an-option-to-not-output-a-warning

I've prepared the PR on GitHub to test [GitHub Copilot code review](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review).