### PR TITLE
KT-78051 Add regression test for value class default argument in inline function

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -1551,7 +1551,12 @@ class ExpressionCodegen(
         }
 
         if (element.origin == JvmLoweredStatementOrigin.DEFAULT_STUB_CALL_TO_IMPLEMENTATION) {
-            return IrInlineDefaultCodegen
+            // IrInlineDefaultCodegen verbatim-copies impl bytecode assuming caller and callee
+            // parameters share JVM types. Value class default args can break this: the $default
+            // stub keeps boxed IC while impl is unboxed (KT-78051). Fall through to general inliner.
+            if (canVerbatimCopyDefaultStubBody(element)) {
+                return IrInlineDefaultCodegen
+            }
         }
 
         val callee = element.symbol.owner
@@ -1590,6 +1595,15 @@ class ExpressionCodegen(
             reifiedTypeInliner,
             markInlinedSuspensionPointAsUnitReturning
         )
+    }
+
+    private fun canVerbatimCopyDefaultStubBody(call: IrFunctionAccessExpression): Boolean {
+        val callee = call.symbol.owner
+        callee.parameters.forEachIndexed { index, calleeParam ->
+            val callerParam = irFunction.parameters.getOrNull(index) ?: return false
+            if (typeMapper.mapType(callerParam.type) != typeMapper.mapType(calleeParam.type)) return false
+        }
+        return true
     }
 
     private fun consumeReifiedOperationMarker(typeParameter: TypeParameterMarker) {

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -1553,7 +1553,12 @@ class ExpressionCodegen(
         }
 
         if (element.origin == JvmLoweredStatementOrigin.DEFAULT_STUB_CALL_TO_IMPLEMENTATION) {
-            return IrInlineDefaultCodegen
+            // IrInlineDefaultCodegen verbatim-copies impl bytecode assuming caller and callee
+            // parameters share JVM types. Value class default args can break this: the $default
+            // stub keeps boxed IC while impl is unboxed (KT-78051). Fall through to general inliner.
+            if (canVerbatimCopyDefaultStubBody(element)) {
+                return IrInlineDefaultCodegen
+            }
         }
 
         val callee = element.symbol.owner
@@ -1591,6 +1596,15 @@ class ExpressionCodegen(
             reifiedTypeInliner,
             markInlinedSuspensionPointAsUnitReturning
         )
+    }
+
+    private fun canVerbatimCopyDefaultStubBody(call: IrFunctionAccessExpression): Boolean {
+        val callee = call.symbol.owner
+        callee.parameters.forEachIndexed { index, calleeParam ->
+            val callerParam = irFunction.parameters.getOrNull(index) ?: return false
+            if (typeMapper.mapType(callerParam.type) != typeMapper.mapType(calleeParam.type)) return false
+        }
+        return true
     }
 
     private fun consumeReifiedOperationMarker(typeParameter: TypeParameterMarker) {

--- a/compiler/testData/codegen/boxJvm/inlineClasses/defaultParameterValues/kt78051.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/defaultParameterValues/kt78051.kt
@@ -1,0 +1,97 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+// IGNORE_DEXING
+
+@JvmInline
+value class ICNullableString(val s: String?)
+
+@JvmInline
+value class ICNullableInt(val x: Int?)
+
+@JvmInline
+value class ICString(val s: String)
+
+@JvmInline
+value class ICInt(val x: Int)
+
+fun fooNullableString(ic: ICNullableString) {
+    if (ic.s != "OK") throw AssertionError("Fail NullableString: ${ic.s}")
+}
+
+fun fooNullableInt(ic: ICNullableInt) {
+    if (ic.x != 42) throw AssertionError("Fail NullableInt: ${ic.x}")
+}
+
+fun fooString(ic: ICString) {
+    if (ic.s != "OK") throw AssertionError("Fail String: ${ic.s}")
+}
+
+fun fooInt(ic: ICInt) {
+    if (ic.x != 42) throw AssertionError("Fail Int: ${ic.x}")
+}
+
+inline fun withDefaultICNullableString(ic: ICNullableString = ICNullableString("OK")) {
+    fooNullableString(ic)
+}
+
+inline fun withDefaultICNullableInt(ic: ICNullableInt = ICNullableInt(42)) {
+    fooNullableInt(ic)
+}
+
+inline fun withDefaultICString(ic: ICString = ICString("OK")) {
+    fooString(ic)
+}
+
+inline fun withDefaultICInt(ic: ICInt = ICInt(42)) {
+    fooInt(ic)
+}
+
+// From the original bug report
+inline fun withDefaultICAndCrossinline(
+    ic: ICNullableString = ICNullableString("OK"),
+    crossinline check: (ICNullableString) -> Unit
+) {
+    check(ic)
+}
+
+// Class member with dispatch receiver — matches original bug report structure.
+// Dispatch receiver sits at parameters[0], shifting value class param indices.
+class Host {
+    private inline fun privateMember(
+        saved: ICNullableString = ICNullableString("OK"),
+        crossinline check: (ICNullableString) -> Unit
+    ) {
+        check(saved)
+    }
+
+    fun run(): String {
+        var result = "FAIL"
+        privateMember { ic ->
+            if (ic.s != "OK") throw AssertionError("Fail private member: ${ic.s}")
+            result = "OK"
+        }
+        return result
+    }
+}
+
+// Nullable IC outer — both stub and impl should agree on JVM type (fast path preserved)
+inline fun nullableOuter(ic: ICNullableString? = null) {
+    if (ic != null) throw AssertionError("Fail nullable outer: expected null")
+}
+
+fun box(): String {
+    withDefaultICNullableString()
+    withDefaultICNullableInt()
+    withDefaultICString()
+    withDefaultICInt()
+
+    withDefaultICAndCrossinline { ic ->
+        if (ic.s != "OK") throw AssertionError("Fail crossinline: ${ic.s}")
+    }
+
+    if (Host().run() != "OK") return "FAIL: private member"
+
+    nullableOuter()
+
+    return "OK"
+}


### PR DESCRIPTION
Adds a regression test for [KT-78051](https://youtrack.jetbrains.com/issue/KT-78051).

The underlying parameter-layout issue was fixed by #8020. This PR preserves coverage for the original value-class default-argument reproducer, including the member-function case with a dispatch receiver and a `crossinline` parameter.

The regression test passes on `master`.