### PR TITLE
add missing contract to `StandaloneAnalysisAPISessionBuilder.buildKtModuleProvider`

### DIFF
--- a/analysis/analysis-api-standalone/src/org/jetbrains/kotlin/analysis/api/standalone/StandaloneAnalysisAPISessionBuilder.kt
+++ b/analysis/analysis-api-standalone/src/org/jetbrains/kotlin/analysis/api/standalone/StandaloneAnalysisAPISessionBuilder.kt
@@ -95,7 +95,11 @@ public class StandaloneAnalysisAPISessionBuilder(
 
     private lateinit var projectStructureProvider: KotlinStaticProjectStructureProvider
 
+    @OptIn(ExperimentalContracts::class)
     public fun buildKtModuleProvider(init: KtModuleProviderBuilder.() -> Unit) {
+        contract {
+            callsInPlace(init, InvocationKind.EXACTLY_ONCE)
+        }
         projectStructureProvider = buildProjectStructureProvider(kotlinCoreProjectEnvironment.environment, project, init)
     }
 


### PR DESCRIPTION
`buildStandaloneAnalysisAPISession` (The way to get an instance of `StandaloneAnalysisAPISessionBuilder`) has contract and the function that `StandaloneAnalysisAPISessionBuilder.buildKtModuleProvider` delegates its job also has the contract so it have sense to add the contract to `buildKtModuleProvider` too.

## Context
I'm working on detekt and this will allow us to change a `lateinit var` to a `val`.