### PR TITLE
KT-84767: Don't add "destination" dir as friend path for non-jvm compilations

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/KotlinCompilationFriendPathsResolver.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/KotlinCompilationFriendPathsResolver.kt
@@ -31,10 +31,13 @@ internal class DefaultKotlinCompilationFriendPathsResolver(
                 friendsFromAssociatedCompilations.from(it.output.classesDirs)
                 // Adding classes that could be produced to non-default destination for JVM target
                 // Check KotlinSourceSetProcessor for details
-                @Suppress("UNCHECKED_CAST")
-                val compileTaskOutput = (it.compileTaskProvider as TaskProvider<KotlinCompileTool>)
-                    .flatMap { task -> task.destinationDirectory }
-                friendsFromAssociatedCompilations.from(compileTaskOutput)
+                // FIXME: KT-85759 Track compile task outputs correctly in the KotlinWithJavaCompilation outputs
+                if (it is KotlinWithJavaCompilation<*, *>) {
+                    @Suppress("UNCHECKED_CAST")
+                    val compileTaskOutput = (it.compileTaskProvider as TaskProvider<KotlinCompileTool>)
+                        .flatMap { task -> task.destinationDirectory }
+                    friendsFromAssociatedCompilations.from(compileTaskOutput)
+                }
             }
             add(friendsFromAssociatedCompilations)
             add(friendArtifactResolver.resolveFriendArtifacts(compilation))

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/AssociateCompilationsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/AssociateCompilationsTest.kt
@@ -7,11 +7,22 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.kotlinJvmExtension
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.internal
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.gradle.util.*
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 
 class AssociateCompilationsTest {
@@ -60,5 +71,117 @@ class AssociateCompilationsTest {
             foo.compileDependencyFiles.files.toList(),
             "Expected 'main classesDirs' to be listed before file dependency 'bar.jar'"
         )
+    }
+
+    @Test
+    fun `test - friendPaths are included in JVM compile dependencies`() =
+        testCustomCompilationAssociation(
+            forTarget = { jvm() },
+            taskCast = { it as KotlinJvmCompile },
+            friendPaths = { friendPaths.files },
+            libraries = { libraries.files },
+            // FIXME: KT-85773 Make JVM friend paths to be in sync with classpath
+            allowedExtraFriendPaths = Regex(".*build.libs.test-jvm\\.jar")
+        )
+
+    @Test
+    fun `test - friendPaths are included in Native compile dependencies`() =
+        testCustomCompilationAssociation(
+            forTarget = { linuxX64() },
+            taskCast = { it as KotlinNativeCompile },
+            friendPaths = { friendModule.files },
+            libraries = { libraries.files }
+        )
+
+    @Test
+    fun `test - friendPaths are included in JS compile dependencies`() =
+        testCustomCompilationAssociation(
+            forTarget = { js() },
+            taskCast = { it as Kotlin2JsCompile },
+            friendPaths = { friendPaths.files },
+            libraries = { libraries.files }
+        )
+
+    @Test
+    fun `test - friendPaths are included in Wasm compile dependencies`() =
+        @OptIn(ExperimentalWasmDsl::class)
+        testCustomCompilationAssociation(
+            forTarget = { wasmWasi() },
+            taskCast = { it as Kotlin2JsCompile },
+            friendPaths = { friendPaths.files },
+            libraries = { libraries.files }
+        )
+
+    @Test
+    fun `test - friendPaths are included in Kotlin JVM compile dependencies`() {
+        val project = buildProject {
+            configureRepositoriesForTests()
+            applyKotlinJvmPlugin()
+        }
+        val kotlin = project.kotlinJvmExtension
+
+        val target = kotlin.target
+        val jvmCustom = target.compilations.create("custom")
+        jvmCustom.associateWith(target.compilations.getByName("main"))
+
+        project.evaluate()
+
+        val compileTask = jvmCustom.compileTaskProvider.get() as KotlinJvmCompile
+        val libraries = compileTask.libraries.files
+        val friendPaths = compileTask.friendPaths.files
+        assertLibrariesContainsFriendPaths(
+            libraries,
+            friendPaths,
+            // FIXME: KT-85773 Make JVM friend paths to be in sync with classpath
+            allowed = Regex(".*build.libs.test\\.jar"))
+    }
+
+    private fun <T> testCustomCompilationAssociation(
+        forTarget: KotlinMultiplatformExtension.() -> KotlinTarget,
+        taskCast: (KotlinCompilationTask<*>) -> T,
+        libraries: T.() -> Collection<File>,
+        friendPaths: T.() -> Collection<File>,
+        allowedExtraFriendPaths: Regex? = null
+    ) {
+        val project = buildProjectWithMPP {
+            configureRepositoriesForTests()
+        }
+        val kotlin = project.multiplatformExtension
+
+        val target = kotlin.forTarget()
+        val jvmCustom = target.compilations.create("custom")
+        jvmCustom.associateWith(target.compilations.getByName("main"))
+
+        project.evaluate()
+
+        val compileTask = taskCast(jvmCustom.compileTaskProvider.get())
+        val libraries = compileTask.libraries()
+        val friendPaths = compileTask.friendPaths()
+        assertLibrariesContainsFriendPaths(libraries, friendPaths, allowedExtraFriendPaths)
+    }
+
+    private fun assertLibrariesContainsFriendPaths(
+        libraries: Collection<File>,
+        friendPaths: Collection<File>,
+        allowed: Regex?
+    ) {
+        val unexpectedFriendPaths = (friendPaths - libraries).let {
+            if (allowed != null) {
+                it.filterNot { path -> allowed.matches(path.absolutePath) }
+            } else {
+                it
+            }
+        }
+
+        if (unexpectedFriendPaths.isNotEmpty()) {
+            fail(buildString {
+                appendLine("Unexpected friendPaths: ")
+                unexpectedFriendPaths.forEach { appendLine("* $it") }
+                appendLine("Libraries:")
+                libraries.forEach { appendLine("* $it") }
+                appendLine("FriendPaths:")
+                friendPaths.forEach { appendLine("* $it") }
+            })
+        }
     }
 }


### PR DESCRIPTION
compilation.output.classesDirs should be enough

And it prevents from K/Native compiler to report warning on unmatching with libraries friend path.