### PR TITLE
[stdlib] rangeUntil docs sample code uses a rangeTo example

### DIFF
--- a/libraries/stdlib/samples/test/samples/ranges/ranges.kt
+++ b/libraries/stdlib/samples/test/samples/ranges/ranges.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertTrue
 class Ranges {
 
     @Sample
-    fun rangeFromComparable() {
+    fun rangeToComparable() {
         val start = Date.valueOf("2017-01-01")
         val end = Date.valueOf("2017-12-31")
         val range = start..end
@@ -36,7 +36,19 @@ class Ranges {
     }
 
     @Sample
-    fun rangeFromDouble() {
+    fun rangeUntilComparable() {
+        val start = Date.valueOf("2017-01-01")
+        val end = Date.valueOf("2017-12-31")
+        val range = start..<end
+        assertPrints(range, "2017-01-01..<2017-12-31")
+
+        assertTrue(Date.valueOf("2017-05-27") in range)
+        assertFalse(Date.valueOf("2017-12-31") in range)
+        assertTrue(Date.valueOf("2017-12-31") !in range)
+    }
+
+    @Sample
+    fun rangeToDouble() {
         val range = 1.0..100.0
         assertPrints(range, "1.0..100.0")
 
@@ -45,12 +57,30 @@ class Ranges {
     }
 
     @Sample
-    fun rangeFromFloat() {
+    fun rangeUntilDouble() {
+        val range = 1.0..<100.0
+        assertPrints(range, "1.0..<100.0")
+
+        assertTrue(3.14 in range)
+        assertFalse(100.0 in range)
+    }
+
+    @Sample
+    fun rangeToFloat() {
         val range = 1f..100f
         assertPrints(range, "1.0..100.0")
 
         assertTrue(3.14f in range)
         assertFalse(100.1f in range)
+    }
+
+    @Sample
+    fun rangeUntilFloat() {
+        val range = 1f..<100f
+        assertPrints(range, "1.0..<100.0")
+
+        assertTrue(3.14f in range)
+        assertFalse(100f in range)
     }
 
     @Sample

--- a/libraries/stdlib/src/kotlin/ranges/Ranges.kt
+++ b/libraries/stdlib/src/kotlin/ranges/Ranges.kt
@@ -32,7 +32,8 @@ private open class ComparableRange<T : Comparable<T>>(
  * Creates a range from this [Comparable] value to the specified [that] value.
  *
  * This value needs to be smaller than or equal to [that] value, otherwise the returned range will be empty.
- * @sample samples.ranges.Ranges.rangeFromComparable
+ *
+ * @sample samples.ranges.Ranges.rangeToComparable
  */
 public operator fun <T : Comparable<T>> T.rangeTo(that: T): ClosedRange<T> = ComparableRange(this, that)
 
@@ -60,7 +61,8 @@ private open class ComparableOpenEndRange<T : Comparable<T>>(
  * Creates an open-ended range from this [Comparable] value to the specified [that] value.
  *
  * This value needs to be smaller than [that] value, otherwise the returned range will be empty.
- * @sample samples.ranges.Ranges.rangeFromComparable
+ *
+ * @sample samples.ranges.Ranges.rangeUntilComparable
  */
 @SinceKotlin("1.9")
 @WasExperimental(ExperimentalStdlibApi::class)
@@ -121,7 +123,8 @@ private class ClosedDoubleRange(
  * Creates a range from this [Double] value to the specified [that] value.
  *
  * Numbers are compared with the ends of this range according to IEEE-754.
- * @sample samples.ranges.Ranges.rangeFromDouble
+ *
+ * @sample samples.ranges.Ranges.rangeToDouble
  */
 @SinceKotlin("1.1")
 public operator fun Double.rangeTo(that: Double): ClosedFloatingPointRange<Double> = ClosedDoubleRange(this, that)
@@ -161,6 +164,8 @@ private class OpenEndDoubleRange(
  * Creates an open-ended range from this [Double] value to the specified [that] value.
  *
  * Numbers are compared with the ends of this range according to IEEE-754.
+ *
+ * @sample samples.ranges.Ranges.rangeUntilDouble
  */
 @SinceKotlin("1.9")
 @WasExperimental(ExperimentalStdlibApi::class)
@@ -202,7 +207,8 @@ private class ClosedFloatRange(
  * Creates a range from this [Float] value to the specified [that] value.
  *
  * Numbers are compared with the ends of this range according to IEEE-754.
- * @sample samples.ranges.Ranges.rangeFromFloat
+ *
+ * @sample samples.ranges.Ranges.rangeToFloat
  */
 @SinceKotlin("1.1")
 public operator fun Float.rangeTo(that: Float): ClosedFloatingPointRange<Float> = ClosedFloatRange(this, that)
@@ -243,6 +249,8 @@ private class OpenEndFloatRange(
  * Creates an open-ended range from this [Float] value to the specified [that] value.
  *
  * Numbers are compared with the ends of this range according to IEEE-754.
+ *
+ * @sample samples.ranges.Ranges.rangeUntilFloat
  */
 @SinceKotlin("1.9")
 @WasExperimental(ExperimentalStdlibApi::class)


### PR DESCRIPTION
Add "rangeUntilComparable" sample, rename "rangeFromComparable" to "rangeToComparable", and update references

^KT-85326 Fixed