### PR TITLE
KT-53034: Call System.gc() before running memory-consuming external processes

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BitcodeCompiler.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BitcodeCompiler.kt
@@ -79,9 +79,11 @@ internal class BitcodeCompiler(
     /**
      * Compile [bitcodeFile] to [objectFile].
      */
-    fun makeObjectFile(bitcodeFile: File, objectFile: File) =
-            when (val configurables = platform.configurables) {
-                is ClangFlags -> clang(configurables, bitcodeFile, objectFile)
-                else -> error("Unsupported configurables kind: ${configurables::class.simpleName}!")
-            }
+    fun makeObjectFile(bitcodeFile: File, objectFile: File) {
+        System.gc() // Release memory before spawning clang++
+        when (val configurables = platform.configurables) {
+            is ClangFlags -> clang(configurables, bitcodeFile, objectFile)
+            else -> error("Unsupported configurables kind: ${configurables::class.simpleName}!")
+        }
+    }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
@@ -158,6 +158,7 @@ internal class Linker(
 }
 
 internal fun runLinkerCommands(context: NativeBackendPhaseContext, commands: List<Command>, cachingInvolved: Boolean) = try {
+    System.gc() // Release memory before spawning linker
     commands.forEach {
         it.logWith(context::log)
         it.execute()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterCompile.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterCompile.kt
@@ -19,5 +19,6 @@ fun produceCAdapterBitcode(clang: ClangArgs, cppFile: File, bitcodeFile: File) {
             "-emit-llvm", "-c",
             "-o", bitcodeFile.absoluteFile.normalize().path
     )
+    System.gc() // Release memory before spawning clang++
     Command(clangCommand).execute()
 }


### PR DESCRIPTION
YouTrack link: https://youtrack.jetbrains.com/issue/KT-53034/Native-call-System.gc-before-running-clang-and-other-memory-consuming-processes-from-the-compiler

Call System.gc() before invoking clang++ and linker to release unused JVM heap memory, reducing memory pressure for these external tools.

The Kotlin/Native compiler calls external tools (clang++, ld) with large inputs. These tools require significant memory. By triggering garbage collection before spawning them, we free up system memory that would otherwise be held by unused JVM objects.