### PR TITLE
KT-61855: Respect -Xtemporary-files-dir for PCH and temp files

### DIFF
--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -16,8 +16,6 @@
 
 package org.jetbrains.kotlin.native.interop.indexer
 
-import java.io.File
-
 enum class Language(val sourceFileExtension: String, val clangLanguageName: String) {
     C("c", "c"),
     CPP("cpp", "c++"),
@@ -58,7 +56,6 @@ interface Compilation {
     val additionalPreambleLines: List<String>
     val compilerArgs: List<String>
     val language: Language
-    val temporaryFilesDir: File?
 }
 
 fun defaultCompilerArgs(language: Language): List<String> =
@@ -92,10 +89,9 @@ fun defaultCompilerArgs(language: Language): List<String> =
 data class CompilationWithPCH(
         override val compilerArgs: List<String>,
         override val language: Language,
-        override val temporaryFilesDir: File? = null
 ) : Compilation {
-    constructor(compilerArgs: List<String>, precompiledHeader: String, language: Language, temporaryFilesDir: File? = null)
-            : this(compilerArgs + listOf("-include-pch", precompiledHeader), language, temporaryFilesDir)
+    constructor(compilerArgs: List<String>, precompiledHeader: String, language: Language)
+            : this(compilerArgs + listOf("-include-pch", precompiledHeader), language)
 
     override val includes: List<IncludeInfo>
         get() = emptyList()
@@ -121,7 +117,6 @@ data class NativeLibrary(
         val headerFilter: NativeLibraryHeaderFilter,
         val objCClassesIncludingCategories: Set<String>,
         val allowIncludingObjCCategoriesFromDefFile: Boolean,
-        override val temporaryFilesDir: File? = null,
 ) : Compilation
 
 data class IndexerResult(val index: NativeIndex, val compilation: Compilation)
@@ -129,7 +124,7 @@ data class IndexerResult(val index: NativeIndex, val compilation: Compilation)
 /**
  * Retrieves the definitions from given C header file using given compiler arguments (e.g. defines).
  */
-fun buildNativeIndex(library: NativeLibrary, verbose: Boolean, allowPrecompiledHeaders: Boolean = true): IndexerResult = buildNativeIndexImpl(library, verbose, allowPrecompiledHeaders)
+fun buildNativeIndex(library: NativeLibrary, verbose: Boolean, allowPrecompiledHeaders: Boolean = true, temporaryFilesDir: java.io.File? = null): IndexerResult = buildNativeIndexImpl(library, verbose, allowPrecompiledHeaders, temporaryFilesDir)
 
 /**
  * This class describes the IR of definitions from C header file(s).

--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -16,6 +16,8 @@
 
 package org.jetbrains.kotlin.native.interop.indexer
 
+import java.io.File
+
 enum class Language(val sourceFileExtension: String, val clangLanguageName: String) {
     C("c", "c"),
     CPP("cpp", "c++"),
@@ -56,6 +58,7 @@ interface Compilation {
     val additionalPreambleLines: List<String>
     val compilerArgs: List<String>
     val language: Language
+    val temporaryFilesDir: File?
 }
 
 fun defaultCompilerArgs(language: Language): List<String> =
@@ -88,10 +91,11 @@ fun defaultCompilerArgs(language: Language): List<String> =
 
 data class CompilationWithPCH(
         override val compilerArgs: List<String>,
-        override val language: Language
+        override val language: Language,
+        override val temporaryFilesDir: File? = null
 ) : Compilation {
-    constructor(compilerArgs: List<String>, precompiledHeader: String, language: Language)
-            : this(compilerArgs + listOf("-include-pch", precompiledHeader), language)
+    constructor(compilerArgs: List<String>, precompiledHeader: String, language: Language, temporaryFilesDir: File? = null)
+            : this(compilerArgs + listOf("-include-pch", precompiledHeader), language, temporaryFilesDir)
 
     override val includes: List<IncludeInfo>
         get() = emptyList()
@@ -117,6 +121,7 @@ data class NativeLibrary(
         val headerFilter: NativeLibraryHeaderFilter,
         val objCClassesIncludingCategories: Set<String>,
         val allowIncludingObjCCategoriesFromDefFile: Boolean,
+        override val temporaryFilesDir: File? = null,
 ) : Compilation
 
 data class IndexerResult(val index: NativeIndex, val compilation: Compilation)

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGeneratorImpl.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGeneratorImpl.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.native.interop.indexer.CompilationWithPCH
 import org.jetbrains.kotlin.native.interop.indexer.Language
 import org.jetbrains.kotlin.native.interop.indexer.mapFragmentIsCompilable
 import org.jetbrains.kotlin.native.interop.indexer.precompileHeaders
+import java.io.File
 
 internal val INVALID_CLANG_IDENTIFIER_REGEX = "[^a-zA-Z1-9_]".toRegex()
 
@@ -31,7 +32,8 @@ class SimpleBridgeGeneratorImpl(
         private val jvmFileClassName: String,
         private val libraryForCStubs: Compilation,
         override val topLevelNativeScope: NativeScope,
-        private val topLevelKotlinScope: KotlinScope
+        private val topLevelKotlinScope: KotlinScope,
+        private val temporaryFilesDir: File? = null,
 ) : SimpleBridgeGenerator {
 
     private var nextUniqueId = 0
@@ -224,7 +226,7 @@ class SimpleBridgeGeneratorImpl(
         val includedBridges = mutableListOf<NativeBridge>()
         val excludedClients = mutableSetOf<NativeBacked>()
 
-        val libraryWithPCH = if (libraryForCStubs is CompilationWithPCH) libraryForCStubs else libraryForCStubs.precompileHeaders()
+        val libraryWithPCH = if (libraryForCStubs is CompilationWithPCH) libraryForCStubs else libraryForCStubs.precompileHeaders(temporaryFilesDir)
 
         nativeBridges.map { it.second.nativeLines }
                 .mapFragmentIsCompilable(libraryWithPCH)

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrBridgeBuilder.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrBridgeBuilder.kt
@@ -59,7 +59,8 @@ class StubIrBridgeBuilder(
                         override val mappingBridgeGenerator: MappingBridgeGenerator
                             get() = this@StubIrBridgeBuilder.mappingBridgeGenerator
                     },
-                    topLevelKotlinScope = kotlinFile
+                    topLevelKotlinScope = kotlinFile,
+                    temporaryFilesDir = context.temporaryFilesDir,
             )
 
     private val mappingBridgeGenerator: MappingBridgeGenerator =

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrDriver.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrDriver.kt
@@ -26,6 +26,7 @@ class StubIrContext(
         val libName: String,
         val allowPrecompiledHeaders: Boolean,
         val metadataVersion: KlibMetadataVersion,
+        val temporaryFilesDir: File? = null,
 ) {
     val libraryForCStubs = configuration.library.copy(
             includes = mutableListOf<IncludeInfo>().apply {
@@ -46,7 +47,7 @@ class StubIrContext(
                         Language.OBJECTIVE_C -> listOf("void objc_terminate();")
                     }
     ).let {
-        if (allowPrecompiledHeaders) it.precompileHeaders() else it
+        if (allowPrecompiledHeaders) it.precompileHeaders(temporaryFilesDir) else it
     }
 
     // TODO: Used only for JVM.

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -599,11 +599,14 @@ internal fun buildNativeLibrary(
         "#define $it \"$it\""
     }
 
+    val temporaryFilesDir = arguments.tempDir?.let { File(it) }
+
     val compilation = CompilationImpl(
             includes = headerFiles.map { IncludeInfo(it, null) },
             additionalPreambleLines = def.defHeaderLines + predefinedMacrosRedefinitions,
             compilerArgs = defaultCompilerArgs(language) + compilerOpts + tool.platformCompilerOpts,
-            language = language
+            language = language,
+            temporaryFilesDir = temporaryFilesDir
     )
 
     val headerFilter: NativeLibraryHeaderFilter
@@ -648,6 +651,7 @@ internal fun buildNativeLibrary(
             headerFilter = headerFilter,
             objCClassesIncludingCategories = objCClassesIncludingCategories,
             allowIncludingObjCCategoriesFromDefFile = def.config.allowIncludingObjCCategoriesFromDefFile,
+            temporaryFilesDir = temporaryFilesDir,
     )
 }
 


### PR DESCRIPTION
Previously, cinterop created .pch files and other temporary files in the system's default temp directory regardless of the `-Xtemporary-files-dir` flag. This made verbose output non-reproducible since the files were marked with deleteOnExit() and removed when the JVM exited.

Now all temporary files (precompiled headers, source files, diagnostics) are created in the user-specified directory when `-Xtemporary-files-dir` is provided, and only use deleteOnExit() when using the system default.