### PR TITLE
[Gradle][K/JS] Add a generic target for projects not specific to node but are also not meant for browser environments

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsTargetDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsTargetDsl.kt
@@ -346,10 +346,6 @@ interface KotlinTargetWithGenericJsDsl {
      * Enables 'generic' as the execution environment for this target,
      * so the project can be used running JavaScript code in generic environments.
      *
-     * When enabled, Kotlin Gradle plugin will download and install
-     * the required environment and dependencies for running and testing
-     * using Node.js.
-     *
      * For more information, see https://kotl.in/kotlin-js-execution-environments
      *
      * @see KotlinJsGenericDsl
@@ -531,7 +527,7 @@ interface KotlinJsNodeDsl : KotlinJsSubTargetDsl {
 }
 
 /**
- * Generic execution environment options for Kotlin JS Wasm targets.
+ * Generic execution environment options for Kotlin JS targets.
  *
  * For more information about execution environments, see
  * https://kotl.in/kotlin-js-execution-environments

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsTargetDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsTargetDsl.kt
@@ -58,6 +58,17 @@ interface KotlinJsSubTargetContainerDsl : KotlinTarget {
     val browser: KotlinJsBrowserDsl
 
     /**
+     * Returns the configuration options for generic execution environments
+     * used for this [KotlinTarget].
+     *
+     * For more information about execution environments, see
+     * https://kotl.in/kotlin-js-execution-environments
+     *
+     * @see org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsGenericDsl
+     */
+    val generic: KotlinJsGenericDsl
+
+    /**
      * Container for all execution environments enabled for this target.
      * Currently, the only supported environments are Node.js and browser.
      */
@@ -132,6 +143,7 @@ interface KotlinJsSubTargetContainerDsl : KotlinTarget {
 interface KotlinJsTargetDsl :
     KotlinTarget,
     KotlinTargetWithNodeJsDsl,
+    KotlinTargetWithGenericJsDsl,
     HasBinaries<KotlinJsBinaryContainer>,
     HasConfigurableKotlinCompilerOptions<KotlinJsCompilerOptions> {
 
@@ -323,6 +335,50 @@ interface KotlinTargetWithNodeJsDsl {
 }
 
 /**
+ * Base options for configuring generic JS for use in
+ * Kotlin JS targets.
+ *
+ * To learn more see:
+ * - [Set up a Kotlin/JS project](https://kotl.in/kotlin-js-setup).
+ */
+interface KotlinTargetWithGenericJsDsl {
+    /**
+     * Enables 'generic' as the execution environment for this target,
+     * so the project can be used running JavaScript code in generic environments.
+     *
+     * When enabled, Kotlin Gradle plugin will download and install
+     * the required environment and dependencies for running and testing
+     * using Node.js.
+     *
+     * For more information, see https://kotl.in/kotlin-js-execution-environments
+     *
+     * @see KotlinJsGenericDsl
+     */
+    fun generic() = generic { }
+
+    /**
+     * Enables 'generic' as the execution environment for this target,
+     * so the project can be used running JavaScript code in generic environments.
+     *
+     * The target can be configured using [body].
+     *
+     * For more information, see https://kotl.in/kotlin-js-execution-environments
+     *
+     * @see KotlinJsGenericDsl
+     */
+    fun generic(body: KotlinJsGenericDsl.() -> Unit)
+
+    /**
+     * [Action] based version of [generic] above.
+     */
+    fun generic(fn: Action<KotlinJsGenericDsl>) {
+        generic {
+            fn.execute(this)
+        }
+    }
+}
+
+/**
  * Common options for the configuring execution environments for Kotlin JS and Wasm targets.
  *
  * For more information about execution environments, see https://kotl.in/kotlin-js-execution-environments
@@ -440,6 +496,49 @@ interface KotlinJsNodeDsl : KotlinJsSubTargetDsl {
      * @see org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
      */
     fun runTask(body: Action<NodeJsExec>)
+
+    /**
+     * _This option is only relevant for JS targets._
+     * _Do not use in WasmJS targets._
+     *
+     * > Note: Passing arguments to the main function is Experimental.
+     * > It may be dropped or changed at any time.
+     *
+     * Enable passing `process.argv` to the main function's `args` parameter.
+     *
+     * See https://kotl.in/kotlin-js-pass-arguments-to-main-function
+     *
+     * @see KotlinJsTargetDsl.passAsArgumentToMainFunction
+     */
+    @ExperimentalMainFunctionArgumentsDsl
+    fun passProcessArgvToMainFunction()
+
+    /**
+     * _This option is only relevant for JS targets._
+     * _Do not use in WasmJS targets._
+     *
+     * > Note: Passing arguments to the main function is Experimental.
+     * > It may be dropped or changed at any time.
+     *
+     * Enable passing `process.argv.slice(2)` to the main function's `args` parameter.
+     *
+     * See https://kotl.in/kotlin-js-pass-arguments-to-main-function
+     *
+     * @see KotlinJsTargetDsl.passAsArgumentToMainFunction
+     */
+    @ExperimentalMainFunctionArgumentsDsl
+    fun passCliArgumentsToMainFunction()
+}
+
+/**
+ * Generic execution environment options for Kotlin JS Wasm targets.
+ *
+ * For more information about execution environments, see
+ * https://kotl.in/kotlin-js-execution-environments
+ *
+ * **Note:** This interface is not intended for implementation by build script or plugin authors.
+ */
+interface KotlinJsGenericDsl : KotlinJsSubTargetDsl {
 
     /**
      * _This option is only relevant for JS targets._

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/GenericJsEnvironmentConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/GenericJsEnvironmentConfigurator.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.targets.js.ir
+
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.tasks.locateTask
+import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
+
+class GenericJsEnvironmentConfigurator(subTarget: KotlinJsIrSubTarget) :
+    JsEnvironmentConfigurator<Exec>(subTarget) {
+
+    override fun configureBinaryRun(binary: JsIrBinary): TaskProvider<Exec> {
+        val binaryRunName = subTarget.disambiguateCamelCased(
+            binary.mode.name.toLowerCaseAsciiOnly(),
+            "run"
+        )
+
+        val locateTask = project.locateTask<Exec>(binaryRunName)
+        if (locateTask != null) return locateTask
+
+        return project.registerTask(binaryRunName)
+    }
+
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/GenericJsEnvironmentConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/GenericJsEnvironmentConfigurator.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.targets.js.ir
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.tasks.locateTask
+import org.jetbrains.kotlin.gradle.tasks.registerTask
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
 
 class GenericJsEnvironmentConfigurator(subTarget: KotlinJsIrSubTarget) :

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
@@ -83,8 +83,6 @@ sealed class JsIrBinary(
                 task.duplicatesStrategy = DuplicatesStrategy.WARN
 
                 task.from.from(linkSyncTaskRegisteredResources)
-
-                task.destinationDirectory.set(compilation.npmProject.dist.mapToFile())
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
@@ -85,7 +85,7 @@ sealed class JsIrBinary(
 
                 task.from.from(linkSyncTaskRegisteredResources)
 
-                task.destinationDirectory.set(if (target.isNodejsConfigured || target.isBrowserConfigured) compilation.npmProject.dist.mapToFile() else project.layout.buildDirectory.dir(KotlinPlatformType.js.name).dir(compilation.outputModuleName))
+                task.destinationDirectory.set(if (target.isNodejsConfigured || target.isBrowserConfigured) compilation.npmProject.dist.mapToFile() else project.layout.buildDirectory.dir(KotlinPlatformType.js.name).map { it.dir(compilation.outputModuleName) }.get().mapToFile())
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
@@ -16,6 +16,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompilerOptionsHelper
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.addToAssemble
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJsCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.fileExtension
@@ -83,6 +84,8 @@ sealed class JsIrBinary(
                 task.duplicatesStrategy = DuplicatesStrategy.WARN
 
                 task.from.from(linkSyncTaskRegisteredResources)
+
+                task.destinationDirectory.set(project.layout.buildDirectory.dir(KotlinPlatformType.js.name).dir(compilation.outputModuleName).mapToFile())
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
@@ -16,7 +16,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompilerOptionsHelper
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.addToAssemble
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJsCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.fileExtension
@@ -84,8 +83,6 @@ sealed class JsIrBinary(
                 task.duplicatesStrategy = DuplicatesStrategy.WARN
 
                 task.from.from(linkSyncTaskRegisteredResources)
-
-                task.destinationDirectory.set(project.layout.buildDirectory.dir(KotlinPlatformType.js.name).dir(compilation.outputModuleName).mapToFile())
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
@@ -83,6 +83,8 @@ sealed class JsIrBinary(
                 task.duplicatesStrategy = DuplicatesStrategy.WARN
 
                 task.from.from(linkSyncTaskRegisteredResources)
+
+                task.destinationDirectory.set(compilation.npmProject.dist.mapToFile())
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsBinaries.kt
@@ -16,6 +16,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompilerOptionsHelper
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.addToAssemble
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJsCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.fileExtension
@@ -84,7 +85,7 @@ sealed class JsIrBinary(
 
                 task.from.from(linkSyncTaskRegisteredResources)
 
-                task.destinationDirectory.set(compilation.npmProject.dist.mapToFile())
+                task.destinationDirectory.set(if (target.isNodejsConfigured || target.isBrowserConfigured) compilation.npmProject.dist.mapToFile() else project.layout.buildDirectory.dir(KotlinPlatformType.js.name).dir(compilation.outputModuleName))
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsEnvironmentConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsEnvironmentConfigurator.kt
@@ -36,10 +36,6 @@ abstract class JsEnvironmentConfigurator<RunTask : Task>(protected val subTarget
                     productionExecutable.linkSyncTask
                 }
 
-                if (subTarget is KotlinJsIrNpmBasedSubTarget || subTarget.target.wasmTargetType != null) {
-                    assembleTask.destinationDirectory.set(compilation.npmProject.dist.mapToFile())
-                }
-
                 if (compilation.isMain()) {
                     project.addToAssemble(assembleTask)
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsEnvironmentConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/JsEnvironmentConfigurator.kt
@@ -36,6 +36,10 @@ abstract class JsEnvironmentConfigurator<RunTask : Task>(protected val subTarget
                     productionExecutable.linkSyncTask
                 }
 
+                if (subTarget is KotlinJsIrNpmBasedSubTarget || subTarget.target.wasmTargetType != null) {
+                    assembleTask.destinationDirectory.set(compilation.npmProject.dist.mapToFile())
+                }
+
                 if (compilation.isMain()) {
                     project.addToAssemble(assembleTask)
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
@@ -20,6 +20,10 @@ internal constructor(
 ) :
     KotlinJsIrSubTarget(target, "generic"),
     KotlinJsGenericDsl {
+
+    override val testTaskDescription: String
+        get() = "Run all ${target.name} tests in a generic environment using the builtin test framework"
+
     @ExperimentalMainFunctionArgumentsDsl
     override fun passProcessArgvToMainFunction() {
         target.passAsArgumentToMainFunction("process.argv")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.targets.js.ir
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalMainFunctionArgumentsDsl
+import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsGenericDsl
+import javax.inject.Inject
+
+abstract class KotlinGenericJsIr
+@Inject
+internal constructor(
+    target: KotlinJsIrTarget,
+    private val objects: ObjectFactory,
+    private val providers: ProviderFactory
+) : KotlinJsGenericDsl {
+    @ExperimentalMainFunctionArgumentsDsl
+    override fun passProcessArgvToMainFunction() {
+        target.passAsArgumentToMainFunction("process.argv")
+    }
+
+    @ExperimentalMainFunctionArgumentsDsl
+    override fun passCliArgumentsToMainFunction() {
+        target.passAsArgumentToMainFunction("process.argv.slice(2)")
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
@@ -17,7 +17,9 @@ internal constructor(
     target: KotlinJsIrTarget,
     private val objects: ObjectFactory,
     private val providers: ProviderFactory
-) : KotlinJsGenericDsl {
+) :
+    KotlinJsIrSubTarget(target, "generic"),
+    KotlinJsGenericDsl {
     @ExperimentalMainFunctionArgumentsDsl
     override fun passProcessArgvToMainFunction() {
         target.passAsArgumentToMainFunction("process.argv")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinGenericJsIr.kt
@@ -9,6 +9,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalMainFunctionArgumentsDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsGenericDsl
+import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import javax.inject.Inject
 
 abstract class KotlinGenericJsIr
@@ -32,5 +33,11 @@ internal constructor(
     @ExperimentalMainFunctionArgumentsDsl
     override fun passCliArgumentsToMainFunction() {
         target.passAsArgumentToMainFunction("process.argv.slice(2)")
+    }
+
+    override fun configureTestDependencies(test: KotlinJsTest, binary: JsIrBinary) {
+    }
+
+    override fun configureDefaultTestFramework(test: KotlinJsTest) {
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -269,6 +269,8 @@ constructor(
                 .all { binary ->
                     val syncTask = binary.linkSyncTask
 
+                    syncTask.destinationDirectory.set(project.layout.buildDirectory.dir(KotlinPlatformType.js.name).dir(compilation.outputModuleName).mapToFile())
+
                     binary.linkTask.configure {
                         it.finalizedBy(syncTask)
                     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -269,8 +269,6 @@ constructor(
                 .all { binary ->
                     val syncTask = binary.linkSyncTask
 
-                    syncTask.destinationDirectory.set(project.layout.buildDirectory.dir(KotlinPlatformType.js.name).dir(compilation.outputModuleName).mapToFile())
-
                     binary.linkTask.configure {
                         it.finalizedBy(syncTask)
                     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -263,6 +263,17 @@ constructor(
     }
 
     private val genericLazyDelegate = lazy {
+        compilations.all { compilation ->
+            compilation.binaries
+                .withType(JsIrBinary::class.java)
+                .all { binary ->
+                    val syncTask = binary.linkSyncTask
+
+                    binary.linkTask.configure {
+                        it.finalizedBy(syncTask)
+                    }
+                }
+        }
         addSubTarget(KotlinGenericJsIr::class.java) {
             configureSubTarget()
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -262,6 +262,18 @@ constructor(
         body(nodejs)
     }
 
+    private val genericLazyDelegate = lazy {
+        addSubTarget(KotlinGenericJsIr::class.java) {
+            configureSubTarget()
+        }
+    }
+
+    override val generic: KotlinJsGenericDsl by genericLazyDelegate
+
+    override fun generic(body: KotlinJsGenericDsl.() -> Unit) {
+        body(generic)
+    }
+
     //d8
     @OptIn(ExperimentalWasmDsl::class)
     private val d8LazyDelegate = lazy {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -276,6 +276,8 @@ constructor(
         }
         addSubTarget(KotlinGenericJsIr::class.java) {
             configureSubTarget()
+            subTargetConfigurators.add(LibraryConfigurator(this))
+            subTargetConfigurators.add(GenericJsEnvironmentConfigurator(this))
         }
     }
 


### PR DESCRIPTION
Kotlin/JS currently only supports 2 execution environments, node and browser. The former is for execution as an application on node, and the latter is for browser scripting on the client. To develop an application in Kotlin that compiles to JS, one needs to use the nodejs option in build.gradle.kts, but this has the caveat that it is very specific to node, building the application as an npm package and pulling in npm + npm dependencies and node itself, among other things. It comes with a lot of extra features and things that may not be desired if the goal is to compile Kotlin to plain JS that can work in a generic environment. To remedy this, I suggest adding a generic target for JS, which will build the project directly into plain, simple executable JS with nothing else included and which is not specific to node or npm. This of course comes with the downside that you can't really use npm with a generic target, but for applications where a minimal build output is desired, it is expected that dependencies would be other libraries written in Kotlin that will be built to yield JS, so this hopefully shouldn't be an issue.