### PR TITLE
Fix KT-78532 Appendable/StringBuilder objcExportErrorOnNameCollisions errors

### DIFF
--- a/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
@@ -7,6 +7,7 @@ package kotlin.native
 
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.experimental.ExperimentalObjCName
+import kotlin.experimental.ExperimentalObjCExportIgnoreNameCollision
 import kotlin.experimental.ExperimentalObjCRefinement
 
 /**
@@ -115,6 +116,25 @@ public actual annotation class CName(actual val externName: String = "", actual 
 @ExperimentalObjCName
 @SinceKotlin("1.8")
 public actual annotation class ObjCName(actual val name: String = "", actual val swiftName: String = "", actual val exact: Boolean = false)
+
+/**
+ * Instructs the Kotlin compiler to suppress name collision errors when generating Objective-C headers
+ * with the `-Xbinary=objcExportErrorOnNameCollisions=true` compiler option.
+ *
+ * This annotation is intended for standard library classes that have inherent overloaded methods
+ * (e.g., Appendable, StringBuilder) where name mangling is unavoidable but should not prevent users
+ * from using these types in their public APIs.
+ */
+@Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.FUNCTION
+)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@ExperimentalObjCExportIgnoreNameCollision
+@SinceKotlin("2.1")
+public actual annotation class ObjCExportIgnoreNameCollision
 
 /**
  * Meta-annotation that instructs the Kotlin compiler to remove the annotated class, function or property from the public Objective-C API.

--- a/libraries/stdlib/native-wasm/src/kotlin/text/Appendable.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/text/Appendable.kt
@@ -5,9 +5,14 @@
 
 package kotlin.text
 
+import kotlin.experimental.ExperimentalObjCExportIgnoreNameCollision
+import kotlin.native.ObjCExportIgnoreNameCollision
+
 /**
  * An object to which char sequences and values can be appended.
  */
+@OptIn(ExperimentalObjCExportIgnoreNameCollision::class)
+@ObjCExportIgnoreNameCollision
 public actual interface Appendable {
     /**
      * Appends the specified character [value] to this Appendable and returns this instance.

--- a/libraries/stdlib/native-wasm/src/kotlin/text/StringBuilder.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/text/StringBuilder.kt
@@ -5,11 +5,16 @@
 
 package kotlin.text
 
+import kotlin.experimental.ExperimentalObjCExportIgnoreNameCollision
+import kotlin.native.ObjCExportIgnoreNameCollision
+
 /**
  * A mutable sequence of characters.
  *
  * String builder can be used to efficiently perform multiple string manipulation operations.
  */
+@OptIn(ExperimentalObjCExportIgnoreNameCollision::class)
+@ObjCExportIgnoreNameCollision
 public actual class StringBuilder
 private constructor (private var array: CharArray) : CharSequence, Appendable {
 

--- a/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
+++ b/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
@@ -7,6 +7,7 @@ package kotlin.native
 
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.experimental.ExperimentalObjCName
+import kotlin.experimental.ExperimentalObjCExportIgnoreNameCollision
 import kotlin.experimental.ExperimentalObjCRefinement
 
 /**
@@ -70,6 +71,26 @@ public expect annotation class FreezingIsDeprecated
 @ExperimentalObjCName
 @SinceKotlin("1.8")
 public expect annotation class ObjCName(val name: String = "", val swiftName: String = "", val exact: Boolean = false)
+
+/**
+ * Instructs the Kotlin compiler to suppress name collision errors when generating Objective-C headers
+ * with the `-Xbinary=objcExportErrorOnNameCollisions=true` compiler option.
+ *
+ * This annotation is intended for standard library classes that have inherent overloaded methods
+ * (e.g., Appendable, StringBuilder) where name mangling is unavoidable but should not prevent users
+ * from using these types in their public APIs.
+ */
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FUNCTION
+)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@OptionalExpectation
+@ExperimentalObjCExportIgnoreNameCollision
+@SinceKotlin("2.1")
+public expect annotation class ObjCExportIgnoreNameCollision()
 
 /**
  * Meta-annotation that instructs the Kotlin compiler to remove the annotated class, function or property from the public Objective-C API.

--- a/libraries/stdlib/src/kotlin/experimental/ExperimentalObjCName.kt
+++ b/libraries/stdlib/src/kotlin/experimental/ExperimentalObjCName.kt
@@ -14,3 +14,13 @@ package kotlin.experimental
 @MustBeDocumented
 @SinceKotlin("1.8")
 public annotation class ExperimentalObjCName
+
+/**
+ * This annotation marks the experimental [ObjCExportIgnoreNameCollision][kotlin.native.ObjCExportIgnoreNameCollision] annotation.
+ */
+@RequiresOptIn
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+@SinceKotlin("2.1")
+public annotation class ExperimentalObjCExportIgnoreNameCollision

--- a/libraries/stdlib/src/kotlin/text/StringBuilder.kt
+++ b/libraries/stdlib/src/kotlin/text/StringBuilder.kt
@@ -6,16 +6,19 @@
 @file:kotlin.jvm.JvmMultifileClass
 @file:kotlin.jvm.JvmName("StringsKt")
 @file:Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+@file:OptIn(kotlin.experimental.ExperimentalObjCExportIgnoreNameCollision::class)
 
 package kotlin.text
 
 import kotlin.contracts.*
+import kotlin.native.ObjCExportIgnoreNameCollision
 
 /**
  * A mutable sequence of characters.
  *
  * String builder can be used to efficiently perform multiple string manipulation operations.
  */
+@ObjCExportIgnoreNameCollision
 public expect class StringBuilder : Appendable, CharSequence {
     /** Constructs an empty string builder. */
     public constructor()

--- a/native/base/src/main/kotlin/org/jetbrains/kotlin/backend/konan/KonanFqNames.kt
+++ b/native/base/src/main/kotlin/org/jetbrains/kotlin/backend/konan/KonanFqNames.kt
@@ -38,6 +38,7 @@ object KonanFqNames {
     val eagerInitialization = FqName("kotlin.native.EagerInitialization")
     val noReorderFields = FqName("kotlin.native.internal.NoReorderFields")
     val objCName = FqName("kotlin.native.ObjCName")
+    val objCExportIgnoreNameCollision = FqName("kotlin.native.ObjCExportIgnoreNameCollision")
     val hidesFromObjC = FqName("kotlin.native.HidesFromObjC")
     val refinesInSwift = FqName("kotlin.native.RefinesInSwift")
     val shouldRefineInSwift = FqName("kotlin.native.ShouldRefineInSwift")

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -885,7 +885,7 @@ class ObjCExportNamerImpl(
                     return it
                 }
 
-                if (!reportedCollision) {
+                if (!reportedCollision && !element.hasObjCExportIgnoreNameCollisionAnnotation()) {
                     reportedCollision = true
                     val conflict = when (res) {
                         is AssignResult.Conflict if res.conflictingElement is DeclarationDescriptor ->
@@ -1164,6 +1164,23 @@ fun abbreviate(name: String): String {
     if (uppers.length >= 3) return uppers
 
     return normalizedName
+}
+
+private fun Any.hasObjCExportIgnoreNameCollisionAnnotation(): Boolean {
+    if (this !is DeclarationDescriptor) return false
+
+    if (annotations.hasAnnotation(KonanFqNames.objCExportIgnoreNameCollision)) {
+        return true
+    }
+
+    if (this is CallableMemberDescriptor) {
+        val containingClass = containingDeclaration as? ClassDescriptor
+        if (containingClass?.annotations?.hasAnnotation(KonanFqNames.objCExportIgnoreNameCollision) == true) {
+            return true
+        }
+    }
+
+    return false
 }
 
 // Note: most usages of this method rely on the fact that concatenation of valid identifiers is valid identifier.


### PR DESCRIPTION
[KT-78532](https://youtrack.jetbrains.com/issue/KT-78532)

Introduce `@ObjCExportIgnoreNameCollision` annotation to suppress name collision errors when generating Objective-C headers with `-Xbinary=objcExportErrorOnNameCollisions=true` compiler option.

`Appendable` and `StringBuilder` have multiple overloaded methods with different parameter types (append(Int), append(String), etc.) that cause mandatory name mangling in ObjC. This prevents users from enabling strict collision checking even when these types only appear in their API signatures without being used from ObjC.

Apply the annotation to `Appendable` and `StringBuilder` to allow these stdlib classes to work with the strict collision mode.