### PR TITLE
test(KT-69504): Add test for data class with KDocs

### DIFF
--- a/native/objcexport-header-generator/ReadMe.md
+++ b/native/objcexport-header-generator/ReadMe.md
@@ -60,6 +60,29 @@ both implementations.
 
 Note: Since the Analysis Api implementation is WIP yet, this test can be used for debugging, but is not fully implemented yet.
 
+### Running a single K1 test locally
+
+On some local setups, running a single `testK1` test needs a few extra Gradle flags:
+
+```bash
+./gradlew \
+  --no-configure-on-demand \
+  -Pkotlin.native.enabled=true \
+  -PdisableBreakpad \
+  :native:objcexport-header-generator:testK1 \
+  --tests "org.jetbrains.kotlin.backend.konan.tests.ObjCExportHeaderGeneratorTest.test - classWithKDoc"
+```
+
+What each flag fixes:
+- `--no-configure-on-demand`: avoids Gradle configuration issues in this repository
+- `-Pkotlin.native.enabled=true`: enables Kotlin/Native test dependencies required by ObjC export tests
+- `-PdisableBreakpad`: avoids unrelated local breakpad build failures in `:kotlin-native:runtime`
+- `--tests "...classWithKDoc"`: runs only the selected test instead of the full `testK1` suite
+
+Together, these flags make it possible to run a single ObjC export K1 test locally without triggering the configuration-on-demand failure, missing Kotlin/Native test classpath entries, or unrelated breakpad runtime build errors.
+
+Replace the value passed to `--tests` to run a different single test.
+
 ### How tests work on TC
 
 On TC all tests are called by `./gradlew check`. ObjCExport module has 2 groups of tests:

--- a/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
+++ b/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
@@ -319,6 +319,11 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
     }
 
     @Test
+    fun `test - simple data class with KDocs`() {
+        doTest(headersTestDataDir.resolve("simpleDataClassWithKDocs"))
+    }
+
+    @Test
     fun `test - special function names`() {
         doTest(headersTestDataDir.resolve("specialFunctionNames"))
     }

--- a/native/objcexport-header-generator/testData/headers/SimpleDataClassWithKDocs/!simpleDataClassWithKDocs.h
+++ b/native/objcexport-header-generator/testData/headers/SimpleDataClassWithKDocs/!simpleDataClassWithKDocs.h
@@ -1,0 +1,64 @@
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSSet.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+
+@class Foo;
+
+NS_ASSUME_NONNULL_BEGIN
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wincompatible-property-type"
+#pragma clang diagnostic ignored "-Wnullability"
+
+#pragma push_macro("_Nullable_result")
+#if !__has_feature(nullability_nullable_result)
+#undef _Nullable_result
+#define _Nullable_result _Nullable
+#endif
+
+
+/**
+ * This class [Foo] is documented.
+ */
+__attribute__((objc_subclassing_restricted))
+@interface Foo : Base
+- (instancetype)initWithText:(NSString *)text number:(int32_t)number __attribute__((swift_name("init(text:number:)"))) __attribute__((objc_designated_initializer));
+
+/**
+ * This class [Foo] is documented.
+ */
+- (Foo *)doCopyText:(NSString *)text number:(int32_t)number __attribute__((swift_name("doCopy(text:number:)")));
+
+/**
+ * This class [Foo] is documented.
+ */
+- (BOOL)isEqual:(id _Nullable)other __attribute__((swift_name("isEqual(_:)")));
+
+/**
+ * This class [Foo] is documented.
+ */
+- (NSUInteger)hash __attribute__((swift_name("hash()")));
+
+/**
+ * This class [Foo] is documented.
+ */
+- (NSString *)description __attribute__((swift_name("description()")));
+
+/**
+ * Basic integer field
+ */
+@property (readonly) int32_t number __attribute__((swift_name("number")));
+
+/**
+ * Basic text field
+ */
+@property (readonly) NSString *text __attribute__((swift_name("text")));
+@end
+
+#pragma pop_macro("_Nullable_result")
+#pragma clang diagnostic pop
+NS_ASSUME_NONNULL_END

--- a/native/objcexport-header-generator/testData/headers/SimpleDataClassWithKDocs/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/SimpleDataClassWithKDocs/Foo.kt
@@ -1,0 +1,13 @@
+/**
+ * This class [Foo] is documented.
+ */
+data class Foo(
+    /**
+     * Basic text field
+     */
+    val text: String,
+    /**
+     * Basic integer field
+     */
+    val number: Int,
+)


### PR DESCRIPTION
I managed to replicate the ticket’s behavior ([see instructions](https://github.com/oscarArismendi/kmp-futured-template/blob/feature/export-kdoc/TODO.md)). However, when testing it here, the issue no longer occurs. It’s likely been fixed in newer Kotlin versions, so I recommend adding a test to ensure it doesn’t surface again in the future