### PR TITLE
[cli] Remove IntelliJ extension points registration from KotlinCoreEnvironment

### DIFF
--- a/build-common/src/org/jetbrains/kotlin/build/BuildMetaInfo.kt
+++ b/build-common/src/org/jetbrains/kotlin/build/BuildMetaInfo.kt
@@ -103,7 +103,6 @@ abstract class BuildMetaInfo {
         "extraHelp",
         "freeArgs",
         "help",
-        "intellijPluginRoot",
         "kotlinHome",
         "listPhases",
         "phasesToDump",

--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -4117,7 +4117,7 @@
                         "releaseVersionsMetadata": {
                             "introducedVersion": "1.1.3",
                             "stabilizedVersion": null,
-                            "deprecatedVersion": null,
+                            "deprecatedVersion": "2.4.20",
                             "removedVersion": null
                         },
                         "argumentType": {

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
@@ -261,8 +261,13 @@ val actualCommonCompilerArguments by compilerArgumentsLevel(CompilerArgumentsLev
         valueDescription = "<path>".asReleaseDependent()
         valueType = StringType.defaultNull
 
+        additionalAnnotations(
+            Deprecated("This flag is deprecated")
+        )
+
         lifecycle(
             introducedVersion = KotlinReleaseVersion.v1_1_3,
+            deprecatedVersion = KotlinReleaseVersion.v2_4_20,
         )
     }
 

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/removed/removedCommonCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/removed/removedCommonCompilerArguments.kt
@@ -10,7 +10,9 @@ import org.jetbrains.kotlin.arguments.dsl.base.KotlinReleaseVersion
 import org.jetbrains.kotlin.arguments.dsl.base.asReleaseDependent
 import org.jetbrains.kotlin.arguments.dsl.base.compilerArgumentsLevel
 import org.jetbrains.kotlin.arguments.dsl.defaultFalse
+import org.jetbrains.kotlin.arguments.dsl.defaultNull
 import org.jetbrains.kotlin.arguments.dsl.types.BooleanType
+import org.jetbrains.kotlin.arguments.dsl.types.StringType
 
 val removedCommonCompilerArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.commonCompilerArguments) {
     compilerArgument {

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/CLIConfigurationKeys.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/CLIConfigurationKeys.kt
@@ -52,10 +52,6 @@ object CLIConfigurationKeys {
     @JvmField
     val ALLOW_KOTLIN_PACKAGE = CompilerConfigurationKey.create<Boolean>("ALLOW_KOTLIN_PACKAGE")
 
-    // Used in Eclipse plugin (see KotlinCLICompiler).
-    @JvmField
-    val INTELLIJ_PLUGIN_ROOT = CompilerConfigurationKey.create<String>("INTELLIJ_PLUGIN_ROOT")
-
     // See K2MetadataCompilerArguments.
     @JvmField
     val METADATA_DESTINATION_DIRECTORY = CompilerConfigurationKey.create<File>("METADATA_DESTINATION_DIRECTORY")
@@ -121,10 +117,6 @@ var CompilerConfiguration.treatWarningsAsErrors: Boolean
 var CompilerConfiguration.allowKotlinPackage: Boolean
     get() = getBoolean(CLIConfigurationKeys.ALLOW_KOTLIN_PACKAGE)
     set(value) { put(CLIConfigurationKeys.ALLOW_KOTLIN_PACKAGE, value) }
-
-var CompilerConfiguration.intellijPluginRoot: String?
-    get() = get(CLIConfigurationKeys.INTELLIJ_PLUGIN_ROOT)
-    set(value) { put(CLIConfigurationKeys.INTELLIJ_PLUGIN_ROOT, requireNotNull(value) { "nullable values are not allowed" }) }
 
 var CompilerConfiguration.metadataDestinationDirectory: File?
     get() = get(CLIConfigurationKeys.METADATA_DESTINATION_DIRECTORY)

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
@@ -582,6 +582,7 @@ with bodies.""",
             field = value
         }
 
+    @Deprecated("This flag is deprecated")
     @Argument(
         value = "-Xintellij-plugin-root",
         valueDescription = "<path>",

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
@@ -56,6 +56,7 @@ fun copyCommonCompilerArguments(from: CommonCompilerArguments, to: CommonCompile
     to.ignoreConstOptimizationErrors = from.ignoreConstOptimizationErrors
     to.incrementalCompilation = from.incrementalCompilation
     to.inlineClasses = from.inlineClasses
+    @Suppress("DEPRECATION")
     to.intellijPluginRoot = from.intellijPluginRoot
     to.kotlinHome = from.kotlinHome
     to.languageVersion = from.languageVersion

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
@@ -38,7 +38,6 @@ import com.intellij.psi.impl.file.impl.JavaFileManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.JavaClassSupers
 import com.intellij.util.io.URLUtil
-import com.intellij.util.lang.UrlClassLoader
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.asJava.KotlinAsJavaSupport
@@ -90,10 +89,7 @@ import org.jetbrains.kotlin.resolve.jvm.modules.JavaModuleResolver
 import org.jetbrains.kotlin.resolve.lazy.declarations.CliDeclarationProviderFactoryService
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactoryService
 import org.jetbrains.kotlin.serialization.DescriptorSerializerPlugin
-import org.jetbrains.kotlin.utils.PathUtil
 import java.io.File
-import java.nio.file.FileSystems
-import java.util.zip.ZipFile
 
 class KotlinCoreEnvironment private constructor(
     val projectEnvironment: ProjectEnvironment,
@@ -454,12 +450,10 @@ class KotlinCoreEnvironment private constructor(
         ): KotlinCoreEnvironment {
             val configuration = initialConfiguration.copy()
             // Tests are supposed to create a single project and dispose it right after use
-            val appEnv =
-                createApplicationEnvironment(
-                    parentDisposable,
-                    configuration,
-                    KotlinCoreApplicationEnvironmentMode.UnitTest,
-                )
+            val appEnv = createApplicationEnvironment(
+                parentDisposable,
+                KotlinCoreApplicationEnvironmentMode.UnitTest,
+            )
             val projectEnv = ProjectEnvironment(parentDisposable, appEnv, configuration)
             return KotlinCoreEnvironment(projectEnv, configuration, extensionConfigs)
         }
@@ -492,7 +486,6 @@ class KotlinCoreEnvironment private constructor(
         fun createProjectEnvironmentForTests(projectDisposable: Disposable, configuration: CompilerConfiguration): ProjectEnvironment {
             val appEnv = createApplicationEnvironment(
                 projectDisposable,
-                configuration,
                 KotlinCoreApplicationEnvironmentMode.UnitTest,
             )
             return ProjectEnvironment(projectDisposable, appEnv, configuration)
@@ -546,12 +539,10 @@ class KotlinCoreEnvironment private constructor(
             synchronized(APPLICATION_LOCK) {
                 if (ourApplicationEnvironment == null) {
                     val disposable = Disposer.newDisposable("Disposable for the KotlinCoreApplicationEnvironment")
-                    ourApplicationEnvironment =
-                        createApplicationEnvironment(
-                            disposable,
-                            configuration,
-                            environmentMode,
-                        )
+                    ourApplicationEnvironment = createApplicationEnvironment(
+                        disposable,
+                        environmentMode,
+                    )
                     ourProjectCount = 0
                     Disposer.register(disposable, Disposable {
                         synchronized(APPLICATION_LOCK) {
@@ -662,44 +653,14 @@ class KotlinCoreEnvironment private constructor(
 
         private fun createApplicationEnvironment(
             parentDisposable: Disposable,
-            configuration: CompilerConfiguration,
             environmentMode: KotlinCoreApplicationEnvironmentMode,
         ): KotlinCoreApplicationEnvironment {
             val applicationEnvironment = KotlinCoreApplicationEnvironment.create(parentDisposable, environmentMode)
-
-            registerApplicationExtensionPointsAndExtensionsFrom(configuration, "extensions/compiler-cli-root.xml")
 
             registerApplicationServicesForCLI(applicationEnvironment)
             registerApplicationServices(applicationEnvironment)
 
             return applicationEnvironment
-        }
-
-        private fun registerApplicationExtensionPointsAndExtensionsFrom(configuration: CompilerConfiguration, configFilePath: String) {
-            fun File.hasConfigFile(configFile: String): Boolean =
-                if (isDirectory) File(this, "META-INF" + File.separator + configFile).exists()
-                else try {
-                    ZipFile(this).use {
-                        it.getEntry("META-INF/$configFile") != null
-                    }
-                } catch (e: Throwable) {
-                    false
-                }
-
-            val pluginRoot: File =
-                configuration.get(CLIConfigurationKeys.INTELLIJ_PLUGIN_ROOT)?.let(::File)
-                    ?: PathUtil.getResourcePathForClass(CompilerSystemProperties::class.java).takeIf { it.hasConfigFile(configFilePath) }
-                    ?: configuration.get(CLIConfigurationKeys.PATH_TO_KOTLIN_COMPILER_JAR)?.takeIf { it.hasConfigFile(configFilePath) }
-                    ?: throw IllegalStateException(
-                        "Unable to find extension point configuration $configFilePath " +
-                                "(cp:\n  ${(Thread.currentThread().contextClassLoader as? UrlClassLoader)?.urls?.joinToString("\n  ") { it.file }})"
-                    )
-
-            CoreApplicationEnvironment.registerExtensionPointAndExtensions(
-                FileSystems.getDefault().getPath(pluginRoot.path),
-                configFilePath,
-                ApplicationManager.getApplication().extensionArea
-            )
         }
 
         @JvmStatic

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/arguments.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/arguments.kt
@@ -40,7 +40,6 @@ fun CompilerConfiguration.setupCommonArguments(
     val modelDumpDir = modelDumpDirString?.takeIf { it.isNotEmpty() && File(it).let { it.isDirectory && it.canWrite() } }
 
     putIfNotNull(CommonConfigurationKeys.DUMP_MODEL, modelDumpDir)
-    putIfNotNull(CLIConfigurationKeys.INTELLIJ_PLUGIN_ROOT, arguments.intellijPluginRoot)
     put(CommonConfigurationKeys.REPORT_OUTPUT_FILES, arguments.reportOutputFiles)
     put(CommonConfigurationKeys.INCREMENTAL_COMPILATION, incrementalCompilationIsEnabled(arguments))
     put(CommonConfigurationKeys.ALLOW_ANY_SCRIPTS_IN_SOURCE_ROOTS, arguments.allowAnyScriptsInSourceRoots)

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/CLIConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/CLIConfigurationKeysContainer.kt
@@ -39,8 +39,6 @@ object CLIConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.cli.c
 
     val ALLOW_KOTLIN_PACKAGE by key<Boolean>()
 
-    val INTELLIJ_PLUGIN_ROOT by key<String>("Used in Eclipse plugin (see KotlinCLICompiler).")
-
     val METADATA_DESTINATION_DIRECTORY by key<File>("See K2MetadataCompilerArguments.")
 
     val PATH_TO_KOTLIN_COMPILER_JAR by key<File>("Path to the Kotlin compiler jar in the Kotlin plugin. Used in FIR IDE uast tests.")


### PR DESCRIPTION
Reasoning: `compiler.xml` contains legacy extension points that were necessary for K1. All the necessary extension points are registered via alternative methods now. So this is just legacy code that will be removed with K1. Removing this code makes kotlin-compiler-embeddable more GraalVM NativeImage-friendly (KT-66662)

With this change, we can also deprecate the `XintellijPluginRoot` CLI option, as it is not used anywhere else