### PR TITLE
[Daemon, BTA] Report FIXED_WARNING properly when -Werror is set

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerSeverityWerrorTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerSeverityWerrorTest.kt
@@ -10,11 +10,11 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments.Compani
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.WarningLevel
 import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogDoesNotContainPatterns
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.project
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 
 @DisplayName("Warnings-as-errors: -Werror promotes warnings to error log level")
@@ -26,14 +26,8 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
         project(strategyConfig) {
             val module = module("deprecated-usage")
             module.compile {
-                val warnLines = logLines[LogLevel.WARN].orEmpty()
-                val errorLines = logLines[LogLevel.ERROR].orEmpty()
-                assertTrue(warnLines.any { "oldFun" in it && "deprecated" in it.lowercase() }) {
-                    "Expected a deprecation warning at WARN level, got: $warnLines"
-                }
-                assertFalse(errorLines.any { "oldFun" in it || "deprecated" in it.lowercase() }) {
-                    "Expected no deprecation message at ERROR level, got: $errorLines"
-                }
+                assertLogContainsPatterns(LogLevel.WARN, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
+                assertLogDoesNotContainPatterns(LogLevel.ERROR, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
             }
         }
     }
@@ -47,14 +41,8 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
                 it.compilerArguments[WERROR] = true
             }) {
                 expectFail()
-                val errorLines = logLines[LogLevel.ERROR].orEmpty()
-                val warnLines = logLines[LogLevel.WARN].orEmpty()
-                assertTrue(errorLines.any { "oldFun" in it && "deprecated" in it.lowercase() }) {
-                    "Expected a deprecation warning promoted to ERROR level, got: $errorLines"
-                }
-                assertFalse(warnLines.any { "oldFun" in it || "deprecated" in it.lowercase() }) {
-                    "Expected no deprecation message at WARN level when Werror is set, got: $warnLines"
-                }
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
+                assertLogDoesNotContainPatterns(LogLevel.WARN, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
             }
         }
     }
@@ -69,14 +57,8 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
                 @OptIn(ExperimentalCompilerArgument::class)
                 it.compilerArguments[X_WARNING_LEVEL] = listOf(WarningLevel("DEPRECATION", WarningLevel.Severity.WARNING))
             }) {
-                val warnLines = logLines[LogLevel.WARN].orEmpty()
-                val errorLines = logLines[LogLevel.ERROR].orEmpty()
-                assertTrue(warnLines.any { "oldFun" in it && "deprecated" in it.lowercase() }) {
-                    "Expected the DEPRECATION warning pinned by -Xwarning-level to stay at WARN level, got warnLines=$warnLines"
-                }
-                assertFalse(errorLines.any { "oldFun" in it || "deprecated" in it.lowercase() }) {
-                    "Expected no DEPRECATION message at ERROR level when -Xwarning-level=DEPRECATION:warning is set, got errorLines=$errorLines"
-                }
+                assertLogContainsPatterns(LogLevel.WARN, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
+                assertLogDoesNotContainPatterns(LogLevel.ERROR, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
             }
         }
     }
@@ -90,14 +72,8 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
                 @OptIn(ExperimentalCompilerArgument::class)
                 it.compilerArguments[X_WARNING_LEVEL] = listOf(WarningLevel("DEPRECATION", WarningLevel.Severity.WARNING))
             }) {
-                val warnLines = logLines[LogLevel.WARN].orEmpty()
-                val errorLines = logLines[LogLevel.ERROR].orEmpty()
-                assertTrue(warnLines.any { "oldFun" in it && "deprecated" in it.lowercase() }) {
-                    "Expected the DEPRECATION warning at WARN level, got warnLines=$warnLines"
-                }
-                assertFalse(errorLines.any { "oldFun" in it || "deprecated" in it.lowercase() }) {
-                    "Expected no DEPRECATION message at ERROR level, got errorLines=$errorLines"
-                }
+                assertLogContainsPatterns(LogLevel.WARN, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
+                assertLogDoesNotContainPatterns(LogLevel.ERROR, Regex(".*oldFun.*"), Regex(".*deprecated.*", RegexOption.IGNORE_CASE))
             }
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerSeverityWerrorTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerSeverityWerrorTest.kt
@@ -5,7 +5,10 @@
 
 package org.jetbrains.kotlin.buildtools.tests.compilation
 
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments.Companion.X_WARNING_LEVEL
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments.Companion.WERROR
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.WarningLevel
 import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
@@ -51,6 +54,49 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
                 }
                 assertFalse(warnLines.any { "oldFun" in it || "deprecated" in it.lowercase() }) {
                     "Expected no deprecation message at WARN level when Werror is set, got: $warnLines"
+                }
+            }
+        }
+    }
+
+    @DisplayName("With -Xwarning-level=DEPRECATION:warning and -Werror, deprecation warning stays at WARN level (not escalated)")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun fixedWarningIsNotEscalatedToErrorWithWerror(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        project(strategyConfig) {
+            val module = module("deprecated-usage")
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[WERROR] = true
+                @OptIn(ExperimentalCompilerArgument::class)
+                it.compilerArguments[X_WARNING_LEVEL] = listOf(WarningLevel("DEPRECATION", WarningLevel.Severity.WARNING))
+            }) {
+                val warnLines = logLines[LogLevel.WARN].orEmpty()
+                val errorLines = logLines[LogLevel.ERROR].orEmpty()
+                assertTrue(warnLines.any { "oldFun" in it && "deprecated" in it.lowercase() }) {
+                    "Expected the DEPRECATION warning pinned by -Xwarning-level to stay at WARN level, got warnLines=$warnLines"
+                }
+                assertFalse(errorLines.any { "oldFun" in it || "deprecated" in it.lowercase() }) {
+                    "Expected no DEPRECATION message at ERROR level when -Xwarning-level=DEPRECATION:warning is set, got errorLines=$errorLines"
+                }
+            }
+        }
+    }
+
+    @DisplayName("With -Xwarning-level=DEPRECATION:warning but no -Werror, deprecation warning still stays at WARN level")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun fixedWarningStaysAtWarnLevelWithoutWerror(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        project(strategyConfig) {
+            val module = module("deprecated-usage")
+            module.compile(compilationConfigAction = {
+                @OptIn(ExperimentalCompilerArgument::class)
+                it.compilerArguments[X_WARNING_LEVEL] = listOf(WarningLevel("DEPRECATION", WarningLevel.Severity.WARNING))
+            }) {
+                val warnLines = logLines[LogLevel.WARN].orEmpty()
+                val errorLines = logLines[LogLevel.ERROR].orEmpty()
+                assertTrue(warnLines.any { "oldFun" in it && "deprecated" in it.lowercase() }) {
+                    "Expected the DEPRECATION warning at WARN level, got warnLines=$warnLines"
+                }
+                assertFalse(errorLines.any { "oldFun" in it || "deprecated" in it.lowercase() }) {
+                    "Expected no DEPRECATION message at ERROR level, got errorLines=$errorLines"
                 }
             }
         }

--- a/compiler/daemon/daemon-client/src/main/kotlin/BasicCompilerServicesWithResultsFacadeServer.kt
+++ b/compiler/daemon/daemon-client/src/main/kotlin/BasicCompilerServicesWithResultsFacadeServer.kt
@@ -60,7 +60,7 @@ fun MessageCollector.reportFromDaemon(outputsCollector: ((File, List<File>) -> U
         ReportCategory.COMPILER_MESSAGE -> {
             val compilerSeverity = when (ReportSeverity.fromCode(severity)) {
                 ReportSeverity.ERROR -> CompilerMessageSeverity.ERROR
-                ReportSeverity.WARNING -> CompilerMessageSeverity.WARNING
+                ReportSeverity.WARNING -> CompilerMessageSeverity.FIXED_WARNING // daemon handles warnings as errors itself, so we should just map it 'as is' without raising the severity
                 ReportSeverity.INFO -> CompilerMessageSeverity.INFO
                 ReportSeverity.DEBUG -> CompilerMessageSeverity.LOGGING
             }
@@ -89,7 +89,7 @@ fun MessageCollector.reportFromDaemon(outputsCollector: ((File, List<File>) -> U
 private fun MessageCollector.reportUnexpected(category: Int, severity: Int, message: String?, attachment: Serializable?) {
     val compilerMessageSeverity = when (ReportSeverity.fromCode(severity)) {
         ReportSeverity.ERROR -> CompilerMessageSeverity.ERROR
-        ReportSeverity.WARNING -> CompilerMessageSeverity.WARNING
+        ReportSeverity.WARNING -> CompilerMessageSeverity.FIXED_WARNING // daemon handles warnings as errors itself, so we should just map it 'as is' without raising the severity
         ReportSeverity.INFO -> CompilerMessageSeverity.INFO
         ReportSeverity.DEBUG -> CompilerMessageSeverity.LOGGING
     }

--- a/compiler/daemon/daemon-client/src/main/kotlin/BasicCompilerServicesWithResultsFacadeServer.kt
+++ b/compiler/daemon/daemon-client/src/main/kotlin/BasicCompilerServicesWithResultsFacadeServer.kt
@@ -27,18 +27,31 @@ import java.rmi.server.UnicastRemoteObject
 
 
 open class BasicCompilerServicesWithResultsFacadeServer(
-        val messageCollector: MessageCollector,
-        val outputsCollector: ((File, List<File>) -> Unit)? = null,
-        port: Int = SOCKET_ANY_FREE_PORT
+    val messageCollector: MessageCollector,
+    val outputsCollector: ((File, List<File>) -> Unit)? = null,
+    port: Int = SOCKET_ANY_FREE_PORT,
 ) : CompilerServicesFacadeBase,
-    UnicastRemoteObject(port, LoopbackNetworkInterface.clientLoopbackSocketFactory, LoopbackNetworkInterface.serverLoopbackSocketFactory)
-{
+    UnicastRemoteObject(port, LoopbackNetworkInterface.clientLoopbackSocketFactory, LoopbackNetworkInterface.serverLoopbackSocketFactory) {
     override fun report(category: Int, severity: Int, message: String?, attachment: Serializable?) {
         messageCollector.reportFromDaemon(outputsCollector, category, severity, message, attachment)
     }
 }
 
-fun MessageCollector.reportFromDaemon(outputsCollector: ((File, List<File>) -> Unit)?, category: Int, severity: Int, message: String?, attachment: Serializable?) {
+fun MessageCollector.reportFromDaemon(
+    outputsCollector: ((File, List<File>) -> Unit)?,
+    category: Int,
+    severity: Int,
+    message: String?,
+    attachment: Serializable?,
+) {
+    fun requireNotNullMessage(category: Int, severity: Int, message: String?, attachment: Serializable?, body: (message: String) -> Unit) {
+        if (message == null) {
+            reportUnexpected(category, severity, message, attachment)
+            return
+        }
+        body(message)
+    }
+
     val reportCategory = ReportCategory.fromCode(category)
 
     when (reportCategory) {
@@ -49,35 +62,26 @@ fun MessageCollector.reportFromDaemon(outputsCollector: ((File, List<File>) -> U
                         outputsCollector.invoke(it, outs.sourceFiles.toList())
                     }
                 }
-            }
-            else {
-                report(CompilerMessageSeverity.OUTPUT, message!!)
+            } else {
+                requireNotNullMessage(category, severity, message, attachment) {
+                    report(CompilerMessageSeverity.OUTPUT, message = it)
+                }
             }
         }
         ReportCategory.EXCEPTION -> {
             report(CompilerMessageSeverity.EXCEPTION, message.orEmpty())
         }
         ReportCategory.COMPILER_MESSAGE -> {
-            val compilerSeverity = when (ReportSeverity.fromCode(severity)) {
-                ReportSeverity.ERROR -> CompilerMessageSeverity.ERROR
-                ReportSeverity.WARNING -> CompilerMessageSeverity.FIXED_WARNING // daemon handles warnings as errors itself, so we should just map it 'as is' without raising the severity
-                ReportSeverity.INFO -> CompilerMessageSeverity.INFO
-                ReportSeverity.DEBUG -> CompilerMessageSeverity.LOGGING
-            }
-            if (message != null) {
-                report(compilerSeverity, message, attachment as? CompilerMessageSourceLocation)
-            }
-            else {
-                reportUnexpected(category, severity, message, attachment)
+            val compilerSeverity = ReportSeverity.fromCode(severity).asCompilerMessageSeverity
+            requireNotNullMessage(category, severity, message, attachment) {
+                report(compilerSeverity, message = it, attachment as? CompilerMessageSourceLocation)
             }
         }
         ReportCategory.DAEMON_MESSAGE,
-        ReportCategory.IC_MESSAGE -> {
-            if (message != null) {
-                report(CompilerMessageSeverity.LOGGING, message)
-            }
-            else {
-                reportUnexpected(category, severity, message, attachment)
+        ReportCategory.IC_MESSAGE,
+            -> {
+            requireNotNullMessage(category, severity, message, attachment) {
+                report(CompilerMessageSeverity.LOGGING, message = it)
             }
         }
         else -> {
@@ -87,12 +91,16 @@ fun MessageCollector.reportFromDaemon(outputsCollector: ((File, List<File>) -> U
 }
 
 private fun MessageCollector.reportUnexpected(category: Int, severity: Int, message: String?, attachment: Serializable?) {
-    val compilerMessageSeverity = when (ReportSeverity.fromCode(severity)) {
+    report(
+        ReportSeverity.fromCode(severity).asCompilerMessageSeverity,
+        "Unexpected message: category=$category; severity=$severity; message='$message'; attachment=$attachment"
+    )
+}
+
+private val ReportSeverity.asCompilerMessageSeverity: CompilerMessageSeverity
+    get() = when (ReportSeverity.fromCode(this.code)) {
         ReportSeverity.ERROR -> CompilerMessageSeverity.ERROR
         ReportSeverity.WARNING -> CompilerMessageSeverity.FIXED_WARNING // daemon handles warnings as errors itself, so we should just map it 'as is' without raising the severity
         ReportSeverity.INFO -> CompilerMessageSeverity.INFO
         ReportSeverity.DEBUG -> CompilerMessageSeverity.LOGGING
     }
-
-    report(compilerMessageSeverity, "Unexpected message: category=$category; severity=$severity; message='$message'; attachment=$attachment")
-}

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -351,14 +351,13 @@ abstract class CompileServiceImplBase(
         servicesFacade: ServicesFacadeT,
         compilationResults: CompilationResultsT,
         hasIncrementalCaches: JpsServicesFacadeT.() -> Boolean,
-        createMessageCollector: (ServicesFacadeT, CompilationOptions) -> MessageCollector,
+        createMessageCollector: (ServicesFacadeT, CompilationOptions, warningsAsErrors: Boolean) -> MessageCollector,
         createReporter: (ServicesFacadeT, CompilationOptions) -> DaemonMessageReporter,
         createServices: (JpsServicesFacadeT, EventManager, Profiler) -> Services,
         getICReporter: (ServicesFacadeT, CompilationResultsT & Any, CompilationOptions) -> RemoteBuildReporter<BuildTimeMetric, BuildPerformanceMetric>,
         compilationId: Int? = null,
     ) = kotlin.run {
         maybeWaitForTestStart()
-        val messageCollector = createMessageCollector(servicesFacade, compilationOptions)
         val daemonReporter = createReporter(servicesFacade, compilationOptions)
         val targetPlatform = compilationOptions.targetPlatform
         log.info("Starting compilation with args: " + compilerArguments.joinToString(" "))
@@ -374,6 +373,8 @@ abstract class CompileServiceImplBase(
         val k2PlatformArgs = compiler.createArguments()
         parseCommandLineArguments(compilerArguments.asList(), k2PlatformArgs)
         val argumentParseError = validateArgumentsAllErrors(k2PlatformArgs.errors)
+
+        val messageCollector = createMessageCollector(servicesFacade, compilationOptions, k2PlatformArgs.allWarningsAsErrors)
 
         if (argumentParseError.isNotEmpty()) {
             argumentParseError.forEach {
@@ -1006,7 +1007,7 @@ class CompileServiceImpl(
             CompileService.CallResult.Error("Sorry, only JVM target platform is supported now")
         else {
             val disposable = Disposer.newDisposable("Disposable for ${CompileServiceImpl::class.simpleName}.leaseReplSession")
-            val messageCollector = CompileServicesFacadeMessageCollector(servicesFacade, compilationOptions)
+            val messageCollector = CompileServicesFacadeMessageCollector(servicesFacade, compilationOptions, false)
             val repl = KotlinJvmReplService(
                 disposable, port, compilerId, templateClasspath, templateClassName,
                 messageCollector, null

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/CompileServicesFacadeMessageCollector.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/report/CompileServicesFacadeMessageCollector.kt
@@ -25,7 +25,8 @@ import org.jetbrains.kotlin.daemon.common.*
 
 internal class CompileServicesFacadeMessageCollector(
         private val servicesFacade: CompilerServicesFacadeBase,
-        compilationOptions: CompilationOptions
+        compilationOptions: CompilationOptions,
+        private val warningsAsErrors: Boolean
 ) : MessageCollector {
     private val mySeverity = compilationOptions.reportSeverity
     private var hasErrors = false
@@ -45,6 +46,8 @@ internal class CompileServicesFacadeMessageCollector(
             }
             else -> {
                 val reportSeverity = when (severity) {
+                    CompilerMessageSeverity.WARNING if warningsAsErrors -> ReportSeverity.ERROR
+                    CompilerMessageSeverity.STRONG_WARNING if warningsAsErrors -> ReportSeverity.ERROR
                     CompilerMessageSeverity.ERROR -> ReportSeverity.ERROR
 
                     CompilerMessageSeverity.WARNING,
@@ -54,9 +57,7 @@ internal class CompileServicesFacadeMessageCollector(
 
                     CompilerMessageSeverity.INFO -> ReportSeverity.INFO
 
-                    CompilerMessageSeverity.EXCEPTION,
                     CompilerMessageSeverity.LOGGING,
-                    CompilerMessageSeverity.OUTPUT
                         -> ReportSeverity.DEBUG
                 }
 


### PR DESCRIPTION
Daemon raises the severity from warning to error if needed itself. BTA treats the severity 'as is' in this case. This solution was chosen in favour of introducing new `ReportSeverity` entry and shifting the existing ones to keep the logic based on `ReportSeverity.code` comparison working as expected. Otherwise, we could break legacy non-BTA consumers of the daemon which still exist.
^KT-85634 Verification Pending