### PR TITLE
[Daemon] Increase autoshutdownUnusedSeconds in LastSessionDaemonTest

### DIFF
--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/BaseDaemonSessionTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/BaseDaemonSessionTest.kt
@@ -83,16 +83,26 @@ abstract class BaseDaemonSessionTest {
         clientMarkerFile.createNewFile()
         sessionMarkerFile.createNewFile()
         logFile?.createNewFile()
-        return KotlinCompilerClient.connectAndLease(
-            compilerId,
-            clientMarkerFile,
-            actualJvmOptions,
-            daemonOptions,
-            DaemonReportingTargets(messages = daemonMessagesCollector, out = System.err),
-            autostart = true,
-            leaseSession = true,
-            sessionAliveFlagFile = sessionMarkerFile,
-        )?.also { compileServices.add(it.compileService) } ?: error("failed to connect daemon")
+        try {
+            return KotlinCompilerClient.connectAndLease(
+                compilerId,
+                clientMarkerFile,
+                actualJvmOptions,
+                daemonOptions,
+                DaemonReportingTargets(messages = daemonMessagesCollector, out = System.err),
+                autostart = true,
+                leaseSession = true,
+                sessionAliveFlagFile = sessionMarkerFile,
+            )?.also { compileServices.add(it.compileService) } ?: error("failed to connect daemon")
+        } catch (e: Exception) {
+            logFile?.useLines {
+                println("Daemon log:")
+                for (line in it) {
+                    println(line)
+                }
+            }
+            throw e
+        }
     }
 }
 

--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/LastSessionDaemonTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/LastSessionDaemonTest.kt
@@ -23,13 +23,13 @@ class LastSessionDaemonTest : BaseDaemonSessionTest() {
         get() = workingDirectory.resolve("daemon.log")
 
     override val defaultDaemonOptions: DaemonOptions
-        get() = super.defaultDaemonOptions.copy(autoshutdownUnusedSeconds = (DAEMON_PERIODIC_CHECK_INTERVAL_MS / 1000).toInt())
+        get() = super.defaultDaemonOptions.copy(autoshutdownUnusedSeconds = (DAEMON_AUTOSHUTDOWN_UNUSED_MS / 1000).toInt())
 
     @DisplayName("Already leased session can perform compilation")
     @Test
     fun canCompileInLastSessionMode() {
         val (compileService, sessionId) = leaseSession(logFile = logFile)
-        sleep(DAEMON_PERIODIC_CHECK_INTERVAL_MS + 1_000)
+        sleep(DAEMON_AUTOSHUTDOWN_UNUSED_MS + DAEMON_PERIODIC_CHECK_INTERVAL_MS)
         logFile.assertLogFileContains("Some sessions are active, waiting for them to finish")
         val testMessageCollector = MessageCollectorImpl()
         val exitCode = KotlinCompilerClient.compile(
@@ -51,9 +51,13 @@ class LastSessionDaemonTest : BaseDaemonSessionTest() {
     @Test
     fun canLeaseNewSession() {
         leaseSession(logFile = logFile)
-        sleep(DAEMON_PERIODIC_CHECK_INTERVAL_MS + 1_000)
+        sleep(DAEMON_AUTOSHUTDOWN_UNUSED_MS + DAEMON_PERIODIC_CHECK_INTERVAL_MS)
         logFile.assertLogFileContains("Some sessions are active, waiting for them to finish")
         // trying to lease a session with the same config again
         leaseSession(logFile = logFile)
+    }
+
+    companion object {
+        private const val DAEMON_AUTOSHUTDOWN_UNUSED_MS = 3000L
     }
 }


### PR DESCRIPTION
Also, add printing the daemon log if leaseSession does not succeed.

Hopefully, the increased timeout fixes flakiness on CI by itself. If not, additional logs would help understanding the issue better. Relates to KTI-3130