### PR TITLE
[FIR] Use FIR visitor instead of CFG to track tailrec in trys

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTailrecFunctionChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirTailrecFunctionChecker.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.fir.analysis.checkers.declaration
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
@@ -16,7 +17,9 @@ import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.utils.isOverride
 import org.jetbrains.kotlin.fir.declarations.utils.isTailRec
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirThisReceiverExpression
+import org.jetbrains.kotlin.fir.expressions.FirTryExpression
 import org.jetbrains.kotlin.fir.expressions.arguments
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.*
@@ -25,10 +28,22 @@ import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.types.canBeNull
 import org.jetbrains.kotlin.fir.types.coneType
-import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
+import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 object FirTailrecFunctionChecker : FirFunctionChecker(MppCheckerKind.Common) {
+    // !!!
+    // Order is important!
+    // Must be ordered from least to most severe.
+    // !!!
+    private enum class TailrecCallKind {
+        Valid,
+        FollowingInstructions,
+        InsideTry,
+        WrongReceiver,
+        DefaultArguments,
+    }
+
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirFunction) {
         if (!declaration.isTailRec) return
@@ -37,37 +52,9 @@ object FirTailrecFunctionChecker : FirFunctionChecker(MppCheckerKind.Common) {
         }
         val graph = declaration.controlFlowGraphReference?.controlFlowGraph ?: return
 
-        // TODO, KT-59668: this is not how CFG works, tail calls inside try-catch should be detected by FIR tree traversal.
-        var tryScopeCount = 0
-        var catchScopeCount = 0
-        var finallyScopeCount = 0
-        var tailrecCount = 0
+        val tailrecCalls = mutableMapOf<FirFunctionCall, TailrecCallKind>()
         graph.traverse(object : ControlFlowGraphVisitorVoid() {
             override fun visitNode(node: CFGNode<*>) {}
-
-            override fun visitTryMainBlockEnterNode(node: TryMainBlockEnterNode) {
-                tryScopeCount++
-            }
-
-            override fun visitTryMainBlockExitNode(node: TryMainBlockExitNode) {
-                tryScopeCount--
-            }
-
-            override fun visitCatchClauseEnterNode(node: CatchClauseEnterNode) {
-                catchScopeCount++
-            }
-
-            override fun visitCatchClauseExitNode(node: CatchClauseExitNode) {
-                catchScopeCount--
-            }
-
-            override fun visitFinallyBlockEnterNode(node: FinallyBlockEnterNode) {
-                finallyScopeCount++
-            }
-
-            override fun visitFinallyBlockExitNode(node: FinallyBlockExitNode) {
-                finallyScopeCount--
-            }
 
             override fun visitFunctionCallExitNode(node: FunctionCallExitNode) {
                 val functionCall = node.fir
@@ -75,7 +62,7 @@ object FirTailrecFunctionChecker : FirFunctionChecker(MppCheckerKind.Common) {
                 if (resolvedSymbol != declaration.symbol) return
                 if (functionCall.arguments.size != resolvedSymbol.valueParameterSymbols.size && resolvedSymbol.isOverride) {
                     // Overridden functions using default arguments at tail call are not included: KT-4285
-                    reporter.reportOn(functionCall.source, FirErrors.NON_TAIL_RECURSIVE_CALL)
+                    tailrecCalls[functionCall] = TailrecCallKind.DefaultArguments
                     return
                 }
                 val dispatchReceiver = functionCall.dispatchReceiver
@@ -85,16 +72,49 @@ object FirTailrecFunctionChecker : FirFunctionChecker(MppCheckerKind.Common) {
                         dispatchReceiverOwner?.classKind?.isSingleton == true
                 if (!sameReceiver) {
                     // A call on a different receiver might get dispatched to a different method, so it can't be optimized.
-                    reporter.reportOn(functionCall.source, FirErrors.NON_TAIL_RECURSIVE_CALL)
-                } else if (tryScopeCount > 0 || catchScopeCount > 0 || finallyScopeCount > 0) {
-                    reporter.reportOn(functionCall.source, FirErrors.TAIL_RECURSION_IN_TRY_IS_NOT_SUPPORTED)
+                    tailrecCalls[functionCall] = TailrecCallKind.WrongReceiver
                 } else if (node.hasMoreFollowingInstructions(declaration, context.session)) {
-                    reporter.reportOn(functionCall.source, FirErrors.NON_TAIL_RECURSIVE_CALL)
+                    tailrecCalls[functionCall] = TailrecCallKind.FollowingInstructions
                 } else if (!node.isDead) {
-                    tailrecCount++
+                    tailrecCalls[functionCall] = TailrecCallKind.Valid
                 }
             }
         })
+
+        // Check that tailrec calls are not inside try-expressions.
+        // DATA(Boolean) = Within try-expression.
+        declaration.body?.accept(object : FirVisitor<Unit, Boolean>() {
+            override fun visitElement(element: FirElement, data: Boolean) {
+                element.acceptChildren(this, data)
+            }
+
+            override fun visitTryExpression(tryExpression: FirTryExpression, data: Boolean) {
+                tryExpression.acceptChildren(this, data = true)
+            }
+
+            override fun visitFunctionCall(functionCall: FirFunctionCall, data: Boolean) {
+                functionCall.acceptChildren(this, data)
+                if (!data) return // Not within try-expression.
+
+                // Increase severity of tailrec kind to 'InsideTry'.
+                val kind = tailrecCalls[functionCall]
+                if (kind != null && kind < TailrecCallKind.InsideTry) {
+                    tailrecCalls[functionCall] = TailrecCallKind.InsideTry
+                }
+            }
+        }, data = false)
+
+        var tailrecCount = 0
+        for ((functionCall, kind) in tailrecCalls) {
+            when (kind) {
+                TailrecCallKind.Valid -> tailrecCount++
+                TailrecCallKind.FollowingInstructions -> reporter.reportOn(functionCall.source, FirErrors.NON_TAIL_RECURSIVE_CALL)
+                TailrecCallKind.InsideTry -> reporter.reportOn(functionCall.source, FirErrors.TAIL_RECURSION_IN_TRY_IS_NOT_SUPPORTED)
+                TailrecCallKind.WrongReceiver -> reporter.reportOn(functionCall.source, FirErrors.NON_TAIL_RECURSIVE_CALL)
+                TailrecCallKind.DefaultArguments -> reporter.reportOn(functionCall.source, FirErrors.NON_TAIL_RECURSIVE_CALL)
+            }
+        }
+
         if (tailrecCount == 0) {
             reporter.reportOn(declaration.source, FirErrors.NO_TAIL_CALLS_FOUND)
         }

--- a/compiler/testData/diagnostics/tests/tailRecInTry.kt
+++ b/compiler/testData/diagnostics/tests/tailRecInTry.kt
@@ -1,4 +1,6 @@
 // RUN_PIPELINE_TILL: BACKEND
+// ISSUES: KT-81932
+
 <!NO_TAIL_CALLS_FOUND!>tailrec<!> fun foo1() {
     try {
         <!TAIL_RECURSION_IN_TRY_IS_NOT_SUPPORTED!>foo1<!>()
@@ -60,6 +62,14 @@
         } else {
             foo1()
         }
+    }
+}
+
+<!NO_TAIL_CALLS_FOUND!>tailrec<!> fun foo5(param: Int) {
+    if (true) {
+        return <!TAIL_RECURSION_IN_TRY_IS_NOT_SUPPORTED!>foo5<!>(param)
+    } else {
+        try { } finally { }
     }
 }
 

--- a/compiler/testData/diagnostics/tests/tailRecInTry.kt
+++ b/compiler/testData/diagnostics/tests/tailRecInTry.kt
@@ -65,9 +65,9 @@
     }
 }
 
-<!NO_TAIL_CALLS_FOUND!>tailrec<!> fun foo5(param: Int) {
+tailrec fun foo5(param: Int) {
     if (true) {
-        return <!TAIL_RECURSION_IN_TRY_IS_NOT_SUPPORTED!>foo5<!>(param)
+        return foo5(param)
     } else {
         try { } finally { }
     }


### PR DESCRIPTION
Traversing the CFG does not result in true control-flow traversal.
Instead, nodes within a CFG are traversed from start to end, where nodes
from different branches may be interleaved. This results in try, catch,
or finally related node to be visited while visiting nodes from a
different branch in an if-expression.

To properly track function calls within try-expressions, the tailrec
checker should use an FIR visitor. Unfortunately, a FIR visitor is not
enough to handle all tailrec related checks. So use an FIR visitor after
other checks are performed to upgrade valid or minor tailrec warnings to
try-expression related warnings.