### PR TITLE
Add caches to callers of JvmDependenciesIndex

### DIFF
--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/CliVirtualFileFinder.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/CliVirtualFileFinder.kt
@@ -5,10 +5,11 @@
 
 package org.jetbrains.kotlin.cli.jvm.compiler
 
+import com.google.common.cache.CacheBuilder
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.GlobalSearchScope
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
-import org.jetbrains.kotlin.cli.jvm.index.JavaRoot
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import org.jetbrains.kotlin.cli.jvm.index.JvmDependenciesIndex
 import org.jetbrains.kotlin.load.kotlin.VirtualFileFinder
 import org.jetbrains.kotlin.name.ClassId
@@ -19,6 +20,7 @@ import org.jetbrains.kotlin.serialization.deserialization.METADATA_FILE_EXTENSIO
 import org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInSerializerProtocol
 import org.jetbrains.kotlin.util.PerformanceManager
 import java.io.InputStream
+import java.util.concurrent.TimeUnit
 
 class CliVirtualFileFinder(
     private val index: JvmDependenciesIndex,
@@ -26,17 +28,23 @@ class CliVirtualFileFinder(
     private val enableSearchInCtSym: Boolean,
     perfManager: PerformanceManager?,
 ) : VirtualFileFinder(perfManager) {
+    private val childrenInPackageCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(2000)
+            .expireAfterAccess(15, TimeUnit.MINUTES)
+            .build<FqName, Map<String, Set<VirtualFile>>>()
+
     override fun findVirtualFileWithHeader(classId: ClassId): VirtualFile? =
         findBinaryOrSigClass(classId)
 
     override fun findSourceOrBinaryVirtualFile(classId: ClassId) =
         findBinaryOrSigClass(classId)
-            ?: findSourceClass(classId, classId.relativeClassName.asString() + ".java")
+            ?: findClass(classId, classId.relativeClassName.asString() + ".java")
 
     override fun findMetadata(classId: ClassId): InputStream? {
         assert(!classId.isNestedClass) { "Nested classes are not supported here: $classId" }
 
-        return findBinaryClass(
+        return findClass(
             classId,
             classId.shortClassName.asString() + DOT_METADATA_FILE_EXTENSION
         )?.inputStream
@@ -44,16 +52,10 @@ class CliVirtualFileFinder(
 
     override fun findMetadataTopLevelClassesInPackage(packageFqName: FqName): Set<String> {
         val result = ObjectOpenHashSet<String>()
-        index.traverseDirectoriesInPackage(packageFqName, continueSearch = { dir, _ ->
-            for (child in dir.children) {
-                if (child.extension == METADATA_FILE_EXTENSION) {
-                    result.add(child.nameWithoutExtension)
-                }
-            }
-
-            true
-        })
-
+        childrenInPackage(packageFqName).values
+            .flatMap { it }
+            .filter { it.extension == METADATA_FILE_EXTENSION }
+            .forEach { result.add(it.nameWithoutExtension) }
         return result
     }
 
@@ -71,28 +73,44 @@ class CliVirtualFileFinder(
         // JvmDependenciesIndex requires the ClassId of the class which we're searching for, to cache the last request+result
         val classId = ClassId(packageFqName, Name.special("<builtins-metadata>"))
 
-        return findBinaryClass(classId, BuiltInSerializerProtocol.getBuiltInsFileName(packageFqName))?.inputStream
+        return findClass(classId, BuiltInSerializerProtocol.getBuiltInsFileName(packageFqName))?.inputStream
     }
 
-    private fun findClass(classId: ClassId, fileName: String, rootType: Set<JavaRoot.RootType>) =
-        index.findClasses(classId, acceptedRootTypes = rootType) { dir, _ ->
-            dir.findChild(fileName)?.takeIf(VirtualFile::isValid)
-        }.firstOrNull { it in scope }
+    private fun findClass(classId: ClassId, fileName: String) =
+        childrenInPackage(classId.packageFqName)[fileName]
+            ?.filter(VirtualFile::isValid)
+            ?.firstOrNull { it in scope }
 
-    private fun findSigFileIfEnabled(
-        dir: VirtualFile,
-        simpleName: String
-    ) = if (enableSearchInCtSym) dir.findChild("$simpleName.sig") else null
+    private fun findBinaryOrSigClass(classId: ClassId): VirtualFile? {
+        val simpleName = classId.relativeClassName.asString().replace('.', '$')
+        val cache = childrenInPackage(classId.packageFqName)
+        cache["$simpleName.class"]?.firstOrNull { it in scope }?.let {
+            return it
+        }
+        return if (enableSearchInCtSym) {
+            cache["$simpleName.sig"]?.firstOrNull { it in scope }
+        } else {
+            null
+        }
+    }
 
-    private fun findBinaryOrSigClass(classId: ClassId, simpleName: String, rootType: Set<JavaRoot.RootType>) =
-        index.findClasses(classId, acceptedRootTypes = rootType) { dir, _ ->
-            val file = dir.findChild("$simpleName.class") ?: findSigFileIfEnabled(dir, simpleName)
-            if (file != null && file.isValid) file else null
-        }.firstOrNull { it in scope }
+    private fun childrenInPackage(packageFqName: FqName): Map<String, Set<VirtualFile>> {
+        return childrenInPackageCache.get(packageFqName) {
+            val files = Object2ObjectOpenHashMap<String, MutableSet<VirtualFile>>()
+            index.traverseDirectoriesInPackage(packageFqName, continueSearch = { dir, _ ->
+                for (child in dir.children) {
+                    if (child.extension == METADATA_FILE_EXTENSION ||
+                        child.extension == "class" ||
+                        child.extension == "sig" ||
+                        child.extension == "java"
+                    ) {
+                        files.getOrPut(child.name) { ObjectOpenHashSet() }.add(child)
+                    }
+                }
 
-    private fun findBinaryOrSigClass(classId: ClassId) =
-        findBinaryOrSigClass(classId, classId.relativeClassName.asString().replace('.', '$'), JavaRoot.OnlyBinary)
-
-    private fun findBinaryClass(classId: ClassId, fileName: String) = findClass(classId, fileName, JavaRoot.OnlyBinary)
-    private fun findSourceClass(classId: ClassId, fileName: String) = findClass(classId, fileName, JavaRoot.OnlySource)
+                true
+            })
+            files
+        }
+    }
 }


### PR DESCRIPTION
For context, see https://youtrack.jetbrains.com/issue/KT-83191.

This CL adds Guava CacheBuilder to `CliVirtualFileFinder` and `KotlinCliJavaFileManagerImpl`. These caches map the package name to the children in the package across all roots/jars and avoids having to iterate through all jars on subsequent calls. This can drastically improve build performance for cases with a large number of roots/jars that have overlapping packages.