### PR TITLE
Update 'maven-compiler-plugin' to 3.15.0

### DIFF
--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -120,7 +120,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.15.0</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>

--- a/libraries/tools/kotlin-maven-plugin/pom.xml
+++ b/libraries/tools/kotlin-maven-plugin/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-maven-plugin/kotlin-maven-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-maven-plugin/kotlin-maven-plugin.pom
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-project/kotlin-project.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-project/kotlin-project.pom
@@ -120,7 +120,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.15.0</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>


### PR DESCRIPTION
To fix detecting java version for JDK 1.8, fix detection of java version when JAVA_TOOL_OPTIONS is set
[reference](https://github.com/apache/maven-compiler-plugin/pull/999)