### PR TITLE
[KT-84822] Add javac `parameters` flag to get same ir in jklib tests

### DIFF
--- a/compiler/jklib.tests/testFixtures/org/jetbrains/kotlin/jklib/test/irText/JKlibJavaSourceConfigurator.kt
+++ b/compiler/jklib.tests/testFixtures/org/jetbrains/kotlin/jklib/test/irText/JKlibJavaSourceConfigurator.kt
@@ -64,7 +64,8 @@ class JKlibJavaSourceConfigurator(testServices: TestServices) : EnvironmentConfi
                 "${module.name}-java-binaries",
                 extraClasspath = jvmClasspathRoots,
                 assertions = testServices.assertions,
-                useJava11 = true // Requires jdk.11.home to be set in build.gradle.kts
+                useJava11 = true, // Requires jdk.11.home to be set in build.gradle.kts
+                extraJavacOptions = listOf("-parameters") // Preserve parameter names during Java compilation so IR tests match
             )
             configuration.addJvmClasspathRoot(compiledJar)
         } catch (e: Throwable) {

--- a/compiler/testData/ir/irText/fakeOverrides/javaBackedCallable.ir.txt
+++ b/compiler/testData/ir/irText/fakeOverrides/javaBackedCallable.ir.txt
@@ -28,9 +28,9 @@ FILE fqName:<root> fileName:/Kotlin1.kt
         public open fun hashCode (): kotlin.Int declared in <root>.BaseJava
     FUN FAKE_OVERRIDE name:setE visibility:public/*package*/ modality:OPEN returnType:kotlin.Unit [fake_override]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BaseJava
-      VALUE_PARAMETER kind:Regular name:p0 index:1 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Int
       overridden:
-        public/*package*/ open fun setE (p0: kotlin.Int): kotlin.Unit declared in <root>.BaseJava
+        public/*package*/ open fun setE (value: kotlin.Int): kotlin.Unit declared in <root>.BaseJava
     FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
@@ -65,9 +65,9 @@ FILE fqName:<root> fileName:/Kotlin2.kt
         public open fun hashCode (): kotlin.Int declared in <root>.Kotlin1
     FUN FAKE_OVERRIDE name:setE visibility:public/*package*/ modality:OPEN returnType:kotlin.Unit [fake_override]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BaseJava
-      VALUE_PARAMETER kind:Regular name:p0 index:1 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Int
       overridden:
-        public/*package*/ open fun setE (p0: kotlin.Int): kotlin.Unit declared in <root>.Kotlin1
+        public/*package*/ open fun setE (value: kotlin.Int): kotlin.Unit declared in <root>.Kotlin1
     FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
@@ -102,9 +102,9 @@ FILE fqName:<root> fileName:/Kotlin3.kt
         public open fun hashCode (): kotlin.Int declared in <root>.Kotlin2
     FUN FAKE_OVERRIDE name:setE visibility:public/*package*/ modality:OPEN returnType:kotlin.Unit [fake_override]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BaseJava
-      VALUE_PARAMETER kind:Regular name:p0 index:1 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Int
       overridden:
-        public/*package*/ open fun setE (p0: kotlin.Int): kotlin.Unit declared in <root>.Kotlin2
+        public/*package*/ open fun setE (value: kotlin.Int): kotlin.Unit declared in <root>.Kotlin2
     FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
@@ -115,9 +115,9 @@ FILE fqName:<root> fileName:/Kotlin3.kt
         VAR name:x type:kotlin.Int [val]
           CALL 'public open fun getE (): kotlin.Int declared in <root>.Kotlin3' type=kotlin.Int origin=GET_PROPERTY
             ARG <this>: GET_VAR '<this>: <root>.Kotlin3 declared in <root>.Kotlin3.test' type=<root>.Kotlin3 origin=IMPLICIT_ARGUMENT
-        CALL 'public/*package*/ open fun setE (p0: kotlin.Int): kotlin.Unit declared in <root>.Kotlin3' type=kotlin.Unit origin=EQ
+        CALL 'public/*package*/ open fun setE (value: kotlin.Int): kotlin.Unit declared in <root>.Kotlin3' type=kotlin.Unit origin=EQ
           ARG <this>: GET_VAR '<this>: <root>.Kotlin3 declared in <root>.Kotlin3.test' type=<root>.Kotlin3 origin=IMPLICIT_ARGUMENT
-          ARG p0: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=PLUS
+          ARG value: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=PLUS
             ARG <this>: GET_VAR 'val x: kotlin.Int declared in <root>.Kotlin3.test' type=kotlin.Int origin=null
             ARG other: CONST Int type=kotlin.Int value=1
         TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit

--- a/compiler/testData/ir/irText/fakeOverrides/javaBackedCallable.kt
+++ b/compiler/testData/ir/irText/fakeOverrides/javaBackedCallable.kt
@@ -1,4 +1,4 @@
-// TARGET_BACKEND: JKLIB
+// TARGET_BACKEND: JVM
 // FILE: BaseJava.java
 
 public class BaseJava {

--- a/compiler/testData/ir/irText/fakeOverrides/javaBackedCallable.kt.txt
+++ b/compiler/testData/ir/irText/fakeOverrides/javaBackedCallable.kt.txt
@@ -31,7 +31,7 @@ class Kotlin3 : Kotlin2 {
 
   fun test() {
     val x: Int = <this>.getE()
-    <this>.setE(p0 = x.plus(other = 1))
+    <this>.setE(value = x.plus(other = 1))
     <this>.getJavaString() /*~> Unit */
     <this>.doJavaAction()
   }

--- a/compiler/tests-common/testFixtures/org/jetbrains/kotlin/test/MockLibraryUtilExt.kt
+++ b/compiler/tests-common/testFixtures/org/jetbrains/kotlin/test/MockLibraryUtilExt.kt
@@ -16,6 +16,7 @@ object MockLibraryUtilExt {
         jarName: String,
         addSources: Boolean = false,
         extraOptions: List<String> = emptyList(),
+        extraJavacOptions: List<String> = emptyList(),
         extraClasspath: List<String> = emptyList(),
     ): File {
         return MockLibraryUtil.compileJavaFilesLibraryToJar(
@@ -23,6 +24,7 @@ object MockLibraryUtilExt {
             jarName,
             addSources,
             extraOptions,
+            extraJavacOptions,
             extraClasspath,
             extraModulepath = listOf(),
             JUnit4Assertions
@@ -37,6 +39,7 @@ object MockLibraryUtilExt {
         addSources: Boolean = false,
         allowKotlinSources: Boolean = true,
         extraOptions: List<String> = emptyList(),
+        extraJavacOptions: List<String> = emptyList(),
         extraClasspath: List<String> = emptyList(),
         useJava11: Boolean = false,
     ): File {
@@ -46,6 +49,7 @@ object MockLibraryUtilExt {
             addSources,
             allowKotlinSources,
             extraOptions,
+            extraJavacOptions,
             extraClasspath,
             extraModulepath = listOf(),
             useJava11

--- a/compiler/tests-compiler-utils/testFixtures/org/jetbrains/kotlin/test/MockLibraryUtil.kt
+++ b/compiler/tests-compiler-utils/testFixtures/org/jetbrains/kotlin/test/MockLibraryUtil.kt
@@ -63,6 +63,7 @@ object MockLibraryUtil {
         addSources: Boolean = false,
         allowKotlinSources: Boolean = true,
         extraOptions: List<String> = emptyList(),
+        extraJavacOptions: List<String> = emptyList(),
         extraClasspath: List<String> = emptyList(),
         extraModulepath: List<String> = emptyList(),
         useJava11: Boolean = false,
@@ -74,6 +75,7 @@ object MockLibraryUtil {
             addSources,
             allowKotlinSources,
             extraOptions,
+            extraJavacOptions,
             extraClasspath,
             extraModulepath,
             useJava11,
@@ -85,6 +87,7 @@ object MockLibraryUtil {
         jarName: String,
         addSources: Boolean = false,
         extraOptions: List<String> = emptyList(),
+        extraJavacOptions: List<String> = emptyList(),
         extraClasspath: List<String> = emptyList(),
         extraModulepath: List<String> = emptyList(),
         assertions: Assertions,
@@ -94,6 +97,7 @@ object MockLibraryUtil {
             sourcesPath, jarName, addSources,
             allowKotlinSources = false,
             extraOptions,
+            extraJavacOptions,
             extraClasspath,
             extraModulepath,
             useJava11,
@@ -108,6 +112,7 @@ object MockLibraryUtil {
         addSources: Boolean = false,
         allowKotlinSources: Boolean = true,
         extraOptions: List<String> = emptyList(),
+        extraJavacOptions: List<String> = emptyList(),
         extraClasspath: List<String> = emptyList(),
         extraModulepath: List<String> = emptyList(),
         useJava11: Boolean = false,
@@ -149,6 +154,7 @@ object MockLibraryUtil {
                 }
                 add("-encoding")
                 add("utf8")
+                addAll(extraJavacOptions)
             }
 
             val jdkHome = if (useJava11) KtTestUtil.getJdk11Home() else null


### PR DESCRIPTION
## Problem

Some JKlib tests were failing due to IR data mismatches when depending on Java sources  By default, the Java compiler was stripping parameter names, causing discrepancies in the IR produced by the Kotlin compiler.

## Solution

Add the `-parameters` flag to the Java compilation of these sources to preserve parameter names in the class files. This allows the Kotlin compiler to read the names from the JARs and produce the expected IR.

### Unrelated change

Making javaBackedTest previously added for jklib testing a jvm test, now it passes with both