### PR TITLE
Fix indentation for generated proguard mappings

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/arrayParameters[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/arrayParameters[mapping=true].txt
@@ -14,4 +14,4 @@ fun Test(ints: IntArray, strings: Array<String>) {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(int[],java.lang.String[],androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(int[],java.lang.String[],androidx.compose.runtime.Composer,int):5:5 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/classMember[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/classMember[mapping=true].txt
@@ -18,4 +18,4 @@ class TestImpl : Test {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestImpl.Test(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:void TestImpl.Test(androidx.compose.runtime.Composer,int):11:11 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/composableLambda[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/composableLambda[mapping=true].txt
@@ -14,13 +14,13 @@
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.App(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:kotlin.Unit TestKt.App$lambda$0(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.App(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit TestKt.App$lambda$0(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.App(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:kotlin.Unit TestKt.App$lambda$0(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.App(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit TestKt.App$lambda$0(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=true].txt
@@ -29,47 +29,47 @@ private fun contentOf(
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
-  1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
+    1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
-  1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):18:18 -> m$<key>
+    1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):16:16 -> m$<key>
-  1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):16:16 -> m$<key>
+    1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
-  1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):16:16 -> m$<key>
-  1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):16:16 -> m$<key>
+    1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/earlyReturnCurrent[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/earlyReturnCurrent[mapping=true].txt
@@ -15,5 +15,5 @@
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/earlyReturn[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/earlyReturn[mapping=true].txt
@@ -14,5 +14,5 @@ fun Test(text: String) {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/endToMarkerNested[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/endToMarkerNested[mapping=true].txt
@@ -21,9 +21,9 @@ fun Test(text: String) {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
-  1:1:void ExtraKt.Wrapper(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.SecondWrapper(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
+    1:1:void ExtraKt.Wrapper(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.SecondWrapper(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/endToMarker[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/endToMarker[mapping=true].txt
@@ -16,7 +16,7 @@ fun Test(text: String) {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:void ExtraKt.Wrapper(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:void ExtraKt.Wrapper(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):5:5 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/funInterface[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/funInterface[mapping=true].txt
@@ -17,4 +17,4 @@ fun Content() {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt$Content$1.Test(androidx.compose.runtime.Composer,int):10:10 -> m$<key>
+    1:1:void TestKt$Content$1.Test(androidx.compose.runtime.Composer,int):10:10 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/groupAroundExhaustiveWhenInline[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/groupAroundExhaustiveWhenInline[mapping=true].txt
@@ -20,11 +20,11 @@ fun Test(param: Value): String {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:void ExtraKt.Str(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:void ExtraKt.Str(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:void ExtraKt.Str(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:java.lang.String TestKt.Test(Value,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:void ExtraKt.Str(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/inlineWithConditional[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/inlineWithConditional[mapping=true].txt
@@ -22,14 +22,14 @@ inline fun Test(isEnabled: Boolean, p1: Int, crossinline content: @Composable ()
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):9:9 -> m$<key>
-  1:1:void TestKt.Test(boolean,int,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
-  1:1:void ExtraKt.A(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):9:9 -> m$<key>
+    1:1:void TestKt.Test(boolean,int,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):15:15 -> m$<key>
+    1:1:void ExtraKt.A(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:void TestKt.Test(boolean,int,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
-  1:1:void ExtraKt.A(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(boolean,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:void TestKt.Test(boolean,int,kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):14:14 -> m$<key>
+    1:1:void ExtraKt.A(androidx.compose.runtime.Composer,int):4:4 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/key[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/key[mapping=true].txt
@@ -19,11 +19,11 @@ fun targetEnterExit(param: String): String =
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):9:9 -> m$<key>
+    1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):9:9 -> m$<key>
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):8:8 -> m$<key>
+    1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:java.lang.String TestKt.targetEnterExit(java.lang.String,androidx.compose.runtime.Composer,int):8:8 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaCaptureWithDefault[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaCaptureWithDefault[mapping=true].txt
@@ -18,5 +18,5 @@ fun Test(isEnabled: Boolean = false) {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(boolean,androidx.compose.runtime.Composer,int,int):5:5 -> m$<key>
-  1:1:kotlin.Unit TestKt$Test$1$1.invokeSuspend$lambda$0$0(boolean,androidx.compose.runtime.Composer,int):9:9 -> m$<key>
+    1:1:void TestKt.Test(boolean,androidx.compose.runtime.Composer,int,int):5:5 -> m$<key>
+    1:1:kotlin.Unit TestKt$Test$1$1.invokeSuspend$lambda$0$0(boolean,androidx.compose.runtime.Composer,int):9:9 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaInField[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaInField[mapping=true].txt
@@ -14,7 +14,7 @@ class Test {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__1246884903$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__1246884903$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__1246884903$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__1246884903$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambda[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambda[mapping=true].txt
@@ -10,7 +10,7 @@ val a = @Composable {}
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__486040309$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__486040309$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__486040309$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__486040309$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/loops[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/loops[mapping=true].txt
@@ -20,6 +20,6 @@ fun Test() {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Content(int,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void TestKt.Test(androidx.compose.runtime.Composer,int):8:8 -> m$<key>
-  1:1:void TestKt.Test(androidx.compose.runtime.Composer,int):9:9 -> m$<key>
+    1:1:void TestKt.Content(int,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(androidx.compose.runtime.Composer,int):8:8 -> m$<key>
+    1:1:void TestKt.Test(androidx.compose.runtime.Composer,int):9:9 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/nestedComposableLambda[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/nestedComposableLambda[mapping=true].txt
@@ -17,15 +17,15 @@
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:kotlin.Unit TestKt.Test$lambda$0$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:kotlin.Unit TestKt.Test$lambda$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit TestKt.Test$lambda$0$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:kotlin.Unit TestKt.Test$lambda$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:kotlin.Unit TestKt.Test$lambda$0$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
-  1:1:kotlin.Unit TestKt.Test$lambda$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit TestKt.Test$lambda$0$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):7:7 -> m$<key>
+    1:1:kotlin.Unit TestKt.Test$lambda$0(java.lang.String,java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.Content(kotlin.jvm.functions.Function2,androidx.compose.runtime.Composer,int):5:5 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/replaceableGroup[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/replaceableGroup[mapping=true].txt
@@ -13,9 +13,9 @@
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.Object TestKt.Test(java.lang.Object,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:java.lang.Object TestKt.Test(java.lang.Object,androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.Object TestKt.Test(java.lang.Object,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
-  1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:java.lang.Object TestKt.Test(java.lang.Object,androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:void ExtraKt.Text(java.lang.String,androidx.compose.runtime.Composer,int):4:4 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/throwInCompose[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/throwInCompose[mapping=true].txt
@@ -27,15 +27,15 @@ private fun throwError(): Nothing = TODO()
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.String TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
-  1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
-  1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:java.lang.String TestKt.TestFunctionThrow(java.lang.String,androidx.compose.runtime.Composer,int):19:19 -> m$<key>
+    1:1:java.lang.String TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
+    1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
+    1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:java.lang.String TestKt.TestFunctionThrow(java.lang.String,androidx.compose.runtime.Composer,int):19:19 -> m$<key>
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-  1:1:java.lang.String TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
-  1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
-  1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
-  1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
-  1:1:java.lang.String TestKt.TestFunctionThrow(java.lang.String,androidx.compose.runtime.Composer,int):19:19 -> m$<key>
+    1:1:java.lang.String TestKt.Test(java.lang.String,androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
+    1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):10:10 -> m$<key>
+    1:1:java.lang.String TestKt.TestConditional(java.lang.String,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
+    1:1:java.lang.String TestKt.TestFunctionThrow(java.lang.String,androidx.compose.runtime.Composer,int):19:19 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/topLevelFunction[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/topLevelFunction[mapping=true].txt
@@ -11,4 +11,4 @@ fun Test() {}
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-  1:1:void TestKt.Test(androidx.compose.runtime.Composer,int):5:5 -> m$<key>
+    1:1:void TestKt.Test(androidx.compose.runtime.Composer,int):5:5 -> m$<key>

--- a/plugins/compose/group-mapping/src/main/kotlin/androidx/compose/compiler/mapping/ComposeMapping.kt
+++ b/plugins/compose/group-mapping/src/main/kotlin/androidx/compose/compiler/mapping/ComposeMapping.kt
@@ -51,7 +51,7 @@ class ComposeMapping(
         if (group.key == null) return
         if (group.line == -1) return
 
-        append("  ")
+        append("    ")
         append("1:1:")
         append(descriptorToProguardString("${cls.classId.fqName}.${method.id.methodName}", method.id.methodDescriptor))
         append(":")


### PR DESCRIPTION
Should be 4 spaces instead of 2.

Fixes: 504284805
Test: Existing tests