### PR TITLE
[CFG] Allow postponed lambda merge nodes in path to tailrec exit

### DIFF
--- a/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNode.kt
+++ b/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNode.kt
@@ -346,7 +346,7 @@ class PostponedLambdaExitNode(owner: ControlFlowGraph, override val fir: FirAnon
     }
 }
 
-class MergePostponedLambdaExitsNode(owner: ControlFlowGraph, override val fir: FirElement, level: Int) : CFGNode<FirElement>(owner, level) {
+class MergePostponedLambdaExitsNode(owner: ControlFlowGraph, override val fir: FirElement, level: Int) : CFGNode<FirElement>(owner, level), TailrecExitNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitMergePostponedLambdaExitsNode(this, data)
     }

--- a/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/whenWithLambda.kt
+++ b/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/whenWithLambda.kt
@@ -4,7 +4,7 @@ tailrec fun withWhen(counter: Int): Int {
     return when (counter) {
         0 -> withWhen(1)
         1 -> counter
-        else -> run { null } ?: <!NON_TAIL_RECURSIVE_CALL!>withWhen<!>(counter - 1)
+        else -> run { null } ?: withWhen(counter - 1)
     }
 }
 

--- a/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/whenWithLambda.kt
+++ b/compiler/testData/codegen/box/diagnostics/functions/tailRecursion/whenWithLambda.kt
@@ -1,0 +1,11 @@
+// ISSUES: KT-82196
+
+tailrec fun withWhen(counter: Int): Int {
+    return when (counter) {
+        0 -> withWhen(1)
+        1 -> counter
+        else -> run { null } ?: <!NON_TAIL_RECURSIVE_CALL!>withWhen<!>(counter - 1)
+    }
+}
+
+fun box(): String = if (withWhen(100000) == 1) "OK" else "FAIL"


### PR DESCRIPTION
When checking if a tailrec recursive call is allowed, the CFG path to
the function exit is followed. Only nodes that implement
`TailrecExitNodeMarker` are allowed, and a warning is reported if other
nodes are found. When postponed lambda nodes are involved, this resulted
in false positive warnings being reported for valid tailrec recursive
calls. Added the marker interface to the postponed lambda merge node, so
these warnings are no longer reported.