### PR TITLE
[Wasm] fix reporting missing custom formatters file (^KT-85881)

### DIFF
--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmBackendPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmBackendPipelinePhase.kt
@@ -42,6 +42,7 @@ object WasmBackendPipelinePhase : WebBackendPipelinePhase<WasmBackendPipelineArt
                 result = compileResult,
                 dir = outputDir,
                 fileNameBase = result.baseFileName,
+                configuration = configuration,
             )
             compileResult
         }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmBackendErrors.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmBackendErrors.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.wasm
+
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
+import org.jetbrains.kotlin.diagnostics.KtSourcelessDiagnosticFactory
+import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
+import org.jetbrains.kotlin.diagnostics.rendering.BaseSourcelessDiagnosticRendererFactory.Companion.MESSAGE_PLACEHOLDER
+import org.jetbrains.kotlin.diagnostics.strongWarningWithoutSource
+
+object WasmBackendErrors : KtDiagnosticsContainer() {
+    val WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER: KtSourcelessDiagnosticFactory by strongWarningWithoutSource()
+
+    override fun getRendererFactory(): BaseDiagnosticRendererFactory {
+        return KtDefaultWasmErrorMessages
+    }
+}
+
+object KtDefaultWasmErrorMessages : BaseDiagnosticRendererFactory() {
+    override val MAP by KtDiagnosticFactoryToRendererMap("KT") { map ->
+        map.put(WasmBackendErrors.WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER, MESSAGE_PLACEHOLDER)
+    }
+}

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmBackendErrors.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmBackendErrors.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.diagnostics.rendering.BaseSourcelessDiagnosticRender
 import org.jetbrains.kotlin.diagnostics.strongWarningWithoutSource
 
 object WasmBackendErrors : KtDiagnosticsContainer() {
-    val WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER: KtSourcelessDiagnosticFactory by strongWarningWithoutSource()
+    val WASM_BACKEND_MISSING_CUSTOM_FORMATTERS: KtSourcelessDiagnosticFactory by strongWarningWithoutSource()
 
     override fun getRendererFactory(): BaseDiagnosticRendererFactory {
         return KtDefaultWasmErrorMessages
@@ -22,6 +22,6 @@ object WasmBackendErrors : KtDiagnosticsContainer() {
 
 object KtDefaultWasmErrorMessages : BaseDiagnosticRendererFactory() {
     override val MAP by KtDiagnosticFactoryToRendererMap("KT") { map ->
-        map.put(WasmBackendErrors.WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER, MESSAGE_PLACEHOLDER)
+        map.put(WasmBackendErrors.WASM_BACKEND_MISSING_CUSTOM_FORMATTERS, MESSAGE_PLACEHOLDER)
     }
 }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.IrModuleInfo
 import org.jetbrains.kotlin.backend.common.linkage.issues.checkNoUnboundSymbols
 import org.jetbrains.kotlin.backend.common.serialization.IrModuleDependencyTrackerImpl
 import org.jetbrains.kotlin.backend.common.serialization.kotlinLibrary
-import org.jetbrains.kotlin.backend.wasm.WasmBackendErrors.WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER
+import org.jetbrains.kotlin.backend.wasm.WasmBackendErrors.WASM_BACKEND_MISSING_CUSTOM_FORMATTERS
 import org.jetbrains.kotlin.backend.wasm.export.ExportModelGenerator
 import org.jetbrains.kotlin.backend.wasm.ic.overrideBuiltInsSignatures
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.*
@@ -746,7 +746,7 @@ fun writeCompilationResult(
         val classLoader = WasmCompilerResult::class.java.classLoader
         val customFormattersInputStream = classLoader.getResourceAsStream(fileName) ?: run {
             val message = "Custom formatters won't work because a required resource is missing from the compiler: $fileName"
-            configuration?.report(WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER, message)
+            configuration?.report(WASM_BACKEND_MISSING_CUSTOM_FORMATTERS, message)
             "console.warn(\"$message\");".byteInputStream()
         }
 

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/wasmCompiler.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.common.IrModuleInfo
 import org.jetbrains.kotlin.backend.common.linkage.issues.checkNoUnboundSymbols
 import org.jetbrains.kotlin.backend.common.serialization.IrModuleDependencyTrackerImpl
 import org.jetbrains.kotlin.backend.common.serialization.kotlinLibrary
+import org.jetbrains.kotlin.backend.wasm.WasmBackendErrors.WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER
 import org.jetbrains.kotlin.backend.wasm.export.ExportModelGenerator
 import org.jetbrains.kotlin.backend.wasm.ic.overrideBuiltInsSignatures
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.*
@@ -17,8 +18,7 @@ import org.jetbrains.kotlin.backend.wasm.lower.JsInteropFunctionsLowering
 import org.jetbrains.kotlin.backend.wasm.lower.markExportedDeclarations
 import org.jetbrains.kotlin.backend.wasm.utils.DwarfGenerator
 import org.jetbrains.kotlin.backend.wasm.utils.SourceMapGenerator
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.phaser.PhaserState
 import org.jetbrains.kotlin.ir.backend.js.MainModule
@@ -725,7 +725,7 @@ fun writeCompilationResult(
     result: WasmCompilerResult,
     dir: File,
     fileNameBase: String,
-    messageCollector: MessageCollector? = null
+    configuration: CompilerConfiguration? = null
 ) {
     dir.mkdirs()
     if (result.wat != null) {
@@ -746,10 +746,7 @@ fun writeCompilationResult(
         val classLoader = WasmCompilerResult::class.java.classLoader
         val customFormattersInputStream = classLoader.getResourceAsStream(fileName) ?: run {
             val message = "Custom formatters won't work because a required resource is missing from the compiler: $fileName"
-            messageCollector?.report(
-                CompilerMessageSeverity.STRONG_WARNING,
-                message
-            )
+            configuration?.report(WASM_BACKEND_MISSING_RESOURCE_FROM_COMPILER, message)
             "console.warn(\"$message\");".byteInputStream()
         }
 


### PR DESCRIPTION
[KT-78277](https://youtrack.jetbrains.com/issue/KT-78277) removes `messageCollector` usages and replaces them with CompilerConfiguration.report 

By now not all diagnostics containers are implemented  - [KT-85898](https://youtrack.jetbrains.com/issue/KT-85898) Register all KtDiagnosticsContainers

This PR registers WasmBackendErrors for reporting errors/warnings at the backend side - by now, only for missing custom formatters