### PR TITLE
[Swift Export] Don't call unavailable operator functions

### DIFF
--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtPropertySymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtPropertySymbol.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.sir.providers.sirDeclarationName
 import org.jetbrains.kotlin.sir.providers.source.KotlinPropertyAccessorOrigin
 import org.jetbrains.kotlin.sir.providers.utils.allRequiredOptIns
 import org.jetbrains.kotlin.sir.providers.utils.throwsAnnotation
+import org.jetbrains.kotlin.sir.util.isUnavailable
 import org.jetbrains.kotlin.sir.util.unavailableTypes
 import org.jetbrains.kotlin.sir.util.replaceOrAddPropagatedUnavailability
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
@@ -128,6 +129,7 @@ internal class SirFunctionFromKtPropertySymbol(
     override val isAsync: Boolean get() = false
 
     private val bridgeProxy: BridgeFunctionProxy? by lazyWithSessions {
+        if (isUnavailable) return@lazyWithSessions null
         val fqName = ktPropertySymbol
             .callableId?.asSingleFqName() ?: return@lazyWithSessions null
 

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtSymbol.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.sir.providers.source.kaSymbolOrNull
 import org.jetbrains.kotlin.sir.providers.toSir
 import org.jetbrains.kotlin.sir.providers.utils.allRequiredOptIns
 import org.jetbrains.kotlin.sir.providers.utils.throwsAnnotation
+import org.jetbrains.kotlin.sir.util.isUnavailable
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.sir.util.unavailableTypes
 import org.jetbrains.kotlin.sir.util.replaceOrAddPropagatedUnavailability
@@ -108,6 +109,7 @@ internal open class SirFunctionFromKtSymbol(
     override val isAsync: Boolean get() = ktSymbol.isSuspend
 
     private val bridgeProxy: BridgeFunctionProxy? by lazyWithSessions {
+        if (isUnavailable) return@lazyWithSessions null
         val fqName = bridgeFqName ?: return@lazyWithSessions null
         val suffix = ""
         val baseName = fqName.baseBridgeName + suffix

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirInitFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirInitFromKtSymbol.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.sir.providers.utils.allRequiredOptIns
 import org.jetbrains.kotlin.sir.providers.utils.isAbstract
 import org.jetbrains.kotlin.sir.providers.utils.throwsAnnotation
 import org.jetbrains.kotlin.sir.util.SirSwiftModule
+import org.jetbrains.kotlin.sir.util.isUnavailable
 import org.jetbrains.kotlin.sir.util.name
 import org.jetbrains.kotlin.sir.util.returnType
 import org.jetbrains.kotlin.sir.util.swiftFqName
@@ -235,6 +236,7 @@ internal class SirRegularInitFromKtSymbol(
 
     private val bridgeInitProxy: BridgeFunctionProxy? by lazyWithSessions {
         if (!isBridged) return@lazyWithSessions null
+        if (isUnavailable) return@lazyWithSessions null
 
         val fqName = ktSymbol.containingClassId?.asSingleFqName()
             ?: return@lazyWithSessions null

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirOperatorFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirOperatorFromKtSymbol.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.sir.builder.buildSetter
 import org.jetbrains.kotlin.sir.providers.SirSession
 import org.jetbrains.kotlin.sir.util.SirSwiftModule
 import org.jetbrains.kotlin.sir.util.allParameters
+import org.jetbrains.kotlin.sir.util.isUnavailable
 import org.jetbrains.kotlin.sir.util.name
 import kotlin.getValue
 
@@ -70,11 +71,14 @@ internal abstract class SirClassOperatorTrampolineFunction(
     override val bridges: List<SirBridge> get() = emptyList()
 
     override var body: SirFunctionBody?
-        get() = SirFunctionBody(
-            listOf(
-                "this.${source.name}(${this.allParameters.drop(1).joinToString { it.forward ?: error("unreachable") }})"
-            )
-        )
+        get() = SirFunctionBody(buildList {
+            if (isUnavailable) {
+                add("fatalError()")
+            } else {
+                val args = this@SirClassOperatorTrampolineFunction.allParameters.drop(1)
+                add("this.${source.name}(${args.joinToString { it.forward ?: error("unreachable") }})")
+            }
+        })
         set(_) = Unit
 }
 

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirVariableFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirVariableFromKtSymbol.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.sir.providers.utils.allRequiredOptIns
 import org.jetbrains.kotlin.sir.providers.utils.throwsAnnotation
 import org.jetbrains.kotlin.sir.providers.withSessions
 import org.jetbrains.kotlin.sir.util.SirSwiftModule
+import org.jetbrains.kotlin.sir.util.isUnavailable
 import org.jetbrains.kotlin.sir.util.unavailableTypes
 import org.jetbrains.kotlin.sir.util.replaceOrAddPropagatedUnavailability
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
@@ -143,7 +144,7 @@ internal abstract class SirAbstractGetter(
 
     private val bridgeProxy: BridgeFunctionProxy? by lazyWithSessions {
         val suffix = "_get"
-        val variable = variable ?: return@lazyWithSessions null
+        val variable = variable?.takeUnless { it.isUnavailable } ?: return@lazyWithSessions null
         val fqName = fqName ?: return@lazyWithSessions null
         val baseName = fqName.baseBridgeName + suffix
         val getterSymbol = variable.kaSymbolOrNull<KaPropertySymbol>()?.getter ?: variable.kaSymbolOrNull<KaVariableSymbol>()
@@ -213,7 +214,7 @@ internal abstract class SirAbstractSetter(
 
     private val bridgeProxy: BridgeFunctionProxy? by lazyWithSessions {
         val suffix = "_set"
-        val variable = variable ?: return@lazyWithSessions null
+        val variable = variable?.takeUnless { it.isUnavailable } ?: return@lazyWithSessions null
         val fqName = fqName ?: return@lazyWithSessions null
         val baseName = fqName.baseBridgeName + suffix
         val setterSymbol = variable.kaSymbolOrNull<KaPropertySymbol>()?.setter ?: variable.kaSymbolOrNull<KaVariableSymbol>()

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.h
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.h
@@ -123,10 +123,6 @@ _Bool kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_annotations
 
 _Bool kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_element__TypesOfArguments__Swift_String_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Array_anyU20ExportedKotlinPackages_kotlin_Annotation__Swift_Bool__(void * self, NSString * elementName, void * descriptor, NSArray<id> * annotations, _Bool isOptional);
 
-_Bool kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_isNullable_get(void * self);
-
-_Bool kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_isNullable_set__TypesOfArguments__Swift_Bool__(void * self, _Bool newValue);
-
 NSString * kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_serialName_get(void * self);
 
 void * kotlinx_serialization_descriptors_PolymorphicKind_OPEN_get();

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.swift
@@ -1087,11 +1087,11 @@ extension ExportedKotlinPackages.kotlinx.serialization.descriptors {
         public var isNullable: Swift.Bool {
             @_spi(kotlinx$serialization$ExperimentalSerializationApi)
             get {
-                return kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_isNullable_get(self.__externalRCRef())
+                fatalError()
             }
             @_spi(kotlinx$serialization$ExperimentalSerializationApi)
             set {
-                return { kotlinx_serialization_descriptors_ClassSerialDescriptorBuilder_isNullable_set__TypesOfArguments__Swift_Bool__(self.__externalRCRef(), newValue); return () }()
+                fatalError()
             }
         }
         public var serialName: Swift.String {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/annotations.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/annotations.kt
@@ -87,6 +87,9 @@ open class normalT {
     open var removedP: Int
         @Deprecated("Removed", level = DeprecationLevel.HIDDEN) get() = 42
         @Deprecated("Removed", level = DeprecationLevel.HIDDEN) set(new) {}
+
+    @Deprecated("Obsoleted", level = DeprecationLevel.ERROR)
+    operator fun plus(increment: normalT): normalT = TODO()
 }
 
 class normalChildT : normalT() {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.h
@@ -3,13 +3,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-_Bool ClassWithDeprecatedMembersFromInterface_deprecatedErrorFunction(void * self);
-
 _Bool ClassWithDeprecatedMembersFromInterface_deprecatedWarningFunction(void * self);
 
 _Bool ClassWithDeprecatedMembersFromInterface_regularFunction(void * self);
-
-void * DeprecatedInterfaceWrapper_deprecatedInterface_get(void * self);
 
 _Bool DeprecatedInterface_foo(void * self);
 
@@ -87,10 +83,6 @@ void * __root___ClassWithDeprecatedMembersFromInterface_init_allocate();
 
 _Bool __root___ClassWithDeprecatedMembersFromInterface_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
 
-void * __root___DeprecatedInterfaceWrapper_init_allocate();
-
-_Bool __root___DeprecatedInterfaceWrapper_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_DeprecatedInterface__(void * __kt, void * deprecatedInterface);
-
 void * __root___FooObject_get();
 
 void * __root___Foo_init_allocate();
@@ -131,8 +123,6 @@ void * __root___WithCompanion_init_allocate();
 
 _Bool __root___WithCompanion_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
 
-_Bool __root___acceptDeprecatedInterface__TypesOfArguments__anyU20main_DeprecatedInterface__(void * arg);
-
 _Bool __root___acceptPublicClassImplDeprecatedInterface__TypesOfArguments__main_PublicClassImplDeprecatedInterface__(void * arg);
 
 _Bool __root___acceptPublicClassImplHiddenInterface__TypesOfArguments__main_PublicClassImplHiddenInterface__(void * arg);
@@ -154,14 +144,6 @@ _Bool __root___deprecatedChildT_init_initialize__TypesOfArguments__Swift_UnsafeM
 _Bool __root___deprecatedF();
 
 _Bool __root___deprecatedImplicitlyF();
-
-void * __root___deprecatedInterfacePropertyWithContext_get__TypesOfArgumentsC1__main_normalT__(void * _0);
-
-_Bool __root___deprecatedInterfacePropertyWithContext_set__TypesOfArgumentsC1__anyU20main_DeprecatedInterface_main_normalT__(void * value, void * _1);
-
-void * __root___deprecatedInterfaceProperty_get();
-
-_Bool __root___deprecatedInterfaceProperty_set__TypesOfArguments__anyU20main_DeprecatedInterface__(void * newValue);
 
 void * __root___deprecatedT_init_allocate();
 
@@ -203,14 +185,6 @@ void * __root___obsoletedChildT_init_allocate();
 
 _Bool __root___obsoletedChildT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
 
-_Bool __root___obsoletedF();
-
-void * __root___obsoletedT_init_allocate();
-
-_Bool __root___obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
-
-_Bool __root___obsoletedV_get();
-
 void * __root___publicClassImplDeprecatedInterfaceProperty_get();
 
 _Bool __root___publicClassImplDeprecatedInterfaceProperty_set__TypesOfArguments__main_PublicClassImplDeprecatedInterface__(void * newValue);
@@ -236,8 +210,6 @@ _Bool __root___renamedV_get();
 _Bool __root___renamedWithArguments__TypesOfArguments__Swift_Int32_Swift_Float__(int32_t x, float y) __attribute((noreturn));
 
 void * __root___returnClassA__TypesOfArguments__main_SwiftClassA__(void * value);
-
-void * __root___returnDeprecatedInterface();
 
 void * __root___returnInterfaceC__TypesOfArguments__anyU20main_SwiftInterfaceC__(void * value);
 
@@ -269,13 +241,9 @@ _Bool deprecatedT_deprecationInheritedT_init_initialize__TypesOfArguments__Swift
 
 _Bool deprecatedT_deprecationInheritedV_get(void * self);
 
-_Bool deprecatedT_deprecationReinforcedF(void * self);
-
 void * deprecatedT_deprecationReinforcedT_init_allocate();
 
 _Bool deprecatedT_deprecationReinforcedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
-
-_Bool deprecatedT_deprecationReinforcedV_get(void * self);
 
 _Bool deprecatedT_deprecationRestatedF(void * self);
 
@@ -306,14 +274,6 @@ _Bool normalChildT_normalF(void * self);
 _Bool normalChildT_normalV_get(void * self);
 
 _Bool normalChildT_obsoletedF(void * self);
-
-_Bool normalChildT_obsoletedInFutureF(void * self);
-
-int32_t normalChildT_obsoletedInFutureP_get(void * self);
-
-_Bool normalChildT_obsoletedInFutureP_set__TypesOfArguments__Swift_Int32__(void * self, int32_t newValue);
-
-_Bool normalChildT_obsoletedInFutureV_get(void * self);
 
 int32_t normalChildT_obsoletedP_get(void * self);
 
@@ -357,8 +317,6 @@ _Bool normalT_normalT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawP
 
 _Bool normalT_normalV_get(void * self);
 
-_Bool normalT_obsoletedF(void * self);
-
 _Bool normalT_obsoletedInFutureF(void * self);
 
 int32_t normalT_obsoletedInFutureP_get(void * self);
@@ -370,12 +328,6 @@ _Bool normalT_obsoletedInFutureV_get(void * self);
 int32_t normalT_obsoletedP_get(void * self);
 
 _Bool normalT_obsoletedP_set__TypesOfArguments__Swift_Int32__(void * self, int32_t newValue);
-
-void * normalT_obsoletedT_init_allocate();
-
-_Bool normalT_obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__(void * __kt, float obsoleted);
-
-_Bool normalT_obsoletedV_get(void * self);
 
 _Bool normalT_removedInFutureF(void * self);
 
@@ -413,12 +365,8 @@ _Bool obsoletedT_deprecationRelaxedT_init_initialize__TypesOfArguments__Swift_Un
 
 _Bool obsoletedT_deprecationRelaxedV_get(void * self);
 
-_Bool obsoletedT_deprecationRestatedF(void * self);
-
 void * obsoletedT_deprecationRestatedT_init_allocate();
 
 _Bool obsoletedT_deprecationRestatedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
-
-_Bool obsoletedT_deprecationRestatedV_get(void * self);
 
 NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.kt
@@ -46,13 +46,6 @@ import kotlin.native.internal.ExportedBridge
 import kotlinx.cinterop.*
 import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
 
-@ExportedBridge("ClassWithDeprecatedMembersFromInterface_deprecatedErrorFunction")
-public fun ClassWithDeprecatedMembersFromInterface_deprecatedErrorFunction(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as ClassWithDeprecatedMembersFromInterface
-    val _result = run { __self.deprecatedErrorFunction() }
-    return run { _result; true }
-}
-
 @ExportedBridge("ClassWithDeprecatedMembersFromInterface_deprecatedWarningFunction")
 public fun ClassWithDeprecatedMembersFromInterface_deprecatedWarningFunction(self: kotlin.native.internal.NativePtr): Boolean {
     val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as ClassWithDeprecatedMembersFromInterface
@@ -65,13 +58,6 @@ public fun ClassWithDeprecatedMembersFromInterface_regularFunction(self: kotlin.
     val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as ClassWithDeprecatedMembersFromInterface
     val _result = run { __self.regularFunction() }
     return run { _result; true }
-}
-
-@ExportedBridge("DeprecatedInterfaceWrapper_deprecatedInterface_get")
-public fun DeprecatedInterfaceWrapper_deprecatedInterface_get(self: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as DeprecatedInterfaceWrapper
-    val _result = run { __self.deprecatedInterface }
-    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
 }
 
 @ExportedBridge("DeprecatedInterface_foo")
@@ -345,20 +331,6 @@ public fun __root___ClassWithDeprecatedMembersFromInterface_init_initialize__Typ
     return run { _result; true }
 }
 
-@ExportedBridge("__root___DeprecatedInterfaceWrapper_init_allocate")
-public fun __root___DeprecatedInterfaceWrapper_init_allocate(): kotlin.native.internal.NativePtr {
-    val _result = run { kotlin.native.internal.createUninitializedInstance<DeprecatedInterfaceWrapper>() }
-    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
-}
-
-@ExportedBridge("__root___DeprecatedInterfaceWrapper_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_DeprecatedInterface__")
-public fun __root___DeprecatedInterfaceWrapper_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_DeprecatedInterface__(__kt: kotlin.native.internal.NativePtr, deprecatedInterface: kotlin.native.internal.NativePtr): Boolean {
-    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
-    val __deprecatedInterface = kotlin.native.internal.ref.dereferenceExternalRCRef(deprecatedInterface) as DeprecatedInterface
-    val _result = run { kotlin.native.internal.initInstance(____kt, DeprecatedInterfaceWrapper(__deprecatedInterface)) }
-    return run { _result; true }
-}
-
 @ExportedBridge("__root___FooObject_get")
 public fun __root___FooObject_get(): kotlin.native.internal.NativePtr {
     val _result = run { FooObject }
@@ -491,13 +463,6 @@ public fun __root___WithCompanion_init_initialize__TypesOfArguments__Swift_Unsaf
     return run { _result; true }
 }
 
-@ExportedBridge("__root___acceptDeprecatedInterface__TypesOfArguments__anyU20main_DeprecatedInterface__")
-public fun __root___acceptDeprecatedInterface__TypesOfArguments__anyU20main_DeprecatedInterface__(arg: kotlin.native.internal.NativePtr): Boolean {
-    val __arg = kotlin.native.internal.ref.dereferenceExternalRCRef(arg) as DeprecatedInterface
-    val _result = run { acceptDeprecatedInterface(__arg) }
-    return run { _result; true }
-}
-
 @ExportedBridge("__root___acceptPublicClassImplDeprecatedInterface__TypesOfArguments__main_PublicClassImplDeprecatedInterface__")
 public fun __root___acceptPublicClassImplDeprecatedInterface__TypesOfArguments__main_PublicClassImplDeprecatedInterface__(arg: kotlin.native.internal.NativePtr): Boolean {
     val __arg = kotlin.native.internal.ref.dereferenceExternalRCRef(arg) as PublicClassImplDeprecatedInterface
@@ -568,34 +533,6 @@ public fun __root___deprecatedF(): Boolean {
 @ExportedBridge("__root___deprecatedImplicitlyF")
 public fun __root___deprecatedImplicitlyF(): Boolean {
     val _result = run { deprecatedImplicitlyF() }
-    return run { _result; true }
-}
-
-@ExportedBridge("__root___deprecatedInterfacePropertyWithContext_get__TypesOfArgumentsC1__main_normalT__")
-public fun __root___deprecatedInterfacePropertyWithContext_get__TypesOfArgumentsC1__main_normalT__(_0: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
-    val ___0 = kotlin.native.internal.ref.dereferenceExternalRCRef(_0) as normalT
-    val _result = run { context(___0) { deprecatedInterfacePropertyWithContext } }
-    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
-}
-
-@ExportedBridge("__root___deprecatedInterfacePropertyWithContext_set__TypesOfArgumentsC1__anyU20main_DeprecatedInterface_main_normalT__")
-public fun __root___deprecatedInterfacePropertyWithContext_set__TypesOfArgumentsC1__anyU20main_DeprecatedInterface_main_normalT__(value: kotlin.native.internal.NativePtr, _1: kotlin.native.internal.NativePtr): Boolean {
-    val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as DeprecatedInterface
-    val ___1 = kotlin.native.internal.ref.dereferenceExternalRCRef(_1) as normalT
-    val _result = run { context(___1) { deprecatedInterfacePropertyWithContext = __value } }
-    return run { _result; true }
-}
-
-@ExportedBridge("__root___deprecatedInterfaceProperty_get")
-public fun __root___deprecatedInterfaceProperty_get(): kotlin.native.internal.NativePtr {
-    val _result = run { deprecatedInterfaceProperty }
-    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
-}
-
-@ExportedBridge("__root___deprecatedInterfaceProperty_set__TypesOfArguments__anyU20main_DeprecatedInterface__")
-public fun __root___deprecatedInterfaceProperty_set__TypesOfArguments__anyU20main_DeprecatedInterface__(newValue: kotlin.native.internal.NativePtr): Boolean {
-    val __newValue = kotlin.native.internal.ref.dereferenceExternalRCRef(newValue) as DeprecatedInterface
-    val _result = run { deprecatedInterfaceProperty = __newValue }
     return run { _result; true }
 }
 
@@ -726,31 +663,6 @@ public fun __root___obsoletedChildT_init_initialize__TypesOfArguments__Swift_Uns
     return run { _result; true }
 }
 
-@ExportedBridge("__root___obsoletedF")
-public fun __root___obsoletedF(): Boolean {
-    val _result = run { obsoletedF() }
-    return run { _result; true }
-}
-
-@ExportedBridge("__root___obsoletedT_init_allocate")
-public fun __root___obsoletedT_init_allocate(): kotlin.native.internal.NativePtr {
-    val _result = run { kotlin.native.internal.createUninitializedInstance<obsoletedT>() }
-    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
-}
-
-@ExportedBridge("__root___obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
-public fun __root___obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
-    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
-    val _result = run { kotlin.native.internal.initInstance(____kt, obsoletedT()) }
-    return run { _result; true }
-}
-
-@ExportedBridge("__root___obsoletedV_get")
-public fun __root___obsoletedV_get(): Boolean {
-    val _result = run { obsoletedV }
-    return run { _result; true }
-}
-
 @ExportedBridge("__root___publicClassImplDeprecatedInterfaceProperty_get")
 public fun __root___publicClassImplDeprecatedInterfaceProperty_get(): kotlin.native.internal.NativePtr {
     val _result = run { publicClassImplDeprecatedInterfaceProperty }
@@ -838,12 +750,6 @@ public fun __root___renamedWithArguments__TypesOfArguments__Swift_Int32_Swift_Fl
 public fun __root___returnClassA__TypesOfArguments__main_SwiftClassA__(value: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
     val __value = kotlin.native.internal.ref.dereferenceExternalRCRef(value) as KotlinClassA
     val _result = run { returnClassA(__value) }
-    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
-}
-
-@ExportedBridge("__root___returnDeprecatedInterface")
-public fun __root___returnDeprecatedInterface(): kotlin.native.internal.NativePtr {
-    val _result = run { returnDeprecatedInterface() }
     return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
 }
 
@@ -948,13 +854,6 @@ public fun deprecatedT_deprecationInheritedV_get(self: kotlin.native.internal.Na
     return run { _result; true }
 }
 
-@ExportedBridge("deprecatedT_deprecationReinforcedF")
-public fun deprecatedT_deprecationReinforcedF(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as deprecatedT
-    val _result = run { __self.deprecationReinforcedF() }
-    return run { _result; true }
-}
-
 @ExportedBridge("deprecatedT_deprecationReinforcedT_init_allocate")
 public fun deprecatedT_deprecationReinforcedT_init_allocate(): kotlin.native.internal.NativePtr {
     val _result = run { kotlin.native.internal.createUninitializedInstance<deprecatedT.deprecationReinforcedT>() }
@@ -965,13 +864,6 @@ public fun deprecatedT_deprecationReinforcedT_init_allocate(): kotlin.native.int
 public fun deprecatedT_deprecationReinforcedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
     val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
     val _result = run { kotlin.native.internal.initInstance(____kt, deprecatedT.deprecationReinforcedT()) }
-    return run { _result; true }
-}
-
-@ExportedBridge("deprecatedT_deprecationReinforcedV_get")
-public fun deprecatedT_deprecationReinforcedV_get(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as deprecatedT
-    val _result = run { __self.deprecationReinforcedV }
     return run { _result; true }
 }
 
@@ -1078,35 +970,6 @@ public fun normalChildT_normalV_get(self: kotlin.native.internal.NativePtr): Boo
 public fun normalChildT_obsoletedF(self: kotlin.native.internal.NativePtr): Boolean {
     val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalChildT
     val _result = run { __self.obsoletedF() }
-    return run { _result; true }
-}
-
-@ExportedBridge("normalChildT_obsoletedInFutureF")
-public fun normalChildT_obsoletedInFutureF(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalChildT
-    val _result = run { __self.obsoletedInFutureF() }
-    return run { _result; true }
-}
-
-@ExportedBridge("normalChildT_obsoletedInFutureP_get")
-public fun normalChildT_obsoletedInFutureP_get(self: kotlin.native.internal.NativePtr): Int {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalChildT
-    val _result = run { __self.obsoletedInFutureP }
-    return _result
-}
-
-@ExportedBridge("normalChildT_obsoletedInFutureP_set__TypesOfArguments__Swift_Int32__")
-public fun normalChildT_obsoletedInFutureP_set__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, newValue: Int): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalChildT
-    val __newValue = newValue
-    val _result = run { __self.obsoletedInFutureP = __newValue }
-    return run { _result; true }
-}
-
-@ExportedBridge("normalChildT_obsoletedInFutureV_get")
-public fun normalChildT_obsoletedInFutureV_get(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalChildT
-    val _result = run { __self.obsoletedInFutureV }
     return run { _result; true }
 }
 
@@ -1260,13 +1123,6 @@ public fun normalT_normalV_get(self: kotlin.native.internal.NativePtr): Boolean 
     return run { _result; true }
 }
 
-@ExportedBridge("normalT_obsoletedF")
-public fun normalT_obsoletedF(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalT
-    val _result = run { __self.obsoletedF() }
-    return run { _result; true }
-}
-
 @ExportedBridge("normalT_obsoletedInFutureF")
 public fun normalT_obsoletedInFutureF(self: kotlin.native.internal.NativePtr): Boolean {
     val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalT
@@ -1308,27 +1164,6 @@ public fun normalT_obsoletedP_set__TypesOfArguments__Swift_Int32__(self: kotlin.
     val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalT
     val __newValue = newValue
     val _result = run { __self.obsoletedP = __newValue }
-    return run { _result; true }
-}
-
-@ExportedBridge("normalT_obsoletedT_init_allocate")
-public fun normalT_obsoletedT_init_allocate(): kotlin.native.internal.NativePtr {
-    val _result = run { kotlin.native.internal.createUninitializedInstance<normalT.obsoletedT>() }
-    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
-}
-
-@ExportedBridge("normalT_obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__")
-public fun normalT_obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__(__kt: kotlin.native.internal.NativePtr, obsoleted: Float): Boolean {
-    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
-    val __obsoleted = obsoleted
-    val _result = run { kotlin.native.internal.initInstance(____kt, normalT.obsoletedT(__obsoleted)) }
-    return run { _result; true }
-}
-
-@ExportedBridge("normalT_obsoletedV_get")
-public fun normalT_obsoletedV_get(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as normalT
-    val _result = run { __self.obsoletedV }
     return run { _result; true }
 }
 
@@ -1457,13 +1292,6 @@ public fun obsoletedT_deprecationRelaxedV_get(self: kotlin.native.internal.Nativ
     return run { _result; true }
 }
 
-@ExportedBridge("obsoletedT_deprecationRestatedF")
-public fun obsoletedT_deprecationRestatedF(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as obsoletedT
-    val _result = run { __self.deprecationRestatedF() }
-    return run { _result; true }
-}
-
 @ExportedBridge("obsoletedT_deprecationRestatedT_init_allocate")
 public fun obsoletedT_deprecationRestatedT_init_allocate(): kotlin.native.internal.NativePtr {
     val _result = run { kotlin.native.internal.createUninitializedInstance<obsoletedT.deprecationRestatedT>() }
@@ -1474,12 +1302,5 @@ public fun obsoletedT_deprecationRestatedT_init_allocate(): kotlin.native.intern
 public fun obsoletedT_deprecationRestatedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
     val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
     val _result = run { kotlin.native.internal.initInstance(____kt, obsoletedT.deprecationRestatedT()) }
-    return run { _result; true }
-}
-
-@ExportedBridge("obsoletedT_deprecationRestatedV_get")
-public fun obsoletedT_deprecationRestatedV_get(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as obsoletedT
-    val _result = run { __self.deprecationRestatedV }
     return run { _result; true }
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.swift
@@ -814,6 +814,19 @@ open class normalT: KotlinRuntime.KotlinBase {
     ) {
         super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
     }
+    @available(*, unavailable, message: "Obsoleted")
+    public static func +(
+        this: main.normalT,
+        increment: main.normalT.normalT
+    ) -> main.normalT.normalT {
+        fatalError()
+    }
+    @available(*, unavailable, message: "Obsoleted")
+    public final func _plus(
+        increment: main.normalT.normalT
+    ) -> main.normalT.normalT {
+        fatalError()
+    }
     @available(*, deprecated, message: "Deprecated")
     open func deprecatedF() -> Swift.Void {
         return { normalT_deprecatedF(self.__externalRCRef()); return () }()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.swift
@@ -90,7 +90,7 @@ public final class ClassWithDeprecatedMembersFromInterface: KotlinRuntime.Kotlin
     }
     @available(*, unavailable, message: "Obsoleted")
     public func deprecatedErrorFunction() -> Swift.Void {
-        return { ClassWithDeprecatedMembersFromInterface_deprecatedErrorFunction(self.__externalRCRef()); return () }()
+        fatalError()
     }
     @available(*, deprecated, message: "Deprecated")
     public func deprecatedWarningFunction() -> Swift.Void {
@@ -104,17 +104,14 @@ public final class DeprecatedInterfaceWrapper: KotlinRuntime.KotlinBase {
     @available(*, unavailable, message: "Unavailable type(s): main.DeprecatedInterface")
     public var deprecatedInterface: any main.DeprecatedInterface {
         get {
-            return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: DeprecatedInterfaceWrapper_deprecatedInterface_get(self.__externalRCRef())) as! any main.DeprecatedInterface
+            fatalError()
         }
     }
     @available(*, unavailable, message: "Unavailable type(s): main.DeprecatedInterface")
     public init(
         deprecatedInterface: any main.DeprecatedInterface
     ) {
-        if Self.self != main.DeprecatedInterfaceWrapper.self { fatalError("Inheritance from exported Kotlin classes is not supported yet: \(String(reflecting: Self.self)) inherits from main.DeprecatedInterfaceWrapper ") }
-        let __kt = __root___DeprecatedInterfaceWrapper_init_allocate()
-        super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
-        { __root___DeprecatedInterfaceWrapper_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20main_DeprecatedInterface__(__kt, deprecatedInterface.__externalRCRef()); return () }()
+        fatalError()
     }
     package override init(
         __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
@@ -531,7 +528,7 @@ open class deprecatedT: KotlinRuntime.KotlinBase {
     @available(*, unavailable, message: "Obsoleted")
     open var deprecationReinforcedV: Swift.Void {
         get {
-            return { deprecatedT_deprecationReinforcedV_get(self.__externalRCRef()); return () }()
+            fatalError()
         }
     }
     @available(*, deprecated, message: "Deprecated")
@@ -558,7 +555,7 @@ open class deprecatedT: KotlinRuntime.KotlinBase {
     }
     @available(*, unavailable, message: "Obsoleted")
     open func deprecationReinforcedF() -> Swift.Void {
-        return { deprecatedT_deprecationReinforcedF(self.__externalRCRef()); return () }()
+        fatalError()
     }
     @available(*, deprecated, message: "Deprecated")
     open func deprecationRestatedF() -> Swift.Void {
@@ -607,17 +604,17 @@ public final class normalChildT: main.normalT {
     public override var obsoletedInFutureP: Swift.Int32 {
         @available(*, unavailable, message: "Deprecated")
         get {
-            return normalChildT_obsoletedInFutureP_get(self.__externalRCRef())
+            fatalError()
         }
         @available(*, unavailable, message: "Deprecated")
         set {
-            return { normalChildT_obsoletedInFutureP_set__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), newValue); return () }()
+            fatalError()
         }
     }
     @available(*, unavailable, message: "Obsoleted")
     public override var obsoletedInFutureV: Swift.Void {
         get {
-            return { normalChildT_obsoletedInFutureV_get(self.__externalRCRef()); return () }()
+            fatalError()
         }
     }
     public override var obsoletedP: Swift.Int32 {
@@ -667,7 +664,7 @@ public final class normalChildT: main.normalT {
     }
     @available(*, unavailable, message: "Obsoleted")
     public override func obsoletedInFutureF() -> Swift.Void {
-        return { normalChildT_obsoletedInFutureF(self.__externalRCRef()); return () }()
+        fatalError()
     }
     public func removedF() -> Swift.Void {
         return { normalChildT_removedF(self.__externalRCRef()); return () }()
@@ -712,10 +709,7 @@ open class normalT: KotlinRuntime.KotlinBase {
         public init(
             obsoleted: Swift.Float
         ) {
-            if Self.self != main.normalT.obsoletedT.self { fatalError("Inheritance from exported Kotlin classes is not supported yet: \(String(reflecting: Self.self)) inherits from main.normalT.obsoletedT ") }
-            let __kt = normalT_obsoletedT_init_allocate()
-            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
-            { normalT_obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__(__kt, obsoleted); return () }()
+            fatalError()
         }
         package override init(
             __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
@@ -792,7 +786,7 @@ open class normalT: KotlinRuntime.KotlinBase {
     @available(*, unavailable, message: "Obsoleted")
     open var obsoletedV: Swift.Void {
         get {
-            return { normalT_obsoletedV_get(self.__externalRCRef()); return () }()
+            fatalError()
         }
     }
     open var removedInFutureP: Swift.Int32 {
@@ -832,7 +826,7 @@ open class normalT: KotlinRuntime.KotlinBase {
     }
     @available(*, unavailable, message: "Obsoleted")
     open func obsoletedF() -> Swift.Void {
-        return { normalT_obsoletedF(self.__externalRCRef()); return () }()
+        fatalError()
     }
     open func obsoletedInFutureF() -> Swift.Void {
         return { normalT_obsoletedInFutureF(self.__externalRCRef()); return () }()
@@ -940,15 +934,12 @@ open class obsoletedT: KotlinRuntime.KotlinBase {
     @available(*, unavailable, message: "Obsoleted")
     open var deprecationRestatedV: Swift.Void {
         get {
-            return { obsoletedT_deprecationRestatedV_get(self.__externalRCRef()); return () }()
+            fatalError()
         }
     }
     @available(*, unavailable, message: "Deprecated")
     public init() {
-        if Self.self != main.obsoletedT.self { fatalError("Inheritance from exported Kotlin classes is not supported yet: \(String(reflecting: Self.self)) inherits from main.obsoletedT ") }
-        let __kt = __root___obsoletedT_init_allocate()
-        super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
-        { __root___obsoletedT_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        fatalError()
     }
     package override init(
         __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
@@ -965,7 +956,7 @@ open class obsoletedT: KotlinRuntime.KotlinBase {
     }
     @available(*, unavailable, message: "Obsoleted")
     open func deprecationRestatedF() -> Swift.Void {
-        return { obsoletedT_deprecationRestatedF(self.__externalRCRef()); return () }()
+        fatalError()
     }
 }
 @available(*, deprecated, message: "Deprecated. Replacement: renamed")
@@ -1007,10 +998,10 @@ public var classA: main.SwiftClassA {
 @available(*, unavailable, message: "Unavailable type(s): main.DeprecatedInterface")
 public var deprecatedInterfaceProperty: any main.DeprecatedInterface {
     get {
-        return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: __root___deprecatedInterfaceProperty_get()) as! any main.DeprecatedInterface
+        fatalError()
     }
     set {
-        return { __root___deprecatedInterfaceProperty_set__TypesOfArguments__anyU20main_DeprecatedInterface__(newValue.__externalRCRef()); return () }()
+        fatalError()
     }
 }
 @available(*, deprecated, message: "Deprecated")
@@ -1061,7 +1052,7 @@ public var objectB: main.ObjCObjectB {
 @available(*, unavailable, message: "Obsoleted")
 public var obsoletedV: Swift.Void {
     get {
-        return { __root___obsoletedV_get(); return () }()
+        fatalError()
     }
 }
 public var publicClassImplDeprecatedInterfaceProperty: main.PublicClassImplDeprecatedInterface {
@@ -1090,7 +1081,7 @@ public var renamedV: Swift.Void {
 public func acceptDeprecatedInterface(
     arg: any main.DeprecatedInterface
 ) -> Swift.Void {
-    return { __root___acceptDeprecatedInterface__TypesOfArguments__anyU20main_DeprecatedInterface__(arg.__externalRCRef()); return () }()
+    fatalError()
 }
 @available(*, unavailable, message: "Declaration uses unsupported types")
 public func acceptHiddenChildT(
@@ -1151,8 +1142,7 @@ public func formattedMessage() -> Swift.Never {
 public func getDeprecatedInterfacePropertyWithContext(
     _ context: main.normalT
 ) -> any main.DeprecatedInterface {
-    let (_0) = context
-    return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: __root___deprecatedInterfacePropertyWithContext_get__TypesOfArgumentsC1__main_normalT__(_0.__externalRCRef())) as! any main.DeprecatedInterface
+    fatalError()
 }
 public func localDeclarations() -> Swift.Void {
     return { __root___localDeclarations(); return () }()
@@ -1178,7 +1168,7 @@ public func multilineMessage() -> Swift.Never {
 }
 @available(*, unavailable, message: "Obsoleted")
 public func obsoletedF() -> Swift.Void {
-    return { __root___obsoletedF(); return () }()
+    fatalError()
 }
 @available(*, deprecated, message: ". Replacement: something")
 public func renamed(
@@ -1219,7 +1209,7 @@ public func returnClassA(
 }
 @available(*, unavailable, message: "Unavailable type(s): main.DeprecatedInterface")
 public func returnDeprecatedInterface() -> any main.DeprecatedInterface {
-    return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: __root___returnDeprecatedInterface()) as! any main.DeprecatedInterface
+    fatalError()
 }
 @available(*, unavailable, message: "Declaration uses unsupported types")
 public func returnHiddenChildT() -> Swift.Never {
@@ -1254,8 +1244,7 @@ public func setDeprecatedInterfacePropertyWithContext(
     _ context: main.normalT,
     value: any main.DeprecatedInterface
 ) -> Swift.Void {
-    let (_1) = context
-    return { __root___deprecatedInterfacePropertyWithContext_set__TypesOfArgumentsC1__anyU20main_DeprecatedInterface_main_normalT__(value.__externalRCRef(), _1.__externalRCRef()); return () }()
+    fatalError()
 }
 @available(*, deprecated, message: ". Replacement: unrenamed")
 public func unrenamed() -> Swift.Never {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.h
@@ -5,8 +5,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 int32_t weird_A_bar_get(void * self);
 
-_Bool weird_A_foo(void * self);
-
 void * weird_A_init_allocate();
 
 _Bool weird_A_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt, void *_Nullable * _Nonnull __error);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.kt
@@ -13,13 +13,6 @@ public fun weird_A_bar_get(self: kotlin.native.internal.NativePtr): Int {
     return _result
 }
 
-@ExportedBridge("weird_A_foo")
-public fun weird_A_foo(self: kotlin.native.internal.NativePtr): Boolean {
-    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as weird.A
-    val _result = run { __self.foo() }
-    return run { _result; true }
-}
-
 @ExportedBridge("weird_A_init_allocate")
 public fun weird_A_init_allocate(): kotlin.native.internal.NativePtr {
     val _result = run { kotlin.native.internal.createUninitializedInstance<weird.A>() }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.swift
@@ -26,7 +26,7 @@ extension ExportedKotlinPackages.weird {
         }
         @available(*, unavailable, message: "")
         open func foo() -> Swift.Void {
-            return { weird_A_foo(self.__externalRCRef()); return () }()
+            fatalError()
         }
         open func `throws`() throws -> Swift.Void {
             var _out_error: UnsafeMutableRawPointer? = nil


### PR DESCRIPTION
^[KT-85918](https://youtrack.jetbrains.com/issue/KT-85918) Fixed

Also stopped generating bridges for unavailable declarations as they will never actually be called anyway.