### PR TITLE
Fix the AnnotationTarget for @ObjCEnum.EntryName 

### DIFF
--- a/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
@@ -137,7 +137,7 @@ public actual annotation class ObjCEnum(actual val name: String = "", actual val
      * always override the Swift name implied or set by other means, even if swiftName is not set explicitly. This annotation does
      * not override the prefix implied or set by ObjCEnum.
      */
-    @Target(AnnotationTarget.FIELD)
+    @Target(AnnotationTarget.PROPERTY)
     @Retention(AnnotationRetention.BINARY)
     public actual annotation class EntryName(actual val name: String, actual val swiftName: String = "")
 }

--- a/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/native/Annotations.kt
@@ -137,7 +137,7 @@ public actual annotation class ObjCEnum(actual val name: String = "", actual val
      * always override the Swift name implied or set by other means, even if swiftName is not set explicitly. This annotation does
      * not override the prefix implied or set by ObjCEnum.
      */
-    @Target(AnnotationTarget.CLASS)
+    @Target(AnnotationTarget.FIELD)
     @Retention(AnnotationRetention.BINARY)
     public actual annotation class EntryName(actual val name: String, actual val swiftName: String = "")
 }

--- a/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
+++ b/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
@@ -93,7 +93,7 @@ public expect annotation class ObjCEnum(val name: String = "", val swiftName: St
      * always override the Swift name implied or set by other means, even if swiftName is not set explicitly. This annotation does
      * not override the prefix implied or set by ObjCEnum.
      */
-    @Target(AnnotationTarget.FIELD)
+    @Target(AnnotationTarget.PROPERTY)
     @Retention(AnnotationRetention.BINARY)
     public annotation class EntryName(val name: String, val swiftName: String = "")
 }

--- a/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
+++ b/libraries/stdlib/src/kotlin/annotations/NativeAnnotations.kt
@@ -93,7 +93,7 @@ public expect annotation class ObjCEnum(val name: String = "", val swiftName: St
      * always override the Swift name implied or set by other means, even if swiftName is not set explicitly. This annotation does
      * not override the prefix implied or set by ObjCEnum.
      */
-    @Target(AnnotationTarget.CLASS)
+    @Target(AnnotationTarget.FIELD)
     @Retention(AnnotationRetention.BINARY)
     public annotation class EntryName(val name: String, val swiftName: String = "")
 }

--- a/native/native.tests/testData/framework/objcexport/nativeEnum.kt
+++ b/native/native.tests/testData/framework/objcexport/nativeEnum.kt
@@ -3,11 +3,13 @@ package nativeEnum
 import kotlin.native.ObjCEnum
 import kotlin.experimental.ExperimentalObjCEnum
 
+// Note that the entries are explicitly not in alphabetical order to show that the compiler doesn't
+// sort them somewhere.
 @OptIn(kotlin.experimental.ExperimentalObjCEnum::class)
 @ObjCEnum("OBJCFoo", swiftName="SwiftFoo")
 enum class MyKotlinEnum {
     ALPHA,
-    COPY,
     @ObjCEnum.EntryName("renamed")
-    ORIGINAL
+    ORIGINAL,
+    COPY,
 }

--- a/native/native.tests/testData/framework/objcexport/nativeEnum.kt
+++ b/native/native.tests/testData/framework/objcexport/nativeEnum.kt
@@ -6,5 +6,8 @@ import kotlin.experimental.ExperimentalObjCEnum
 @OptIn(kotlin.experimental.ExperimentalObjCEnum::class)
 @ObjCEnum("OBJCFoo", swiftName="SwiftFoo")
 enum class MyKotlinEnum {
-    ALPHA, COPY, BAR_FOO
+    ALPHA,
+    COPY,
+    @ObjCEnum.EntryName("renamed")
+    ORIGINAL
 }

--- a/native/native.tests/testData/framework/objcexport/nativeEnum.swift
+++ b/native/native.tests/testData/framework/objcexport/nativeEnum.swift
@@ -2,12 +2,12 @@ import Kt
 
 
 private func testNativeEnumValues() throws {
-    let ktEnum = MyKotlinEnum.barFoo
+    let ktEnum = MyKotlinEnum.original
     let nsEnum = ktEnum.nsEnum
 
     switch(nsEnum) {
         case SwiftFoo.alpha: try fail()
-        case .barFoo: try assertEquals(actual: nsEnum, expected: ktEnum.nsEnum)
+        case .renamed: try assertEquals(actual: nsEnum, expected: ktEnum.nsEnum)
         case .theCopy: try fail()
     }
 }


### PR DESCRIPTION
Followup for https://github.com/JetBrains/kotlin/pull/5683

- Use the right anntoation target for enum entries
- Update the integration test to use EntryName to verfify that this is actually fully working as expected end-to-end

Not sure how existing tests for this feature are passing; I guess they run with a limited compiler? I have checked that the test change is failing without the fix.