### PR TITLE
JVM: typeOf: use KTypeProjection's static fields/methods in generated code

### DIFF
--- a/analysis/analysis-api/testData/components/compilerFacility/compilation/codeFragments/reifiedTypeParams/complextGeneric.txt
+++ b/analysis/analysis-api/testData/components/compilerFacility/compilation/codeFragments/reifiedTypeParams/complextGeneric.txt
@@ -23,25 +23,21 @@ public final class CodeFragment {
    L0
     LINENUMBER 27 L0
     LDC Ljava/util/Map;.class
-    GETSTATIC kotlin/reflect/KTypeProjection.Companion : Lkotlin/reflect/KTypeProjection$Companion;
     LDC Ljava/util/Set;.class
-    GETSTATIC kotlin/reflect/KTypeProjection.Companion : Lkotlin/reflect/KTypeProjection$Companion;
     LDC Ljava/lang/String;.class
     INVOKESTATIC kotlin/jvm/internal/Reflection.typeOf (Ljava/lang/Class;)Lkotlin/reflect/KType;
-    INVOKEVIRTUAL kotlin/reflect/KTypeProjection$Companion.covariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
+    INVOKESTATIC kotlin/reflect/KTypeProjection.covariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
     INVOKESTATIC kotlin/jvm/internal/Reflection.typeOf (Ljava/lang/Class;Lkotlin/reflect/KTypeProjection;)Lkotlin/reflect/KType;
-    INVOKEVIRTUAL kotlin/reflect/KTypeProjection$Companion.contravariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
-    GETSTATIC kotlin/reflect/KTypeProjection.Companion : Lkotlin/reflect/KTypeProjection$Companion;
+    INVOKESTATIC kotlin/reflect/KTypeProjection.contravariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
     LDC LA;.class
-    GETSTATIC kotlin/reflect/KTypeProjection.Companion : Lkotlin/reflect/KTypeProjection$Companion;
     GETSTATIC java/lang/Integer.TYPE : Ljava/lang/Class;
     INVOKESTATIC kotlin/jvm/internal/Reflection.typeOf (Ljava/lang/Class;)Lkotlin/reflect/KType;
-    INVOKEVIRTUAL kotlin/reflect/KTypeProjection$Companion.contravariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
+    INVOKESTATIC kotlin/reflect/KTypeProjection.contravariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
     INVOKESTATIC kotlin/jvm/internal/Reflection.typeOf (Ljava/lang/Class;Lkotlin/reflect/KTypeProjection;)Lkotlin/reflect/KType;
-    INVOKEVIRTUAL kotlin/reflect/KTypeProjection$Companion.invariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
+    INVOKESTATIC kotlin/reflect/KTypeProjection.invariant (Lkotlin/reflect/KType;)Lkotlin/reflect/KTypeProjection;
     INVOKESTATIC kotlin/jvm/internal/Reflection.typeOf (Ljava/lang/Class;Lkotlin/reflect/KTypeProjection;Lkotlin/reflect/KTypeProjection;)Lkotlin/reflect/KType;
     INVOKEVIRTUAL java/lang/Object.toString ()Ljava/lang/String;
     ARETURN
-    MAXSTACK = 6
+    MAXSTACK = 4
     MAXLOCALS = 0
 }

--- a/compiler/backend.common.jvm/src/org/jetbrains/kotlin/resolve/jvm/AsmTypes.java
+++ b/compiler/backend.common.jvm/src/org/jetbrains/kotlin/resolve/jvm/AsmTypes.java
@@ -60,7 +60,6 @@ public class AsmTypes {
 
     public static final Type K_TYPE = reflect("KType");
     public static final Type K_TYPE_PROJECTION = reflect("KTypeProjection");
-    public static final Type K_TYPE_PROJECTION_COMPANION = reflect("KTypeProjection$Companion");
     public static final Type K_TYPE_PARAMETER = reflect("KTypeParameter");
     public static final Type K_VARIANCE = reflect("KVariance");
 

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/typeOf.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/typeOf.kt
@@ -147,10 +147,8 @@ private fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.generateTypeO
     intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport<KT>,
     isTypeParameterBound: Boolean,
 ) {
-    // KTypeProjection companion members could be made `@JvmStatic`, see KT-30083 and KT-30084
-    v.getstatic(K_TYPE_PROJECTION.internalName, "Companion", K_TYPE_PROJECTION_COMPANION.descriptor)
     if (projection.isStarProjection()) {
-        v.invokevirtual(K_TYPE_PROJECTION_COMPANION.internalName, "getSTAR", Type.getMethodDescriptor(K_TYPE_PROJECTION), false)
+        v.getstatic(K_TYPE_PROJECTION.internalName, "star", K_TYPE_PROJECTION.descriptor)
         return
     }
 
@@ -161,5 +159,5 @@ private fun <KT : KotlinTypeMarker> TypeSystemCommonBackendContext.generateTypeO
         TypeVariance.IN -> "contravariant"
         TypeVariance.OUT -> "covariant"
     }
-    v.invokevirtual(K_TYPE_PROJECTION_COMPANION.internalName, methodName, Type.getMethodDescriptor(K_TYPE_PROJECTION, K_TYPE), false)
+    v.invokestatic(K_TYPE_PROJECTION.internalName, methodName, Type.getMethodDescriptor(K_TYPE_PROJECTION, K_TYPE), false)
 }


### PR DESCRIPTION
This makes the generated code slightly smaller. These fields/methods were annotated with @JvmField/@JvmStatic for 6 years, since 1.4.

^KT-86104