### PR TITLE
[FIR, Tests] Don't use constraint that contains out-of-scope type parameters.

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/stages/ArgumentCheckingProcessor.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/stages/ArgumentCheckingProcessor.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.fir.resolve.calls.stages.ArgumentCheckingProcessor.a
 import org.jetbrains.kotlin.fir.resolve.createFunctionType
 import org.jetbrains.kotlin.fir.resolve.inference.ConeTypeVariableForLambdaParameterType
 import org.jetbrains.kotlin.fir.resolve.inference.ConeTypeVariableForLambdaReturnType
+import org.jetbrains.kotlin.fir.resolve.inference.FirPCLAInferenceSession
 import org.jetbrains.kotlin.fir.resolve.inference.csBuilder
 import org.jetbrains.kotlin.fir.resolve.inference.extractLambdaInfoFromFunctionType
 import org.jetbrains.kotlin.fir.resolve.inference.model.ConeArgumentConstraintPosition
@@ -38,6 +39,7 @@ import org.jetbrains.kotlin.resolve.calls.inference.components.PostponedArgument
 import org.jetbrains.kotlin.resolve.calls.inference.components.TypeVariableDirectionCalculator.ResolveDirection.UNKNOWN
 import org.jetbrains.kotlin.resolve.calls.inference.isSubtypeConstraintCompatible
 import org.jetbrains.kotlin.resolve.calls.inference.model.ArgumentConstraintPosition
+import org.jetbrains.kotlin.resolve.calls.inference.model.ArgumentConstraintPositionWithOutOfScopeTypeMarker
 import org.jetbrains.kotlin.resolve.calls.inference.model.ConstraintKind
 import org.jetbrains.kotlin.resolve.calls.inference.model.ConstraintPosition
 import org.jetbrains.kotlin.resolve.calls.inference.model.SimpleConstraintSystemConstraintPosition
@@ -275,6 +277,28 @@ internal object ArgumentCheckingProcessor {
         return true
     }
 
+    /**
+     * Checks whether the given type contains type parameters that are out of scope in the current constraint system state.
+     * @see FirPCLAInferenceSession.outerCandidateDeclarationsSnapshot
+     */
+    private fun ArgumentContext.containsOutOfScopeTypeParameter(type: ConeKotlinType): Boolean {
+        val pclaSession = context.bodyResolveContext.inferenceSession as? FirPCLAInferenceSession
+        val outerDeclarations = pclaSession?.outerCandidateDeclarationsSnapshot ?: emptySet()
+        if (outerDeclarations.isEmpty()) return false
+
+        with(session.typeContext) {
+            return type.contains {
+                val typeConstructor = it.typeConstructor()
+                if (typeConstructor is ConeTypeParameterLookupTag) {
+                    val typeParamOwner = typeConstructor.typeParameterSymbol.containingDeclarationSymbol
+                    typeParamOwner !in outerDeclarations
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
     private fun ArgumentContext.checkApplicabilityForArgumentType(
         atom: ConeResolutionAtom,
         argumentTypeBeforeCapturing: ConeKotlinType,
@@ -283,6 +307,12 @@ internal object ArgumentCheckingProcessor {
         if (expectedType == null) return
 
         val argumentType = captureFromTypeParameterUpperBoundIfNeeded(argumentTypeBeforeCapturing, expectedType, session)
+        val effectivePosition =
+            if (position is ArgumentConstraintPosition<*> && containsOutOfScopeTypeParameter(argumentType)) {
+                ArgumentConstraintPositionWithOutOfScopeTypeMarker(position)
+            } else {
+                position
+            }
 
         when {
             isReceiver && isDispatch -> {
@@ -296,12 +326,12 @@ internal object ArgumentCheckingProcessor {
             }
 
             else -> {
-                if (csBuilder.addSubtypeConstraintIfCompatible(argumentType, expectedType, position)) return // no errors
+                if (csBuilder.addSubtypeConstraintIfCompatible(argumentType, expectedType, effectivePosition)) return // no errors
 
                 val smartcastExpression = atom.expression as? FirSmartCastExpression
                 if (smartcastExpression != null && !smartcastExpression.isStable) {
                     val unstableType = smartcastExpression.smartcastType.coneType
-                    if (csBuilder.addSubtypeConstraintIfCompatible(unstableType, expectedType, position)) {
+                    if (csBuilder.addSubtypeConstraintIfCompatible(unstableType, expectedType, effectivePosition)) {
                         reportDiagnostic(
                             UnstableSmartCast(
                                 smartcastExpression,
@@ -321,10 +351,10 @@ internal object ArgumentCheckingProcessor {
 
                 val nullableExpectedType = expectedType.withNullability(nullable = true, session.typeContext)
 
-                if (csBuilder.addSubtypeConstraintIfCompatible(argumentType, nullableExpectedType, position)) {
+                if (csBuilder.addSubtypeConstraintIfCompatible(argumentType, nullableExpectedType, effectivePosition)) {
                     reportDiagnostic(InapplicableNullableReceiver(argumentType))
                 } else {
-                    csBuilder.addSubtypeConstraint(argumentType, expectedType, position)
+                    csBuilder.addSubtypeConstraint(argumentType, expectedType, effectivePosition)
                     reportDiagnostic(InapplicableWrongReceiver(expectedType, argumentType))
                 }
             }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirPCLAInferenceSession.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/inference/FirPCLAInferenceSession.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.fir.resolve.inference.model.ConeSemiFixVariableConst
 import org.jetbrains.kotlin.fir.resolve.substitution.ConeSubstitutor
 import org.jetbrains.kotlin.fir.resolve.substitution.asCone
 import org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.BodyResolveContext
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.hasContextParameters
 import org.jetbrains.kotlin.fir.types.*
@@ -40,6 +41,30 @@ class FirPCLAInferenceSession(
     private val outerCandidate: Candidate,
     private val inferenceComponents: InferenceComponents,
 ) : FirInferenceSession() {
+
+    /**
+     * A snapshot of declarations containing the [outerCandidate], captured at session creation time.
+     *
+     * Used as the inference boundary for out-of-scope type parameter detection.
+     * When a type parameter appears in a PCLA lambda argument,
+     * we check whether its declaring declaration is contained within this boundary.
+     *
+     * See KT-85684 and KT-60855.
+     *
+     * ```kt
+     * fun foo() = buildList {
+     *     fun <T> local(t: T) {
+     *         add(t) // Constraint T <: E (E is type variable in MutableList<E> from buildList)
+     *     }
+     * }
+     * ```
+     *
+     * The constraint T <: E is unsolvable because T is an out-of-scope type parameter.
+     *
+     * @see org.jetbrains.kotlin.fir.resolve.calls.stages.ArgumentCheckingProcessor.containsOutOfScopeTypeParameter
+     */
+    internal val outerCandidateDeclarationsSnapshot: Set<FirBasedSymbol<*>> =
+        outerCandidate.callInfo.containingDeclarations.map { it.symbol }.toSet()
 
     var currentCommonSystem: NewConstraintSystemImpl = prepareSharedBaseSystem(outerCandidate.system, inferenceComponents)
         private set

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/DiagnosticReporterByTrackingStrategy.kt
@@ -619,6 +619,9 @@ class DiagnosticReporterByTrackingStrategy(
                     )
                 }
             }
+            is ArgumentConstraintPositionWithOutOfScopeTypeMarker<*> -> {
+                reportConstraintErrorByPosition(error, position.delegate)
+            }
         }
     }
 

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/VariableFixationFinder.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/VariableFixationFinder.kt
@@ -88,8 +88,11 @@ abstract class VariableFixationFinder(
         val variable: TypeConstructorMarker,
         private val hasProperConstraint: Boolean,
         private val hasDependencyOnOuterTypeVariable: Boolean = false,
+        private val hasDependencyOnOutOfScopeTypeParameter: Boolean = false
     ) {
-        val isReady: Boolean get() = hasProperConstraint && !hasDependencyOnOuterTypeVariable
+        val isReady: Boolean
+            get() = hasProperConstraint && !hasDependencyOnOuterTypeVariable
+                    && !hasDependencyOnOutOfScopeTypeParameter
     }
 
     context(c: Context)

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/VariableReadinessCalculator.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/components/VariableReadinessCalculator.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.resolve.calls.inference.components
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.resolve.calls.inference.components.VariableFixationFinder.Context
 import org.jetbrains.kotlin.resolve.calls.inference.components.VariableFixationFinder.VariableForFixation
+import org.jetbrains.kotlin.resolve.calls.inference.model.ArgumentConstraintPositionWithOutOfScopeTypeMarker
 import org.jetbrains.kotlin.types.model.*
 import org.jetbrains.kotlin.resolve.calls.inference.components.VariableReadinessCalculator.TypeVariableFixationReadinessQuality as Q
 
@@ -31,6 +32,11 @@ class VariableReadinessCalculator(
         // In PCLA case, a not-yet-fixed type variable in the argument position still gives us a proper constraint.
         HAS_PROPER_CONSTRAINTS,
         HAS_NO_OUTER_TYPE_VARIABLE_DEPENDENCY,
+
+        // A proper constraint is a constraint that does not have out-of-scope type parameters.
+        // See examples in KT-85684 and KT-60855.
+        // See Also: FirPCLAInferenceSession.outerCandidateDeclarationsSnapshot
+        HAS_NO_OUT_OF_SCOPE_TYPE_PARAMETER,
 
         // *** A prioritizer needed for KT-74999 (the Traversable vs. Path choice) ***
         // Currently, only used in 2.2+, and helps with self-type based declared upper bounds in particular situations.
@@ -124,6 +130,9 @@ class VariableReadinessCalculator(
 
         readiness[Q.HAS_PROPER_CONSTRAINTS] = hasProperArgumentConstraints() || areAllProperConstraintsSelfTypeBased
         readiness[Q.HAS_NO_OUTER_TYPE_VARIABLE_DEPENDENCY] = !dependencyProvider.isRelatedToOuterTypeVariable(this)
+        readiness[Q.HAS_NO_OUT_OF_SCOPE_TYPE_PARAMETER] = constraints.none {
+            it.isProperArgumentConstraint() && it.position.from is ArgumentConstraintPositionWithOutOfScopeTypeMarker<*>
+        }
 
         readiness[Q.HAS_CAPTURED_UPPER_BOUND_WITH_SELF_TYPES] = areAllProperConstraintsSelfTypeBased
                 && fixationEnhancementsIn22
@@ -180,6 +189,7 @@ class VariableReadinessCalculator(
                 variable = candidate,
                 hasProperConstraint = readiness[Q.HAS_PROPER_CONSTRAINTS],
                 hasDependencyOnOuterTypeVariable = !readiness[Q.HAS_NO_OUTER_TYPE_VARIABLE_DEPENDENCY],
+                hasDependencyOnOutOfScopeTypeParameter = !readiness[Q.HAS_NO_OUT_OF_SCOPE_TYPE_PARAMETER]
             )
         }
     }

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/model/ConstraintPositionAndErrors.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/resolve/calls/inference/model/ConstraintPositionAndErrors.kt
@@ -72,6 +72,12 @@ abstract class KnownTypeParameterConstraintPosition<T : KotlinTypeMarker>(val ty
 
 sealed class ArgumentConstraintPosition<out T>(val argument: T) : ConstraintPosition()
 
+class ArgumentConstraintPositionWithOutOfScopeTypeMarker<T>(
+    val delegate: ArgumentConstraintPosition<T>
+) : ArgumentConstraintPosition<T>(delegate.argument) {
+    override fun toString(): String = "$delegate with out-of-scope type"
+}
+
 abstract class RegularArgumentConstraintPosition<out T>(argument: T) : ArgumentConstraintPosition<T>(argument),
     OnlyInputTypeConstraintPosition {
     override fun toString(): String = "Argument $argument"

--- a/compiler/testData/diagnostics/tests/inference/pcla/GenericLocalClassWithLeakingTypeParameter.kt
+++ b/compiler/testData/diagnostics/tests/inference/pcla/GenericLocalClassWithLeakingTypeParameter.kt
@@ -1,3 +1,4 @@
+// RUN_PIPELINE_TILL: FRONTEND
 // ISSUE: KT-60855
 /* ATTENTION:
  * this test monitors an unfixed compiler bug;
@@ -10,7 +11,7 @@
 
 class Buildee<CT> {
     fun yield(arg: CT) {}
-    fun materialize(): CT = reference as CT
+    fun materialize(): CT = reference <!UNCHECKED_CAST!>as CT<!>
 }
 
 fun <FT> build(
@@ -20,16 +21,16 @@ fun <FT> build(
 }
 
 private var reference: Any? = null
-val <T> Buildee<T>.typeArgumentValue: T get() = reference as T
+val <T> Buildee<T>.typeArgumentValue: T get() = reference <!UNCHECKED_CAST!>as T<!>
 
 class UserKlass
 
 // test 1: PTV is in consuming position (yield-case)
 fun testYield() {
     fun testTypeInfoOriginInsideLocalClass() {
-        val buildee = build {
+        val buildee = <!CANNOT_INFER_PARAMETER_TYPE!>build<!> {
             class Local<T> {
-                fun localOnlyFunc(): T = UserKlass() as T
+                fun localOnlyFunc(): T = UserKlass() <!UNCHECKED_CAST!>as T<!>
 
                 fun initialize() {
                     reference = Local<T>()
@@ -40,14 +41,14 @@ fun testYield() {
             }
             Local<UserKlass>().initialize()
         }
-        val result = buildee.typeArgumentValue.localOnlyFunc()
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>result<!>
+        val result = buildee.<!CANNOT_INFER_PARAMETER_TYPE!>typeArgumentValue<!>.<!UNRESOLVED_REFERENCE!>localOnlyFunc<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("ERROR CLASS: Unresolved name: localOnlyFunc")!>result<!>
     }
 
     fun testThisExpression() {
-        val buildee = build {
+        val buildee = <!CANNOT_INFER_PARAMETER_TYPE!>build<!> {
             class Local<T> {
-                fun localOnlyFunc(): T = UserKlass() as T
+                fun localOnlyFunc(): T = UserKlass() <!UNCHECKED_CAST!>as T<!>
 
                 fun initialize() {
                     reference = this
@@ -57,8 +58,8 @@ fun testYield() {
             }
             Local<UserKlass>().initialize()
         }
-        val result = buildee.typeArgumentValue.localOnlyFunc()
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>result<!>
+        val result = buildee.<!CANNOT_INFER_PARAMETER_TYPE!>typeArgumentValue<!>.<!UNRESOLVED_REFERENCE!>localOnlyFunc<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("ERROR CLASS: Unresolved name: localOnlyFunc")!>result<!>
     }
 
     testTypeInfoOriginInsideLocalClass()
@@ -70,7 +71,7 @@ fun testMaterialize() {
     fun testTypeInfoOriginInsideLocalClass() {
         val buildee = build {
             class Local<T> {
-                fun localOnlyFunc(): T = UserKlass() as T
+                fun localOnlyFunc(): T = UserKlass() <!UNCHECKED_CAST!>as T<!>
 
                 fun initialize() {
                     reference = Local<T>()
@@ -86,21 +87,21 @@ fun testMaterialize() {
     }
 
     fun testThisExpression() {
-        val buildee = build {
+        val buildee = <!CANNOT_INFER_PARAMETER_TYPE!>build<!> {
             class Local<T> {
-                fun localOnlyFunc(): T = UserKlass() as T
+                fun localOnlyFunc(): T = UserKlass() <!UNCHECKED_CAST!>as T<!>
 
                 fun initialize() {
                     reference = this
 
                     fun <T> shareTypeInfo(from: T, to: T) {}
-                    shareTypeInfo(this, materialize())
+                    <!CANNOT_INFER_PARAMETER_TYPE!>shareTypeInfo<!>(this, materialize())
                 }
             }
             Local<UserKlass>().initialize()
         }
-        val result = buildee.typeArgumentValue.localOnlyFunc()
-        <!DEBUG_INFO_EXPRESSION_TYPE("T")!>result<!>
+        val result = buildee.<!CANNOT_INFER_PARAMETER_TYPE!>typeArgumentValue<!>.<!UNRESOLVED_REFERENCE!>localOnlyFunc<!>()
+        <!DEBUG_INFO_EXPRESSION_TYPE("ERROR CLASS: Unresolved name: localOnlyFunc")!>result<!>
     }
 
     testTypeInfoOriginInsideLocalClass()
@@ -112,3 +113,7 @@ fun box(): String {
     testMaterialize()
     return "OK"
 }
+
+/* GENERATED_FIR_TAGS: asExpression, assignment, classDeclaration, functionDeclaration, functionalType, getter,
+lambdaLiteral, localClass, localFunction, localProperty, nullableType, propertyDeclaration,
+propertyWithExtensionReceiver, stringLiteral, thisExpression, typeParameter, typeWithExtension */

--- a/compiler/testData/diagnostics/tests/inference/pcla/issues/kt85684.kt
+++ b/compiler/testData/diagnostics/tests/inference/pcla/issues/kt85684.kt
@@ -1,0 +1,14 @@
+// RUN_PIPELINE_TILL: FRONTEND
+// ISSUE: KT-85684
+// WITH_STDLIB
+
+class Box<T>(val value: T?)
+fun foo() = <!CANNOT_INFER_PARAMETER_TYPE!>buildList<!> {
+    fun <T> local() {
+        add(Box<T>(null))
+    }
+    local<String>()
+}
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, lambdaLiteral, localFunction, nullableType,
+primaryConstructor, propertyDeclaration, typeParameter */


### PR DESCRIPTION

#KT-85684 fixed.
Change behavior of KT-60855.