### PR TITLE
fix: clarify the difference between blank and empty

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Indent.kt
+++ b/libraries/stdlib/src/kotlin/text/Indent.kt
@@ -10,7 +10,7 @@ package kotlin.text
 
 /**
  * Trims leading whitespace characters followed by [marginPrefix] from every line of a source string and removes
- * the first and the last lines if they are blank (notice difference blank vs empty).
+ * the first and the last lines if they are blank (note the difference in [isBlank] vs. [isEmpty]).
  *
  * Doesn't affect a line if it doesn't contain [marginPrefix] except the first and the last blank lines.
  *


### PR DESCRIPTION
Add links to clarify blank and empty definitions. The link is in "See also", but the confusion starts at the first line.