### PR TITLE
[Swift Export] Don't export multiple upper bounds generic classes

### DIFF
--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirVisibilityCheckerImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirVisibilityCheckerImpl.kt
@@ -174,6 +174,10 @@ public class SirVisibilityCheckerImpl(
             return@withSessions SirAvailability.Unavailable("From ignored package")
         }
 
+        if (typeParameters.any { it.upperBounds.size > 1 }) {
+            return@withSessions SirAvailability.Unavailable("Classes with multiple generic upper bounds are not supported yet")
+        }
+
         // Any is exported as a KotlinBase class.
         if (classId == KaStandardTypeClassIds.ANY) {
             return@withSessions SirAvailability.Unavailable("ClassId = Any")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/generics.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/generics.kt
@@ -118,6 +118,8 @@ typealias BFun = (B<*>) -> Unit
 
 fun returnBFun(): BFun = TODO()
 
+class MultipleUpperBounds<T> where T : Producer<String>, T : Consumer<String>
+
 // MODULE: f_bounded_type
 // EXPORT_TO_SWIFT
 // FILE: f_bounded_type.kt


### PR DESCRIPTION
^KT-85784 Fixed