### PR TITLE
Fix `StabilityInferencer`'s handling of `internal` types

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
@@ -58,10 +58,7 @@ abstract class AbstractLiveLiteralTransformTests(
                             pluginContext: IrPluginContext,
                         ) {
                             val keyVisitor = DurableKeyVisitor(builtKeys)
-                            val stabilityInferencer = StabilityInferencer(
-                                pluginContext.moduleDescriptor,
-                                emptySet()
-                            )
+                            val stabilityInferencer = StabilityInferencer(emptySet())
                             val featureFlags = FeatureFlags()
                             val transformer = object : LiveLiteralTransformer(
                                 liveLiteralsEnabled || liveLiteralsV2Enabled,

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/FunctionBodySkippingTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/FunctionBodySkippingTransformTests.kt
@@ -600,6 +600,23 @@ class FunctionBodySkippingTransformTests(
     )
 
     @Test
+    fun testInternalStableUnstableParams(): Unit = comparisonPropagation(
+        """
+            internal class Foo(var value: Int = 0)
+        """,
+        """
+            @Composable
+            internal fun CanSkip(foo: Foo = Foo()) {
+                used(foo)
+            }
+            @Composable 
+            internal fun CannotSkip(foo: Foo) {
+                used(foo)
+            }
+        """
+    )
+
+    @Test
     fun testOptionalUnstableWithStableExtensionReceiver(): Unit = comparisonPropagation(
         """
             class Foo(var value: Int = 0)

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testInternalStableUnstableParams[useFir = false].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testInternalStableUnstableParams[useFir = false].txt
@@ -1,0 +1,81 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.ReadOnlyComposable
+
+
+@Composable
+internal fun CanSkip(foo: Foo = Foo()) {
+    used(foo)
+}
+@Composable 
+internal fun CannotSkip(foo: Foo) {
+    used(foo)
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+@Composable
+internal fun CanSkip(foo: Foo?, %composer: Composer?, %changed: Int, %default: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(CanSkip):Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (%default and 0b0001 == 0 && %composer.changedInstance(foo)) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    %composer.startDefaults()
+    if (%changed and 0b0001 == 0 || %composer.defaultsInvalid) {
+      if (%default and 0b0001 != 0) {
+        foo = Foo()
+        %dirty = %dirty and 0b1110.inv()
+      }
+    } else {
+      %composer.skipToGroupEnd()
+      if (%default and 0b0001 != 0) {
+        %dirty = %dirty and 0b1110.inv()
+      }
+    }
+    %composer.endDefaults()
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    used(foo as Foo)
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    CanSkip(foo, %composer, updateChangedFlags(%changed or 0b0001), %default)
+  }
+}
+@Composable
+internal fun CannotSkip(foo: Foo, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(CannotSkip):Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (%composer.changedInstance(foo)) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    used(foo)
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    CannotSkip(foo, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testInternalStableUnstableParams[useFir = true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testInternalStableUnstableParams[useFir = true].txt
@@ -1,0 +1,81 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.ReadOnlyComposable
+
+
+@Composable
+internal fun CanSkip(foo: Foo = Foo()) {
+    used(foo)
+}
+@Composable 
+internal fun CannotSkip(foo: Foo) {
+    used(foo)
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+@Composable
+internal fun CanSkip(foo: Foo?, %composer: Composer?, %changed: Int, %default: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(CanSkip)N(foo):Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (%default and 0b0001 == 0 && %composer.changedInstance(foo)) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    %composer.startDefaults()
+    if (%changed and 0b0001 == 0 || %composer.defaultsInvalid) {
+      if (%default and 0b0001 != 0) {
+        foo = Foo()
+        %dirty = %dirty and 0b1110.inv()
+      }
+    } else {
+      %composer.skipToGroupEnd()
+      if (%default and 0b0001 != 0) {
+        %dirty = %dirty and 0b1110.inv()
+      }
+    }
+    %composer.endDefaults()
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    used(foo as Foo)
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    CanSkip(foo, %composer, updateChangedFlags(%changed or 0b0001), %default)
+  }
+}
+@Composable
+internal fun CannotSkip(foo: Foo, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(CannotSkip)N(foo):Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (%composer.changedInstance(foo)) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    used(foo)
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    CannotSkip(foo, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
@@ -64,10 +64,7 @@ class ComposeIrGenerationExtension(
             return
         }
 
-        val stabilityInferencer = StabilityInferencer(
-            pluginContext.moduleDescriptor,
-            stableTypeMatchers,
-        )
+        val stabilityInferencer = StabilityInferencer(stableTypeMatchers)
 
         if (useK2) {
             moduleFragment.acceptVoid(ComposableLambdaAnnotator(pluginContext))


### PR DESCRIPTION
In the past, if an `internal` type `T` was inferred to be stable when it was compiled in a compilation unit `A`, we would infer it to be stable when compiling a compilation unit `B` that uses the type. This caused failures in situations in which `T` was later made unstable by an edit and `A` was incrementally recompiled, but `B` was not. This change eliminates the possibility of such failures.

Test: ClassStabilityTransformTests.testInferredStabilityOfInternalTypesFromOtherCompilationUnits
Fixes: 427530633