### PR TITLE
KT-57335 Add test for inline class over Vector128

### DIFF
--- a/native/native.tests/testData/codegen/vector/kt57335.kt
+++ b/native/native.tests/testData/codegen/vector/kt57335.kt
@@ -39,10 +39,10 @@ fun box(): String {
     val sumVecV4 = v4.toString()
 
     if (sumVecV3 != "Vector3(11.0, 22.0, 33.0)") {
-        return "FAIL: sumVecV3 is ${sumVecTwo}"
+        return "FAIL: sumVecV3 is ${sumVecV3}"
     }
     if (sumVecV4 != "Vector4(11.0, 22.0, 33.0, 44.0)") {
-        return "FAIL: sumVecV4 is ${sumVec}"
+        return "FAIL: sumVecV4 is ${sumVecV4}"
     }
 
     return "OK"

--- a/native/native.tests/testData/codegen/vector/kt57335.kt
+++ b/native/native.tests/testData/codegen/vector/kt57335.kt
@@ -2,8 +2,8 @@
 // WITH_PLATFORM_LIBS
 // FREE_COMPILER_ARGS: -opt-in=kotlin.ExperimentalStdlibApi,kotlinx.cinterop.ExperimentalForeignApi
 
-// FILE: lib.kt
 import kotlinx.cinterop.*
+import kotlin.test.*
 
 value class Vector3(val data: Vector128) {
     constructor(x: Float, y: Float, z: Float) : this(vectorOf(x, y, z, 0f))
@@ -28,22 +28,28 @@ value class Vector4(val data: Vector128) {
     override fun toString(): String = "Vector4(${x}, ${y}, ${z}, ${w})"
 }
 
-// FILE: main.kt
-import kotlinx.cinterop.*
-
-@OptIn(ExperimentalForeignApi::class)
-fun box(): String {
+fun performTest(): String {
     val v3 = Vector3(1f, 2f, 3f) + Vector3(10f, 20f, 30f)
     val v4 = Vector4(1f, 2f, 3f, 4f) + Vector4(10f, 20f, 30f, 40f)
+
     val sumVecV3 = v3.toString()
     val sumVecV4 = v4.toString()
 
-    if (sumVecV3 != "Vector3(11.0, 22.0, 33.0)") {
-        return "FAIL: sumVecV3 is ${sumVecV3}"
-    }
-    if (sumVecV4 != "Vector4(11.0, 22.0, 33.0, 44.0)") {
-        return "FAIL: sumVecV4 is ${sumVecV4}"
-    }
+    if (sumVecV3 != "Vector3(11.0, 22.0, 33.0)") return "FAIL: sumVecV3 is ${sumVecV3}"
+    if (sumVecV4 != "Vector4(11.0, 22.0, 33.0, 44.0)") return "FAIL: sumVecV4 is ${sumVecV4}"
 
+    return "OK"
+}
+
+fun confuseStackAndRun(depth: Int): String {
+    if (depth == 0) return performTest()
+    return confuseStackAndRun(depth - 1)
+}
+
+fun box(): String {
+    for (i in 0..10) {
+        val result = confuseStackAndRun(i)
+        if (result != "OK") return result
+    }
     return "OK"
 }

--- a/native/native.tests/testData/codegen/vector/kt57335.kt
+++ b/native/native.tests/testData/codegen/vector/kt57335.kt
@@ -1,0 +1,49 @@
+// TARGET_BACKEND: NATIVE
+// WITH_PLATFORM_LIBS
+// FREE_COMPILER_ARGS: -opt-in=kotlin.ExperimentalStdlibApi,kotlinx.cinterop.ExperimentalForeignApi
+
+// FILE: lib.kt
+import kotlinx.cinterop.*
+
+value class Vector3(val data: Vector128) {
+    constructor(x: Float, y: Float, z: Float) : this(vectorOf(x, y, z, 0f))
+
+    val x: Float get() = data.getFloatAt(0)
+    val y: Float get() = data.getFloatAt(1)
+    val z: Float get() = data.getFloatAt(2)
+
+    operator fun plus(v: Vector3): Vector3 = Vector3(this.x + v.x, this.y + v.y, this.z + v.z)
+    override fun toString(): String = "Vector3(${x}, ${y}, ${z})"
+}
+
+value class Vector4(val data: Vector128) {
+    constructor(x: Float, y: Float, z: Float, w: Float) : this(vectorOf(x, y, z, w))
+
+    val x: Float get() = data.getFloatAt(0)
+    val y: Float get() = data.getFloatAt(1)
+    val z: Float get() = data.getFloatAt(2)
+    val w: Float get() = data.getFloatAt(3)
+
+    operator fun plus(v: Vector4): Vector4 = Vector4(this.x + v.x, this.y + v.y, this.z + v.z, this.w + v.w)
+    override fun toString(): String = "Vector4(${x}, ${y}, ${z}, ${w})"
+}
+
+// FILE: main.kt
+import kotlinx.cinterop.*
+
+@OptIn(ExperimentalForeignApi::class)
+fun box(): String {
+    val v3 = Vector3(1f, 2f, 3f) + Vector3(10f, 20f, 30f)
+    val v4 = Vector4(1f, 2f, 3f, 4f) + Vector4(10f, 20f, 30f, 40f)
+    val sumVecV3 = v3.toString()
+    val sumVecV4 = v4.toString()
+
+    if (sumVecV3 != "Vector3(11.0, 22.0, 33.0)") {
+        return "FAIL: sumVecV3 is ${sumVecTwo}"
+    }
+    if (sumVecV4 != "Vector4(11.0, 22.0, 33.0, 44.0)") {
+        return "FAIL: sumVecV4 is ${sumVec}"
+    }
+
+    return "OK"
+}

--- a/native/native.tests/testData/codegen/vector/kt57335.kt
+++ b/native/native.tests/testData/codegen/vector/kt57335.kt
@@ -28,28 +28,59 @@ value class Vector4(val data: Vector128) {
     override fun toString(): String = "Vector4(${x}, ${y}, ${z}, ${w})"
 }
 
-fun performTest(): String {
+var globalAnySink: Any? = null
+
+fun doMathAndForceBoxing() {
     val v3 = Vector3(1f, 2f, 3f) + Vector3(10f, 20f, 30f)
     val v4 = Vector4(1f, 2f, 3f, 4f) + Vector4(10f, 20f, 30f, 40f)
 
-    val sumVecV3 = v3.toString()
-    val sumVecV4 = v4.toString()
+    globalAnySink = v3 as Any
+    globalAnySink = v4 as Any
 
-    if (sumVecV3 != "Vector3(11.0, 22.0, 33.0)") return "FAIL: sumVecV3 is ${sumVecV3}"
-    if (sumVecV4 != "Vector4(11.0, 22.0, 33.0, 44.0)") return "FAIL: sumVecV4 is ${sumVecV4}"
-
-    return "OK"
+    val v3Boxed = globalAnySink as Vector4
+    if (v3Boxed.x != 11f) throw Exception("Math failed")
 }
 
-fun confuseStackAndRun(depth: Int): String {
-    if (depth == 0) return performTest()
-    return confuseStackAndRun(depth - 1)
+interface StackShifter {
+    fun executeCall()
+}
+
+class Shift0 : StackShifter {
+    override fun executeCall() {
+        doMathAndForceBoxing()
+    }
+}
+class Shift1 : StackShifter {
+    override fun executeCall() {
+        val a = 1L; doMathAndForceBoxing(); globalAnySink = a
+    }
+}
+class Shift2 : StackShifter {
+    override fun executeCall() {
+        val a=1L; val b=2L; doMathAndForceBoxing(); globalAnySink = a+b
+    }
+}
+class Shift3 : StackShifter {
+    override fun executeCall() {
+        val a=1L; val b=2L; val c=3L; doMathAndForceBoxing(); globalAnySink = a+b+c
+    }
+}
+class Shift4 : StackShifter {
+    override fun executeCall() {
+        val a=1L; val b=2L; val c=3L; val d=4L; doMathAndForceBoxing(); globalAnySink = a+b+c+d
+    }
 }
 
 fun box(): String {
-    for (i in 0..10) {
-        val result = confuseStackAndRun(i)
-        if (result != "OK") return result
+    val shifters = arrayOf(Shift0(), Shift1(), Shift2(), Shift3(), Shift4())
+
+    for (shifter in shifters) {
+        try {
+            shifter.executeCall()
+        } catch (e: Exception) {
+            return "FAIL: Crash dynamically caught or unexpected exception ${e.message}"
+        }
     }
+
     return "OK"
 }


### PR DESCRIPTION
Added a test to verify that the built-in classes wrapping Vector128 are functioning correctly and that values are being passed through registers

[KT-57335](https://youtrack.jetbrains.com/issue/KT-57335/Add-test-for-inline-class-over-Vector128)