### PR TITLE
chore: remove lagacy `.fleet` config

### DIFF
--- a/.fleet/settings.json
+++ b/.fleet/settings.json
@@ -1,9 +1,0 @@
-{
-    "backend.maxHeapSizeMb": 2602,
-
-    // https://youtrack.jetbrains.com/issue/FL-22276
-    // Fleet cannot handle nested maven projects until FL-22276
-    "ignored.project.globs": [
-        "**/pom.xml"
-    ]
-}

--- a/.space/CODEOWNERS
+++ b/.space/CODEOWNERS
@@ -71,8 +71,6 @@
 /.idea/ "Kotlin Build Infrastructure"
 /.idea/kotlinTestDataPluginTestDataPaths.xml dmitriy.novozhilov@jetbrains.com kirill.rakhman@jetbrains.com sergej.jaskiewicz@jetbrains.com
 
-/.fleet/ "Kotlin Build Infrastructure"
-
 /.space/ "Kotlin Build Infrastructure"
 
 # AI


### PR DESCRIPTION
Since Fleet is already announced to sunset, it's config can be removed.