### PR TITLE
[FIR] Add receiver type to UNRESOLVED_REFERENCE error message if present

### DIFF
--- a/analysis/analysis-api-fir/analysis-api-fir-generator/src/org/jetbrains/kotlin/analysis/api/fir/generator/HLDiagnosticConverter.kt
+++ b/analysis/analysis-api-fir/analysis-api-fir-generator/src/org/jetbrains/kotlin/analysis/api/fir/generator/HLDiagnosticConverter.kt
@@ -225,6 +225,14 @@ internal object FirToKtConversionCreator {
                 "org.jetbrains.kotlin.KtPsiSourceElement"
             )
         ),
+        ConeKotlinType::class to HLFunctionCallConversion(
+            "{0}?.let { firSymbolBuilder.typeBuilder.buildKtType(it) }",
+            KaType::class.createType(nullable = true)
+        ),
+        FirTypeRef::class to HLFunctionCallConversion(
+            "{0}?.let { firSymbolBuilder.typeBuilder.buildKtType(it) }",
+            KaType::class.createType(nullable = true)
+        ),
     )
 
     private val typeMapping: Map<KClass<*>, HLFunctionCallConversion> = mapOf(

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
@@ -4507,6 +4507,7 @@ private fun KaDiagnosticConverterBuilder.addConversions102() {
         UnresolvedReferenceImpl(
             firDiagnostic.a,
             firDiagnostic.b,
+            firDiagnostic.c?.let { firSymbolBuilder.typeBuilder.buildKtType(it) },
             firDiagnostic as KtPsiDiagnostic,
             token,
         )

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnostics.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnostics.kt
@@ -289,6 +289,7 @@ sealed interface KaFirDiagnostic<PSI : PsiElement> : KaDiagnosticWithPsi<PSI> {
         override val diagnosticClass get() = UnresolvedReference::class
         val reference: String
         val operator: String?
+        val receiverType: KaType?
     }
 
     interface UnresolvedReferenceWrongReceiver : KaFirDiagnostic<PsiElement> {

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
@@ -331,6 +331,7 @@ internal class UnsupportedArrayLiteralOutsideOfAnnotationWarningImpl(
 internal class UnresolvedReferenceImpl(
     override val reference: String,
     override val operator: String?,
+    override val receiverType: KaType?,
     firDiagnostic: KtPsiDiagnostic,
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<PsiElement>(firDiagnostic, token), KaFirDiagnostic.UnresolvedReference

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/callableReference.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/callableReference.call.txt
@@ -1225,7 +1225,7 @@ KtNameReferenceExpression(944,960): 'topLevelVariable'
 KtDotQualifiedExpression(966,993): '::lateinitVar.isInitialized'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized' on receiver of type 'KMutableProperty0<MyClass>'.>
 
 KtCallableReferenceExpression(966,979): '::lateinitVar'
   KaCallResolutionSuccess:
@@ -1250,7 +1250,7 @@ KtNameReferenceExpression(968,979): 'lateinitVar'
 KtNameReferenceExpression(980,993): 'isInitialized'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized' on receiver of type 'KMutableProperty0<MyClass>'.>
 
 KtNamedFunction(997,1223): 'fun <T : Number> typeClass(classWithType: ClassWithType<T>) {'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/callableReference.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/callableReference.references.txt
@@ -467,7 +467,7 @@ KtNameReferenceExpression(980,993): 'isInitialized'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized' on receiver of type 'KMutableProperty0<MyClass>'.>
     symbols:
       Nothing (Unresolved reference)
 

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/callableReference.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/callableReference.symbol.txt
@@ -685,7 +685,7 @@ KtNameReferenceExpression(944,960): 'topLevelVariable'
 KtDotQualifiedExpression(966,993): '::lateinitVar.isInitialized'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized' on receiver of type 'KMutableProperty0<MyClass>'.>
 
 KtCallableReferenceExpression(966,979): '::lateinitVar'
   KaSymbolResolutionSuccess:
@@ -702,7 +702,7 @@ KtNameReferenceExpression(968,979): 'lateinitVar'
 KtNameReferenceExpression(980,993): 'isInitialized'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'isInitialized' on receiver of type 'KMutableProperty0<MyClass>'.>
 
 KtNamedFunction(997,1223): 'fun <T : Number> typeClass(classWithType: ClassWithType<T>) {'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/nestedInheritors/guard.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/nestedInheritors/guard.call.txt
@@ -610,7 +610,7 @@ KtNameReferenceExpression(764,798): 'IndirectSealedInheritorOfOpenClass'
 KtDotQualifiedExpression(802,815): 'instance.prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'OpenClass'.>
 
 KtNameReferenceExpression(802,810): 'instance'
   KaCallResolutionSuccess:
@@ -632,7 +632,7 @@ KtNameReferenceExpression(802,810): 'instance'
 KtNameReferenceExpression(811,815): 'prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'OpenClass'.>
 
 KtWhenEntry(824,837): 'else -> "100"'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/nestedInheritors/guard.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/nestedInheritors/guard.references.txt
@@ -213,6 +213,6 @@ KtNameReferenceExpression(811,815): 'prop'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'OpenClass'.>
     symbols:
       Nothing (Unresolved reference)

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/nestedInheritors/guard.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/nestedInheritors/guard.symbol.txt
@@ -401,7 +401,7 @@ KtNameReferenceExpression(764,798): 'IndirectSealedInheritorOfOpenClass'
 KtDotQualifiedExpression(802,815): 'instance.prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'OpenClass'.>
 
 KtNameReferenceExpression(802,810): 'instance'
   KaSymbolResolutionSuccess:
@@ -412,7 +412,7 @@ KtNameReferenceExpression(802,810): 'instance'
 KtNameReferenceExpression(811,815): 'prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'OpenClass'.>
 
 KtWhenEntry(824,837): 'else -> "100"'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/javaInterop.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/javaInterop.call.txt
@@ -74,7 +74,7 @@ KtNameReferenceExpression(118,127): 'JCOption1'
 KtDotQualifiedExpression(131,145): 'instance.prop1'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'JClass'.>
 
 KtNameReferenceExpression(131,139): 'instance'
   KaCallResolutionSuccess:
@@ -96,7 +96,7 @@ KtNameReferenceExpression(131,139): 'instance'
 KtNameReferenceExpression(140,145): 'prop1'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'JClass'.>
 
 KtWhenEntry(151,181): 'is JCOption2 -> instance.prop2'
   null
@@ -118,7 +118,7 @@ KtNameReferenceExpression(154,163): 'JCOption2'
 KtDotQualifiedExpression(167,181): 'instance.prop2'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'JClass'.>
 
 KtNameReferenceExpression(167,175): 'instance'
   KaCallResolutionSuccess:
@@ -140,7 +140,7 @@ KtNameReferenceExpression(167,175): 'instance'
 KtNameReferenceExpression(176,181): 'prop2'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'JClass'.>
 
 KtWhenEntry(187,213): 'is Nested -> instance.prop'
   null
@@ -162,7 +162,7 @@ KtNameReferenceExpression(190,196): 'Nested'
 KtDotQualifiedExpression(200,213): 'instance.prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'JClass'.>
 
 KtNameReferenceExpression(200,208): 'instance'
   KaCallResolutionSuccess:
@@ -184,7 +184,7 @@ KtNameReferenceExpression(200,208): 'instance'
 KtNameReferenceExpression(209,213): 'prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'JClass'.>
 
 KtNamedFunction(218,426): 'fun testSealedJClassInIf(instance: SealedJClass): Int {'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/javaInterop.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/javaInterop.references.txt
@@ -48,7 +48,7 @@ KtNameReferenceExpression(140,145): 'prop1'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'JClass'.>
     symbols:
       Nothing (Unresolved reference)
 
@@ -74,7 +74,7 @@ KtNameReferenceExpression(176,181): 'prop2'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'JClass'.>
     symbols:
       Nothing (Unresolved reference)
 
@@ -100,7 +100,7 @@ KtNameReferenceExpression(209,213): 'prop'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'JClass'.>
     symbols:
       Nothing (Unresolved reference)
 

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/javaInterop.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/javaInterop.symbol.txt
@@ -63,7 +63,7 @@ KtNameReferenceExpression(118,127): 'JCOption1'
 KtDotQualifiedExpression(131,145): 'instance.prop1'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'JClass'.>
 
 KtNameReferenceExpression(131,139): 'instance'
   KaSymbolResolutionSuccess:
@@ -74,7 +74,7 @@ KtNameReferenceExpression(131,139): 'instance'
 KtNameReferenceExpression(140,145): 'prop1'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'JClass'.>
 
 KtWhenEntry(151,181): 'is JCOption2 -> instance.prop2'
   null
@@ -96,7 +96,7 @@ KtNameReferenceExpression(154,163): 'JCOption2'
 KtDotQualifiedExpression(167,181): 'instance.prop2'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'JClass'.>
 
 KtNameReferenceExpression(167,175): 'instance'
   KaSymbolResolutionSuccess:
@@ -107,7 +107,7 @@ KtNameReferenceExpression(167,175): 'instance'
 KtNameReferenceExpression(176,181): 'prop2'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'JClass'.>
 
 KtWhenEntry(187,213): 'is Nested -> instance.prop'
   null
@@ -129,7 +129,7 @@ KtNameReferenceExpression(190,196): 'Nested'
 KtDotQualifiedExpression(200,213): 'instance.prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'JClass'.>
 
 KtNameReferenceExpression(200,208): 'instance'
   KaSymbolResolutionSuccess:
@@ -140,7 +140,7 @@ KtNameReferenceExpression(200,208): 'instance'
 KtNameReferenceExpression(209,213): 'prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'JClass'.>
 
 KtNamedFunction(218,426): 'fun testSealedJClassInIf(instance: SealedJClass): Int {'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/singleDefiniteExpectedType.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/singleDefiniteExpectedType.call.txt
@@ -1982,7 +1982,7 @@ KtNameReferenceExpression(1870,1885): 'NestedInheritor'
 KtDotQualifiedExpression(1889,1902): 'instance.prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtNameReferenceExpression(1889,1897): 'instance'
   KaCallResolutionSuccess:
@@ -2004,7 +2004,7 @@ KtNameReferenceExpression(1889,1897): 'instance'
 KtNameReferenceExpression(1898,1902): 'prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtWhenEntry(1915,1962): 'is NestedNestedInheritor -> instance.propNested'
   null
@@ -2026,7 +2026,7 @@ KtNameReferenceExpression(1918,1939): 'NestedNestedInheritor'
 KtDotQualifiedExpression(1943,1962): 'instance.propNested'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtNameReferenceExpression(1943,1951): 'instance'
   KaCallResolutionSuccess:
@@ -2048,7 +2048,7 @@ KtNameReferenceExpression(1943,1951): 'instance'
 KtNameReferenceExpression(1952,1962): 'propNested'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtWhenEntry(1975,1988): 'else -> "100"'
   null
@@ -2221,7 +2221,7 @@ KtNameReferenceExpression(2176,2191): 'NestedInheritor'
 KtDotQualifiedExpression(2195,2208): 'instance.prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtNameReferenceExpression(2195,2203): 'instance'
   KaCallResolutionSuccess:
@@ -2243,7 +2243,7 @@ KtNameReferenceExpression(2195,2203): 'instance'
 KtNameReferenceExpression(2204,2208): 'prop'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtWhenEntry(2221,2268): 'is NestedNestedInheritor -> instance.propNested'
   null
@@ -2265,7 +2265,7 @@ KtNameReferenceExpression(2224,2245): 'NestedNestedInheritor'
 KtDotQualifiedExpression(2249,2268): 'instance.propNested'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface'.>
 
 KtNameReferenceExpression(2249,2257): 'instance'
   KaCallResolutionSuccess:
@@ -2287,7 +2287,7 @@ KtNameReferenceExpression(2249,2257): 'instance'
 KtNameReferenceExpression(2258,2268): 'propNested'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface'.>
 
 KtWhenEntry(2281,2294): 'else -> "100"'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/singleDefiniteExpectedType.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/singleDefiniteExpectedType.references.txt
@@ -852,7 +852,7 @@ KtNameReferenceExpression(1898,1902): 'prop'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
     symbols:
       Nothing (Unresolved reference)
 
@@ -878,7 +878,7 @@ KtNameReferenceExpression(1952,1962): 'propNested'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface.NestedInheritor'.>
     symbols:
       Nothing (Unresolved reference)
 
@@ -993,7 +993,7 @@ KtNameReferenceExpression(2204,2208): 'prop'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
     symbols:
       Nothing (Unresolved reference)
 
@@ -1019,7 +1019,7 @@ KtNameReferenceExpression(2258,2268): 'propNested'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface'.>
     symbols:
       Nothing (Unresolved reference)
 

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/singleDefiniteExpectedType.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/singleDefiniteExpectedType.symbol.txt
@@ -1323,7 +1323,7 @@ KtNameReferenceExpression(1870,1885): 'NestedInheritor'
 KtDotQualifiedExpression(1889,1902): 'instance.prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtNameReferenceExpression(1889,1897): 'instance'
   KaSymbolResolutionSuccess:
@@ -1334,7 +1334,7 @@ KtNameReferenceExpression(1889,1897): 'instance'
 KtNameReferenceExpression(1898,1902): 'prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtWhenEntry(1915,1962): 'is NestedNestedInheritor -> instance.propNested'
   null
@@ -1356,7 +1356,7 @@ KtNameReferenceExpression(1918,1939): 'NestedNestedInheritor'
 KtDotQualifiedExpression(1943,1962): 'instance.propNested'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtNameReferenceExpression(1943,1951): 'instance'
   KaSymbolResolutionSuccess:
@@ -1367,7 +1367,7 @@ KtNameReferenceExpression(1943,1951): 'instance'
 KtNameReferenceExpression(1952,1962): 'propNested'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtWhenEntry(1975,1988): 'else -> "100"'
   null
@@ -1513,7 +1513,7 @@ KtNameReferenceExpression(2176,2191): 'NestedInheritor'
 KtDotQualifiedExpression(2195,2208): 'instance.prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtNameReferenceExpression(2195,2203): 'instance'
   KaSymbolResolutionSuccess:
@@ -1524,7 +1524,7 @@ KtNameReferenceExpression(2195,2203): 'instance'
 KtNameReferenceExpression(2204,2208): 'prop'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop' on receiver of type 'SealedInterface.NestedInheritor'.>
 
 KtWhenEntry(2221,2268): 'is NestedNestedInheritor -> instance.propNested'
   null
@@ -1546,7 +1546,7 @@ KtNameReferenceExpression(2224,2245): 'NestedNestedInheritor'
 KtDotQualifiedExpression(2249,2268): 'instance.propNested'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface'.>
 
 KtNameReferenceExpression(2249,2257): 'instance'
   KaSymbolResolutionSuccess:
@@ -1557,7 +1557,7 @@ KtNameReferenceExpression(2249,2257): 'instance'
 KtNameReferenceExpression(2258,2268): 'propNested'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'propNested' on receiver of type 'SealedInterface'.>
 
 KtWhenEntry(2281,2294): 'else -> "100"'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/typeCast.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/typeCast.call.txt
@@ -1561,7 +1561,7 @@ KtDotQualifiedExpression(1177,1196): 'v2.prop1.hashCode()'
 KtDotQualifiedExpression(1177,1185): 'v2.prop1'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtNameReferenceExpression(1177,1179): 'v2'
   KaCallResolutionSuccess:
@@ -1583,7 +1583,7 @@ KtNameReferenceExpression(1177,1179): 'v2'
 KtNameReferenceExpression(1180,1185): 'prop1'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtCallExpression(1186,1196): 'hashCode()'
   KaCallResolutionError:
@@ -2158,7 +2158,7 @@ KtSafeQualifiedExpression(1512,1527): 'i?.prop2?.dec()'
 KtSafeQualifiedExpression(1512,1520): 'i?.prop2'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'SealedClass'.>
 
 KtNameReferenceExpression(1512,1513): 'i'
   KaCallResolutionSuccess:
@@ -2180,7 +2180,7 @@ KtNameReferenceExpression(1512,1513): 'i'
 KtNameReferenceExpression(1515,1520): 'prop2'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'SealedClass'.>
 
 KtCallExpression(1522,1527): 'dec()'
   KaCallResolutionError:
@@ -2405,7 +2405,7 @@ KtSafeQualifiedExpression(1644,1665): 'v2?.prop1?.hashCode()'
 KtSafeQualifiedExpression(1644,1653): 'v2?.prop1'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtNameReferenceExpression(1644,1646): 'v2'
   KaCallResolutionSuccess:
@@ -2427,7 +2427,7 @@ KtNameReferenceExpression(1644,1646): 'v2'
 KtNameReferenceExpression(1648,1653): 'prop1'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtCallExpression(1655,1665): 'hashCode()'
   KaCallResolutionError:

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/typeCast.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/typeCast.references.txt
@@ -552,7 +552,7 @@ KtNameReferenceExpression(1180,1185): 'prop1'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
     symbols:
       Nothing (Unresolved reference)
 
@@ -854,7 +854,7 @@ KtNameReferenceExpression(1515,1520): 'prop2'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'SealedClass'.>
     symbols:
       Nothing (Unresolved reference)
 
@@ -982,7 +982,7 @@ KtNameReferenceExpression(1648,1653): 'prop1'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
     symbols:
       Nothing (Unresolved reference)
 

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/typeCast.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/contextSensitiveResolution/typePosition/typeCast.symbol.txt
@@ -841,7 +841,7 @@ KtDotQualifiedExpression(1177,1196): 'v2.prop1.hashCode()'
 KtDotQualifiedExpression(1177,1185): 'v2.prop1'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtNameReferenceExpression(1177,1179): 'v2'
   KaSymbolResolutionSuccess:
@@ -852,7 +852,7 @@ KtNameReferenceExpression(1177,1179): 'v2'
 KtNameReferenceExpression(1180,1185): 'prop1'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtCallExpression(1186,1196): 'hashCode()'
   KaSymbolResolutionError:
@@ -1167,7 +1167,7 @@ KtSafeQualifiedExpression(1512,1527): 'i?.prop2?.dec()'
 KtSafeQualifiedExpression(1512,1520): 'i?.prop2'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'SealedClass'.>
 
 KtNameReferenceExpression(1512,1513): 'i'
   KaSymbolResolutionSuccess:
@@ -1178,7 +1178,7 @@ KtNameReferenceExpression(1512,1513): 'i'
 KtNameReferenceExpression(1515,1520): 'prop2'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop2' on receiver of type 'SealedClass'.>
 
 KtCallExpression(1522,1527): 'dec()'
   KaSymbolResolutionError:
@@ -1300,7 +1300,7 @@ KtSafeQualifiedExpression(1644,1665): 'v2?.prop1?.hashCode()'
 KtSafeQualifiedExpression(1644,1653): 'v2?.prop1'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtNameReferenceExpression(1644,1646): 'v2'
   KaSymbolResolutionSuccess:
@@ -1311,7 +1311,7 @@ KtNameReferenceExpression(1644,1646): 'v2'
 KtNameReferenceExpression(1648,1653): 'prop1'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'prop1' on receiver of type 'SealedClass'.>
 
 KtCallExpression(1655,1665): 'hashCode()'
   KaSymbolResolutionError:

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringFullFormErrors.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringFullFormErrors.call.txt
@@ -102,7 +102,7 @@ KtDestructuringDeclarationEntry(145,150): 'val a'
 KtDestructuringDeclarationEntry(152,162): 'var second'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(167,168): 'x'
   KaCallResolutionSuccess:
@@ -142,7 +142,7 @@ KtDestructuringDeclaration(187,202): '(var first) = x'
 KtDestructuringDeclarationEntry(188,197): 'var first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(201,202): 'x'
   KaCallResolutionSuccess:
@@ -182,7 +182,7 @@ KtDestructuringDeclaration(221,244): '(val first: String) = x'
 KtDestructuringDeclarationEntry(222,239): 'val first: String'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(233,239): 'String'
   null
@@ -231,7 +231,7 @@ KtDestructuringDeclaration(263,283): '(val aa = first) = x'
 KtDestructuringDeclarationEntry(264,278): 'val aa = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(273,278): 'first'
   null
@@ -274,7 +274,7 @@ KtDestructuringDeclaration(302,330): '(val aa: String = first) = x'
 KtDestructuringDeclarationEntry(303,325): 'val aa: String = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(311,317): 'String'
   null
@@ -744,12 +744,12 @@ KtDestructuringDeclaration(630,654): '(val first, val second,)'
 KtDestructuringDeclarationEntry(631,640): 'val first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(642,652): 'val second'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtContainerNode(658,659): 'x'
   null
@@ -841,7 +841,7 @@ KtDestructuringDeclaration(673,684): '(val first)'
 KtDestructuringDeclarationEntry(674,683): 'val first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtContainerNode(688,689): 'x'
   null
@@ -933,7 +933,7 @@ KtDestructuringDeclaration(703,722): '(val first: String)'
 KtDestructuringDeclarationEntry(704,721): 'val first: String'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(715,721): 'String'
   null
@@ -1034,7 +1034,7 @@ KtDestructuringDeclaration(741,757): '(val aa = first)'
 KtDestructuringDeclarationEntry(742,756): 'val aa = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(751,756): 'first'
   null
@@ -1129,7 +1129,7 @@ KtDestructuringDeclaration(776,800): '(val aa: String = first)'
 KtDestructuringDeclarationEntry(777,799): 'val aa: String = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(785,791): 'String'
   null
@@ -1796,12 +1796,12 @@ KtDestructuringDeclaration(1043,1067): '(val first, val second,)'
 KtDestructuringDeclarationEntry(1044,1053): 'val first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(1055,1065): 'val second'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1071,1071): ''
   null
@@ -1893,7 +1893,7 @@ KtDestructuringDeclaration(1083,1094): '(val first)'
 KtDestructuringDeclarationEntry(1084,1093): 'val first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1098,1098): ''
   null
@@ -1985,7 +1985,7 @@ KtDestructuringDeclaration(1110,1129): '(val first: String)'
 KtDestructuringDeclarationEntry(1111,1128): 'val first: String'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1122,1128): 'String'
   null
@@ -2086,7 +2086,7 @@ KtDestructuringDeclaration(1145,1161): '(val aa = first)'
 KtDestructuringDeclarationEntry(1146,1160): 'val aa = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(1155,1160): 'first'
   null
@@ -2181,7 +2181,7 @@ KtDestructuringDeclaration(1177,1201): '(val aa: String = first)'
 KtDestructuringDeclarationEntry(1178,1200): 'val aa: String = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1186,1192): 'String'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringFullFormErrors.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringFullFormErrors.references.txt
@@ -44,7 +44,7 @@ KtDestructuringDeclarationEntry(152,162): 'var second'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -63,7 +63,7 @@ KtDestructuringDeclarationEntry(188,197): 'var first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -82,7 +82,7 @@ KtDestructuringDeclarationEntry(222,239): 'val first: String'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -111,7 +111,7 @@ KtDestructuringDeclarationEntry(264,278): 'val aa = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -138,7 +138,7 @@ KtDestructuringDeclarationEntry(303,325): 'val aa: String = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -409,7 +409,7 @@ KtDestructuringDeclarationEntry(631,640): 'val first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -420,7 +420,7 @@ KtDestructuringDeclarationEntry(642,652): 'val second'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -449,7 +449,7 @@ KtDestructuringDeclarationEntry(674,683): 'val first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -478,7 +478,7 @@ KtDestructuringDeclarationEntry(704,721): 'val first: String'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -517,7 +517,7 @@ KtDestructuringDeclarationEntry(742,756): 'val aa = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -554,7 +554,7 @@ KtDestructuringDeclarationEntry(777,799): 'val aa: String = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -831,7 +831,7 @@ KtDestructuringDeclarationEntry(1044,1053): 'val first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -842,7 +842,7 @@ KtDestructuringDeclarationEntry(1055,1065): 'val second'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -869,7 +869,7 @@ KtDestructuringDeclarationEntry(1084,1093): 'val first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -896,7 +896,7 @@ KtDestructuringDeclarationEntry(1111,1128): 'val first: String'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -933,7 +933,7 @@ KtDestructuringDeclarationEntry(1146,1160): 'val aa = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -968,7 +968,7 @@ KtDestructuringDeclarationEntry(1178,1200): 'val aa: String = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringFullFormErrors.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringFullFormErrors.symbol.txt
@@ -88,7 +88,7 @@ KtDestructuringDeclarationEntry(145,150): 'val a'
 KtDestructuringDeclarationEntry(152,162): 'var second'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(167,168): 'x'
   KaSymbolResolutionSuccess:
@@ -117,7 +117,7 @@ KtDestructuringDeclaration(187,202): '(var first) = x'
 KtDestructuringDeclarationEntry(188,197): 'var first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(201,202): 'x'
   KaSymbolResolutionSuccess:
@@ -146,7 +146,7 @@ KtDestructuringDeclaration(221,244): '(val first: String) = x'
 KtDestructuringDeclarationEntry(222,239): 'val first: String'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(233,239): 'String'
   null
@@ -184,7 +184,7 @@ KtDestructuringDeclaration(263,283): '(val aa = first) = x'
 KtDestructuringDeclarationEntry(264,278): 'val aa = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(273,278): 'first'
   null
@@ -216,7 +216,7 @@ KtDestructuringDeclaration(302,330): '(val aa: String = first) = x'
 KtDestructuringDeclarationEntry(303,325): 'val aa: String = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(311,317): 'String'
   null
@@ -528,12 +528,12 @@ KtDestructuringDeclaration(630,654): '(val first, val second,)'
 KtDestructuringDeclarationEntry(631,640): 'val first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(642,652): 'val second'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtContainerNode(658,659): 'x'
   null
@@ -567,7 +567,7 @@ KtDestructuringDeclaration(673,684): '(val first)'
 KtDestructuringDeclarationEntry(674,683): 'val first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtContainerNode(688,689): 'x'
   null
@@ -601,7 +601,7 @@ KtDestructuringDeclaration(703,722): '(val first: String)'
 KtDestructuringDeclarationEntry(704,721): 'val first: String'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(715,721): 'String'
   null
@@ -644,7 +644,7 @@ KtDestructuringDeclaration(741,757): '(val aa = first)'
 KtDestructuringDeclarationEntry(742,756): 'val aa = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(751,756): 'first'
   null
@@ -681,7 +681,7 @@ KtDestructuringDeclaration(776,800): '(val aa: String = first)'
 KtDestructuringDeclarationEntry(777,799): 'val aa: String = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(785,791): 'String'
   null
@@ -995,12 +995,12 @@ KtDestructuringDeclaration(1043,1067): '(val first, val second,)'
 KtDestructuringDeclarationEntry(1044,1053): 'val first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(1055,1065): 'val second'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1071,1071): ''
   null
@@ -1038,7 +1038,7 @@ KtDestructuringDeclaration(1083,1094): '(val first)'
 KtDestructuringDeclarationEntry(1084,1093): 'val first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1098,1098): ''
   null
@@ -1076,7 +1076,7 @@ KtDestructuringDeclaration(1110,1129): '(val first: String)'
 KtDestructuringDeclarationEntry(1111,1128): 'val first: String'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1122,1128): 'String'
   null
@@ -1123,7 +1123,7 @@ KtDestructuringDeclaration(1145,1161): '(val aa = first)'
 KtDestructuringDeclarationEntry(1146,1160): 'val aa = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(1155,1160): 'first'
   null
@@ -1164,7 +1164,7 @@ KtDestructuringDeclaration(1177,1201): '(val aa: String = first)'
 KtDestructuringDeclarationEntry(1178,1200): 'val aa: String = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1186,1192): 'String'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringShortFormErrorsAfter.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringShortFormErrorsAfter.call.txt
@@ -102,7 +102,7 @@ KtDestructuringDeclarationEntry(188,189): 'a'
 KtDestructuringDeclarationEntry(191,197): 'second'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(202,203): 'x'
   KaCallResolutionSuccess:
@@ -142,7 +142,7 @@ KtDestructuringDeclaration(222,237): 'var (first) = x'
 KtDestructuringDeclarationEntry(227,232): 'first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(236,237): 'x'
   KaCallResolutionSuccess:
@@ -182,7 +182,7 @@ KtDestructuringDeclaration(256,279): 'val (first: String) = x'
 KtDestructuringDeclarationEntry(261,274): 'first: String'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(268,274): 'String'
   null
@@ -535,7 +535,7 @@ KtDestructuringDeclaration(521,541): 'val (aa = first) = x'
 KtDestructuringDeclarationEntry(526,536): 'aa = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(531,536): 'first'
   null
@@ -578,7 +578,7 @@ KtDestructuringDeclaration(560,588): 'val (aa: String = first) = x'
 KtDestructuringDeclarationEntry(565,583): 'aa: String = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(569,575): 'String'
   null
@@ -834,12 +834,12 @@ KtDestructuringDeclaration(727,743): '(first, second,)'
 KtDestructuringDeclarationEntry(728,733): 'first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(735,741): 'second'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtContainerNode(747,748): 'x'
   null
@@ -931,7 +931,7 @@ KtDestructuringDeclaration(762,769): '(first)'
 KtDestructuringDeclarationEntry(763,768): 'first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtContainerNode(773,774): 'x'
   null
@@ -1023,7 +1023,7 @@ KtDestructuringDeclaration(788,803): '(first: String)'
 KtDestructuringDeclarationEntry(789,802): 'first: String'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(796,802): 'String'
   null
@@ -1462,7 +1462,7 @@ KtDestructuringDeclaration(929,941): '(aa = first)'
 KtDestructuringDeclarationEntry(930,940): 'aa = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(935,940): 'first'
   null
@@ -1557,7 +1557,7 @@ KtDestructuringDeclaration(960,980): '(aa: String = first)'
 KtDestructuringDeclarationEntry(961,979): 'aa: String = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(965,971): 'String'
   null
@@ -1886,12 +1886,12 @@ KtDestructuringDeclaration(1109,1125): '(first, second,)'
 KtDestructuringDeclarationEntry(1110,1115): 'first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(1117,1123): 'second'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1129,1129): ''
   null
@@ -1983,7 +1983,7 @@ KtDestructuringDeclaration(1141,1148): '(first)'
 KtDestructuringDeclarationEntry(1142,1147): 'first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1152,1152): ''
   null
@@ -2075,7 +2075,7 @@ KtDestructuringDeclaration(1164,1179): '(first: String)'
 KtDestructuringDeclarationEntry(1165,1178): 'first: String'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1172,1178): 'String'
   null
@@ -2514,7 +2514,7 @@ KtDestructuringDeclaration(1293,1305): '(aa = first)'
 KtDestructuringDeclarationEntry(1294,1304): 'aa = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(1299,1304): 'first'
   null
@@ -2609,7 +2609,7 @@ KtDestructuringDeclaration(1321,1341): '(aa: String = first)'
 KtDestructuringDeclarationEntry(1322,1340): 'aa: String = first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1326,1332): 'String'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringShortFormErrorsAfter.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringShortFormErrorsAfter.references.txt
@@ -44,7 +44,7 @@ KtDestructuringDeclarationEntry(191,197): 'second'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -63,7 +63,7 @@ KtDestructuringDeclarationEntry(227,232): 'first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -82,7 +82,7 @@ KtDestructuringDeclarationEntry(261,274): 'first: String'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -286,7 +286,7 @@ KtDestructuringDeclarationEntry(526,536): 'aa = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -313,7 +313,7 @@ KtDestructuringDeclarationEntry(565,583): 'aa: String = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -465,7 +465,7 @@ KtDestructuringDeclarationEntry(728,733): 'first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -476,7 +476,7 @@ KtDestructuringDeclarationEntry(735,741): 'second'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -505,7 +505,7 @@ KtDestructuringDeclarationEntry(763,768): 'first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -534,7 +534,7 @@ KtDestructuringDeclarationEntry(789,802): 'first: String'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -701,7 +701,7 @@ KtDestructuringDeclarationEntry(930,940): 'aa = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -738,7 +738,7 @@ KtDestructuringDeclarationEntry(961,979): 'aa: String = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -887,7 +887,7 @@ KtDestructuringDeclarationEntry(1110,1115): 'first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -898,7 +898,7 @@ KtDestructuringDeclarationEntry(1117,1123): 'second'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -925,7 +925,7 @@ KtDestructuringDeclarationEntry(1142,1147): 'first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -952,7 +952,7 @@ KtDestructuringDeclarationEntry(1165,1178): 'first: String'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -1111,7 +1111,7 @@ KtDestructuringDeclarationEntry(1294,1304): 'aa = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -1146,7 +1146,7 @@ KtDestructuringDeclarationEntry(1322,1340): 'aa: String = first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringShortFormErrorsAfter.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/nameBasedDestructuringShortFormErrorsAfter.symbol.txt
@@ -88,7 +88,7 @@ KtDestructuringDeclarationEntry(188,189): 'a'
 KtDestructuringDeclarationEntry(191,197): 'second'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(202,203): 'x'
   KaSymbolResolutionSuccess:
@@ -117,7 +117,7 @@ KtDestructuringDeclaration(222,237): 'var (first) = x'
 KtDestructuringDeclarationEntry(227,232): 'first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(236,237): 'x'
   KaSymbolResolutionSuccess:
@@ -146,7 +146,7 @@ KtDestructuringDeclaration(256,279): 'val (first: String) = x'
 KtDestructuringDeclarationEntry(261,274): 'first: String'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(268,274): 'String'
   null
@@ -388,7 +388,7 @@ KtDestructuringDeclaration(521,541): 'val (aa = first) = x'
 KtDestructuringDeclarationEntry(526,536): 'aa = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(531,536): 'first'
   null
@@ -420,7 +420,7 @@ KtDestructuringDeclaration(560,588): 'val (aa: String = first) = x'
 KtDestructuringDeclarationEntry(565,583): 'aa: String = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(569,575): 'String'
   null
@@ -579,12 +579,12 @@ KtDestructuringDeclaration(727,743): '(first, second,)'
 KtDestructuringDeclarationEntry(728,733): 'first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(735,741): 'second'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtContainerNode(747,748): 'x'
   null
@@ -618,7 +618,7 @@ KtDestructuringDeclaration(762,769): '(first)'
 KtDestructuringDeclarationEntry(763,768): 'first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtContainerNode(773,774): 'x'
   null
@@ -652,7 +652,7 @@ KtDestructuringDeclaration(788,803): '(first: String)'
 KtDestructuringDeclarationEntry(789,802): 'first: String'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(796,802): 'String'
   null
@@ -831,7 +831,7 @@ KtDestructuringDeclaration(929,941): '(aa = first)'
 KtDestructuringDeclarationEntry(930,940): 'aa = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(935,940): 'first'
   null
@@ -868,7 +868,7 @@ KtDestructuringDeclaration(960,980): '(aa: String = first)'
 KtDestructuringDeclarationEntry(961,979): 'aa: String = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(965,971): 'String'
   null
@@ -1046,12 +1046,12 @@ KtDestructuringDeclaration(1109,1125): '(first, second,)'
 KtDestructuringDeclarationEntry(1110,1115): 'first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtDestructuringDeclarationEntry(1117,1123): 'second'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'second' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1129,1129): ''
   null
@@ -1089,7 +1089,7 @@ KtDestructuringDeclaration(1141,1148): '(first)'
 KtDestructuringDeclarationEntry(1142,1147): 'first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtBlockExpression(1152,1152): ''
   null
@@ -1127,7 +1127,7 @@ KtDestructuringDeclaration(1164,1179): '(first: String)'
 KtDestructuringDeclarationEntry(1165,1178): 'first: String'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1172,1178): 'String'
   null
@@ -1322,7 +1322,7 @@ KtDestructuringDeclaration(1293,1305): '(aa = first)'
 KtDestructuringDeclarationEntry(1294,1304): 'aa = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtNameReferenceExpression(1299,1304): 'first'
   null
@@ -1363,7 +1363,7 @@ KtDestructuringDeclaration(1321,1341): '(aa: String = first)'
 KtDestructuringDeclarationEntry(1322,1340): 'aa: String = first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'first' on receiver of type 'Tuple'.>
 
 KtTypeReference(1326,1332): 'String'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringFullFormErrors.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringFullFormErrors.call.txt
@@ -278,7 +278,7 @@ KtDestructuringDeclaration(323,338): '[val first] = y'
 KtDestructuringDeclarationEntry(324,333): 'val first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtNameReferenceExpression(337,338): 'y'
   KaCallResolutionSuccess:
@@ -627,7 +627,7 @@ KtForExpression(508,541): 'for ([val first: String] in y) {}'
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
     iteratorCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'NonDataTuple'.>
     nextCallAttempt = KaCallResolutionError:
       candidateCalls = []
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
@@ -1110,7 +1110,7 @@ KtDestructuringDeclaration(728,739): '[val first]'
 KtDestructuringDeclarationEntry(729,738): 'val first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtBlockExpression(743,743): ''
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringFullFormErrors.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringFullFormErrors.references.txt
@@ -132,7 +132,7 @@ KtDestructuringDeclarationEntry(324,333): 'val first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -282,7 +282,7 @@ KtForExpression(508,541): 'for ([val first: String] in y) {}'
     usesContextSensitiveResolution: false
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'NonDataTuple'.>
       attempts[1]: KaSymbolResolutionError
         diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
       attempts[2]: KaSymbolResolutionError
@@ -465,7 +465,7 @@ KtDestructuringDeclarationEntry(729,738): 'val first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringFullFormErrors.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringFullFormErrors.symbol.txt
@@ -214,7 +214,7 @@ KtDestructuringDeclaration(323,338): '[val first] = y'
 KtDestructuringDeclarationEntry(324,333): 'val first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtNameReferenceExpression(337,338): 'y'
   KaSymbolResolutionSuccess:
@@ -392,7 +392,7 @@ KtForExpression(508,541): 'for ([val first: String] in y) {}'
     attempts = [
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'NonDataTuple'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
         diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>,
@@ -664,7 +664,7 @@ KtDestructuringDeclaration(728,739): '[val first]'
 KtDestructuringDeclarationEntry(729,738): 'val first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtBlockExpression(743,743): ''
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringShortFormErrors.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringShortFormErrors.call.txt
@@ -278,7 +278,7 @@ KtDestructuringDeclaration(319,334): 'val [first] = y'
 KtDestructuringDeclarationEntry(324,329): 'first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtNameReferenceExpression(333,334): 'y'
   KaCallResolutionSuccess:
@@ -627,7 +627,7 @@ KtForExpression(492,521): 'for ([first: String] in y) {}'
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
     iteratorCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'NonDataTuple'.>
     nextCallAttempt = KaCallResolutionError:
       candidateCalls = []
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
@@ -1110,7 +1110,7 @@ KtDestructuringDeclaration(696,703): '[first]'
 KtDestructuringDeclarationEntry(697,702): 'first'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtBlockExpression(707,707): ''
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringShortFormErrors.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringShortFormErrors.references.txt
@@ -132,7 +132,7 @@ KtDestructuringDeclarationEntry(324,329): 'first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:
@@ -282,7 +282,7 @@ KtForExpression(492,521): 'for ([first: String] in y) {}'
     usesContextSensitiveResolution: false
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'NonDataTuple'.>
       attempts[1]: KaSymbolResolutionError
         diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
       attempts[2]: KaSymbolResolutionError
@@ -465,7 +465,7 @@ KtDestructuringDeclarationEntry(697,702): 'first'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
     symbols:
       Nothing (Unresolved reference)
     resolveToSymbols:

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringShortFormErrors.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/destructuring/positionalDestructuringShortFormErrors.symbol.txt
@@ -214,7 +214,7 @@ KtDestructuringDeclaration(319,334): 'val [first] = y'
 KtDestructuringDeclarationEntry(324,329): 'first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtNameReferenceExpression(333,334): 'y'
   KaSymbolResolutionSuccess:
@@ -392,7 +392,7 @@ KtForExpression(492,521): 'for ([first: String] in y) {}'
     attempts = [
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'NonDataTuple'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
         diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>,
@@ -664,7 +664,7 @@ KtDestructuringDeclaration(696,703): '[first]'
 KtDestructuringDeclarationEntry(697,702): 'first'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'component1' on receiver of type 'NonDataTuple'.>
 
 KtBlockExpression(707,707): ''
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/lambdaParameters.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/lambdaParameters.call.txt
@@ -261,7 +261,7 @@ KtNameReferenceExpression(107,111): 'prop'
 KtDotQualifiedExpression(118,132): 'prop.action2()'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2' on receiver of type 'Int'.>
 
 KtNameReferenceExpression(118,122): 'prop'
   KaCallResolutionSuccess:
@@ -283,12 +283,12 @@ KtNameReferenceExpression(118,122): 'prop'
 KtCallExpression(123,132): 'action2()'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2' on receiver of type 'Int'.>
 
 KtNameReferenceExpression(123,130): 'action2'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2' on receiver of type 'Int'.>
 
 KtValueArgumentList(130,132): '()'
   null

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/lambdaParameters.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/lambdaParameters.references.txt
@@ -107,7 +107,7 @@ KtNameReferenceExpression(123,130): 'action2'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2' on receiver of type 'Int'.>
     symbols:
       Nothing (Unresolved reference)
 

--- a/analysis/analysis-api/testData/components/resolver/allByPsi/lambdaParameters.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/allByPsi/lambdaParameters.symbol.txt
@@ -142,7 +142,7 @@ KtNameReferenceExpression(107,111): 'prop'
 KtDotQualifiedExpression(118,132): 'prop.action2()'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2' on receiver of type 'Int'.>
 
 KtNameReferenceExpression(118,122): 'prop'
   KaSymbolResolutionSuccess:
@@ -153,12 +153,12 @@ KtNameReferenceExpression(118,122): 'prop'
 KtCallExpression(123,132): 'action2()'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2' on receiver of type 'Int'.>
 
 KtNameReferenceExpression(123,130): 'action2'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'action2' on receiver of type 'Int'.>
 
 KtValueArgumentList(130,132): '()'
   null

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutAccessors.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutAccessors.call.txt
@@ -38,7 +38,7 @@ KtPropertyDelegate(328,364): 'by ProvideDelegateHolder("provided")'
       diagnostic = ERROR<OTHER_ERROR: Inapplicable(INAPPLICABLE): myPack/provideDelegate>
     valueGetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
     valueSetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutAccessors.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutAccessors.references.txt
@@ -4,9 +4,9 @@ KtPropertyDelegate(328,364): 'by ProvideDelegateHolder("provided")'
     usesContextSensitiveResolution: false
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
       attempts[2]: KaSymbolResolutionError
         diagnostic: ERROR<OTHER_ERROR: Inapplicable(INAPPLICABLE): myPack/provideDelegate>
     symbols:

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutAccessors.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutAccessors.symbol.txt
@@ -3,10 +3,10 @@ KtPropertyDelegate(328,364): 'by ProvideDelegateHolder("provided")'
     attempts = [
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>,
       KaSymbolResolutionError:
         candidateSymbols = [
           myPack/provideDelegate(<extension receiver>: myPack.ProvideDelegateHolder, thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): myPack.GenericDelegate<T>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutGet.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutGet.call.txt
@@ -37,7 +37,7 @@ KtPropertyDelegate(419,455): 'by ProvideDelegateHolder("provided")'
         valueArgumentMapping = {}
     valueGetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
     valueSetterCallAttempt = KaCallResolutionSuccess:
       call = KaSimpleFunctionCall:
         contextArgumentMapping = {}

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutGet.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutGet.references.txt
@@ -5,7 +5,7 @@ KtPropertyDelegate(419,455): 'by ProvideDelegateHolder("provided")'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
     symbols:
       0: (in myPack) operator fun <T> myPack.ProvideDelegateHolder.provideDelegate(thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): myPack.GenericDelegate<T>
       1: (in myPack.GenericDelegate) operator fun setValue(thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, newValue: T)

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutGet.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutGet.symbol.txt
@@ -8,5 +8,5 @@ KtPropertyDelegate(419,455): 'by ProvideDelegateHolder("provided")'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutSet.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutSet.call.txt
@@ -70,4 +70,4 @@ KtPropertyDelegate(429,465): 'by ProvideDelegateHolder("provided")'
         valueArgumentMapping = {}
     valueSetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutSet.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutSet.references.txt
@@ -5,7 +5,7 @@ KtPropertyDelegate(429,465): 'by ProvideDelegateHolder("provided")'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
     symbols:
       0: (in myPack) operator fun <T> myPack.ProvideDelegateHolder.provideDelegate(thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): myPack.GenericDelegate<T>
       1: (in myPack.GenericDelegate) operator fun getValue(thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): T

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutSet.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaProviderWithoutSet.symbol.txt
@@ -8,5 +8,5 @@ KtPropertyDelegate(429,465): 'by ProvideDelegateHolder("provided")'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<TypeVariable(T)>'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaUnrelatedProvider.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaUnrelatedProvider.call.txt
@@ -3,7 +3,7 @@ KtPropertyDelegate(502,538): 'by ProvideDelegateHolder("provided")'
     provideDelegateCallAttempt = null
     valueGetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'ProvideDelegateHolder'.>
     valueSetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'ProvideDelegateHolder'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaUnrelatedProvider.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaUnrelatedProvider.references.txt
@@ -4,8 +4,8 @@ KtPropertyDelegate(502,538): 'by ProvideDelegateHolder("provided")'
     usesContextSensitiveResolution: false
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'ProvideDelegateHolder'.>
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'ProvideDelegateHolder'.>
     symbols:
       Nothing (Unresolved reference)

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaUnrelatedProvider.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateViaUnrelatedProvider.symbol.txt
@@ -3,8 +3,8 @@ KtPropertyDelegate(502,538): 'by ProvideDelegateHolder("provided")'
     attempts = [
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'ProvideDelegateHolder'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'ProvideDelegateHolder'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutGetter.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutGetter.call.txt
@@ -3,7 +3,7 @@ KtPropertyDelegate(74,109): 'by GenericDelegate<String>("hello")'
     provideDelegateCallAttempt = null
     valueGetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<String>'.>
     valueSetterCallAttempt = KaCallResolutionSuccess:
       call = KaSimpleFunctionCall:
         contextArgumentMapping = {}

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutGetter.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutGetter.references.txt
@@ -5,6 +5,6 @@ KtPropertyDelegate(74,109): 'by GenericDelegate<String>("hello")'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<String>'.>
     symbols:
       (in myPack.GenericDelegate) operator fun setValue(thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, newValue: T)

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutGetter.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutGetter.symbol.txt
@@ -7,5 +7,5 @@ KtPropertyDelegate(74,109): 'by GenericDelegate<String>("hello")'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'GenericDelegate<String>'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutSetter.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutSetter.call.txt
@@ -36,4 +36,4 @@ KtPropertyDelegate(74,109): 'by GenericDelegate<String>("hello")'
         valueArgumentMapping = {}
     valueSetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<String>'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutSetter.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutSetter.references.txt
@@ -5,6 +5,6 @@ KtPropertyDelegate(74,109): 'by GenericDelegate<String>("hello")'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<String>'.>
     symbols:
       (in myPack.GenericDelegate) operator fun getValue(thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): T

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutSetter.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/genericDelegateWithoutSetter.symbol.txt
@@ -7,5 +7,5 @@ KtPropertyDelegate(74,109): 'by GenericDelegate<String>("hello")'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'setValue' on receiver of type 'GenericDelegate<String>'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/provideDelegate_badDelegate.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/provideDelegate_badDelegate.call.txt
@@ -35,5 +35,5 @@ KtPropertyDelegate(127,135): 'by Bar()'
         valueArgumentMapping = {}
     valueGetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'NoDelegate'.>
     valueSetterCallAttempt = null

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/provideDelegate_badDelegate.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/provideDelegate_badDelegate.references.txt
@@ -5,6 +5,6 @@ KtPropertyDelegate(127,135): 'by Bar()'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'NoDelegate'.>
     symbols:
       (in ROOT) operator fun Bar.provideDelegate(_this: kotlin.Any?, p: kotlin.Any?): NoDelegate

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/provideDelegate_badDelegate.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/provideDelegate_badDelegate.symbol.txt
@@ -7,5 +7,5 @@ KtPropertyDelegate(127,135): 'by Bar()'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'NoDelegate'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/unresolved.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/unresolved.call.txt
@@ -3,5 +3,5 @@ KtPropertyDelegate(13,21): 'by Bar()'
     provideDelegateCallAttempt = null
     valueGetterCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'Bar'.>
     valueSetterCallAttempt = null

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/unresolved.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/unresolved.references.txt
@@ -3,6 +3,6 @@ KtPropertyDelegate(13,21): 'by Bar()'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'Bar'.>
     symbols:
       Nothing (Unresolved reference)

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/unresolved.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/delegatedPropertyAccessors/withErrors/unresolved.symbol.txt
@@ -1,4 +1,4 @@
 KtPropertyDelegate(13,21): 'by Bar()'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'getValue' on receiver of type 'Bar'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextAndNextMissing.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextAndNextMissing.call.txt
@@ -2,7 +2,7 @@ KtForExpression(23,37): 'for(i in f) {}'
   KaForLoopCallResolutionAttempt:
     hasNextCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Iterator'.>
     iteratorCallAttempt = KaCallResolutionSuccess:
       call = KaSimpleFunctionCall:
         contextArgumentMapping = {}
@@ -23,4 +23,4 @@ KtForExpression(23,37): 'for(i in f) {}'
         valueArgumentMapping = {}
     nextCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Iterator'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextAndNextMissing.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextAndNextMissing.references.txt
@@ -5,8 +5,8 @@ KtForExpression(23,37): 'for(i in f) {}'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Iterator'.>
       attempts[2]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Iterator'.>
     symbols:
       (in Foo) operator fun iterator(): Iterator

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextAndNextMissing.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextAndNextMissing.symbol.txt
@@ -7,8 +7,8 @@ KtForExpression(23,37): 'for(i in f) {}'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Iterator'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Iterator'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextMissing.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextMissing.call.txt
@@ -2,7 +2,7 @@ KtForExpression(23,37): 'for(i in f) {}'
   KaForLoopCallResolutionAttempt:
     hasNextCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Iterator'.>
     iteratorCallAttempt = KaCallResolutionSuccess:
       call = KaSimpleFunctionCall:
         contextArgumentMapping = {}

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextMissing.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextMissing.references.txt
@@ -5,7 +5,7 @@ KtForExpression(23,37): 'for(i in f) {}'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Iterator'.>
     symbols:
       0: (in Foo) operator fun iterator(): Iterator
       1: (in Iterator) operator fun next(): kotlin.Any

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextMissing.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/hasNextMissing.symbol.txt
@@ -8,5 +8,5 @@ KtForExpression(23,37): 'for(i in f) {}'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Iterator'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorIncorrect.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorIncorrect.call.txt
@@ -2,7 +2,7 @@ KtForExpression(23,37): 'for(i in f) {}'
   KaForLoopCallResolutionAttempt:
     hasNextCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Any'.>
     iteratorCallAttempt = KaCallResolutionError:
       candidateCalls = [
         KaSimpleFunctionCall:
@@ -27,4 +27,4 @@ KtForExpression(23,37): 'for(i in f) {}'
       fun Int.iterator(): Any>
     nextCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Any'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorIncorrect.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorIncorrect.references.txt
@@ -7,8 +7,8 @@ KtForExpression(23,37): 'for(i in f) {}'
         diagnostic: ERROR<UNRESOLVED_REFERENCE_WRONG_RECEIVER: Unresolved reference. None of the following candidates is applicable because of a receiver type mismatch:
         fun Int.iterator(): Any>
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Any'.>
       attempts[2]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Any'.>
     symbols:
       (in ROOT) operator fun kotlin.Int.iterator(): kotlin.Any

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorIncorrect.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorIncorrect.symbol.txt
@@ -9,8 +9,8 @@ KtForExpression(23,37): 'for(i in f) {}'
         fun Int.iterator(): Any>,
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext' on receiver of type 'Any'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Any'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorMissing.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorMissing.call.txt
@@ -5,7 +5,7 @@ KtForExpression(23,37): 'for(i in f) {}'
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
     iteratorCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'Foo'.>
     nextCallAttempt = KaCallResolutionError:
       candidateCalls = []
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorMissing.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorMissing.references.txt
@@ -4,7 +4,7 @@ KtForExpression(23,37): 'for(i in f) {}'
     usesContextSensitiveResolution: false
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'Foo'.>
       attempts[1]: KaSymbolResolutionError
         diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
       attempts[2]: KaSymbolResolutionError

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorMissing.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/iteratorMissing.symbol.txt
@@ -3,7 +3,7 @@ KtForExpression(23,37): 'for(i in f) {}'
     attempts = [
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'Foo'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
         diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>,

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/nextMissing.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/nextMissing.call.txt
@@ -38,4 +38,4 @@ KtForExpression(23,37): 'for(i in f) {}'
         valueArgumentMapping = {}
     nextCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Iterator'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/nextMissing.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/nextMissing.references.txt
@@ -5,7 +5,7 @@ KtForExpression(23,37): 'for(i in f) {}'
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionSuccess
       attempts[1]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Iterator'.>
     symbols:
       0: (in Foo) operator fun iterator(): Iterator
       1: (in Iterator) operator fun hasNext(): kotlin.Boolean

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/nextMissing.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/inSource/withErrors/nextMissing.symbol.txt
@@ -8,5 +8,5 @@ KtForExpression(23,37): 'for(i in f) {}'
         ],
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next' on receiver of type 'Iterator'.>
     ]

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/withErrors/unresolvedIterator.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/withErrors/unresolvedIterator.call.txt
@@ -5,7 +5,7 @@ KtForExpression(15,32): 'for (x in Y()) {}'
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
     iteratorCallAttempt = KaCallResolutionError:
       candidateCalls = []
-      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+      diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'Y'.>
     nextCallAttempt = KaCallResolutionError:
       candidateCalls = []
       diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'next'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/withErrors/unresolvedIterator.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/withErrors/unresolvedIterator.references.txt
@@ -4,7 +4,7 @@ KtForExpression(15,32): 'for (x in Y()) {}'
     usesContextSensitiveResolution: false
     attempt: KaCompoundSymbolResolutionError
       attempts[0]: KaSymbolResolutionError
-        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>
+        diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'Y'.>
       attempts[1]: KaSymbolResolutionError
         diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>
       attempts[2]: KaSymbolResolutionError

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/withErrors/unresolvedIterator.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/forLoopIn/withErrors/unresolvedIterator.symbol.txt
@@ -3,7 +3,7 @@ KtForExpression(15,32): 'for (x in Y()) {}'
     attempts = [
       KaSymbolResolutionError:
         candidateSymbols = []
-        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator'.>,
+        diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'iterator' on receiver of type 'Y'.>,
       KaSymbolResolutionError:
         candidateSymbols = []
         diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'hasNext'.>,

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/withTestCompilerPluginEnabled/customSerlializable_localDeclarations.call.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/withTestCompilerPluginEnabled/customSerlializable_localDeclarations.call.txt
@@ -1,4 +1,4 @@
 KtNameReferenceExpression(388,408): 'serializeFirstTarget'
   KaCallResolutionError:
     candidateCalls = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'serializeFirstTarget'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'serializeFirstTarget' on receiver of type 'Serializer'.>

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/withTestCompilerPluginEnabled/customSerlializable_localDeclarations.references.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/withTestCompilerPluginEnabled/customSerlializable_localDeclarations.references.txt
@@ -3,6 +3,6 @@ KtNameReferenceExpression(388,408): 'serializeFirstTarget'
     isImplicitReferenceToCompanion: false
     usesContextSensitiveResolution: false
     attempt: KaSymbolResolutionError
-    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'serializeFirstTarget'.>
+    diagnostic: ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'serializeFirstTarget' on receiver of type 'Serializer'.>
     symbols:
       Nothing (Unresolved reference)

--- a/analysis/analysis-api/testData/components/resolver/singleByPsi/withTestCompilerPluginEnabled/customSerlializable_localDeclarations.symbol.txt
+++ b/analysis/analysis-api/testData/components/resolver/singleByPsi/withTestCompilerPluginEnabled/customSerlializable_localDeclarations.symbol.txt
@@ -1,4 +1,4 @@
 KtNameReferenceExpression(388,408): 'serializeFirstTarget'
   KaSymbolResolutionError:
     candidateSymbols = []
-    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'serializeFirstTarget'.>
+    diagnostic = ERROR<UNRESOLVED_REFERENCE: Unresolved reference 'serializeFirstTarget' on receiver of type 'Serializer'.>

--- a/compiler/fir/analysis-tests/testData/resolve/receiverType.kt
+++ b/compiler/fir/analysis-tests/testData/resolve/receiverType.kt
@@ -1,0 +1,23 @@
+// RUN_PIPELINE_TILL: FRONTEND
+// ISSUE: KT-73431
+// RENDER_DIAGNOSTIC_ARGUMENTS
+package stuff
+
+fun foo(testInput: SomeTestData): TestResult {
+    val unused = <!UNRESOLVED_REFERENCE("someInfo")!>someInfo<!>()
+    val unused2 = testInput.testInfo().<!UNRESOLVED_REFERENCE("testData;  on receiver of type 'List<TestInfo<Boolean, HasTestResult>>'")!>testData<!>().someMethod()
+    return TODO()
+}
+class SomeTestData {
+    fun testInfo(): List<TestInfo<Boolean, HasTestResult>> { return TODO() }
+}
+class TestInfo<Boolean, HasTestResult> {
+    fun testData(): HasTestResult { return TODO() }
+}
+class HasTestResult {
+    fun testResult(): TestResult { return TODO() }
+}
+class TestResult
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, localProperty, nullableType, propertyDeclaration,
+typeParameter */

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirDiagnosticsList.kt
@@ -132,6 +132,7 @@ object DIAGNOSTICS_LIST : DiagnosticList("FirErrors") {
         val UNRESOLVED_REFERENCE by error<PsiElement>(PositioningStrategy.REFERENCED_NAME_BY_QUALIFIED) {
             parameter<String>("reference")
             parameter<String?>("operator")
+            parameter<ConeKotlinType?>("receiverType")
         }
         val UNRESOLVED_REFERENCE_WRONG_RECEIVER by error<PsiElement>(PositioningStrategy.REFERENCE_BY_QUALIFIED) {
             parameter<Collection<Symbol>>("candidates")

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrors.kt
@@ -199,7 +199,7 @@ object FirErrors : KtDiagnosticsContainer() {
     val UNSUPPORTED_ARRAY_LITERAL_OUTSIDE_OF_ANNOTATION: KtDiagnosticFactoryForDeprecation0 = KtDiagnosticFactoryForDeprecation0("UNSUPPORTED_ARRAY_LITERAL_OUTSIDE_OF_ANNOTATION", ForbidArrayLiteralsInNonAnnotationContexts, SourceElementPositioningStrategies.DEFAULT, PsiElement::class, getRendererFactory())
 
     // Unresolved
-    val UNRESOLVED_REFERENCE: KtDiagnosticFactory2<String, String?> = KtDiagnosticFactory2("UNRESOLVED_REFERENCE", ERROR, SourceElementPositioningStrategies.REFERENCED_NAME_BY_QUALIFIED, PsiElement::class, getRendererFactory())
+    val UNRESOLVED_REFERENCE: KtDiagnosticFactory3<String, String?, ConeKotlinType?> = KtDiagnosticFactory3("UNRESOLVED_REFERENCE", ERROR, SourceElementPositioningStrategies.REFERENCED_NAME_BY_QUALIFIED, PsiElement::class, getRendererFactory())
     val UNRESOLVED_REFERENCE_WRONG_RECEIVER: KtDiagnosticFactory1<Collection<FirBasedSymbol<*>>> = KtDiagnosticFactory1("UNRESOLVED_REFERENCE_WRONG_RECEIVER", ERROR, SourceElementPositioningStrategies.REFERENCE_BY_QUALIFIED, PsiElement::class, getRendererFactory())
     val INACCESSIBLE_OUTER_CLASS_RECEIVER: KtDiagnosticFactory1<FirBasedSymbol<*>> = KtDiagnosticFactory1("INACCESSIBLE_OUTER_CLASS_RECEIVER", ERROR, SourceElementPositioningStrategies.REFERENCE_BY_QUALIFIED, PsiElement::class, getRendererFactory())
     val UNRESOLVED_IMPORT: KtDiagnosticFactory1<String> = KtDiagnosticFactory1("UNRESOLVED_IMPORT", ERROR, SourceElementPositioningStrategies.IMPORT_LAST_NAME, PsiElement::class, getRendererFactory())

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrorsDefaultMessages.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirErrorsDefaultMessages.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.CAND
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.DECLARATION_FQ_NAME
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.DECLARATION_NAME
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.FOR_OPTIONAL_OPERATOR
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.FOR_OPTIONAL_RECEIVER
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.FUNCTIONAL_TYPE_KINDS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.IGNORABILITY_STATUS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers.KOTLIN_TARGETS
@@ -1029,9 +1030,10 @@ object FirErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
         // Unresolved
         map.put(
             UNRESOLVED_REFERENCE,
-            "Unresolved reference ''{0}''{1}.",
+            "Unresolved reference ''{0}''{1}{2}.",
             NULLABLE_STRING,
             FOR_OPTIONAL_OPERATOR,
+            FOR_OPTIONAL_RECEIVER,
         )
         map.put(
             UNRESOLVED_REFERENCE_WRONG_RECEIVER,

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/coneDiagnosticToFirDiagnostic.kt
@@ -514,11 +514,18 @@ private fun ConeDiagnostic.mapOtherDiagnostic(
         source,
         this.name.asString(),
         null,
+        null,
         session,
     )
 
-    is ConeUnresolvedSymbolError -> FirErrors.UNRESOLVED_REFERENCE.createOn(source, this.classId.asString(), null, session)
-    is ConeUnresolvedNameError -> FirErrors.UNRESOLVED_REFERENCE.createOn(source, name.asString(), operatorToken, session)
+    is ConeUnresolvedSymbolError -> FirErrors.UNRESOLVED_REFERENCE.createOn(source, this.classId.asString(), null, null, session)
+    is ConeUnresolvedNameError -> FirErrors.UNRESOLVED_REFERENCE.createOn(
+        source,
+        name.asString(),
+        operatorToken,
+        receiverType?.unwrapToSimpleTypeUsingLowerBound(),
+        session
+    )
     is ConeUnresolvedTypeQualifierError -> {
         when {
             // this.qualifiers will contain all resolved qualifiers from the left up to (including) the first unresolved qualifier.
@@ -527,10 +534,10 @@ private fun ConeDiagnostic.mapOtherDiagnostic(
             // Resolved.<!UNRESOLVED_REFERENCE!>Unresolved<!>, Resolved.<!UNRESOLVED_REFERENCE!>Unresolved<!>.Foo
             source?.kind == KtRealSourceElementKind -> {
                 val lastQualifier = this.qualifiers.last()
-                FirErrors.UNRESOLVED_REFERENCE.createOn(lastQualifier.source, lastQualifier.name.asString(), null, session)
+                FirErrors.UNRESOLVED_REFERENCE.createOn(lastQualifier.source, lastQualifier.name.asString(), null, null, session)
             }
             else -> {
-                FirErrors.UNRESOLVED_REFERENCE.createOn(source, this.qualifier, null, session)
+                FirErrors.UNRESOLVED_REFERENCE.createOn(source, this.qualifier, null, null, session)
             }
         }
     }
@@ -561,6 +568,7 @@ private fun ConeDiagnostic.mapOtherDiagnostic(
         FirErrors.UNRESOLVED_REFERENCE.createOn(
             source,
             ((this.candidateSymbol as? FirCallableSymbol)?.name ?: SpecialNames.NO_NAME_PROVIDED).asString(),
+            null,
             null,
             session,
         )

--- a/compiler/fir/diagnostic-renderers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDiagnosticRenderers.kt
+++ b/compiler/fir/diagnostic-renderers/src/org/jetbrains/kotlin/fir/analysis/diagnostics/FirDiagnosticRenderers.kt
@@ -30,7 +30,9 @@ import org.jetbrains.kotlin.fir.resolve.getContainingClassSymbol
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.*
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.hasError
 import org.jetbrains.kotlin.metadata.deserialization.VersionRequirement
 import org.jetbrains.kotlin.mpp.DeclarationSymbolMarker
 import org.jetbrains.kotlin.name.CallableId
@@ -363,6 +365,10 @@ object FirDiagnosticRenderers {
 
     val FOR_OPTIONAL_OPERATOR = Renderer { it: String? ->
         if (!it.isNullOrBlank()) " for operator '$it'" else ""
+    }
+
+    val FOR_OPTIONAL_RECEIVER = ContextDependentRenderer { type: ConeKotlinType?, ctx ->
+        if (type?.hasError() == false) " on receiver of type '${RENDER_TYPE.render(type, ctx)}'" else ""
     }
 
     val OF_OPTIONAL_NAME = Renderer { name: Name? ->

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirCallResolver.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirCallResolver.kt
@@ -962,7 +962,11 @@ class FirCallResolver(
                         when {
                             classLikeBySuperRef?.isInterface == true -> ConeNoConstructorError
                             classLikeBySuperRef?.isExpect == true -> ConeNoImplicitDefaultConstructorOnExpectClass
-                            else -> ConeUnresolvedNameError(name, operatorToken, explicitReceiver?.resolvedType)
+                            else -> ConeUnresolvedNameError(
+                                name,
+                                operatorToken,
+                                explicitReceiver?.takeIf { it !is FirResolvedQualifier }?.resolvedType.takeIf { it is ConeClassLikeType },
+                                )
                         }
                     }
                 }

--- a/compiler/testData/cli/jvm/noReflect.out
+++ b/compiler/testData/cli/jvm/noReflect.out
@@ -1,4 +1,4 @@
-compiler/testData/cli/jvm/noReflect.kt:4:19: error: unresolved reference 'primaryConstructor'.
+compiler/testData/cli/jvm/noReflect.kt:4:19: error: unresolved reference 'primaryConstructor' on receiver of type 'KClass<String>'.
     String::class.primaryConstructor
                   ^^^^^^^^^^^^^^^^^^
 COMPILATION_ERROR

--- a/compiler/testData/cli/jvm/noStdlibK2.out
+++ b/compiler/testData/cli/jvm/noStdlibK2.out
@@ -1,7 +1,7 @@
 compiler/testData/cli/jvm/noStdlibK2.kt:4:5: error: cannot access built-in declaration 'kotlin.String'. Ensure that you have a dependency on the Kotlin standard library.
     String::class.primaryConstructor
     ^^^^^^
-compiler/testData/cli/jvm/noStdlibK2.kt:4:19: error: unresolved reference 'primaryConstructor'.
+compiler/testData/cli/jvm/noStdlibK2.kt:4:19: error: unresolved reference 'primaryConstructor' on receiver of type 'KClass<String>'.
     String::class.primaryConstructor
                   ^^^^^^^^^^^^^^^^^^
 compiler/testData/cli/jvm/noStdlibK2.kt:6:7: error: cannot access built-in declaration 'kotlin.Unit'. Ensure that you have a dependency on the Kotlin standard library.

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/output.fir.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/output.fir.txt
@@ -10,13 +10,13 @@ fun <T : Sub> withTypeParam() {}
 compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/source.kt:12:11: error: cannot access 'test.Super' which is a supertype of 'Sub'. Check your module classpath for missing or conflicting dependencies.
     Sub().unresolved()
           ^^^^^^^^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/source.kt:12:11: error: unresolved reference 'unresolved'.
+compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/source.kt:12:11: error: unresolved reference 'unresolved' on receiver of type 'Sub'.
     Sub().unresolved()
           ^^^^^^^^^^
 compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/source.kt:13:14: error: cannot access 'test.Super' which is a supertype of 'SubSub'. Check your module classpath for missing or conflicting dependencies.
     SubSub().unresolved()
              ^^^^^^^^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/source.kt:13:14: error: unresolved reference 'unresolved'.
+compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/source.kt:13:14: error: unresolved reference 'unresolved' on receiver of type 'SubSub'.
     SubSub().unresolved()
              ^^^^^^^^^^
 compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyErrorPositions/source.kt:14:15: error: cannot access 'test.Super' which is a supertype of '<anonymous>'. Check your module classpath for missing or conflicting dependencies.

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInJava/output.fir.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInJava/output.fir.txt
@@ -4,7 +4,7 @@ class SubSub : Sub()
 compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInJava/source.kt:5:22: error: cannot access 'test.Super' which is a supertype of 'SubSub'. Check your module classpath for missing or conflicting dependencies.
 fun bar() = SubSub().foo()
                      ^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInJava/source.kt:5:22: error: unresolved reference 'foo'.
+compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInJava/source.kt:5:22: error: unresolved reference 'foo' on receiver of type 'SubSub'.
 fun bar() = SubSub().foo()
                      ^^^
 COMPILATION_ERROR

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInKotlin/output.fir.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInKotlin/output.fir.txt
@@ -4,7 +4,7 @@ class SubSub : Sub()
 compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInKotlin/source.kt:5:22: error: cannot access 'test.Super' which is a supertype of 'SubSub'. Check your module classpath for missing or conflicting dependencies.
 fun bar() = SubSub().foo()
                      ^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInKotlin/source.kt:5:22: error: unresolved reference 'foo'.
+compiler/testData/compileKotlinAgainstCustomBinaries/incompleteHierarchyInKotlin/source.kt:5:22: error: unresolved reference 'foo' on receiver of type 'SubSub'.
 fun bar() = SubSub().foo()
                      ^^^
 COMPILATION_ERROR

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/missingDependencyJava/output.fir.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/missingDependencyJava/output.fir.txt
@@ -4,7 +4,7 @@ compiler/testData/compileKotlinAgainstCustomBinaries/missingDependencyJava/sourc
 compiler/testData/compileKotlinAgainstCustomBinaries/missingDependencyJava/source.kt:5:5: error: cannot access class 'test.Bar'. Check your module classpath for missing or conflicting dependencies.
     bar.bar()
     ^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/missingDependencyJava/source.kt:5:9: error: unresolved reference 'bar'.
+compiler/testData/compileKotlinAgainstCustomBinaries/missingDependencyJava/source.kt:5:9: error: unresolved reference 'bar' on receiver of type 'test.Bar'.
     bar.bar()
         ^^^
 COMPILATION_ERROR

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseFeatureJs/output.fir.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseFeatureJs/output.fir.txt
@@ -14,7 +14,7 @@ compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreRe
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseFeatureJs/source.kt:9:22: error: package 'a' was compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler. Enabled pre-release features: <!POISONING_LANGUAGE_FEATURE!>
     val methodCall = param.method()
                      ^^^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseFeatureJs/source.kt:9:28: error: unresolved reference 'method'.
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseFeatureJs/source.kt:9:28: error: unresolved reference 'method' on receiver of type 'A'.
     val methodCall = param.method()
                            ^^^^^^
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseFeatureJs/source.kt:10:30: error: package 'a' was compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler. Enabled pre-release features: <!POISONING_LANGUAGE_FEATURE!>

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/output.fir.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/output.fir.txt
@@ -14,7 +14,7 @@ compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreRe
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:22: error: class 'a.A' was compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler.
     val methodCall = param.method()
                      ^^^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:28: error: unresolved reference 'method'.
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:8:28: error: unresolved reference 'method' on receiver of type 'A'.
     val methodCall = param.method()
                            ^^^^^^
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibrary/source.kt:9:30: error: class 'a.A' was compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler.

--- a/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibraryJs/output.fir.txt
+++ b/compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibraryJs/output.fir.txt
@@ -14,7 +14,7 @@ compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreRe
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibraryJs/source.kt:8:22: error: package 'a' was compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler.
     val methodCall = param.method()
                      ^^^^^
-compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibraryJs/source.kt:8:28: error: unresolved reference 'method'.
+compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibraryJs/source.kt:8:28: error: unresolved reference 'method' on receiver of type 'A'.
     val methodCall = param.method()
                            ^^^^^^
 compiler/testData/compileKotlinAgainstCustomBinaries/releaseCompilerAgainstPreReleaseLibraryJs/source.kt:9:30: error: package 'a' was compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler.

--- a/compiler/testData/diagnostics/tests/incompleteCode/diagnosticWithSyntaxError/doubleColonWithArgument.kt
+++ b/compiler/testData/diagnostics/tests/incompleteCode/diagnosticWithSyntaxError/doubleColonWithArgument.kt
@@ -14,8 +14,8 @@ fun foo() {
     C::lam<!SYNTAX!>(::lam)<!>
     C::lam<!SYNTAX!>(fun() {})<!>
 
-    <!UNRESOLVED_REFERENCE("invoke")!>String::class<!>(<!UNRESOLVED_REFERENCE!>unresolved<!>)
-    <!UNRESOLVED_REFERENCE("invoke")!>String::class<!>(fun() {})
+    <!UNRESOLVED_REFERENCE("invoke;  on receiver of type 'KClass<String>'")!>String::class<!>(<!UNRESOLVED_REFERENCE!>unresolved<!>)
+    <!UNRESOLVED_REFERENCE("invoke;  on receiver of type 'KClass<String>'")!>String::class<!>(fun() {})
 }
 
 /* GENERATED_FIR_TAGS: callableReference, functionDeclaration, lambdaLiteral, propertyDeclaration, stringLiteral */

--- a/compiler/testData/diagnostics/tests/operatorsOverloading/unresolvedOperator.fir.diag.txt
+++ b/compiler/testData/diagnostics/tests/operatorsOverloading/unresolvedOperator.fir.diag.txt
@@ -1,23 +1,23 @@
-/unresolvedOperator.kt:(98,100): error: Unresolved reference 'inc' for operator '++'.
+/unresolvedOperator.kt:(98,100): error: Unresolved reference 'inc' for operator '++' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(106,108): error: Unresolved reference 'dec' for operator '--'.
+/unresolvedOperator.kt:(106,108): error: Unresolved reference 'dec' for operator '--' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(113,114): error: Unresolved reference 'unaryPlus' for operator '+'.
+/unresolvedOperator.kt:(113,114): error: Unresolved reference 'unaryPlus' for operator '+' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(120,121): error: Unresolved reference 'unaryMinus' for operator '-'.
+/unresolvedOperator.kt:(120,121): error: Unresolved reference 'unaryMinus' for operator '-' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(127,128): error: Unresolved reference 'not' for operator '!'.
+/unresolvedOperator.kt:(127,128): error: Unresolved reference 'not' for operator '!' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(136,137): error: Unresolved reference 'times' for operator '*'.
+/unresolvedOperator.kt:(136,137): error: Unresolved reference 'times' for operator '*' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(149,150): error: Unresolved reference 'plus' for operator '+'.
+/unresolvedOperator.kt:(149,150): error: Unresolved reference 'plus' for operator '+' on receiver of type 'Boolean'.
 
-/unresolvedOperator.kt:(163,164): error: Unresolved reference 'minus' for operator '-'.
+/unresolvedOperator.kt:(163,164): error: Unresolved reference 'minus' for operator '-' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(173,174): error: Unresolved reference 'div' for operator '/'.
+/unresolvedOperator.kt:(173,174): error: Unresolved reference 'div' for operator '/' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(183,184): error: Unresolved reference 'rem' for operator '%'.
+/unresolvedOperator.kt:(183,184): error: Unresolved reference 'rem' for operator '%' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(193,195): error: Unresolved reference 'rangeTo' for operator '..'.
+/unresolvedOperator.kt:(193,195): error: Unresolved reference 'rangeTo' for operator '..' on receiver of type 'String'.
 
-/unresolvedOperator.kt:(204,207): error: Unresolved reference 'rangeUntil' for operator '..<'.
+/unresolvedOperator.kt:(204,207): error: Unresolved reference 'rangeUntil' for operator '..<' on receiver of type 'String'.

--- a/compiler/testData/diagnostics/testsWithStdLib/labelClashes.fir.diag.txt
+++ b/compiler/testData/diagnostics/testsWithStdLib/labelClashes.fir.diag.txt
@@ -2,25 +2,25 @@
 
 /labelClashes.kt:(180,185): warning: There is more than one label with such a name in this scope.
 
-/labelClashes.kt:(186,189): error: Unresolved reference 'inc'.
+/labelClashes.kt:(186,189): error: Unresolved reference 'inc' on receiver of type 'String'.
 
 /labelClashes.kt:(221,225): error: Cannot infer type for type parameter 'R'. Specify it explicitly.
 
 /labelClashes.kt:(248,252): warning: There is more than one label with such a name in this scope.
 
-/labelClashes.kt:(253,256): error: Unresolved reference 'inc'.
+/labelClashes.kt:(253,256): error: Unresolved reference 'inc' on receiver of type 'String'.
 
 /labelClashes.kt:(337,341): error: Cannot infer type for type parameter 'R'. Specify it explicitly.
 
 /labelClashes.kt:(364,369): warning: There is more than one label with such a name in this scope.
 
-/labelClashes.kt:(370,373): error: Unresolved reference 'foo'.
+/labelClashes.kt:(370,373): error: Unresolved reference 'foo' on receiver of type 'String'.
 
 /labelClashes.kt:(395,399): error: Cannot infer type for type parameter 'R'. Specify it explicitly.
 
 /labelClashes.kt:(427,432): warning: There is more than one label with such a name in this scope.
 
-/labelClashes.kt:(433,436): error: Unresolved reference 'foo'.
+/labelClashes.kt:(433,436): error: Unresolved reference 'foo' on receiver of type 'String'.
 
 /labelClashes.kt:(744,748): error: Cannot infer type for type parameter 'R'. Specify it explicitly.
 
@@ -32,7 +32,7 @@
 
 /labelClashes.kt:(833,838): warning: There is more than one label with such a name in this scope.
 
-/labelClashes.kt:(839,842): error: Unresolved reference 'inc'.
+/labelClashes.kt:(839,842): error: Unresolved reference 'inc' on receiver of type 'String'.
 
 /labelClashes.kt:(941,946): warning: There is more than one label with such a name in this scope.
 

--- a/compiler/testData/multiplatform/innerGenericClass/output.txt
+++ b/compiler/testData/multiplatform/innerGenericClass/output.txt
@@ -6,6 +6,6 @@ Output:
 Exit code: COMPILATION_ERROR
 Output:
 warning: no target platform specified, using default
-compiler/testData/multiplatform/innerGenericClass/common2.kt:8:15: error: unresolved reference 'unresolved'.
+compiler/testData/multiplatform/innerGenericClass/common2.kt:8:15: error: unresolved reference 'unresolved' on receiver of type 'String?'.
     b.getAE().unresolved()
               ^^^^^^^^^^

--- a/jps/jps-plugin/testData/incremental/lookupTracker/jvm/syntheticProperties/fir-build.log
+++ b/jps/jps-plugin/testData/incremental/lookupTracker/jvm/syntheticProperties/fir-build.log
@@ -3,7 +3,7 @@ Compiling files:
   src/KotlinClass.kt
   src/usages.kt
 Exit code: COMPILATION_ERROR
-  Unresolved reference 'setFoo'.
+  Unresolved reference 'setFoo' on receiver of type 'JavaClass'.
   'val' cannot be reassigned.
   Overload resolution ambiguity between candidates:
 var bazBaz: Int
@@ -11,11 +11,11 @@ val bazBaz: Int
   Overload resolution ambiguity between candidates:
 var bazBaz: Int
 val bazBaz: Int
-  Unresolved reference 'boo'.
+  Unresolved reference 'boo' on receiver of type 'JavaClass'.
   Overload resolution ambiguity between candidates:
 var bazBaz: Int
 val bazBaz: Int
   Overload resolution ambiguity between candidates:
 var bazBaz: Int
 val bazBaz: Int
-  Unresolved reference 'boo'.
+  Unresolved reference 'boo' on receiver of type 'KotlinClass'.

--- a/plugins/assign-plugin/testData/diagnostics/otherOperators.fir.diag.txt
+++ b/plugins/assign-plugin/testData/diagnostics/otherOperators.fir.diag.txt
@@ -1,14 +1,14 @@
-/otherOperators.kt:(456,458): error: Unresolved reference 'plusAssign'.
+/otherOperators.kt:(456,458): error: Unresolved reference 'plusAssign' on receiver of type 'StringProperty'.
 
-/otherOperators.kt:(502,504): error: Unresolved reference 'plusAssign'.
+/otherOperators.kt:(502,504): error: Unresolved reference 'plusAssign' on receiver of type 'StringProperty'.
 
-/otherOperators.kt:(560,562): error: Unresolved reference 'compareTo'.
+/otherOperators.kt:(560,562): error: Unresolved reference 'compareTo' on receiver of type 'StringProperty'.
 
-/otherOperators.kt:(606,608): error: Unresolved reference 'compareTo'.
+/otherOperators.kt:(606,608): error: Unresolved reference 'compareTo' on receiver of type 'StringProperty?'.
 
-/otherOperators.kt:(664,666): error: Unresolved reference 'compareTo'.
+/otherOperators.kt:(664,666): error: Unresolved reference 'compareTo' on receiver of type 'StringProperty'.
 
-/otherOperators.kt:(710,712): error: Unresolved reference 'compareTo'.
+/otherOperators.kt:(710,712): error: Unresolved reference 'compareTo' on receiver of type 'StringProperty?'.
 
 /otherOperators.kt:(769,772): error: No 'set' operator method providing array access.
 

--- a/plugins/assign-plugin/testData/diagnostics/plusAssignPrecedence.fir.diag.txt
+++ b/plugins/assign-plugin/testData/diagnostics/plusAssignPrecedence.fir.diag.txt
@@ -1,6 +1,6 @@
-/plusAssignPrecedence.kt:(2202,2204): error: Unresolved reference 'plusAssign'.
+/plusAssignPrecedence.kt:(2202,2204): error: Unresolved reference 'plusAssign' on receiver of type 'StringProperty'.
 
-/plusAssignPrecedence.kt:(2227,2229): error: Unresolved reference 'plusAssign'.
+/plusAssignPrecedence.kt:(2227,2229): error: Unresolved reference 'plusAssign' on receiver of type 'StringProperty'.
 
 /plusAssignPrecedence.kt:(2308,2310): error: Ambiguity between assign operator candidates:
 fun plus(v: String): StringPropertyWithPlusAndPlusAssign


### PR DESCRIPTION
This helps the user know the type they are acting on, which would make it more obvious the user is acting on the wrong type. Also update frontend and autogenerated tests for UNRESOLVED_REFERENCE error message

#KT-73431