### PR TITLE
Context - Parameters: lambda with arguments

### DIFF
--- a/generators/builtins/contextParameters.kt
+++ b/generators/builtins/contextParameters.kt
@@ -38,6 +38,8 @@ class GenerateContextFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) 
 
         val values = if (parameterTypes.size == 1) "value" else "values"
         val receivers = if (parameterTypes.size == 1) "receiver" else "receivers"
+        val argumentsWord = if (parameterTypes.size == 1) "argument" else "arguments"
+        val optionalComment = if (lambdaWithParams) " and as lambda $argumentsWord" else ""
 
         val contextParams = parameters
         val lambdaParams = if (lambdaWithParams) parameters else ""
@@ -58,7 +60,7 @@ class GenerateContextFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) 
         out.println(
             """
 /**
- * Runs the specified [block] with the given $values in context scope.
+ * Runs the specified [block] with the given $values in context scope$optionalComment.
  *
  * As opposed to [with], [context] only makes the $values available for
  * context parameter resolution, but not as implicit $receivers.

--- a/generators/builtins/contextParameters.kt
+++ b/generators/builtins/contextParameters.kt
@@ -29,6 +29,7 @@ class GenerateContextFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) 
         val types = parameterTypes.joinToString()
 
         val values = if (parameterTypes.size == 1) "value" else "values"
+        val argumentsWord = if (parameterTypes.size == 1) "argument" else "arguments"
         val receivers = if (parameterTypes.size == 1) "receiver" else "receivers"
 
         out.println(
@@ -50,7 +51,7 @@ public inline fun <$types, $resultType> context($parameters, block: context($typ
 }
 
 /**
- * Runs the specified [block] with the given $values in context scope and in the arguments.
+ * Runs the specified [block] with the given $values in context scope and in the $argumentsWord.
  *
  * As opposed to [with], [context] doesn't make the the $values available as implicit $receivers
  *

--- a/generators/builtins/contextParameters.kt
+++ b/generators/builtins/contextParameters.kt
@@ -12,16 +12,16 @@ class GenerateContextFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) 
     override fun getMultifileClassName(): String = "ContextParametersKt"
 
     override fun generateBody() {
-        generateFunction(listOf("with"), listOf("T"), "R", lambdaWithParams = true)
+        generateSingleFunction(listOf("with"), listOf("T"), "R", lambdaWithParams = true)
         for (i in 2..6) {
             val parameterNames = ('a' .. 'z').take(i)
-            generateFunction(
+            generateSingleFunction(
                 parameterNames.map { it.toString() },
                 parameterNames.map { it.uppercase() },
                 "R",
                 lambdaWithParams = false
             )
-            generateFunction(
+            generateSingleFunction(
                 parameterNames.map { it.toString() },
                 parameterNames.map { it.uppercase() },
                 "R",
@@ -30,7 +30,7 @@ class GenerateContextFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) 
         }
     }
 
-    fun generateFunction(parameterNames: List<String>, parameterTypes: List<String>, resultType: String, lambdaWithParams: Boolean) {
+    fun generateSingleFunction(parameterNames: List<String>, parameterTypes: List<String>, resultType: String, lambdaWithParams: Boolean) {
         val arguments = parameterNames.joinToString()
         val parameters = parameterNames.zip(parameterTypes) { name, type -> "$name: $type" }.joinToString()
         val contextTypes = parameterTypes.joinToString()

--- a/generators/builtins/contextParameters.kt
+++ b/generators/builtins/contextParameters.kt
@@ -53,7 +53,7 @@ public inline fun <$types, $resultType> context($parameters, block: context($typ
 /**
  * Runs the specified [block] with the given $values in context scope and in the $argumentsWord.
  *
- * As opposed to [with], [context] doesn't make the the $values available as implicit $receivers
+ * As opposed to [with], [context] doesn't make the $values available as implicit $receivers
  *
  * @sample samples.misc.ContextParameters.useContext
  */

--- a/generators/builtins/contextParameters.kt
+++ b/generators/builtins/contextParameters.kt
@@ -36,8 +36,7 @@ class GenerateContextFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) 
 /**
  * Runs the specified [block] with the given $values in context scope.
  *
- * As opposed to [with], [context] only makes the $values available for
- * context parameter resolution, but not as implicit $receivers.
+ * As opposed to [with], [context] doesn't make the the $values available as implicit $receivers
  *
  * @sample samples.misc.ContextParameters.useContext
  */
@@ -48,6 +47,24 @@ public inline fun <$types, $resultType> context($parameters, block: context($typ
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
     }
     return block($arguments)
+}
+
+/**
+ * Runs the specified [block] with the given $values in context scope and in the arguments.
+ *
+ * As opposed to [with], [context] doesn't make the the $values available as implicit $receivers
+ *
+ * @sample samples.misc.ContextParameters.useContext
+ */
+@kotlin.internal.InlineOnly
+@SinceKotlin("2.2")
+public inline fun <$types, $resultType> withRoles($parameters, block: context($types) ($types) -> $resultType): $resultType {
+    kotlin.contracts.contract {
+        callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+    }
+    return context($arguments) {
+        block($arguments)
+    }
 }
 """
         )

--- a/generators/builtins/contextParameters.kt
+++ b/generators/builtins/contextParameters.kt
@@ -59,7 +59,7 @@ public inline fun <$types, $resultType> context($parameters, block: context($typ
  */
 @kotlin.internal.InlineOnly
 @SinceKotlin("2.2")
-public inline fun <$types, $resultType> withRoles($parameters, block: context($types) ($types) -> $resultType): $resultType {
+public inline fun <$types, $resultType> context($parameters, block: context($types) ($types) -> $resultType): $resultType {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
     }

--- a/libraries/stdlib/src/kotlin/contextParameters/Context.kt
+++ b/libraries/stdlib/src/kotlin/contextParameters/Context.kt
@@ -12,7 +12,7 @@ package kotlin
 
 
 /**
- * Runs the specified [block] with the given value in context scope.
+ * Runs the specified [block] with the given value in context scope and as lambda argument.
  *
  * As opposed to [with], [context] only makes the value available for
  * context parameter resolution, but not as implicit receiver.
@@ -48,7 +48,7 @@ public inline fun <A, B, R> context(a: A, b: B, block: context(A, B) () -> R): R
 
 
 /**
- * Runs the specified [block] with the given values in context scope.
+ * Runs the specified [block] with the given values in context scope and as lambda arguments.
  *
  * As opposed to [with], [context] only makes the values available for
  * context parameter resolution, but not as implicit receivers.
@@ -86,7 +86,7 @@ public inline fun <A, B, C, R> context(a: A, b: B, c: C, block: context(A, B, C)
 
 
 /**
- * Runs the specified [block] with the given values in context scope.
+ * Runs the specified [block] with the given values in context scope and as lambda arguments.
  *
  * As opposed to [with], [context] only makes the values available for
  * context parameter resolution, but not as implicit receivers.
@@ -124,7 +124,7 @@ public inline fun <A, B, C, D, R> context(a: A, b: B, c: C, d: D, block: context
 
 
 /**
- * Runs the specified [block] with the given values in context scope.
+ * Runs the specified [block] with the given values in context scope and as lambda arguments.
  *
  * As opposed to [with], [context] only makes the values available for
  * context parameter resolution, but not as implicit receivers.
@@ -162,7 +162,7 @@ public inline fun <A, B, C, D, E, R> context(a: A, b: B, c: C, d: D, e: E, block
 
 
 /**
- * Runs the specified [block] with the given values in context scope.
+ * Runs the specified [block] with the given values in context scope and as lambda arguments.
  *
  * As opposed to [with], [context] only makes the values available for
  * context parameter resolution, but not as implicit receivers.
@@ -200,7 +200,7 @@ public inline fun <A, B, C, D, E, F, R> context(a: A, b: B, c: C, d: D, e: E, f:
 
 
 /**
- * Runs the specified [block] with the given values in context scope.
+ * Runs the specified [block] with the given values in context scope and as lambda arguments.
  *
  * As opposed to [with], [context] only makes the values available for
  * context parameter resolution, but not as implicit receivers.

--- a/libraries/stdlib/src/kotlin/contextParameters/Context.kt
+++ b/libraries/stdlib/src/kotlin/contextParameters/Context.kt
@@ -21,11 +21,11 @@ package kotlin
  */
 @kotlin.internal.InlineOnly
 @SinceKotlin("2.2")
-public inline fun <T, R> context(with: T, block: context(T) () -> R): R {
+public inline fun <T, R> context(with: T, block: context(T) (T) -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
     }
-    return block(with)
+    return block(with, with)
 }
 
 
@@ -57,11 +57,51 @@ public inline fun <A, B, R> context(a: A, b: B, block: context(A, B) () -> R): R
  */
 @kotlin.internal.InlineOnly
 @SinceKotlin("2.2")
+public inline fun <A, B, R> context(a: A, b: B, block: context(A, B) (A, B) -> R): R {
+    kotlin.contracts.contract {
+        callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+    }
+    return context(a, b) {
+        block(a, b)
+    }
+}
+
+
+/**
+ * Runs the specified [block] with the given values in context scope.
+ *
+ * As opposed to [with], [context] only makes the values available for
+ * context parameter resolution, but not as implicit receivers.
+ *
+ * @sample samples.misc.ContextParameters.useContext
+ */
+@kotlin.internal.InlineOnly
+@SinceKotlin("2.2")
 public inline fun <A, B, C, R> context(a: A, b: B, c: C, block: context(A, B, C) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
     }
     return block(a, b, c)
+}
+
+
+/**
+ * Runs the specified [block] with the given values in context scope.
+ *
+ * As opposed to [with], [context] only makes the values available for
+ * context parameter resolution, but not as implicit receivers.
+ *
+ * @sample samples.misc.ContextParameters.useContext
+ */
+@kotlin.internal.InlineOnly
+@SinceKotlin("2.2")
+public inline fun <A, B, C, R> context(a: A, b: B, c: C, block: context(A, B, C) (A, B, C) -> R): R {
+    kotlin.contracts.contract {
+        callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+    }
+    return context(a, b, c) {
+        block(a, b, c)
+    }
 }
 
 
@@ -93,6 +133,26 @@ public inline fun <A, B, C, D, R> context(a: A, b: B, c: C, d: D, block: context
  */
 @kotlin.internal.InlineOnly
 @SinceKotlin("2.2")
+public inline fun <A, B, C, D, R> context(a: A, b: B, c: C, d: D, block: context(A, B, C, D) (A, B, C, D) -> R): R {
+    kotlin.contracts.contract {
+        callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+    }
+    return context(a, b, c, d) {
+        block(a, b, c, d)
+    }
+}
+
+
+/**
+ * Runs the specified [block] with the given values in context scope.
+ *
+ * As opposed to [with], [context] only makes the values available for
+ * context parameter resolution, but not as implicit receivers.
+ *
+ * @sample samples.misc.ContextParameters.useContext
+ */
+@kotlin.internal.InlineOnly
+@SinceKotlin("2.2")
 public inline fun <A, B, C, D, E, R> context(a: A, b: B, c: C, d: D, e: E, block: context(A, B, C, D, E) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
@@ -111,10 +171,50 @@ public inline fun <A, B, C, D, E, R> context(a: A, b: B, c: C, d: D, e: E, block
  */
 @kotlin.internal.InlineOnly
 @SinceKotlin("2.2")
+public inline fun <A, B, C, D, E, R> context(a: A, b: B, c: C, d: D, e: E, block: context(A, B, C, D, E) (A, B, C, D, E) -> R): R {
+    kotlin.contracts.contract {
+        callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+    }
+    return context(a, b, c, d, e) {
+        block(a, b, c, d, e)
+    }
+}
+
+
+/**
+ * Runs the specified [block] with the given values in context scope.
+ *
+ * As opposed to [with], [context] only makes the values available for
+ * context parameter resolution, but not as implicit receivers.
+ *
+ * @sample samples.misc.ContextParameters.useContext
+ */
+@kotlin.internal.InlineOnly
+@SinceKotlin("2.2")
 public inline fun <A, B, C, D, E, F, R> context(a: A, b: B, c: C, d: D, e: E, f: F, block: context(A, B, C, D, E, F) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
     }
     return block(a, b, c, d, e, f)
+}
+
+
+/**
+ * Runs the specified [block] with the given values in context scope.
+ *
+ * As opposed to [with], [context] only makes the values available for
+ * context parameter resolution, but not as implicit receivers.
+ *
+ * @sample samples.misc.ContextParameters.useContext
+ */
+@kotlin.internal.InlineOnly
+@SinceKotlin("2.2")
+public inline fun <A, B, C, D, E, F, R> context(a: A, b: B, c: C, d: D, e: E, f: F, block: context(A, B, C, D, E, F) (A, B, C, D, E, F) -> R): R {
+    kotlin.contracts.contract {
+        callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+    }
+    return context(a, b, c, d, e, f) {
+        block(a, b, c, d, e, f)
+    }
 }
 


### PR DESCRIPTION
Update to the UPDATE: I actually dont think contextOf usage as superior, naming should be free because context objects already are guaranteed to have a unique name and the variables would likely be just the lower case version of the class name (also i decided contextOf was better because i thought it worked better with try, but i was wrong, the contextOf call is checked by the compiler and therefore I can write it outside the try). Additionally, while I did get used to it, context of still brings noise and it would be better to avoid it.

In general, I think we won't see the community embrace context params as a convenient way to use the context objects in the lambda, without also leaking objects outside the context. I would rather prefer context had this feature out of the box so the community  use context in that way (without the ceremony and noise of contextOf<>)

UPDATE (old, now invalid): I am not so bullish about the claim that this advances DCI that much. I began embracing contextOf and it avoids naming the variable at all which it is a very ceremonious process. I do think it would be more intuitive and make it sit right in within the Kotlin language, but I am not so bullish about this.

Dear @serras

I would like to make the case that adding extra context functions (that also add arguments to the block lambda) is a good idea that would make this feature feel more natural in the Kotlin language and reduce the ceremony and noise associated with trying to create context scoped context-parameters.

## Possible now, Proposal enables: Ceremony, noise and path of least resistance

```kotlin
fun main() {
    class ContextObject
    
    // Possible now
    val contextObject = ContextObject()
    context(contextObject) {
        // contextObject can be used
    }
    // !!! context Object has leaked outside its scope.

    // Possible now
    context(ContextObject()) {
        val contextObject = contextOf<ContextObject>()
        // contextObject can be used but not without noise and ceremony
    }
    // context object was scoped only to it's context but not without noise and ceremony


    // PROPOSAL enables: (order based resolution)
    context(ContextObject()) {
        contextObject ->
        // contextObject can be used
    }
    // context object was scoped only to it's context.

    // PROPOSAL enables (order based resolution with a clean type check):
    context(ContextObject()) {
        contextObject: ContextObject ->
        // contextObject can be used
    }
    // context object was scoped only to it's context.
}
```
Let's take in consideration that the path of least resistance available is to leak the context, at least if you want to use it inside the lambda directly (without calling another function that requires and names the context).

With the changes proposed, even in this example with a single object, the option that requires less characters (and therefore could be considered the path of least resistance) becomes the one doing `contextObject ->`. It is a clear winner with less character and ceremony and no function calls to contextOf. It feels and acts more integrated to the language.

And while the second option in terms of character count is actually the one that leaks the context, if you were trying to scope the context and already went for the path of least resistance I would argue that at that point it is only natural to add the type safety in the lambda argument. So in this way I would consider `contextObject: ContextObject ->` the next natural choice (despite higher char count to the leaky version).

Ok, that was a very simple example to explain the notions of noise and ceremony and the practices it encourages (leaking objects outside of the scope). 

## DCI example with 2 parameters and an algorithm with 2 sequential contexts

This is a DCI (Data Context Interaction) example in Kotlin:

```kotlin
/** DCI Context (with Infrastructure injected in the constructor) */
class CreateNewUser(private val userRepo: UserRepoEffect, private val crypto: CryptoEffect) {
   // DCI Roles ...

    fun execute(username: String, password: ByteArray): CreateUserResult {
        val hashedPassword = context(NewUsername(username), NewPassword(password)) {
         // newUserName, newPassword ->
            newUserName: NewUsername, newPassword: NewPassword ->
         // val newUserName: context<NewUsername>(); val newPassword: contextOf<NewPassword>();
            try {
                newUserName.validate().onFailureHalt { return it }
                newPassword.validate().onFailureHalt { return it }
                val byteArray = newPassword.`to secure password hash`()
                byteArray
            }
            finally { `wipe sensitive password data`() }
        }
        context(NewUsername(username), EncryptedPassword(hashedPassword)) {// uses the existing context call
            try { userRepo.`persist new user`() }
            finally { `wipe sensitive encripted password data`() }
        }
        return Success
    }
   // ...
}
```

Right now we are limited to the noisiest option. Even with two objects, it is starting to add a lot of clutter. One way to avoid the contextOf calls and that noise, is to create additional functions for each stage.

However, we have lost the big picture, the clarity. We can not longer see the complete algorithm across multiple contexts:

```kotlin
    fun execute(username: String, password: ByteArray): CreateUserResult {
       // Clean but, I have lost the global picture, I now have to hunt down different functions 
       // and piece the process together in my head, rather than having it directly in the code.
        val hashedPassword = this.`Interaction - validate and hash password`()
        this.`Interaction - persist user()
        return Success
    }
```

I know perhaps there is a strict budget of how many functions we want to generate, and we may be tempted to implement the minimum and let library authors write layers on top. However, I truly think that the ability to name the context arguments in the lambda feels very natural and something that should truly be supported at a language level.

What do you think?

PS: The proposal is to add and not to replace existing functions because that would force functions that do not need these lambda arguments to declare them adding a tiny bit of ceremony but to those who don't really need any and already don't have any.

If the existing context calls were replaced by the proposal ones then _, _ -> becomes necessary for as many objects as you inject:
```kotlin
        withRoles(NewUsername(username), EncryptedPassword(hashedPassword)) { _, _ ->
            try { userRepo.`persist new user`() }
            finally { `wipe sensitive encripted password data`() }
        }
```
Also I don't know if that is even technically possible since the new generated functions with arguments rely on the argument-less to do their job.