### PR TITLE
[K/N] Avoid redundant dladdr invocation per throwable frame

### DIFF
--- a/kotlin-native/runtime/src/main/cpp/ExecFormat.cpp
+++ b/kotlin-native/runtime/src/main/cpp/ExecFormat.cpp
@@ -343,10 +343,8 @@ extern "C" bool AddressToSymbol(const void* address, char* resultBuffer, size_t 
 
 #include <dlfcn.h>
 
-extern "C" bool AddressToSymbol(const void* address, char* resultBuffer, size_t resultBufferSize, ptrdiff_t &resultOffset) {
+bool AddressToSymbolWithDlInfo(const void* address, const Dl_info& info, char* resultBuffer, size_t resultBufferSize, ptrdiff_t& resultOffset) {
     if (address == nullptr) return false;
-    Dl_info info;
-    if (dladdr(address, &info) == 0) return false;
     const char *result = nullptr;
     char symbuf[20];
 
@@ -370,6 +368,13 @@ extern "C" bool AddressToSymbol(const void* address, char* resultBuffer, size_t 
         resultBuffer[resultBufferSize - 1] = '\0';
         return true;
     }
+}
+
+extern "C" bool AddressToSymbol(const void* address, char* resultBuffer, size_t resultBufferSize, ptrdiff_t &resultOffset) {
+    if (address == nullptr) return false;
+    Dl_info info;
+    if (dladdr(address, &info) == 0) return false;
+    return AddressToSymbolWithDlInfo(address, info, resultBuffer, resultBufferSize, resultOffset);
 }
 
 #else

--- a/kotlin-native/runtime/src/main/cpp/ExecFormat.h
+++ b/kotlin-native/runtime/src/main/cpp/ExecFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 JetBrains s.r.o.
+ * Copyright 2010-2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,18 @@
 
 #include <stddef.h>
 
+#if __has_include("dlfcn.h")
+#include <dlfcn.h>
+#endif
+
 extern "C" {
 
 bool AddressToSymbol(const void* address, char* resultBuffer, size_t resultBufferSize, ptrdiff_t &resultOffset);
 
 }  // extern "C"
+
+#if defined(__cplusplus) && __has_include("dlfcn.h")
+bool AddressToSymbolWithDlInfo(const void* address, const Dl_info& info, char* resultBuffer, size_t resultBufferSize, ptrdiff_t& resultOffset);
+#endif
 
 #endif  // RUNTIME_EXECFORMAT_H

--- a/kotlin-native/runtime/src/main/cpp/StackTrace.cpp
+++ b/kotlin-native/runtime/src/main/cpp/StackTrace.cpp
@@ -206,19 +206,22 @@ std_support::span<char> snprintf_with_addr(std_support::span<char> buffer, size_
 
 #if __has_include("dlfcn.h")
     Dl_info info{};
-    dladdr(addr, &info);
-
-    if (info.dli_fname) {
-        const char* tmp = strrchr(info.dli_fname, '/');
-        if (tmp == nullptr) {
-            image = info.dli_fname;
-        } else {
-            image = tmp + 1;
+    if (dladdr(addr, &info) != 0) {
+        if (info.dli_fname) {
+            const char* tmp = strrchr(info.dli_fname, '/');
+            if (tmp == nullptr) {
+                image = info.dli_fname;
+            } else {
+                image = tmp + 1;
+            }
         }
+        AddressToSymbolWithDlInfo(addr, info, symbol, sizeof(symbol), symbol_offset);
+    } else {
+        AddressToSymbol(addr, symbol, sizeof(symbol), symbol_offset);
     }
-#endif
-
+#else
     AddressToSymbol(addr, symbol, sizeof(symbol), symbol_offset);
+#endif
 
     buffer = FormatToSpan(buffer, "%-4zd%-35s %-18p %s + %td ", frame, image, addr, symbol, symbol_offset);
     if (is_inline) {


### PR DESCRIPTION
When symbolizing an exception (GetStackTraceStrings), on Apple and Linux platforms we invoke dladdr twice: once to extract the image name and once to get symbol name. Reuse of Dl_info improves the throughput of symbolification twofold

^KT-85893 Fixed