### PR TITLE
[Swift Export] Fix kotlinFqName for generic interfaces

### DIFF
--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/StandaloneSirTypeNamer.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/StandaloneSirTypeNamer.kt
@@ -83,9 +83,14 @@ internal object StandaloneSirTypeNamer : SirTypeNamer {
         is SirErrorType, is SirFunctionalType, is SirUnsupportedType, is SirTupleType -> null
     } ?: kotlinFqName(type)
 
+    @OptIn(KaExperimentalApi::class)
     private fun kotlinFqName(type: SirExistentialType): String = type.protocols.single().let { (protocol, _) ->
-        if (protocol == KotlinRuntimeSupportModule.kotlinBridgeable) "kotlin.Any"
-        else protocol.kaSymbolOrNull<KaClassLikeSymbol>()!!.classId!!.asFqNameString()
+        if (protocol == KotlinRuntimeSupportModule.kotlinBridgeable) return@let "kotlin.Any"
+        val symbol = protocol.kaSymbolOrNull<KaClassLikeSymbol>()!!
+        val fqName = symbol.classId!!.asFqNameString()
+        // Generics aren't supported yet, so we don't have the actual typeArguments, fallback to the upperbound
+        val typeArgs = symbol.typeParameters.takeIf { it.isNotEmpty() }?.joinToString(prefix = "<", postfix = ">") { "*" } ?: ""
+        "$fqName$typeArgs"
     }
 
     @OptIn(KaExperimentalApi::class)

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/generics.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/generics.kt
@@ -108,6 +108,10 @@ fun produceBox(box: (Box<String>) -> Unit): Unit = TODO() // unsupported input g
 
 fun produceBoxUpperBound(box: (Box<Any?>) -> Unit): Unit = TODO()
 
+typealias BFun = (B<*>) -> Unit
+
+fun returnBFun(): BFun = TODO()
+
 // MODULE: f_bounded_type
 // EXPORT_TO_SWIFT
 // FILE: f_bounded_type.kt

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.h
@@ -95,6 +95,8 @@ void * _Nullable __root___foo__TypesOfArguments__Swift_Optional_anyU20KotlinRunt
 
 _Bool __root___produceBoxUpperBound__TypesOfArguments__U28main_BoxU29202D_U20Swift_Void__(_Bool (^box)(void *));
 
+void * __root___returnBFun();
+
 void * __root___returnBoxFun();
 
 _Bool __root___takeBoxStarProjection__TypesOfArguments__main_Box__(void * box);
@@ -102,6 +104,8 @@ _Bool __root___takeBoxStarProjection__TypesOfArguments__main_Box__(void * box);
 _Bool __root___takeBoxUpperBound__TypesOfArguments__main_Box__(void * box);
 
 _Bool __root___takeBoxUpperBoundClosure__TypesOfArguments__U2829202D_U20main_Box__(void * (^box)(void));
+
+_Bool main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_B__(void * pointerToBlock, void * _1);
 
 void * main_internal_functional_type_caller_mainU2EBox__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * pointerToBlock);
 

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.kt
@@ -358,6 +358,12 @@ public fun __root___produceBoxUpperBound__TypesOfArguments__U28main_BoxU29202D_U
     return run { _result; true }
 }
 
+@ExportedBridge("__root___returnBFun")
+public fun __root___returnBFun(): kotlin.native.internal.NativePtr {
+    val _result = run { returnBFun() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
 @ExportedBridge("__root___returnBoxFun")
 public fun __root___returnBoxFun(): kotlin.native.internal.NativePtr {
     val _result = run { returnBoxFun() }
@@ -388,6 +394,14 @@ public fun __root___takeBoxUpperBoundClosure__TypesOfArguments__U2829202D_U20mai
         }
     }
     val _result = run { takeBoxUpperBoundClosure(__box) }
+    return run { _result; true }
+}
+
+@ExportedBridge("main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_B__")
+public fun main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_B__(pointerToBlock: kotlin.native.internal.NativePtr, _1: kotlin.native.internal.NativePtr): Boolean {
+    val __pointerToBlock = kotlin.native.internal.ref.dereferenceExternalRCRef(pointerToBlock)!!
+    val ___1 = kotlin.native.internal.ref.dereferenceExternalRCRef(_1) as B<kotlin.Any?>
+    val _result = run { (__pointerToBlock as Function1<B<*>, Unit>).invoke(___1) }
     return run { _result; true }
 }
 

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.swift
@@ -3,6 +3,7 @@ import KotlinRuntime
 import KotlinRuntimeSupport
 import KotlinStdlib
 
+public typealias BFun = (any main.B) -> Swift.Void
 public typealias BoxFun = () -> main.Box
 public typealias BoxFunIn = (main.Box) -> Swift.Int32
 public protocol A: KotlinRuntime.KotlinBase {
@@ -327,6 +328,12 @@ public func produceBoxUpperBound(
         let originalBlock = box
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(main.Box.__createClassWrapper(externalRCRef: arg0)); return true }() }
     }()); return () }()
+}
+public func returnBFun() -> main.BFun {
+    return {
+        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: __root___returnBFun(), options: .asBestFittingWrapper)!
+        return { _1 in return { main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_B__(pointerToBlock.__externalRCRef()!, _1.__externalRCRef()); return () }() }
+    }()
 }
 public func returnBoxFun() -> main.BoxFun {
     return {


### PR DESCRIPTION
This fixes the issue where type arguments weren't specified in the Kotlin bridge function for a generic interface in a typealias.

We are using star-projection since we don't yet support generics.

^KT-85715 Fixed