### PR TITLE
[Wasm] Remove disableFailOnNoDiscoveredTests from Wasm per-module tests

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
@@ -286,10 +286,6 @@ class KotlinWasmGradlePluginIT : AbstractKotlinWasmGradlePluginIT() {
             }
         }
     }
-
-    override fun GradleProject.disableFailOnNoDiscoveredTests(gradleVersion: GradleVersion) {
-        // do nothing
-    }
 }
 
 class KotlinWasmPerModuleGradlePluginIT : AbstractKotlinWasmGradlePluginIT() {
@@ -332,23 +328,6 @@ class KotlinWasmPerModuleGradlePluginIT : AbstractKotlinWasmGradlePluginIT() {
                             it.fileSize() < developmentSize.getValue(it.name)
                         }
                     }
-            }
-        }
-    }
-
-    // For per-module and incremental compilation, generation of startUnitTests does not work
-    // It leads to errors with Gradl 9, because of no tests
-    // KT-85463
-    @OptIn(ExperimentalWasmDsl::class)
-    override fun GradleProject.disableFailOnNoDiscoveredTests(gradleVersion: GradleVersion) {
-        if (gradleVersion < GradleVersion.version("9.0")) return
-        buildScriptInjection {
-            kotlinMultiplatform.wasmJs {
-                nodejs {
-                    testTask {
-                        it.failOnNoDiscoveredTests.set(false)
-                    }
-                }
             }
         }
     }
@@ -645,8 +624,6 @@ abstract class AbstractKotlinWasmGradlePluginIT : KGPBaseTest() {
     fun wasmJsImportMetaUrlLibrary(gradleVersion: GradleVersion) {
         project("mpp-wasm-js-browser-nodejs", gradleVersion) {
 
-            disableFailOnNoDiscoveredTests(gradleVersion)
-
             build(":assemble", ":wasmJsNodeTest") {
                 assertTasksExecuted(":compileProductionExecutableKotlinWasmJs")
                 assertTasksExecuted(":compileKotlinWasmJs")
@@ -665,8 +642,6 @@ abstract class AbstractKotlinWasmGradlePluginIT : KGPBaseTest() {
     @GradleTest
     fun wasmSyncTaskCopiesMainResourcesToTest(gradleVersion: GradleVersion) {
         project("mpp-wasm-js-browser-nodejs", gradleVersion) {
-            disableFailOnNoDiscoveredTests(gradleVersion)
-
             build(":wasmJsNodeTest") {
                 assertTasksExecuted(":wasmJsNodeTest")
                 assertTasksExecuted(":wasmJsTestTestDevelopmentExecutableCompileSync")
@@ -968,8 +943,6 @@ abstract class AbstractKotlinWasmGradlePluginIT : KGPBaseTest() {
             // `:compileKotlinWasmJs` task is not compatible with CC on Gradle 7
             buildOptions = defaultBuildOptions.disableConfigurationCacheForGradle7(gradleVersion),
         ) {
-            disableFailOnNoDiscoveredTests(gradleVersion)
-
             fun BuildResult.moduleVersion(rootModulePath: String, moduleName: String): String =
                 projectPath.resolve(rootModulePath).toFile()
                     .resolve(NpmProject.PACKAGE_JSON)
@@ -1161,6 +1134,4 @@ abstract class AbstractKotlinWasmGradlePluginIT : KGPBaseTest() {
             }
         }
     }
-
-    abstract fun GradleProject.disableFailOnNoDiscoveredTests(gradleVersion: GradleVersion)
 }


### PR DESCRIPTION
We disabled it because wasm incremental compilation interfered with wasm per-module compilation It led to not generating of startUnitTests method in a binary.

^KT-85688 fixed