### PR TITLE
[K/N] Rework static StaticInitializersLowering

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrUtils.kt
@@ -51,23 +51,6 @@ internal val IrClass.isArrayWithFixedSizeItems: Boolean
 
 fun IrClass.isAbstract() = this.modality == Modality.SEALED || this.modality == Modality.ABSTRACT
 
-private fun IrStatement.isConst(): Boolean = when (this) {
-    is IrConst, is IrConstantValue -> true
-    is IrBlock -> {
-        if (statements.isEmpty())
-            true
-        else {
-            // This might happen after the local declarations lowering where local declarations are replaced with an empty composite.
-            statements.take(statements.size - 1).all { it is IrComposite && it.statements.isEmpty() }
-                    && statements.last().isConst()
-        }
-    }
-    else -> false
-}
-
-internal val IrField.hasNonConstInitializer: Boolean
-    get() = initializer?.expression?.isConst() == false
-
 private enum class TypeKind {
     ABSENT,
     VOID,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -242,16 +242,14 @@ internal interface ContextUtils : RuntimeAware {
 internal fun stringAsBytes(str: String) = str.toByteArray(Charsets.UTF_8)
 
 internal class ScopeInitializersGenerationState {
-    val topLevelFields = mutableListOf<IrField>()
-    var globalInitFunction: IrSimpleFunction? = null
     var globalInitState: LLVMValueRef? = null
-    var threadLocalInitFunction: IrSimpleFunction? = null
     var threadLocalInitState: AddressAccess? = null
-    val globalSharedObjects = mutableSetOf<LLVMValueRef>()
-    fun isEmpty() = topLevelFields.isEmpty() &&
+    var globalEagerInitFunction: LlvmCallable? = null
+    var threadLocalEagerInitFunction: LlvmCallable? = null
+    fun isEmpty() = globalEagerInitFunction == null &&
+            threadLocalEagerInitFunction == null &&
             globalInitState == null &&
-            threadLocalInitState == null &&
-            globalSharedObjects.isEmpty()
+            threadLocalInitState == null
 }
 
 internal class InitializersGenerationState {
@@ -423,7 +421,7 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
 
     val allocInstanceFunction = importRtFunction("AllocInstance", true)
     val allocArrayFunction = importRtFunction("AllocArrayInstance", true)
-    val initAndRegisterGlobalFunction = importRtFunction("InitAndRegisterGlobal", false)
+    val registerGlobalFunction = importRtFunction("RegisterGlobal", false)
     val updateHeapRefFunction = importRtFunction("UpdateHeapRef", false)
     val updateStackRefFunction = importRtFunction("UpdateStackRef", false)
     val updateReturnRefFunction = importRtFunction("UpdateReturnRef", false)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -26,11 +26,9 @@ import org.jetbrains.kotlin.ir.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.objcinterop.*
-import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.isNullable
-import org.jetbrains.kotlin.ir.util.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
@@ -84,11 +82,6 @@ internal val IrField.storageKind: FieldStorageKind
             else -> FieldStorageKind.GLOBAL
         }
     }
-
-internal val IrField.needsGCRegistration
-    get() = type.binaryTypeIsReference() && // only for references
-                (hasNonConstInitializer || // which are initialized from heap object
-                        !isFinal) // or are not final
 
 
 internal fun IrSimpleFunction.shouldGenerateBody(): Boolean = modality != Modality.ABSTRACT && !isExternal
@@ -332,68 +325,11 @@ internal class CodeGeneratorVisitor(
         CAdapterCodegen(codegen, generationState).buildAllAdaptersRecursively(elements)
     }
 
-    private fun FunctionGenerationContext.initThreadLocalField(irField: IrField) {
-        val initializer = irField.initializer ?: return
-        val address = staticFieldPtr(irField, this)
-        storeAny(evaluateExpression(initializer.expression), address, irField.type.binaryTypeIsReference(), false)
-    }
-
-    private fun FunctionGenerationContext.initGlobalField(irField: IrField) {
-        val address = staticFieldPtr(irField, this)
-        val initialValue = if (irField.hasNonConstInitializer) {
-            evaluateExpression(irField.initializer!!.expression)
-        } else {
-            null
-        }
-        if (irField.needsGCRegistration) {
-            call(llvm.initAndRegisterGlobalFunction, listOf(address, initialValue ?: llvm.kNull))
-        } else if (initialValue != null) {
-            storeAny(initialValue, address, irField.type.binaryTypeIsReference(), false)
-        }
-    }
-
-    private fun buildInitializerFunctions(scopeState: ScopeInitializersGenerationState) {
-        scopeState.globalInitFunction?.let { fileInitFunction ->
-            generateFunction(codegen, fileInitFunction, fileInitFunction.location(start = true), fileInitFunction.location(start = false)) {
-                using(FunctionScope(fileInitFunction, this)) {
-                    val parameterScope = ParameterScope(fileInitFunction, functionGenerationContext)
-                    using(parameterScope) usingParameterScope@{
-                        using(VariableScope()) usingVariableScope@{
-                            scopeState.topLevelFields
-                                    .filter { it.storageKind != FieldStorageKind.THREAD_LOCAL }
-                                    .filterNot { context.shouldBeInitializedEagerly(it) }
-                                    .forEach { initGlobalField(it) }
-                            ret(null)
-                        }
-                    }
-                }
-            }
-        }
-
-        scopeState.threadLocalInitFunction?.let { fileInitFunction ->
-            generateFunction(codegen, fileInitFunction, fileInitFunction.location(start = true), fileInitFunction.location(start = false)) {
-                using(FunctionScope(fileInitFunction, this)) {
-                    val parameterScope = ParameterScope(fileInitFunction, functionGenerationContext)
-                    using(parameterScope) usingParameterScope@{
-                        using(VariableScope()) usingVariableScope@{
-                            scopeState.topLevelFields
-                                    .filter { it.storageKind == FieldStorageKind.THREAD_LOCAL }
-                                    .filterNot { context.shouldBeInitializedEagerly(it) }
-                                    .forEach { initThreadLocalField(it) }
-                            ret(null)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     private fun runAndProcessInitializers(konanLibrary: KotlinLibrary?, f: () -> Unit) {
         val oldScopeState = llvm.initializersGenerationState.reset(ScopeInitializersGenerationState())
         f()
         val scopeState = llvm.initializersGenerationState.reset(oldScopeState)
         scopeState.takeIf { !it.isEmpty() }?.let {
-            buildInitializerFunctions(it)
             val runtimeInitializer = createInitBody(it)
             llvm.irStaticInitializers.add(IrStaticInitializer(konanLibrary, runtimeInitializer))
         }
@@ -465,18 +401,12 @@ internal class CodeGeneratorVisitor(
 
                 // Globals initializers may contain accesses to objects, so visit them first.
                 appendingTo(bbInit) {
-                    state.topLevelFields
-                            .filter { context.shouldBeInitializedEagerly(it) }
-                            .filterNot { it.storageKind == FieldStorageKind.THREAD_LOCAL }
-                            .forEach { initGlobalField(it) }
+                    state.globalEagerInitFunction?.let { call(it, listOf(), exceptionHandler = ExceptionHandler.Caller) }
                     ret(null)
                 }
 
                 appendingTo(bbLocalInit) {
-                    state.topLevelFields
-                            .filter { context.shouldBeInitializedEagerly(it) }
-                            .filter { it.storageKind == FieldStorageKind.THREAD_LOCAL }
-                            .forEach { initThreadLocalField(it) }
+                    state.threadLocalEagerInitFunction?.let { call(it, listOf(), exceptionHandler = ExceptionHandler.Caller) }
                     ret(null)
                 }
 
@@ -767,30 +697,38 @@ internal class CodeGeneratorVisitor(
         return
     }
 
+    fun handleStaticInitializer(declaration: IrSimpleFunction) {
+        val scopeState = llvm.initializersGenerationState.scopeState
+        when (declaration.origin) {
+            StaticInitializersOrigins.STATIC_GLOBAL_INITIALIZER -> {
+                require(scopeState.globalInitState == null) { "There can only be at most one global file initializer" }
+                scopeState.globalInitState = getGlobalInitStateFor(declaration.parent as IrDeclarationContainer)
+            }
+            StaticInitializersOrigins.STATIC_THREAD_LOCAL_INITIALIZER, StaticInitializersOrigins.STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER -> {
+                require(scopeState.threadLocalInitState == null) { "There can only be at most one thread local file initializer" }
+                scopeState.threadLocalInitState = getThreadLocalInitStateFor(declaration.parent as IrDeclarationContainer)
+            }
+            StaticInitializersOrigins.EAGER_STATIC_GLOBAL_INITIALIZER -> {
+                require(scopeState.globalEagerInitFunction == null) { "There can only be at most one global eager file initializer" }
+                scopeState.globalEagerInitFunction = codegen.llvmFunction(declaration)
+            }
+            StaticInitializersOrigins.EAGER_STATIC_THREAD_LOCAL_INITIALIZER -> {
+                require(scopeState.threadLocalEagerInitFunction == null) { "There can only be at most one thread local eager file initializer" }
+                scopeState.threadLocalEagerInitFunction = codegen.llvmFunction(declaration)
+            }
+            else -> return
+        }
+        require(declaration.hasShape()) { "Static initializer must be parameterless" }
+        require(declaration.returnsUnit()) { "Static initializer must return Unit" }
+    }
+
     override fun visitSimpleFunction(declaration: IrSimpleFunction) {
         context.log{"visitFunction                  : ${ir2string(declaration)}"}
 
         if (declaration.isOverridable && declaration.origin !is DECLARATION_ORIGIN_BRIDGE_METHOD)
             buildVirtualFunctionTrampoline(declaration)
 
-        val scopeState = llvm.initializersGenerationState.scopeState
-        if (declaration.origin == DECLARATION_ORIGIN_STATIC_GLOBAL_INITIALIZER) {
-            require(scopeState.globalInitFunction == null) { "There can only be at most one global file initializer" }
-            require(declaration.body == null) { "The body of file initializer should be null" }
-            require(declaration.hasShape()) { "File initializer must be parameterless" }
-            require(declaration.returnsUnit()) { "File initializer must return Unit" }
-            scopeState.globalInitFunction = declaration
-            scopeState.globalInitState = getGlobalInitStateFor(declaration.parent as IrDeclarationContainer)
-        }
-        if (declaration.origin == DECLARATION_ORIGIN_STATIC_THREAD_LOCAL_INITIALIZER
-                || declaration.origin == DECLARATION_ORIGIN_STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER) {
-            require(scopeState.threadLocalInitFunction == null) { "There can only be at most one thread local file initializer" }
-            require(declaration.body == null) { "The body of file initializer should be null" }
-            require(declaration.hasShape()) { "File initializer must be parameterless" }
-            require(declaration.returnsUnit()) { "File initializer must return Unit" }
-            scopeState.threadLocalInitFunction = declaration
-            scopeState.threadLocalInitState = getThreadLocalInitStateFor(declaration.parent as IrDeclarationContainer)
-        }
+        handleStaticInitializer(declaration)
 
         if (!declaration.shouldGenerateBody())
             return
@@ -870,30 +808,19 @@ internal class CodeGeneratorVisitor(
         declaration.backingField?.acceptVoid(this)
     }
 
-    private fun needGlobalInit(field: IrField): Boolean {
-        if (field.parent !is IrPackageFragment) return field.isStatic
-        // TODO: add some smartness here. Maybe if package of the field is in never accessed
-        // assume its global init can be actually omitted.
-        return true
-    }
-
     override fun visitField(declaration: IrField) {
         context.log{"visitField                     : ${ir2string(declaration)}"}
         debugFieldDeclaration(declaration)
-        if (needGlobalInit(declaration)) {
+        if (declaration.isStatic) {
             val type = declaration.type.toLLVMType(llvm)
             val globalPropertyAccess = generationState.llvmDeclarations.forStaticField(declaration).storageAddressAccess
             val initializer = declaration.initializer?.expression
             val globalProperty = (globalPropertyAccess as? GlobalAddressAccess)?.getAddress(null)
             if (globalProperty != null) {
-                LLVMSetInitializer(globalProperty, when {
-                    initializer == null || declaration.hasNonConstInitializer -> LLVMConstNull(type)
-                    else -> evaluateExpression(initializer)
-                })
+                LLVMSetInitializer(globalProperty, initializer?.let { evaluateExpression(it) } ?: LLVMConstNull(type))
                 // (Cannot do this before the global is initialized).
                 LLVMSetLinkage(globalProperty, LLVMLinkage.LLVMInternalLinkage)
             }
-            llvm.initializersGenerationState.scopeState.topLevelFields.add(declaration)
         }
     }
 
@@ -1762,6 +1689,7 @@ internal class CodeGeneratorVisitor(
 
     private fun evaluateSetField(value: IrSetField): LLVMValueRef {
         context.log{"evaluateSetField               : ${ir2string(value)}"}
+        val field = value.symbol.owner
         if (value.origin == IrStatementOrigin.INITIALIZE_FIELD
                 && isZeroConstValue(value.value)) {
             var receiver = value.receiver
@@ -1779,20 +1707,23 @@ internal class CodeGeneratorVisitor(
         val address: LLVMValueRef
         val alignment: Int
         if (thisPtr != null) {
-            require(!value.symbol.owner.isStatic) { "Unexpected receiver for a static field: ${value.render()}" }
+            require(!field.isStatic) { "Unexpected receiver for a static field: ${value.render()}" }
             require(thisPtr.type == llvm.pointerType) {
                 LLVMPrintTypeToString(thisPtr.type)?.toKString().toString()
             }
-            address = fieldPtrOfClass(thisPtr, value.symbol.owner)
-            alignment = generationState.llvmDeclarations.forField(value.symbol.owner).alignment
+            address = fieldPtrOfClass(thisPtr, field)
+            alignment = generationState.llvmDeclarations.forField(field).alignment
         } else {
-            require(value.symbol.owner.isStatic) { "A receiver expected for a non-static field: ${value.render()}" }
-            address = staticFieldPtr(value.symbol.owner, functionGenerationContext)
-            alignment = generationState.llvmDeclarations.forStaticField(value.symbol.owner).alignment
+            require(field.isStatic) { "A receiver expected for a non-static field: ${value.render()}" }
+            address = staticFieldPtr(field, functionGenerationContext)
+            alignment = generationState.llvmDeclarations.forStaticField(field).alignment
+        }
+        if (value.origin == StaticInitializersOrigins.INITIALIZE_GLOBAL_FIELD && field.type.binaryTypeIsReference()) {
+            call(llvm.registerGlobalFunction, listOf(address))
         }
         functionGenerationContext.storeAny(
-                valueToAssign, address, value.symbol.owner.type.binaryTypeIsReference(), false,
-                isVolatile = value.symbol.owner.hasAnnotation(KonanFqNames.volatile),
+                valueToAssign, address, field.type.binaryTypeIsReference(), false,
+                isVolatile = field.hasAnnotation(KonanFqNames.volatile),
                 alignment = alignment,
         )
 
@@ -2412,9 +2343,9 @@ internal class CodeGeneratorVisitor(
         return when {
             function.isTypedIntrinsic -> intrinsicGenerator.evaluateCall(callee, args, resultSlot)
             function.isBuiltInOperator -> evaluateOperatorCall(callee, args)
-            function.origin == DECLARATION_ORIGIN_STATIC_GLOBAL_INITIALIZER -> evaluateFileGlobalInitializerCall(function)
-            function.origin == DECLARATION_ORIGIN_STATIC_THREAD_LOCAL_INITIALIZER -> evaluateFileThreadLocalInitializerCall(function)
-            function.origin == DECLARATION_ORIGIN_STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER -> evaluateFileStandaloneThreadLocalInitializerCall(function)
+            function.origin == StaticInitializersOrigins.STATIC_GLOBAL_INITIALIZER -> evaluateFileGlobalInitializerCall(function)
+            function.origin == StaticInitializersOrigins.STATIC_THREAD_LOCAL_INITIALIZER -> evaluateFileThreadLocalInitializerCall(function)
+            function.origin == StaticInitializersOrigins.STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER -> evaluateFileStandaloneThreadLocalInitializerCall(function)
             else -> evaluateSimpleFunctionCall(function, args, resultLifetime, callee.superQualifierSymbol?.owner, resultSlot)
         }
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
@@ -7,36 +7,50 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.ConfigChecks
-import org.jetbrains.kotlin.backend.konan.Context
-import org.jetbrains.kotlin.backend.konan.ir.hasNonConstInitializer
-import org.jetbrains.kotlin.backend.konan.DECLARATION_ORIGIN_ENTRY_POINT
-import org.jetbrains.kotlin.backend.konan.KonanFqNames
-import org.jetbrains.kotlin.backend.konan.llvm.*
+import org.jetbrains.kotlin.backend.konan.*
+import org.jetbrains.kotlin.backend.konan.binaryTypeIsReference
+import org.jetbrains.kotlin.backend.konan.llvm.FieldStorageKind
+import org.jetbrains.kotlin.backend.konan.llvm.storageKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrElement
-import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irNull
+import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrBlockBody
-import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
+import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
-internal val DECLARATION_ORIGIN_STATIC_GLOBAL_INITIALIZER = IrDeclarationOriginImpl("STATIC_GLOBAL_INITIALIZER")
-internal val DECLARATION_ORIGIN_STATIC_THREAD_LOCAL_INITIALIZER = IrDeclarationOriginImpl("STATIC_THREAD_LOCAL_INITIALIZER")
-internal val DECLARATION_ORIGIN_STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER = IrDeclarationOriginImpl("STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER")
+internal object StaticInitializersOrigins {
+    internal val STATIC_GLOBAL_INITIALIZER by IrDeclarationOriginImpl.Synthetic
+    internal val STATIC_THREAD_LOCAL_INITIALIZER by IrDeclarationOriginImpl.Synthetic
+    internal val STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER by IrDeclarationOriginImpl.Synthetic
 
-internal val IrFunction.isStaticInitializer: Boolean
-    get() = origin == DECLARATION_ORIGIN_STATIC_GLOBAL_INITIALIZER
-            || origin == DECLARATION_ORIGIN_STATIC_THREAD_LOCAL_INITIALIZER
-            || origin == DECLARATION_ORIGIN_STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER
+    internal val EAGER_STATIC_GLOBAL_INITIALIZER by IrDeclarationOriginImpl.Synthetic
+    internal val EAGER_STATIC_THREAD_LOCAL_INITIALIZER by IrDeclarationOriginImpl.Synthetic
 
-internal fun IrBuilderWithScope.irCallFileInitializer(initializer: IrFunctionSymbol) =
-        irCall(initializer)
+    internal val INITIALIZE_GLOBAL_FIELD by IrStatementOriginImpl
+    internal val INITIALIZE_THREAD_LOCAL_FIELD by IrStatementOriginImpl
+}
+
+internal val IrFunction.isGlobalStaticInitializer: Boolean
+    get() = origin == StaticInitializersOrigins.STATIC_GLOBAL_INITIALIZER
+internal val IrFunction.isThreadLocalStaticInitializer: Boolean
+    get() = origin == StaticInitializersOrigins.STATIC_THREAD_LOCAL_INITIALIZER
+            || origin == StaticInitializersOrigins.STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER
+internal val IrFunction.isLazyStaticInitializer: Boolean
+    get() = isGlobalStaticInitializer || isThreadLocalStaticInitializer
+
+internal val IrFunction.isEagerStaticInitializer: Boolean
+    get() = origin == StaticInitializersOrigins.EAGER_STATIC_GLOBAL_INITIALIZER
+            || origin == StaticInitializersOrigins.EAGER_STATIC_THREAD_LOCAL_INITIALIZER
+
 
 internal fun ConfigChecks.shouldBeInitializedEagerly(irField: IrField): Boolean {
     if (irField.parent is IrFile || irField.correspondingPropertySymbol?.owner?.parent is IrFile) {
@@ -46,7 +60,6 @@ internal fun ConfigChecks.shouldBeInitializedEagerly(irField: IrField): Boolean 
     return annotations.hasAnnotation(KonanFqNames.eagerInitialization)
 }
 
-// TODO: ExplicitlyExported for IR proto are not longer needed.
 internal class StaticInitializersLowering(val context: Context) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         irFile.acceptVoid(object : IrVisitorVoid() {
@@ -64,67 +77,158 @@ internal class StaticInitializersLowering(val context: Context) : FileLoweringPa
         })
     }
 
-    fun processDeclarationContainter(container: IrDeclarationContainer) {
-        var requireGlobalInitializer = false
-        var requireThreadLocalInitializer = false
-        for (declaration in container.declarations) {
-            val irField = (declaration as? IrField) ?: (declaration as? IrProperty)?.backingField
-            if (irField == null || !irField.isStatic || !irField.needsInitializationAtRuntime || context.shouldBeInitializedEagerly(irField)) continue
-            if (irField.storageKind != FieldStorageKind.THREAD_LOCAL) {
-                requireGlobalInitializer = true
-            } else {
-                requireThreadLocalInitializer = true // Either marked with thread local or only main thread visible.
+    private fun IrStatement.isConst(): Boolean = when (this) {
+        is IrConst, is IrConstantValue -> true
+        is IrBlock -> {
+            if (statements.isEmpty())
+                true
+            else {
+                // This might happen after the local declarations lowering where local declarations are replaced with an empty composite.
+                statements.take(statements.size - 1).all { it is IrComposite && it.statements.isEmpty() }
+                        && statements.last().isConst()
             }
         }
-        // TODO: think about pure initializers.
-        if (!requireGlobalInitializer && !requireThreadLocalInitializer) {
-            return
+        else -> false
+    }
+
+    fun processDeclarationContainter(container: IrDeclarationContainer) {
+        val threadLocalInitializers = mutableListOf<IrExpression>()
+        val globalInitializers = mutableListOf<IrExpression>()
+        val eagerThreadLocalInitializers = mutableListOf<IrExpression>()
+        val eagerGlobalInitializers = mutableListOf<IrExpression>()
+
+        val builder = context.irBuiltIns.createIrBuilder((container as IrSymbolOwner).symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET)
+
+        for (declaration in container.declarations) {
+            val irField = (declaration as? IrField) ?: (declaration as? IrProperty)?.backingField
+            if (irField == null || !irField.isStatic) continue
+            val initializer = irField.initializer?.expression
+            val isThreadLocal = irField.storageKind == FieldStorageKind.THREAD_LOCAL
+            /**
+             * Optimization: initialize constantly to avoid runtime checks if possible.
+             *
+             * To do it, we need to know initializer in compile time, and the field must be
+             * safe to be ignored by garbage collector.
+             *
+             * The latter is the case if it's either a final field initialized by constant or
+             * a field of a primitive type.
+             *
+             * Potentially, we could use this optimization for final thread-local fields initialized
+             * by constants, but it's not supported in code generation, and it's not clear why you would
+             * have such a field.
+             */
+            if (initializer?.isConst() == true && !isThreadLocal) {
+                if (!irField.type.binaryTypeIsReference() || irField.isFinal) {
+                    continue
+                }
+            }
+            val realInitializer = when {
+                initializer != null -> initializer
+                irField.type.binaryTypeIsReference() -> builder.irNull() // we need to initialize with something to register with GC
+                else -> continue
+            }
+            val isEager = context.shouldBeInitializedEagerly(irField)
+            val initializers = when (isThreadLocal) {
+                false if isEager -> eagerGlobalInitializers
+                true if isEager -> eagerThreadLocalInitializers
+                false -> globalInitializers
+                true -> threadLocalInitializers
+            }
+            initializers.add(builder.irSetField(
+                    receiver = null,
+                    field = irField,
+                    value = realInitializer,
+                    origin = if (isThreadLocal) StaticInitializersOrigins.INITIALIZE_THREAD_LOCAL_FIELD else StaticInitializersOrigins.INITIALIZE_GLOBAL_FIELD
+            ))
+            irField.initializer = null
         }
 
-        val globalInitFunction =
-                if (requireGlobalInitializer)
-                    buildInitFileFunction(container, "\$init_global", DECLARATION_ORIGIN_STATIC_GLOBAL_INITIALIZER)
-                else null
-        val threadLocalInitFunction =
-                if (requireThreadLocalInitializer)
-                    buildInitFileFunction(container, "\$init_thread_local",
-                            if (requireGlobalInitializer)
-                                DECLARATION_ORIGIN_STATIC_THREAD_LOCAL_INITIALIZER
-                            else DECLARATION_ORIGIN_STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER
-                    )
-                else null
+        val globalInitFunction = runIf(globalInitializers.isNotEmpty()) {
+            buildInitFunction(
+                    container = container,
+                    name = $$"$init_global",
+                    origin = StaticInitializersOrigins.STATIC_GLOBAL_INITIALIZER,
+                    initializers = globalInitializers
+            )
+        }
+        val threadLocalInitFunction = runIf(threadLocalInitializers.isNotEmpty()) {
+            buildInitFunction(
+                    container = container,
+                    name = $$"$init_thread_local",
+                    origin = when {
+                        globalInitializers.isNotEmpty() -> StaticInitializersOrigins.STATIC_THREAD_LOCAL_INITIALIZER
+                        else -> StaticInitializersOrigins.STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER
+                    },
+                    initializers = threadLocalInitializers
+            )
+        }
 
+        runIf(eagerGlobalInitializers.isNotEmpty()) {
+            buildInitFunction(
+                    container = container,
+                    name = $$"$init_global_eager",
+                    origin = StaticInitializersOrigins.EAGER_STATIC_GLOBAL_INITIALIZER,
+                    initializers = eagerGlobalInitializers
+            )
+        }
+
+        runIf(eagerThreadLocalInitializers.isNotEmpty()) {
+            buildInitFunction(
+                    container = container,
+                    name = $$"$init_thread_local_eager",
+                    origin = StaticInitializersOrigins.EAGER_STATIC_THREAD_LOCAL_INITIALIZER,
+                    initializers = eagerThreadLocalInitializers
+            )
+        }
+
+        if (globalInitFunction == null && threadLocalInitFunction == null) return
+        
         fun IrFunction.addInitializersCall() {
             val body = body ?: return
             val statements = (body as IrBlockBody).statements
             context.createIrBuilder(symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).run {
                 // The order of calling initializers: first global, then thread-local.
                 // It is ok for a thread local top level property to reference a global, but not vice versa.
-                threadLocalInitFunction?.let { statements.add(0, irCallFileInitializer(it.symbol)) }
-                globalInitFunction?.let { statements.add(0, irCallFileInitializer(it.symbol)) }
+                threadLocalInitFunction?.let { statements.add(0, irCall(it.symbol)) }
+                globalInitFunction?.let { statements.add(0, irCall(it.symbol)) }
             }
         }
 
-        container.simpleFunctions()
-                .filter { it.dispatchReceiverParameter == null }
-                .filterNot { it.origin == DECLARATION_ORIGIN_ENTRY_POINT }
-                .forEach { it.addInitializersCall() }
-        (container as? IrClass)?.constructors?.forEach { it.addInitializersCall() }
+        for (function in container.simpleFunctions()) {
+            if (function.dispatchReceiverParameter != null) continue // already initialized when instance was created
+            if (function.origin == DECLARATION_ORIGIN_ENTRY_POINT) continue // is not really in any class
+            if (function.isLazyStaticInitializer || function.isEagerStaticInitializer) continue // don't initialize recursively
+            function.addInitializersCall()
+        }
+        if (container is IrClass) {
+            for (constructor in container.constructors) {
+                constructor.addInitializersCall()
+            }
+        }
     }
 
-    private fun buildInitFileFunction(container: IrDeclarationContainer, name: String, origin: IrDeclarationOrigin) = context.irFactory.buildFun {
+    private fun buildInitFunction(
+            container: IrDeclarationContainer,
+            name: String,
+            origin: IrDeclarationOrigin,
+            initializers: List<IrExpression>
+    ) = context.irFactory.buildFun {
         startOffset = SYNTHETIC_OFFSET
         endOffset = SYNTHETIC_OFFSET
         this.origin = origin
-        this.name = Name.identifier(name)
+        // File name is added to avoid having same-named top-level private functions in the same package.
+        // While llvm handles it by adding suffix automatically, it still leads to less predictable binaries.
+        // With adding container.name to name, it would clash only if you have the same file name in the same package,
+        // which is a much less common case, because it doesn't work on jvm.
+        // For classes, it's not necessary, as the class fqname would be added to the mangled function name anyway
+        this.name = if (container is IrFile) Name.identifier(name + '$' + container.name) else Name.identifier(name)
         visibility = DescriptorVisibilities.PRIVATE
         returnType = context.irBuiltIns.unitType
     }.apply {
         parent = container
+        body = context.irFactory.createBlockBody(startOffset, endOffset, initializers)
+                .setDeclarationsParent(this)
         container.declarations.add(0, this)
     }
-
-    private val IrField.needsInitializationAtRuntime: Boolean
-        get() = hasNonConstInitializer || needsGCRegistration
 
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DataFlowIR.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DataFlowIR.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.localHash
 import org.jetbrains.kotlin.backend.konan.lower.DECLARATION_ORIGIN_BRIDGE_METHOD
 import org.jetbrains.kotlin.backend.konan.lower.bridgeTarget
 import org.jetbrains.kotlin.backend.konan.lower.getDefaultValueForOverriddenBuiltinFunction
+import org.jetbrains.kotlin.backend.konan.lower.isEagerStaticInitializer
 import org.jetbrains.kotlin.backend.konan.util.CustomBitSet
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrElement
@@ -102,6 +103,7 @@ internal object DataFlowIR {
         val RETURNS_UNIT = 4
         val RETURNS_NOTHING = 8
         val EXPLICITLY_EXPORTED = 16
+        val IS_EAGER_STATIC_INITIALIZER = 32
     }
 
     class FunctionParameter(val type: Type, val boxFunction: FunctionSymbol?, val unboxFunction: FunctionSymbol?)
@@ -120,6 +122,7 @@ internal object DataFlowIR {
         val returnsUnit = attributes.and(FunctionAttributes.RETURNS_UNIT) != 0
         val returnsNothing = attributes.and(FunctionAttributes.RETURNS_NOTHING) != 0
         val explicitlyExported = attributes.and(FunctionAttributes.EXPLICITLY_EXPORTED) != 0
+        val isEagerStaticInitializer = attributes.and(FunctionAttributes.IS_EAGER_STATIC_INITIALIZER) != 0
 
         val irFunction: IrSimpleFunction? get() = irDeclaration as? IrSimpleFunction
         val irFile: IrFile? get() = irDeclaration?.fileOrNull
@@ -641,6 +644,9 @@ internal object DataFlowIR {
                     || it.getExternalObjCMethodInfo() != null // TODO-DCE-OBJC-INIT
                     || it.hasAnnotation(RuntimeNames.objCMethodImp)) {
                 attributes = attributes or FunctionAttributes.EXPLICITLY_EXPORTED
+            }
+            if (function.isEagerStaticInitializer) {
+                attributes = attributes or FunctionAttributes.IS_EAGER_STATIC_INITIALIZER
             }
             val symbol = when {
                 it.isExternal || it.isBuiltInOperator -> {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DevirtualizationAnalysis.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DevirtualizationAnalysis.kt
@@ -83,9 +83,9 @@ internal object DevirtualizationAnalysis {
                             .filter { moduleDFG.functions.containsKey(it) }
         }
 
-        // TODO: Are globals initializers always called whether they are actually reachable from roots or not?
-        // TODO: With the changed semantics of global initializers this is no longer the case - rework.
-        val globalInitializers = moduleDFG.symbolTable.functionMap.values.filter { it.isStaticFieldInitializer }
+        val globalInitializers = moduleDFG.symbolTable.functionMap.values.filter {
+            it.isStaticFieldInitializer || it.isEagerStaticInitializer
+        }
         val explicitlyExported = moduleDFG.symbolTable.functionMap.values.filter { it.explicitlyExported }
 
         // Conservatively assume each associated object could be called.

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/PreCodegenInliner.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/PreCodegenInliner.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.backend.konan.ir.isBoxOrUnbox
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.lower.PreCodegenFunctionInlining
 import org.jetbrains.kotlin.backend.konan.lower.bridgeTarget
+import org.jetbrains.kotlin.backend.konan.lower.isEagerStaticInitializer
+import org.jetbrains.kotlin.backend.konan.lower.isLazyStaticInitializer
 import org.jetbrains.kotlin.backend.konan.lower.liveVariablesAtSuspensionPoint
 import org.jetbrains.kotlin.backend.konan.lower.originalConstructor
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -135,6 +137,8 @@ internal class PreCodegenInliner(
                                 && calleeSize <= inlineThreshold
                                 && calleeIrFunction.symbol != context.symbols.entryPoint // Might be unexpected to not see [main] in stacktraces.
                                 && !calleeIrFunction.isBoxOrUnbox()
+                                && !calleeIrFunction.isLazyStaticInitializer
+                                && !calleeIrFunction.isEagerStaticInitializer
                                 && calleeIrFunction.konanLibrary?.isCInteropLibrary() != true
                                 && !calleeIrFunction.hasAnnotation(noInline)
                                 && calleeIrFunction.correspondingPropertySymbol?.owner?.hasAnnotation(noInline) != true

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/StaticInitializersOptimization.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/StaticInitializersOptimization.kt
@@ -18,8 +18,7 @@ import org.jetbrains.kotlin.backend.konan.logMultiple
 import org.jetbrains.kotlin.backend.konan.lower.*
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
-import org.jetbrains.kotlin.ir.builders.irBlock
+import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.symbols.IrReturnTargetSymbol
@@ -241,7 +240,7 @@ internal object StaticInitializersOptimization {
         }
 
         private val IrFunction.calledInitializer get() =
-            (body?.statements?.get(0) as? IrCall)?.symbol?.owner?.takeIf { it.isStaticInitializer }?.parent as IrDeclarationContainer?
+            (body?.statements?.get(0) as? IrCall)?.symbol?.owner?.takeIf { it.isLazyStaticInitializer }?.parent as IrDeclarationContainer?
 
         private fun intraproceduralAnalysis(
                 node: CallGraphNode,
@@ -476,7 +475,7 @@ internal object StaticInitializersOptimization {
                 }
 
                 override fun visitCall(expression: IrCall, data: BitSet): BitSet {
-                    if (expression.symbol.owner.isStaticInitializer)
+                    if (expression.symbol.owner.isLazyStaticInitializer)
                         return data.withSetBit(initializedContainers.containerIds[expression.symbol.owner.parent as IrDeclarationContainer]!!)
                     if (expression.symbol == executeImplSymbol)
                         return processExecuteImpl(expression, data)
@@ -549,11 +548,10 @@ internal object StaticInitializersOptimization {
                 val initializerCalls = (body as IrBlockBody).statements
                         .take(2) // The very first statements by construction.
                         .filter {
-                            val calleeOrigin = (it as? IrCall)?.symbol?.owner?.origin
-                            val isNotOptimizedAwayGlobalInitializerCall = calleeOrigin == DECLARATION_ORIGIN_STATIC_GLOBAL_INITIALIZER
+                            val potentialInitializerCallee = (it as? IrCall)?.symbol?.owner ?: return@filter false
+                            val isNotOptimizedAwayGlobalInitializerCall = potentialInitializerCallee.isGlobalStaticInitializer
                                     && callee !in analysisResult.functionsRequiringGlobalInitializerCall
-                            val isNotOptimizedAwayThreadLocalInitializerCall = (calleeOrigin == DECLARATION_ORIGIN_STATIC_THREAD_LOCAL_INITIALIZER
-                                    || calleeOrigin == DECLARATION_ORIGIN_STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER)
+                            val isNotOptimizedAwayThreadLocalInitializerCall = potentialInitializerCallee.isThreadLocalStaticInitializer
                                     && callee !in analysisResult.functionsRequiringThreadLocalInitializerCall
                             if (isNotOptimizedAwayGlobalInitializerCall)
                                 ++numberOfCallSitesToFunctionsWithGlobalInitializerCall
@@ -573,7 +571,7 @@ internal object StaticInitializersOptimization {
 
                 changedDeclarations.add(data!!.scope.scopeOwnerSymbol.owner as IrDeclaration)
                 return data.irBlock(expression) {
-                    initializerCalls.forEach { +irCallFileInitializer((it as IrCall).symbol) }
+                    initializerCalls.forEach { +irCall((it as IrCall).symbol) }
                     +expression
                 }
             }
@@ -586,8 +584,7 @@ internal object StaticInitializersOptimization {
                 val globalInitializerCallIndex = statements
                         .take(2) // The very first statements by construction.
                         .indexOfFirst {
-                            val calleeOrigin = (it as? IrCall)?.symbol?.owner?.origin
-                            calleeOrigin == DECLARATION_ORIGIN_STATIC_GLOBAL_INITIALIZER
+                            (it as? IrCall)?.symbol?.owner?.isGlobalStaticInitializer == true
                         }
                 if (globalInitializerCallIndex >= 0) {
                     ++numberOfFunctionsWithGlobalInitializerCall
@@ -600,9 +597,7 @@ internal object StaticInitializersOptimization {
                 val threadLocalInitializerCallIndex = statements
                         .take(2)
                         .indexOfFirst {
-                            val calleeOrigin = (it as? IrCall)?.symbol?.owner?.origin
-                            calleeOrigin == DECLARATION_ORIGIN_STATIC_THREAD_LOCAL_INITIALIZER
-                                    || calleeOrigin == DECLARATION_ORIGIN_STATIC_STANDALONE_THREAD_LOCAL_INITIALIZER
+                            (it as? IrCall)?.symbol?.owner?.isThreadLocalStaticInitializer == true
                         }
                 if (threadLocalInitializerCallIndex >= 0) {
                     ++numberOfFunctionsWithThreadLocalInitializerCall

--- a/kotlin-native/runtime/src/compiler_interface/cpp/CompilerCInterface.cpp
+++ b/kotlin-native/runtime/src/compiler_interface/cpp/CompilerCInterface.cpp
@@ -35,7 +35,7 @@ touchType(FrameOverlay)
 
 touchFunction(AllocInstance)
 touchFunction(AllocArrayInstance)
-touchFunction(InitAndRegisterGlobal)
+touchFunction(RegisterGlobal)
 touchFunction(UpdateHeapRef)
 touchFunction(UpdateStackRef)
 touchFunction(UpdateVolatileHeapRef)

--- a/kotlin-native/runtime/src/main/cpp/Memory.h
+++ b/kotlin-native/runtime/src/main/cpp/Memory.h
@@ -182,10 +182,7 @@ OBJ_GETTER(AllocInstance, const TypeInfo* type_info) RUNTIME_NOTHROW;
 OBJ_GETTER(AllocArrayInstance, const TypeInfo* type_info, int32_t elements);
 
 
-// `initialValue` may be `nullptr`, which signifies that the appropriate initial value was already
-// set by static initialization.
-// TODO: When global initialization becomes lazy, this signature won't do.
-void InitAndRegisterGlobal(ObjHeader** location, const ObjHeader* initialValue) RUNTIME_NOTHROW;
+void RegisterGlobal(ObjHeader** location) RUNTIME_NOTHROW;
 
 //
 // Object reference management.

--- a/kotlin-native/runtime/src/mm/cpp/Memory.cpp
+++ b/kotlin-native/runtime/src/mm/cpp/Memory.cpp
@@ -115,14 +115,10 @@ extern "C" OBJ_GETTER(AllocArrayInstance, const TypeInfo* typeInfo, int32_t elem
     RETURN_RESULT_OF(mm::AllocateArray, threadData, typeInfo, static_cast<uint32_t>(elements));
 }
 
-extern "C" RUNTIME_NOTHROW void InitAndRegisterGlobal(ObjHeader** location, const ObjHeader* initialValue) {
+extern "C" RUNTIME_NOTHROW void RegisterGlobal(ObjHeader** location) {
     auto* threadData = mm::ThreadRegistry::Instance().CurrentThreadData();
     AssertThreadState(threadData, ThreadState::kRunnable);
     mm::GlobalsRegistry::Instance().RegisterStorageForGlobal(threadData, location);
-    // Null `initialValue` means that the appropriate value was already set by static initialization.
-    if (initialValue != nullptr) {
-        UpdateHeapRef(location, const_cast<ObjHeader*>(initialValue));
-    }
 }
 
 extern "C" PERFORMANCE_INLINE RUNTIME_NOTHROW void ZeroHeapRef(ObjHeader** location) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/smoke/BasicTestIncrementalCompilationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/smoke/BasicTestIncrementalCompilationIT.kt
@@ -39,8 +39,9 @@ open class BasicTestIncrementalCompilationIT : KmpIncrementalITBase() {
             ":app:jvmTest",
             ":lib:jvmTest",
 
-            ":app:nativeTest",
-            ":lib:nativeTest",
+            // for native, we check only recompilation, but not test run, as sometimes after recompilation exactly same binary is produced.
+            ":app:linkDebugTestNative",
+            ":lib:linkDebugTestNative",
         )
     override val gradleTask: String
         get() = "build"
@@ -75,7 +76,7 @@ open class BasicTestIncrementalCompilationIT : KmpIncrementalITBase() {
                 ":app:compileTestKotlinJs",
                 ":app:jsTest",
                 ":app:jvmTest",
-                ":app:nativeTest",
+                ":app:linkDebugTestNative",
             ),
         ) {
             assertIncrementalCompilation(listOf(changedInAppCommon).relativizeTo(projectPath))
@@ -117,7 +118,7 @@ open class BasicTestIncrementalCompilationIT : KmpIncrementalITBase() {
         checkIncrementalBuild(
             tasksExpectedToExecute = setOf(
                 ":app:compileTestKotlinNative",
-                ":app:nativeTest",
+                ":app:linkDebugTestNative",
             ),
         )
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/smoke/BasicTestIncrementalCompilationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/smoke/BasicTestIncrementalCompilationIT.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.mpp.smoke
 
 import org.gradle.api.logging.LogLevel
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.mpp.KmpIncrementalITBase
 import org.jetbrains.kotlin.gradle.testbase.*
@@ -52,6 +53,11 @@ open class BasicTestIncrementalCompilationIT : KmpIncrementalITBase() {
     fun testAffectingTestDependencies(gradleVersion: GradleVersion): Unit = withProject(gradleVersion) {
         build("build")
 
+        // Unused code shouldn't change native binary and trigger test execution
+        fun BuildResult.assertNativeTestIsUpToDateAfterChanginUnusedCode() {
+            assertTasksUpToDate(":app:nativeTest")
+        }
+
         /**
          * Step 1 - touch lib/common, affect all tests in app and lib
          */
@@ -60,6 +66,8 @@ open class BasicTestIncrementalCompilationIT : KmpIncrementalITBase() {
         checkIncrementalBuild(
             tasksExpectedToExecute = mainCompileTasks,
         ) {
+            assertNativeTestIsUpToDateAfterChanginUnusedCode()
+
             assertIncrementalCompilation(listOf(changedInLibCommon).relativizeTo(projectPath))
         }
 
@@ -79,6 +87,8 @@ open class BasicTestIncrementalCompilationIT : KmpIncrementalITBase() {
                 ":app:linkDebugTestNative",
             ),
         ) {
+            assertNativeTestIsUpToDateAfterChanginUnusedCode()
+
             assertIncrementalCompilation(listOf(changedInAppCommon).relativizeTo(projectPath))
         }
 
@@ -120,6 +130,8 @@ open class BasicTestIncrementalCompilationIT : KmpIncrementalITBase() {
                 ":app:compileTestKotlinNative",
                 ":app:linkDebugTestNative",
             ),
-        )
+        ) {
+            assertNativeTestIsUpToDateAfterChanginUnusedCode()
+        }
     }
 }


### PR DESCRIPTION
In before, bodies of static init functions were generated directly in codegen. After this change, the proper IrBody is generated for them, and handled in all cases.

As nice side effect, initializers of such fields stopped being global DCE roots on their own, and becoming reachable only if some function in this file is reachable.

Another tricky part is registering in GC. In before, while generating bodies in codegen it was done automatically, now it's done by checking IrSetField's origin.

^KT-74763 Fixed