### PR TITLE
Refactor: apply formatting to `eachCount` in `GroupingJVM`

### DIFF
--- a/libraries/stdlib/jvm/src/kotlin/collections/GroupingJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/GroupingJVM.kt
@@ -19,9 +19,10 @@ package kotlin.collections
 @SinceKotlin("1.1")
 public actual fun <T, K> Grouping<T, K>.eachCount(): Map<K, Int> =
 // fold(0) { acc, e -> acc + 1 } optimized for boxing
-    foldTo(destination = mutableMapOf(),
-           initialValueSelector = { _, _ -> kotlin.jvm.internal.Ref.IntRef() },
-           operation = { _, acc, _ -> acc.apply { element += 1 } })
+    foldTo(
+        destination = mutableMapOf(),
+        initialValueSelector = { _, _ -> kotlin.jvm.internal.Ref.IntRef() },
+        operation = { _, acc, _ -> acc.apply { element += 1 } })
         .mapValuesInPlace { it.value.element }
 
 /*

--- a/libraries/stdlib/jvm/src/kotlin/collections/GroupingJVM.kt
+++ b/libraries/stdlib/jvm/src/kotlin/collections/GroupingJVM.kt
@@ -18,12 +18,12 @@ package kotlin.collections
  */
 @SinceKotlin("1.1")
 public actual fun <T, K> Grouping<T, K>.eachCount(): Map<K, Int> =
-// fold(0) { acc, e -> acc + 1 } optimized for boxing
+    // fold(0) { acc, e -> acc + 1 } optimized for boxing
     foldTo(
         destination = mutableMapOf(),
         initialValueSelector = { _, _ -> kotlin.jvm.internal.Ref.IntRef() },
-        operation = { _, acc, _ -> acc.apply { element += 1 } })
-        .mapValuesInPlace { it.value.element }
+        operation = { _, acc, _ -> acc.apply { element += 1 } }
+    ).mapValuesInPlace { it.value.element }
 
 /*
 /**


### PR DESCRIPTION
Only a very minor refactoring was done in this PR and, according to common code convention, all parameters were placed on a new line (in line with the codebase).