### PR TITLE
[PSI] Avoid reflection during KtNodeTypes instantiation

### DIFF
--- a/compiler/psi/psi-api/api/psi-api.api
+++ b/compiler/psi/psi-api/api/psi-api.api
@@ -1,10 +1,12 @@
 public class org/jetbrains/kotlin/KtNodeType : com/intellij/psi/tree/IElementType {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Class;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/function/Function;)V
 	public fun createPsi (Lcom/intellij/lang/ASTNode;)Lorg/jetbrains/kotlin/psi/KtElement;
 }
 
 public class org/jetbrains/kotlin/KtNodeType$KtLeftBoundNodeType : org/jetbrains/kotlin/KtNodeType {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Class;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/function/Function;)V
 	public fun isLeftBound ()Z
 }
 

--- a/compiler/psi/psi-api/api/psi-api.undocumented
+++ b/compiler/psi/psi-api/api/psi-api.undocumented
@@ -81,7 +81,9 @@ org.jetbrains.kotlin.KotlinElementTypeProvider.valueParameterType
 org.jetbrains.kotlin.KtNodeType
 org.jetbrains.kotlin.KtNodeType.KtLeftBoundNodeType
 org.jetbrains.kotlin.KtNodeType.KtLeftBoundNodeType:constructor(String, Class<? extends KtElement>)
+org.jetbrains.kotlin.KtNodeType.KtLeftBoundNodeType:constructor(String, Function<ASTNode, KtElement>)
 org.jetbrains.kotlin.KtNodeType:constructor(String, Class<? extends KtElement>)
+org.jetbrains.kotlin.KtNodeType:constructor(String, Function<ASTNode, KtElement>)
 org.jetbrains.kotlin.KtNodeType:createPsi(ASTNode)
 org.jetbrains.kotlin.KtNodeTypes
 org.jetbrains.kotlin.KtNodeTypes:ANNOTATED_EXPRESSION

--- a/compiler/psi/psi-api/src/org/jetbrains/kotlin/KtNodeType.java
+++ b/compiler/psi/psi-api/src/org/jetbrains/kotlin/KtNodeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 JetBrains s.r.o.
+ * Copyright 2010-2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,35 +25,59 @@ import org.jetbrains.kotlin.psi.KtElement;
 import org.jetbrains.kotlin.psi.KtElementImpl;
 
 import java.lang.reflect.Constructor;
+import java.util.function.Function;
 
 public class KtNodeType extends IElementType {
-    private final Constructor<? extends KtElement> myPsiFactory;
+    private final Function<ASTNode, KtElement> myPsiFactory;
 
+    @Deprecated  // Deprecated in the favor of second constructor, should not be used
     public KtNodeType(@NotNull @NonNls String debugName, Class<? extends KtElement> psiClass) {
+        this(debugName, createFactory(psiClass));
+    }
+
+    public KtNodeType(@NotNull @NonNls String debugName, Function<ASTNode, KtElement> psiFactory) {
         super(debugName, KotlinLanguage.INSTANCE);
-        try {
-            myPsiFactory = psiClass != null ? psiClass.getConstructor(ASTNode.class) : null;
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("Must have a constructor with ASTNode");
-        }
+        myPsiFactory = psiFactory;
     }
 
     public KtElement createPsi(ASTNode node) {
         assert node.getElementType() == this;
-
-        try {
-            if (myPsiFactory == null) {
-                return new KtElementImpl(node);
-            }
-            return myPsiFactory.newInstance(node);
-        } catch (Exception e) {
-            throw new RuntimeException("Error creating psi element for node", e);
+        if (myPsiFactory == null) {
+            return new KtElementImpl(node);
         }
+        return myPsiFactory.apply(node);
+    }
+
+    private static Function<ASTNode, KtElement> createFactory(Class<? extends KtElement> psiClass) {
+        if (psiClass == null) {
+            return null;
+        }
+
+        Constructor<? extends KtElement> constructor;
+        try {
+            constructor = psiClass.getConstructor(ASTNode.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Must have a constructor with ASTNode", e);
+        }
+
+        return node -> {
+            try {
+                return constructor.newInstance(node);
+            } catch (Exception e) {
+                throw new RuntimeException("Error creating psi element for node", e);
+            }
+        };
     }
 
     public static class KtLeftBoundNodeType extends KtNodeType {
+        @SuppressWarnings("unused")
+        @Deprecated  // Deprecated in the favor of second constructor, should not be used
         public KtLeftBoundNodeType(@NotNull @NonNls String debugName, Class<? extends KtElement> psiClass) {
             super(debugName, psiClass);
+        }
+
+        public KtLeftBoundNodeType(@NotNull @NonNls String debugName, Function<ASTNode, KtElement> psiFactory) {
+            super(debugName, psiFactory);
         }
 
         @Override

--- a/compiler/psi/psi-api/src/org/jetbrains/kotlin/KtNodeTypes.java
+++ b/compiler/psi/psi-api/src/org/jetbrains/kotlin/KtNodeTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -18,8 +18,8 @@ public interface KtNodeTypes {
     IElementType CLASS     = KtStubBasedElementTypes.CLASS;
     IElementType FUN       = KtStubBasedElementTypes.FUNCTION;
     IElementType PROPERTY  = KtStubBasedElementTypes.PROPERTY;
-    IElementType DESTRUCTURING_DECLARATION = new KtNodeType("DESTRUCTURING_DECLARATION", KtDestructuringDeclaration.class);
-    IElementType DESTRUCTURING_DECLARATION_ENTRY = new KtNodeType("DESTRUCTURING_DECLARATION_ENTRY", KtDestructuringDeclarationEntry.class);
+    IElementType DESTRUCTURING_DECLARATION = new KtNodeType("DESTRUCTURING_DECLARATION", KtDestructuringDeclaration::new);
+    IElementType DESTRUCTURING_DECLARATION_ENTRY = new KtNodeType("DESTRUCTURING_DECLARATION_ENTRY", KtDestructuringDeclarationEntry::new);
 
     IElementType OBJECT_DECLARATION = KtStubBasedElementTypes.OBJECT_DECLARATION;
     IElementType TYPEALIAS = KtStubBasedElementTypes.TYPEALIAS;
@@ -46,7 +46,7 @@ public interface KtNodeTypes {
     IElementType DELEGATED_SUPER_TYPE_ENTRY         = KtStubBasedElementTypes.DELEGATED_SUPER_TYPE_ENTRY;
     IElementType SUPER_TYPE_CALL_ENTRY              = KtStubBasedElementTypes.SUPER_TYPE_CALL_ENTRY;
     IElementType SUPER_TYPE_ENTRY                   = KtStubBasedElementTypes.SUPER_TYPE_ENTRY;
-    IElementType PROPERTY_DELEGATE                  = new KtNodeType("PROPERTY_DELEGATE", KtPropertyDelegate.class);
+    IElementType PROPERTY_DELEGATE                  = new KtNodeType("PROPERTY_DELEGATE", KtPropertyDelegate::new);
     IElementType CONSTRUCTOR_CALLEE                 = KtStubBasedElementTypes.CONSTRUCTOR_CALLEE;
     IElementType VALUE_PARAMETER_LIST               = KtStubBasedElementTypes.VALUE_PARAMETER_LIST;
     IElementType VALUE_PARAMETER                    = KtStubBasedElementTypes.VALUE_PARAMETER;
@@ -84,8 +84,8 @@ public interface KtNodeTypes {
     IElementType TYPE_CONSTRAINT_LIST    = KtStubBasedElementTypes.TYPE_CONSTRAINT_LIST;
     IElementType TYPE_CONSTRAINT         = KtStubBasedElementTypes.TYPE_CONSTRAINT;
 
-    IElementType CONSTRUCTOR_DELEGATION_CALL = new KtNodeType.KtLeftBoundNodeType("CONSTRUCTOR_DELEGATION_CALL", KtConstructorDelegationCall.class);
-    IElementType CONSTRUCTOR_DELEGATION_REFERENCE = new KtNodeType.KtLeftBoundNodeType("CONSTRUCTOR_DELEGATION_REFERENCE", KtConstructorDelegationReferenceExpression.class);
+    IElementType CONSTRUCTOR_DELEGATION_CALL = new KtNodeType.KtLeftBoundNodeType("CONSTRUCTOR_DELEGATION_CALL", KtConstructorDelegationCall::new);
+    IElementType CONSTRUCTOR_DELEGATION_REFERENCE = new KtNodeType.KtLeftBoundNodeType("CONSTRUCTOR_DELEGATION_REFERENCE", KtConstructorDelegationReferenceExpression::new);
 
     IElementType NULL               = KtStubBasedElementTypes.NULL;
     IElementType BOOLEAN_CONSTANT   = KtStubBasedElementTypes.BOOLEAN_CONSTANT;
@@ -100,63 +100,63 @@ public interface KtNodeTypes {
     IElementType ESCAPE_STRING_TEMPLATE_ENTRY  = KtStubBasedElementTypes.ESCAPE_STRING_TEMPLATE_ENTRY;
     IElementType STRING_INTERPOLATION_PREFIX   = KtStubBasedElementTypes.STRING_INTERPOLATION_PREFIX;
 
-    IElementType PARENTHESIZED             = new KtNodeType("PARENTHESIZED", KtParenthesizedExpression.class);
-    IElementType RETURN                    = new KtNodeType("RETURN", KtReturnExpression.class);
-    IElementType THROW                     = new KtNodeType("THROW", KtThrowExpression.class);
-    IElementType CONTINUE                  = new KtNodeType("CONTINUE", KtContinueExpression.class);
-    IElementType BREAK                     = new KtNodeType("BREAK", KtBreakExpression.class);
-    IElementType IF                        = new KtNodeType("IF", KtIfExpression.class);
-    IElementType CONDITION                 = new KtNodeType("CONDITION", KtContainerNode.class);
-    IElementType THEN                      = new KtNodeType("THEN", KtContainerNodeForControlStructureBody.class);
-    IElementType ELSE                      = new KtNodeType("ELSE", KtContainerNodeForControlStructureBody.class);
-    IElementType TRY                       = new KtNodeType("TRY", KtTryExpression.class);
-    IElementType CATCH                     = new KtNodeType("CATCH", KtCatchClause.class);
-    IElementType FINALLY                   = new KtNodeType("FINALLY", KtFinallySection.class);
-    IElementType FOR                       = new KtNodeType("FOR", KtForExpression.class);
-    IElementType WHILE                     = new KtNodeType("WHILE", KtWhileExpression.class);
-    IElementType DO_WHILE                  = new KtNodeType("DO_WHILE", KtDoWhileExpression.class);
-    IElementType LOOP_RANGE                = new KtNodeType("LOOP_RANGE", KtContainerNode.class);
-    IElementType BODY                      = new KtNodeType("BODY", KtContainerNodeForControlStructureBody.class);
+    IElementType PARENTHESIZED             = new KtNodeType("PARENTHESIZED", KtParenthesizedExpression::new);
+    IElementType RETURN                    = new KtNodeType("RETURN", KtReturnExpression::new);
+    IElementType THROW                     = new KtNodeType("THROW", KtThrowExpression::new);
+    IElementType CONTINUE                  = new KtNodeType("CONTINUE", KtContinueExpression::new);
+    IElementType BREAK                     = new KtNodeType("BREAK", KtBreakExpression::new);
+    IElementType IF                        = new KtNodeType("IF", KtIfExpression::new);
+    IElementType CONDITION                 = new KtNodeType("CONDITION", KtContainerNode::new);
+    IElementType THEN                      = new KtNodeType("THEN", KtContainerNodeForControlStructureBody::new);
+    IElementType ELSE                      = new KtNodeType("ELSE", KtContainerNodeForControlStructureBody::new);
+    IElementType TRY                       = new KtNodeType("TRY", KtTryExpression::new);
+    IElementType CATCH                     = new KtNodeType("CATCH", KtCatchClause::new);
+    IElementType FINALLY                   = new KtNodeType("FINALLY", KtFinallySection::new);
+    IElementType FOR                       = new KtNodeType("FOR", KtForExpression::new);
+    IElementType WHILE                     = new KtNodeType("WHILE", KtWhileExpression::new);
+    IElementType DO_WHILE                  = new KtNodeType("DO_WHILE", KtDoWhileExpression::new);
+    IElementType LOOP_RANGE                = new KtNodeType("LOOP_RANGE", KtContainerNode::new);
+    IElementType BODY                      = new KtNodeType("BODY", KtContainerNodeForControlStructureBody::new);
 
     IElementType BLOCK                     = KtStubBasedElementTypes.BLOCK;
 
     IElementType LAMBDA_EXPRESSION         = KtStubBasedElementTypes.LAMBDA_EXPRESSION;
 
-    IElementType FUNCTION_LITERAL          = new KtNodeType("FUNCTION_LITERAL", KtFunctionLiteral.class);
-    IElementType ANNOTATED_EXPRESSION      = new KtNodeType("ANNOTATED_EXPRESSION", KtAnnotatedExpression.class);
+    IElementType FUNCTION_LITERAL          = new KtNodeType("FUNCTION_LITERAL", KtFunctionLiteral::new);
+    IElementType ANNOTATED_EXPRESSION      = new KtNodeType("ANNOTATED_EXPRESSION", KtAnnotatedExpression::new);
 
     IElementType REFERENCE_EXPRESSION     = KtStubBasedElementTypes.REFERENCE_EXPRESSION;
     IElementType ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION = KtStubBasedElementTypes.ENUM_ENTRY_SUPERCLASS_REFERENCE_EXPRESSION;
-    IElementType OPERATION_REFERENCE       = new KtNodeType("OPERATION_REFERENCE", KtOperationReferenceExpression.class);
-    IElementType LABEL                     = new KtNodeType("LABEL", KtLabelReferenceExpression.class);
+    IElementType OPERATION_REFERENCE       = new KtNodeType("OPERATION_REFERENCE", KtOperationReferenceExpression::new);
+    IElementType LABEL                     = new KtNodeType("LABEL", KtLabelReferenceExpression::new);
 
-    IElementType LABEL_QUALIFIER           = new KtNodeType("LABEL_QUALIFIER", KtContainerNode.class);
+    IElementType LABEL_QUALIFIER           = new KtNodeType("LABEL_QUALIFIER", KtContainerNode::new);
 
-    IElementType THIS_EXPRESSION           = new KtNodeType("THIS_EXPRESSION", KtThisExpression.class);
-    IElementType SUPER_EXPRESSION          = new KtNodeType("SUPER_EXPRESSION", KtSuperExpression.class);
-    IElementType BINARY_EXPRESSION         = new KtNodeType("BINARY_EXPRESSION", KtBinaryExpression.class);
-    IElementType BINARY_WITH_TYPE          = new KtNodeType("BINARY_WITH_TYPE", KtBinaryExpressionWithTypeRHS.class);
-    IElementType IS_EXPRESSION             = new KtNodeType("IS_EXPRESSION", KtIsExpression.class);
-    IElementType PREFIX_EXPRESSION         = new KtNodeType("PREFIX_EXPRESSION", KtPrefixExpression.class);
-    IElementType POSTFIX_EXPRESSION        = new KtNodeType("POSTFIX_EXPRESSION", KtPostfixExpression.class);
-    IElementType LABELED_EXPRESSION        = new KtNodeType("LABELED_EXPRESSION", KtLabeledExpression.class);
+    IElementType THIS_EXPRESSION           = new KtNodeType("THIS_EXPRESSION", KtThisExpression::new);
+    IElementType SUPER_EXPRESSION          = new KtNodeType("SUPER_EXPRESSION", KtSuperExpression::new);
+    IElementType BINARY_EXPRESSION         = new KtNodeType("BINARY_EXPRESSION", KtBinaryExpression::new);
+    IElementType BINARY_WITH_TYPE          = new KtNodeType("BINARY_WITH_TYPE", KtBinaryExpressionWithTypeRHS::new);
+    IElementType IS_EXPRESSION             = new KtNodeType("IS_EXPRESSION", KtIsExpression::new);
+    IElementType PREFIX_EXPRESSION         = new KtNodeType("PREFIX_EXPRESSION", KtPrefixExpression::new);
+    IElementType POSTFIX_EXPRESSION        = new KtNodeType("POSTFIX_EXPRESSION", KtPostfixExpression::new);
+    IElementType LABELED_EXPRESSION        = new KtNodeType("LABELED_EXPRESSION", KtLabeledExpression::new);
     IElementType CALL_EXPRESSION           = KtStubBasedElementTypes.CALL_EXPRESSION;
-    IElementType ARRAY_ACCESS_EXPRESSION   = new KtNodeType("ARRAY_ACCESS_EXPRESSION", KtArrayAccessExpression.class);
-    IElementType INDICES                   = new KtNodeType("INDICES", KtContainerNode.class);
+    IElementType ARRAY_ACCESS_EXPRESSION   = new KtNodeType("ARRAY_ACCESS_EXPRESSION", KtArrayAccessExpression::new);
+    IElementType INDICES                   = new KtNodeType("INDICES", KtContainerNode::new);
     IElementType DOT_QUALIFIED_EXPRESSION  = KtStubBasedElementTypes.DOT_QUALIFIED_EXPRESSION;
-    IElementType CALLABLE_REFERENCE_EXPRESSION = new KtNodeType("CALLABLE_REFERENCE_EXPRESSION", KtCallableReferenceExpression.class);
+    IElementType CALLABLE_REFERENCE_EXPRESSION = new KtNodeType("CALLABLE_REFERENCE_EXPRESSION", KtCallableReferenceExpression::new);
     IElementType CLASS_LITERAL_EXPRESSION  = KtStubBasedElementTypes.CLASS_LITERAL_EXPRESSION;
-    IElementType SAFE_ACCESS_EXPRESSION    = new KtNodeType("SAFE_ACCESS_EXPRESSION", KtSafeQualifiedExpression.class);
+    IElementType SAFE_ACCESS_EXPRESSION    = new KtNodeType("SAFE_ACCESS_EXPRESSION", KtSafeQualifiedExpression::new);
 
-    IElementType OBJECT_LITERAL            = new KtNodeType("OBJECT_LITERAL", KtObjectLiteralExpression.class);
+    IElementType OBJECT_LITERAL            = new KtNodeType("OBJECT_LITERAL", KtObjectLiteralExpression::new);
 
-    IElementType WHEN                      = new KtNodeType("WHEN", KtWhenExpression.class);
-    IElementType WHEN_ENTRY                = new KtNodeType("WHEN_ENTRY", KtWhenEntry.class);
-    IElementType WHEN_ENTRY_GUARD          = new KtNodeType("WHEN_ENTRY_GUARD", KtWhenEntryGuard.class);
+    IElementType WHEN                      = new KtNodeType("WHEN", KtWhenExpression::new);
+    IElementType WHEN_ENTRY                = new KtNodeType("WHEN_ENTRY", KtWhenEntry::new);
+    IElementType WHEN_ENTRY_GUARD          = new KtNodeType("WHEN_ENTRY_GUARD", KtWhenEntryGuard::new);
 
-    IElementType WHEN_CONDITION_IN_RANGE   = new KtNodeType("WHEN_CONDITION_IN_RANGE", KtWhenConditionInRange.class);
-    IElementType WHEN_CONDITION_IS_PATTERN = new KtNodeType("WHEN_CONDITION_IS_PATTERN", KtWhenConditionIsPattern.class);
-    IElementType WHEN_CONDITION_EXPRESSION = new KtNodeType("WHEN_CONDITION_WITH_EXPRESSION", KtWhenConditionWithExpression.class);
+    IElementType WHEN_CONDITION_IN_RANGE   = new KtNodeType("WHEN_CONDITION_IN_RANGE", KtWhenConditionInRange::new);
+    IElementType WHEN_CONDITION_IS_PATTERN = new KtNodeType("WHEN_CONDITION_IS_PATTERN", KtWhenConditionIsPattern::new);
+    IElementType WHEN_CONDITION_EXPRESSION = new KtNodeType("WHEN_CONDITION_WITH_EXPRESSION", KtWhenConditionWithExpression::new);
 
     IElementType COLLECTION_LITERAL_EXPRESSION = KtStubBasedElementTypes.COLLECTION_LITERAL_EXPRESSION;
 


### PR DESCRIPTION
Rationale: replace expensive and GraalVM-incompatible reflective KtElement instantiation with KtElement SAM-conversion into a functional type. Makes kotlin-compiler-embeddable NativeImage-friendly, insignificantly speeds up parser instantiation.

Compatibility note:

* Nothing is deprecated and/or removed
* KtNodeType.createPsi now rethrows an exception from the constructor instead of wrapping it into RuntimeException

^KT-85427 fixed