### PR TITLE
[Build tools] Populate `explicitArguments` with in-process compilation mode

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerSeverityWerrorTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerSeverityWerrorTest.kt
@@ -77,4 +77,21 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
             }
         }
     }
+
+    // KT-85813: in-process compilation skips checkRedundantArguments because explicitArguments
+    // is not carried over when BTA converts applyArgumentStrings → toCompilerArguments().
+    // Daemon mode round-trips via toArgumentStrings() so the daemon re-parses and sets explicitArguments.
+    @DisplayName("KT-85813: With -Xcontext-parameters (redundant in LV 2.4+) and -Werror, warning is promoted to compilation error")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun missingWarningWithInProcessMode(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jvmProject(strategyConfig) {
+            val module = module("jvm-module-1")
+            module.compile(compilationConfigAction = {
+                it.compilerArguments.applyArgumentStrings(listOf("-Xcontext-parameters"))
+                it.compilerArguments[WERROR] = true
+            }) {
+                expectFail()
+            }
+        }
+    }
 }

--- a/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/JvmCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/gen/org/jetbrains/kotlin/buildtools/internal/compat/arguments/JvmCompilerArgumentsImpl.kt
@@ -176,7 +176,8 @@ internal class JvmCompilerArgumentsImpl(
   override fun build(): JvmCompilerArguments = deepCopy()
 
   @Suppress("DEPRECATION")
-  public fun toCompilerArguments(arguments: K2JVMCompilerArguments = K2JVMCompilerArguments()): K2JVMCompilerArguments {
+  public fun toCompilerArguments(): K2JVMCompilerArguments {
+    val arguments = K2JVMCompilerArguments()
     super.toCompilerArguments(arguments)
     val unknownArgs = optionsMap.keys.filter { it !in knownArguments }
     if (unknownArgs.isNotEmpty()) {

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaImplOptionsGenerator.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaImplOptionsGenerator.kt
@@ -866,13 +866,11 @@ private fun toCompilerConverterFunBuilder(
     parentClass: TypeName?,
 ): FunSpec.Builder = FunSpec.builder("toCompilerArguments").apply {
     val compilerArgumentsClass = level.getCompilerArgumentsClassName()
-    addParameter(
-        ParameterSpec.builder("arguments", compilerArgumentsClass).apply {
-            if (level.isLeaf()) {
-                defaultValue("%T()", compilerArgumentsClass)
-            }
-        }.build()
-    )
+    if (!level.isLeaf()) {
+        addParameter("arguments", compilerArgumentsClass)
+    } else {
+        addStatement("val arguments = %T()", compilerArgumentsClass)
+    }
     annotation<Suppress> {
         addMember("%S", "DEPRECATION")
     }

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaImplOptionsGenerator.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/BtaImplOptionsGenerator.kt
@@ -143,7 +143,12 @@ internal class BtaImplOptionsGenerator(
                         MemberName("org.jetbrains.kotlin.cli.common.arguments", "parseCommandLineArguments"),
                         level.getCompilerArgumentsClassName()
                     )
-
+                    if (!generateCompatLayer) {
+                        toCompilerConverterFun.addStatement(
+                            "%M(arguments)",
+                            MemberName("org.jetbrains.kotlin.buildtools.internal.arguments", "populateExplicitArguments")
+                        )
+                    }
                     constructorSpecBuilder.addStatement("applyCompilerArguments(%T())", level.getCompilerArgumentsClassName())
                 }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JsArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JsArgumentsImpl.kt
@@ -98,7 +98,8 @@ internal class JsArgumentsImpl(
   override fun build(): JsArguments = deepCopy()
 
   @Suppress("DEPRECATION")
-  public fun toCompilerArguments(arguments: K2JSCompilerArguments = K2JSCompilerArguments()): K2JSCompilerArguments {
+  public fun toCompilerArguments(): K2JSCompilerArguments {
+    val arguments = K2JSCompilerArguments()
     super.toCompilerArguments(arguments)
     val unknownArgs = optionsMap.keys.filter { it !in knownArguments }
     if (unknownArgs.isNotEmpty()) {

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JsArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JsArgumentsImpl.kt
@@ -128,6 +128,7 @@ internal class JsArgumentsImpl(
     try { if (OUTPUT in this) { arguments.setUsingReflection("outputFile", get(OUTPUT))} } catch (e: NoSuchMethodError) { throw IllegalStateException("""Compiler parameter not recognized: OUTPUT. Current compiler version is: $KC_VERSION, but the argument was removed in 2.2.0""").initCause(e) }
     if (TARGET in this) { arguments.target = get(TARGET)?.stringValue}
     arguments.internalArguments = parseCommandLineArguments<K2JSCompilerArguments>(internalArguments.toList()).internalArguments
+    populateExplicitArguments(arguments)
     return arguments
   }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
@@ -270,6 +270,7 @@ internal class JvmCompilerArgumentsImpl(
     if (X_NULLABILITY_ANNOTATIONS in this) { arguments.applyNullabilityAnnotations(get(X_NULLABILITY_ANNOTATIONS))}
     if (X_JSR305 in this) { arguments.applyJsr305(get(X_JSR305))}
     arguments.internalArguments = parseCommandLineArguments<K2JVMCompilerArguments>(internalArguments.toList()).internalArguments
+    populateExplicitArguments(arguments)
     return arguments
   }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
@@ -183,7 +183,8 @@ internal class JvmCompilerArgumentsImpl(
   override fun build(): JvmCompilerArguments = deepCopy()
 
   @Suppress("DEPRECATION")
-  public fun toCompilerArguments(arguments: K2JVMCompilerArguments = K2JVMCompilerArguments()): K2JVMCompilerArguments {
+  public fun toCompilerArguments(): K2JVMCompilerArguments {
+    val arguments = K2JVMCompilerArguments()
     super.toCompilerArguments(arguments)
     val unknownArgs = optionsMap.keys.filter { it !in knownArguments }
     if (unknownArgs.isNotEmpty()) {

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
@@ -122,6 +122,7 @@ internal class WasmArgumentsImpl(
     if (X_WASM_USE_NEW_EXCEPTION_PROPOSAL in this) { arguments.wasmUseNewExceptionProposal = get(X_WASM_USE_NEW_EXCEPTION_PROPOSAL)}
     if (X_WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS in this) { arguments.wasmUseTrapsInsteadOfExceptions = get(X_WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS)}
     arguments.internalArguments = parseCommandLineArguments<KotlinWasmCompilerArguments>(internalArguments.toList()).internalArguments
+    populateExplicitArguments(arguments)
     return arguments
   }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
@@ -94,7 +94,8 @@ internal class WasmArgumentsImpl(
   override fun build(): WasmArguments = deepCopy()
 
   @Suppress("DEPRECATION")
-  public fun toCompilerArguments(arguments: KotlinWasmCompilerArguments = KotlinWasmCompilerArguments()): KotlinWasmCompilerArguments {
+  public fun toCompilerArguments(): KotlinWasmCompilerArguments {
+    val arguments = KotlinWasmCompilerArguments()
     super.toCompilerArguments(arguments)
     val unknownArgs = optionsMap.keys.filter { it !in knownArguments }
     if (unknownArgs.isNotEmpty()) {

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/arguments/argumentUtils.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/arguments/argumentUtils.kt
@@ -10,6 +10,7 @@ package org.jetbrains.kotlin.buildtools.internal.arguments
 import org.jetbrains.kotlin.buildtools.api.CompilerArgumentsParseException
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.cli.common.arguments.CommonToolArguments
+import org.jetbrains.kotlin.cli.common.arguments.getArgumentsInfo
 import java.nio.file.Path
 import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KProperty
@@ -63,5 +64,26 @@ internal fun List<String>.checkNoneContains(other: CharSequence) {
                     "This character is currently not supported in this context. " +
                     "If you need its support, please let us know: https://youtrack.jetbrains.com/issue/KT-85553"
         )
+    }
+}
+
+internal fun populateExplicitArguments(arguments: CommonToolArguments) {
+    val argumentsInfo = getArgumentsInfo(arguments.javaClass)
+
+    arguments.explicitArguments = buildMap {
+        for (argumentField in argumentsInfo.cliArgNameToArguments.values) {
+            val actualValue = argumentField.getter.invoke(arguments)
+            val defaultValue = argumentsInfo.getDefaultValue(argumentField)
+
+            val isDefaultValue = if (actualValue is Array<*>) {
+                actualValue.contentEquals(defaultValue as Array<*>)
+            } else {
+                actualValue == defaultValue
+            }
+
+            if (!isDefaultValue) {
+                this[argumentField] = listOf(actualValue)
+            }
+        }
     }
 }


### PR DESCRIPTION
It fixes reporting of diagnostics that rely on this property (`REDUNDANT_CLI_ARG`).