### PR TITLE
[K/N] Make the full build of a CustomBitSet lazy

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/CustomBitSet.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/CustomBitSet.kt
@@ -5,6 +5,11 @@
 
 package org.jetbrains.kotlin.backend.konan.util
 
+import it.unimi.dsi.fastutil.ints.IntArraySet
+import it.unimi.dsi.fastutil.ints.IntSet
+
+const val LAZY_CONVERSION_THRESHOLD = 8
+
 /**
  * Provides some bulk operations needed for devirtualization
  */
@@ -12,13 +17,23 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     var size = size
         private set
     private var data = data
+    private var lazy: IntSet? = null
 
-    constructor() : this(0, EMPTY)
+    constructor() : this(0, EMPTY) {
+        lazy = IntArraySet(LAZY_CONVERSION_THRESHOLD)
+    }
 
     constructor(nodesCount: Int) : this(0, LongArray((nodesCount shr 6) + 1))
 
+    private fun buildFromLazy() {
+        val lazy = lazy ?: return
+        this.lazy = null
+        if (lazy.isNotEmpty()) ensureCapacity(lazy.max() ushr 6)
+        lazy.forEach(::set)
+    }
+
     private fun ensureCapacity(index: Int) {
-        if (data.size <= index) {
+        if (lazy == null && data.size <= index) {
             val oldData = data
             data = LongArray((oldData.size * 2).coerceAtLeast(index + 1))
             oldData.copyInto(data)
@@ -27,6 +42,12 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun set(bitIndex: Int) {
+        lazy?.let { lazy ->
+            size = size.coerceAtLeast(bitIndex.ushr(6) + 1)
+            lazy.add(bitIndex)
+            if (lazy.size == LAZY_CONVERSION_THRESHOLD) buildFromLazy()
+            return
+        }
         val index = bitIndex shr 6
         val offset = bitIndex and 0x3f
         ensureCapacity(index)
@@ -34,13 +55,22 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun clear(bitIndex: Int) {
+        lazy?.let { lazy ->
+            lazy.remove(bitIndex)
+            size = if (lazy.isNotEmpty()) lazy.max().ushr(6) + 1 else 0
+            return
+        }
         val index = bitIndex shr 6
         val offset = bitIndex and 0x3f
         ensureCapacity(index)
         data[index] = data[index] and (1L shl offset).inv()
+        while (size > 0 && data[size - 1] == 0L) size--
     }
 
     operator fun get(bitIndex: Int): Boolean {
+        lazy?.let { lazy ->
+            return bitIndex in lazy
+        }
         val index = bitIndex shr 6
         val offset = bitIndex and 0x3f
         return index < size && (data[index] and (1L shl offset)) != 0L
@@ -55,6 +85,9 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun cardinality(): Int {
+        lazy?.let { lazy ->
+            return lazy.size
+        }
         var cardinality = 0
         for (i in 0 until size) {
             cardinality += data[i].countOneBits()
@@ -63,6 +96,10 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     inline fun forEachBit(block: (Int) -> Unit) {
+        lazy?.let { lazy ->
+            lazy.forEach(block)
+            return
+        }
         for (index in 0 until size) {
             var d = data[index]
             val idx = index shl 6
@@ -75,16 +112,26 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     inline fun forEachWord(block: (Long) -> Unit) {
+        buildFromLazy()
         for (i in 0..<size)
             block(data[i])
     }
 
     fun clear() {
-        data.fill(0L)
         size = 0
+        lazy?.let { lazy ->
+            lazy.clear()
+            return
+        }
+        data.fill(0L)
     }
 
     fun or(another: CustomBitSet) {
+        another.lazy?.let { alazy ->
+            alazy.forEach { set(it) }
+            return
+        }
+        buildFromLazy()
         val adata = another.data
         val asize = another.size
         ensureCapacity(asize - 1)
@@ -94,6 +141,15 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun orWithFilterHasChanged(another: CustomBitSet): Boolean {
+        another.lazy?.let { alazy ->
+            var changed = false
+            alazy.forEach {
+                changed = changed or !get(it)
+                set(it)
+            }
+            return changed
+        }
+        buildFromLazy()
         val adata = another.data
         val asize = another.size
         ensureCapacity(asize - 1)
@@ -109,6 +165,27 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
 
 
     fun orWithFilterHasChanged(another: CustomBitSet, filter: CustomBitSet): Boolean {
+        another.lazy?.let { alazy ->
+            var changed = false
+            alazy.forEach {
+                if (filter[it]) {
+                    changed = changed or !get(it)
+                    set(it)
+                }
+            }
+            return changed
+        }
+        buildFromLazy()
+        filter.lazy?.let { flazy ->
+            var changed = false
+            flazy.forEach { bit ->
+                if (!this[bit] && another[bit]) {
+                    changed = true
+                    set(bit)
+                }
+            }
+            return changed
+        }
         val fdata = filter.data
         val fsize = filter.size
         val adata = another.data
@@ -128,6 +205,21 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun and(another: CustomBitSet) {
+        lazy?.let { lazy ->
+            lazy.retainAll { another[it] }
+            return
+        }
+        another.lazy?.let { alazy ->
+            val newLazy = IntArraySet(LAZY_CONVERSION_THRESHOLD)
+            alazy.forEach { bit ->
+                if (this[bit]) {
+                    newLazy.add(bit)
+                }
+            }
+            lazy = newLazy
+            data = EMPTY
+            return
+        }
         val adata = another.data
         val asize = another.size
         ensureCapacity(asize - 1)
@@ -140,6 +232,14 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun andNot(another: CustomBitSet) {
+        lazy?.let { lazy ->
+            lazy.retainAll { !another[it] }
+            return
+        }
+        another.lazy?.let { alazy ->
+            alazy.forEach { clear(it) }
+            return
+        }
         val adata = another.data
         val asize = another.size
         ensureCapacity(asize - 1)
@@ -149,6 +249,12 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun intersects(another: CustomBitSet): Boolean {
+        lazy?.let { lazy ->
+            return lazy.any { another[it] }
+        }
+        another.lazy?.let { alazy ->
+            return alazy.any { this[it] }
+        }
         val adata = another.data
         val minSize = kotlin.math.min(size, another.size)
         for (i in 0..<minSize) {
@@ -159,6 +265,15 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     operator fun contains(another: CustomBitSet): Boolean {
+        lazy?.let { lazy ->
+            another.forEachBit {
+                if (it !in lazy) return false
+            }
+            return true
+        }
+        another.lazy?.let { alazy ->
+            return alazy.all { this[it] }
+        }
         // Check if [another] is a subset of [this]
         val adata = another.data
         val asize = another.size
@@ -175,11 +290,18 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
     }
 
     fun copy(): CustomBitSet {
+        lazy?.let { lazy ->
+            val res = CustomBitSet()
+            res.size = this.size
+            res.lazy!!.addAll(lazy)
+            return res
+        }
         return CustomBitSet(size, data.copyOf())
     }
 
     val isEmpty
         get(): Boolean {
+            lazy?.let { return it.isEmpty() }
             for (i in 0 until size) {
                 if (data[i] != 0L) return false
             }
@@ -188,12 +310,19 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
 
     override fun hashCode(): Int {
         val h = hashCodeLong()
-        return ((h shr 32) xor h).toInt()
+        return ((h ushr 32) xor h).toInt()
     }
 
     override fun equals(other: Any?): Boolean {
         if (other !is CustomBitSet) return false
         if (size != other.size) return false
+        if (lazy != null || other.lazy != null) {
+            if (cardinality() != other.cardinality()) return false
+            forEachBit {
+                if (!other[it]) return false
+            }
+            return true
+        }
 
         for (i in 0 until size) {
             if (data[i] != other.data[i]) return false
@@ -204,9 +333,16 @@ internal class CustomBitSet private constructor(size: Int, data: LongArray) {
 
     fun hashCodeLong(): Long {
         var h = 1234L
-
+        lazy?.let { lazy ->
+            lazy.forEach { bit ->
+                val i = bit ushr 6
+                val datai = 1L shl (bit and 63)
+                h += datai * (i + 1)
+            }
+            return h
+        }
         for (i in size - 1 downTo 0) {
-            h = h xor (data[i] * (i + 1))
+            h += data[i] * (i + 1)
         }
 
         return h

--- a/prepare/compiler/compiler.pro
+++ b/prepare/compiler/compiler.pro
@@ -401,6 +401,12 @@
     public java.lang.Object computeIfAbsent(java.lang.Object, it.unimi.dsi.fastutil.objects.Object2ObjectFunction);
 }
 
+# IntArraySet(int) is called from K/N backend (CustomBitSet), which is not part of the ProGuard
+# input, so ProGuard cannot see the call and would otherwise strip this constructor.
+-keep class it.unimi.dsi.fastutil.ints.IntArraySet {
+    public <init>(int);
+}
+
 -dontwarn kotlinx.coroutines.internal.intellij.IntellijCoroutines
 
 -dontwarn org.jetbrains.kotlin.buildtools.internal.cri.**


### PR DESCRIPTION
This changes the representation of CustomBitSet to initially be an explicit list of set bits, until the cardinality grows beyond a fixed size. This saves a lot of memory, since many of the use cases of CustomBitSet are sparse.