### PR TITLE
Fix JNI header location

### DIFF
--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/tools/NativePlugin.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/tools/NativePlugin.kt
@@ -223,17 +223,16 @@ open class NativeToolsExtension(val project: Project) {
     val llvmDir by nativeDependenciesExtension::llvmPath
     val hostPlatform by nativeDependenciesExtension::hostPlatform
 
-    // This is copied from `ClangArgs`
-    private val jdkDir: File
-        get() = File(System.getProperty("java.home")).canonicalFile.let { home ->
-            if (home.resolve("include").exists()) {
-                home
-            } else {
-                home.parentFile.also {
-                    check(it.resolve("include").exists())
-                }
-            }
-        }
+    // Keep in sync with ClangArgs.kt
+    private val jdkDir by lazy {
+        val home = File(System.getProperty("java.home")).canonicalFile
+        val parent = home.parentFile
+        val javaHome = System.getenv("JAVA_HOME")?.let(::File)
+
+        listOfNotNull(home, parent, javaHome)
+                .firstOrNull { it.resolve("include").exists() }
+                ?: error("JNI headers not found")
+    }
 
     private val reproducibilityRootsMap: Map<File, String>
         get() = reproducibilityRootsMap(project, nativeDependenciesExtension, jdkDir)

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -238,14 +238,18 @@ sealed class ClangArgs(
     /**
      * Should be used when compiling library for JNI.
      * For example, it is used for Kotlin/Native's Clang and LLVM libraries.
+     *
+     * Keep in sync with NativePlugin.kt
      */
     class Jni(configurables: Configurables) : ClangArgs(configurables, forJni = true) {
         private val jdkDir by lazy {
-            val home = File.javaHome.absoluteFile
-            if (home.child("include").exists)
-                home.absolutePath
-            else
-                home.parentFile.absolutePath
+            val home = File(System.getProperty("java.home")).canonicalFile
+            val parent = home.parentFile
+            val javaHome = System.getenv("JAVA_HOME")?.let(::File)
+
+            listOfNotNull(home, parent, javaHome)
+                .firstOrNull { it.child("include").exists }?.absolutePath
+                ?: error("JNI headers not found")
         }
 
         val hostCompilerArgsForJni: Array<String> by lazy {


### PR DESCRIPTION
The existing solution for finding the location of the JNI headers relies on the java.home of the running process. This can fail, when the gradle daemon is started from a JRE, which usually do not include the header files. This fix instead uses gradle's JavaToolChainService to find an appropriate JDK to access the headers from.

#KT-82607 Fixed