### PR TITLE
Fix KotlinCompileDaemon compatibility not discriminated by JVM version

### DIFF
--- a/compiler/daemon/daemon-client/src/main/kotlin/KotlinCompilerClient.kt
+++ b/compiler/daemon/daemon-client/src/main/kotlin/KotlinCompilerClient.kt
@@ -20,6 +20,8 @@ import org.jetbrains.kotlin.cli.common.CompilerSystemProperties
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.daemon.client.KotlinCompilerClient.DAEMON_CONNECT_CYCLE_ATTEMPTS
+import org.jetbrains.kotlin.daemon.client.KotlinCompilerClient.JAVA_TOOL_OPTIONS_ENV_VARIABLE
 import org.jetbrains.kotlin.daemon.common.*
 import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.load.kotlin.incremental.components.IncrementalCompilationComponents
@@ -457,9 +459,17 @@ object KotlinCompilerClient {
         report: (DaemonReportCategory, String) -> Unit,
     ): DaemonSearchResult {
         registryDir.mkdirs()
+        val javaLanguageVersion = JavaLanguageVersion.parse(CompilerSystemProperties.JAVA_VERSION.value)
         val timestampMarker = Files.createTempFile(registryDir.toPath(), "kotlin-daemon-client-tsmarker", null).toFile()
         val aliveWithMetadata = try {
-            walkDaemons(registryDir, compilerId, timestampMarker, report = report, filter = { file, _ -> file !in ignoredDaemonSessionFiles }).toList()
+            walkDaemons(
+                registryDir,
+                compilerId,
+                timestampMarker,
+                report = report,
+                filter = { file, _ -> file !in ignoredDaemonSessionFiles })
+                .toList()
+                .filter { it.javaLanguageVersion == javaLanguageVersion }
         } finally {
             timestampMarker.delete()
         }
@@ -477,7 +487,7 @@ object KotlinCompilerClient {
 
     internal data class GcAutoConfiguration(
         var shouldAutoConfigureGc: Boolean = true,
-        val preferredGc: String = "Parallel"
+        val preferredGc: String = "Parallel",
     )
 
     private fun getEnvironmentVariablesForTests(reportingTargets: DaemonReportingTargets): Map<String, String> {
@@ -505,7 +515,7 @@ object KotlinCompilerClient {
      * In that case the worst thing we may face, we won't configure the [GcAutoConfiguration.preferredGc] GC.
      * That sounds acceptable.
      */
-    private fun getImplicitJvmArguments(environmentVariablesForTests: Map<String, String>) : List<String> {
+    private fun getImplicitJvmArguments(environmentVariablesForTests: Map<String, String>): List<String> {
         val javaToolOptions = environmentVariablesForTests[JAVA_TOOL_OPTIONS_ENV_VARIABLE]
             ?: System.getenv(JAVA_TOOL_OPTIONS_ENV_VARIABLE)
             ?: return emptyList()
@@ -523,6 +533,7 @@ object KotlinCompilerClient {
         initialClientInfo: InitialClientInformation,
     ): Boolean {
         val javaExecutable = File(File(CompilerSystemProperties.JAVA_HOME.safeValue, "bin"), "java")
+        val javaLanguageVersion = JavaLanguageVersion.parse(CompilerSystemProperties.JAVA_VERSION.value)
         val serverHostname = CompilerSystemProperties.JAVA_RMI_SERVER_HOSTNAME.value
             ?: error("${CompilerSystemProperties.JAVA_RMI_SERVER_HOSTNAME.property} is not set!")
         val platformSpecificOptions = listOf(
@@ -530,9 +541,8 @@ object KotlinCompilerClient {
             "-Djava.awt.headless=true",
             "-D${CompilerSystemProperties.JAVA_RMI_SERVER_HOSTNAME.property}=$serverHostname"
         )
-        val javaVersion = CompilerSystemProperties.JAVA_VERSION.value?.toIntOrNull()
         val javaIllegalAccessWorkaround =
-            if (javaVersion != null && javaVersion >= 16)
+            if (javaLanguageVersion >= JavaLanguageVersion.of(16))
                 listOf("--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
             else emptyList()
         val environmentVariablesForTests = getEnvironmentVariablesForTests(reportingTargets)

--- a/compiler/daemon/daemon-client/src/main/kotlin/KotlinCompilerClient.kt
+++ b/compiler/daemon/daemon-client/src/main/kotlin/KotlinCompilerClient.kt
@@ -465,11 +465,11 @@ object KotlinCompilerClient {
             walkDaemons(
                 registryDir,
                 compilerId,
+                javaLanguageVersion,
                 timestampMarker,
                 report = report,
                 filter = { file, _ -> file !in ignoredDaemonSessionFiles })
                 .toList()
-                .filter { it.javaLanguageVersion == javaLanguageVersion }
         } finally {
             timestampMarker.delete()
         }

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.daemon.common
 import java.io.File
 import java.nio.file.Files
 import java.rmi.registry.LocateRegistry
+import kotlin.io.path.Path
 
 
 internal const val MAX_PORT_NUMBER = 0xffff
@@ -28,10 +29,8 @@ enum class DaemonReportCategory {
     DEBUG, INFO, EXCEPTION;
 }
 
-
 fun makeRunFilenameString(timestamp: String, digest: String, port: String, escapeSequence: String = ""): String =
     "$COMPILE_DAEMON_DEFAULT_FILES_PREFIX$escapeSequence.$timestamp$escapeSequence.$digest$escapeSequence.$port$escapeSequence.run"
-
 
 fun makePortFromRunFilenameExtractor(digest: String): (String) -> Int? {
     val regex = makeRunFilenameString(timestamp = "[0-9TZ:\\.\\+-]+", digest = digest, port = "(\\d+)", escapeSequence = "\\").toRegex()
@@ -48,7 +47,6 @@ data class DaemonWithMetadata(
     val daemon: CompileService,
     val runFile: File,
     val jvmOptions: DaemonJVMOptions,
-    val javaLanguageVersion: JavaLanguageVersion,
 )
 
 // TODO: write metadata into discovery file to speed up selection
@@ -58,12 +56,13 @@ data class DaemonWithMetadata(
 fun walkDaemons(
     registryDir: File,
     compilerId: CompilerId,
+    javaLanguageVersion: JavaLanguageVersion,
     fileToCompareTimestamp: File,
     filter: (File, Int) -> Boolean = { _, _ -> true },
     report: (DaemonReportCategory, String) -> Unit = { _, _ -> },
 ): Sequence<DaemonWithMetadata> {
-    val classPathDigest = compilerId.digest()
-    val portExtractor = makePortFromRunFilenameExtractor(classPathDigest)
+    val runFileDigest = makeRunFileDigest(javaLanguageVersion, compilerId.compilerClasspath.map { Path(it) })
+    val portExtractor = makePortFromRunFilenameExtractor(runFileDigest)
     return registryDir.walk()
         .map { Pair(it, portExtractor(it.name)) }
         .filter { (file, port) -> port != null && filter(file, port) }
@@ -95,8 +94,7 @@ fun walkDaemons(
             try {
                 daemon?.let {
                     val jvmOptions = it.getDaemonJVMOptions().get()
-                    val javaLanguageVersion = it.getJavaLanguageVersion().get()
-                    DaemonWithMetadata(it, file, jvmOptions, javaLanguageVersion)
+                    DaemonWithMetadata(it, file, jvmOptions)
                 }
             } catch (e: Exception) {
                 report(DaemonReportCategory.INFO, "ERROR: unable to retrieve daemon JVM options, assuming daemon is dead: ${e.message}")

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/ClientUtils.kt
@@ -44,7 +44,12 @@ fun makePortFromRunFilenameExtractor(digest: String): (String) -> Int? {
 
 private const val ORPHANED_RUN_FILE_AGE_THRESHOLD_MS = 1000000L
 
-data class DaemonWithMetadata(val daemon: CompileService, val runFile: File, val jvmOptions: DaemonJVMOptions)
+data class DaemonWithMetadata(
+    val daemon: CompileService,
+    val runFile: File,
+    val jvmOptions: DaemonJVMOptions,
+    val javaLanguageVersion: JavaLanguageVersion,
+)
 
 // TODO: write metadata into discovery file to speed up selection
 // TODO: consider using compiler jar signature (checksum) as a CompilerID (plus java version, plus ???) instead of classpath checksum
@@ -88,7 +93,11 @@ fun walkDaemons(
                 }
             }
             try {
-                daemon?.let { DaemonWithMetadata(it, file, it.getDaemonJVMOptions().get()) }
+                daemon?.let {
+                    val jvmOptions = it.getDaemonJVMOptions().get()
+                    val javaLanguageVersion = it.getJavaLanguageVersion().get()
+                    DaemonWithMetadata(it, file, jvmOptions, javaLanguageVersion)
+                }
             } catch (e: Exception) {
                 report(DaemonReportCategory.INFO, "ERROR: unable to retrieve daemon JVM options, assuming daemon is dead: ${e.message}")
                 null

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt
@@ -95,9 +95,6 @@ interface CompileService : Remote {
     fun getKotlinVersion(): CallResult<String>
 
     @Throws(RemoteException::class)
-    fun getJavaLanguageVersion(): CallResult<JavaLanguageVersion>
-
-    @Throws(RemoteException::class)
     fun getDaemonJVMOptions(): CallResult<DaemonJVMOptions>
 
     @Throws(RemoteException::class)

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompileService.kt
@@ -95,6 +95,9 @@ interface CompileService : Remote {
     fun getKotlinVersion(): CallResult<String>
 
     @Throws(RemoteException::class)
+    fun getJavaLanguageVersion(): CallResult<JavaLanguageVersion>
+
+    @Throws(RemoteException::class)
     fun getDaemonJVMOptions(): CallResult<DaemonJVMOptions>
 
     @Throws(RemoteException::class)

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt
@@ -21,7 +21,6 @@ import java.io.File
 import java.io.Serializable
 import java.lang.management.ManagementFactory
 import java.security.MessageDigest
-import java.util.*
 import kotlin.reflect.KMutableProperty1
 
 const val COMPILER_JAR_NAME: String = "kotlin-compiler.jar"
@@ -305,10 +304,10 @@ data class CompilerId(
     override val mappers: List<PropMapper<*, *, *>>
         get() = listOf(
             PropMapper(
-            this,
-            CompilerId::compilerClasspath,
-            toString = { it.joinToString(File.pathSeparator) },
-            fromString = { it.trimQuotes().split(File.pathSeparator) }), StringPropMapper(this, CompilerId::compilerVersion)
+                this,
+                CompilerId::compilerClasspath,
+                toString = { it.joinToString(File.pathSeparator) },
+                fromString = { it.trimQuotes().split(File.pathSeparator) }), StringPropMapper(this, CompilerId::compilerVersion)
         )
 
     fun digest(): String = compilerClasspath.map { File(it).absolutePath }.distinctStringsDigest().toHexString()
@@ -386,14 +385,14 @@ fun configureDaemonJVMOptions(
     CompilerSystemProperties.COMPILE_DAEMON_JVM_OPTIONS_PROPERTY.value?.let {
         opts.jvmParams.addAll(
             it.trimQuotes()
-                                  .split("(?<!\\\\),".toRegex())  // using independent non-capturing group with negative lookahead zero length assertion to split only on non-escaped commas
-                                  .map {
-                                      it.replace(
-                                          "\\\\(.)".toRegex(),
-                                          "$1"
-                                      )
-                                  } // de-escaping characters escaped by backslash, straightforward, without exceptions
-                                  .filterExtractProps(opts.mappers, "-", opts.restMapper))
+                .split("(?<!\\\\),".toRegex())  // using independent non-capturing group with negative lookahead zero length assertion to split only on non-escaped commas
+                .map {
+                    it.replace(
+                        "\\\\(.)".toRegex(),
+                        "$1"
+                    )
+                } // de-escaping characters escaped by backslash, straightforward, without exceptions
+                .filterExtractProps(opts.mappers, "-", opts.restMapper))
     }
 
     // assuming that from the conflicting options the last one is taken
@@ -431,8 +430,8 @@ fun configureDaemonOptions(opts: DaemonOptions): DaemonOptions {
         val unrecognized = it.trimQuotes().split(",").filterExtractProps(opts.mappers, "")
         if (unrecognized.any()) throw IllegalArgumentException(
             "Unrecognized daemon options passed via property ${CompilerSystemProperties.COMPILE_DAEMON_OPTIONS_PROPERTY.property}: " + unrecognized.joinToString(
-            " "
-        ) + "\nSupported options: " + opts.mappers.joinToString(", ", transform = { it.names.first() })
+                " "
+            ) + "\nSupported options: " + opts.mappers.joinToString(", ", transform = { it.names.first() })
         )
     }
     CompilerSystemProperties.COMPILE_DAEMON_VERBOSE_REPORT_PROPERTY.value?.let { opts.verbose = true }

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/DaemonParams.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.cli.common.CompilerSystemProperties
 import java.io.File
 import java.io.Serializable
 import java.lang.management.ManagementFactory
+import java.nio.file.Path
 import java.security.MessageDigest
 import kotlin.reflect.KMutableProperty1
 
@@ -47,8 +48,7 @@ val COMPILE_DAEMON_DEFAULT_RUN_DIR_PATH: String
         "kotlin", "daemon"
     )
 
-val CLASSPATH_ID_DIGEST = "MD5"
-
+private const val MD5_ALGORITHM = "MD5"
 
 open class PropMapper<C, V, out P : KMutableProperty1<C, V>>(
     val dest: C,
@@ -290,11 +290,21 @@ data class DaemonOptions(
 val DaemonOptions.runFilesPathOrDefault: String
     get() = if (runFilesPath.isBlank()) COMPILE_DAEMON_DEFAULT_RUN_DIR_PATH else runFilesPath
 
-fun Iterable<String>.distinctStringsDigest(): ByteArray =
-    MessageDigest.getInstance(CLASSPATH_ID_DIGEST).digest(this.distinct().sorted().joinToString("").toByteArray())
+fun makeRunFileDigest(javaLanguageVersion: JavaLanguageVersion, compilerClasspath: List<Path>): String {
+    val entries: List<String> = buildList {
+        add("jvm")
+        add("${javaLanguageVersion.version}")
+        add("classpath")
+        addAll(compilerClasspath.map { it.toFile().absolutePath }.distinct().sorted())
+    }
 
-fun ByteArray.toHexString(): String = joinToString("", transform = { "%02x".format(it) })
+    return entries.digest().toHexString()
+}
 
+private fun Iterable<String>.digest(): ByteArray =
+    MessageDigest.getInstance(MD5_ALGORITHM).digest(this.joinToString("").toByteArray())
+
+private fun ByteArray.toHexString(): String = joinToString("", transform = { "%02x".format(it) })
 
 data class CompilerId(
     var compilerClasspath: List<String> = listOf(),
@@ -309,8 +319,6 @@ data class CompilerId(
                 toString = { it.joinToString(File.pathSeparator) },
                 fromString = { it.trimQuotes().split(File.pathSeparator) }), StringPropMapper(this, CompilerId::compilerVersion)
         )
-
-    fun digest(): String = compilerClasspath.map { File(it).absolutePath }.distinctStringsDigest().toHexString()
 
     companion object {
         @JvmStatic

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/JavaLanguageVersion.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/JavaLanguageVersion.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.daemon.common
+
+import java.io.Serializable
+
+/**
+ * Represents a Java major version (e.g. 8, 11, 17, 21) parsed from a Java version string
+ * such as those produced by the `java.specification.version` or `java.version` system properties.
+ */
+interface JavaLanguageVersion : Comparable<JavaLanguageVersion>, Serializable {
+
+    val version: Int
+
+    override fun compareTo(other: JavaLanguageVersion): Int = version.compareTo(other.version)
+
+    companion object {
+        fun of(languageVersion: Int): JavaLanguageVersion {
+            require(languageVersion > 0) { "Java language version must be positive, got $languageVersion" }
+            return JavaLanguageVersionImpl(languageVersion)
+        }
+
+        fun parse(versionString: String?): JavaLanguageVersion {
+            if (versionString == null) return UnknownJavaLanguageVersion
+            val versionNumber = parseMajorVersion(versionString) ?: return UnknownJavaLanguageVersion
+            return JavaLanguageVersionImpl(versionNumber)
+        }
+
+        private fun parseMajorVersion(version: String): Int? {
+            val trimmed = version.trim()
+            // Legacy format: 1.X[.Y[_Z]] → X (e.g. "1.8" or "1.8.0_292" → 8)
+            if (trimmed.startsWith("1.")) {
+                return trimmed.drop(2).takeWhile(Char::isDigit).toIntOrNull()
+            }
+            // Modern format: X[.Y.Z][-qualifier][+build] → X (e.g. "17" or "17.0.1+12-LTS" → 17)
+            return trimmed.takeWhile(Char::isDigit).toIntOrNull()
+        }
+    }
+}
+
+private data object UnknownJavaLanguageVersion : JavaLanguageVersion {
+
+    override val version: Int = -1
+
+    @Suppress("unused")
+    private const val serialVersionUID: Long = 1L
+
+    @Suppress("unused")
+    private fun readResolve(): Any = UnknownJavaLanguageVersion
+}
+
+private data class JavaLanguageVersionImpl(override val version: Int) : JavaLanguageVersion {
+
+    override fun toString(): String {
+        if (version < 5) {
+            return "1.${version}"
+        }
+        return "$version"
+    }
+
+    companion object {
+        @Suppress("unused")
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/DaemonJavaLanguageVersionTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/DaemonJavaLanguageVersionTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.daemon
+
+import org.jetbrains.kotlin.cli.common.CompilerSystemProperties
+import org.jetbrains.kotlin.daemon.client.DaemonReportMessage
+import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+
+@DisplayName("Kotlin daemon Java language version compatibility (KT-71048)")
+class DaemonJavaLanguageVersionTest : BaseDaemonSessionTest() {
+
+    @DisplayName("getJavaLanguageVersion() returns a known (non-unknown) language version over RMI")
+    @Test
+    fun testGetJavaLanguageVersionReturnsKnownVersion() {
+        val (compileService, _) = leaseSession()
+        val result = compileService.getJavaLanguageVersion()
+        assertTrue(result.isGood, "getJavaLanguageVersion() RMI call must succeed")
+        val version = result.get()
+        assertTrue(
+            version.version > 0,
+            "Daemon must report a real Java major language version (> 0), got ${version.version}"
+        )
+    }
+
+    @DisplayName("getJavaLanguageVersion() reports the same major language version as the client JVM")
+    @Test
+    fun testDaemonVersionMatchesClientJvm() {
+        val clientVersion = JavaLanguageVersion.parse(CompilerSystemProperties.JAVA_VERSION.value)
+        val (compileService, _) = leaseSession()
+
+        val daemonVersion = compileService.getJavaLanguageVersion().get()
+
+        assertEquals(
+            clientVersion.version, daemonVersion.version,
+            "Daemon Java major language version must equal the client JVM language version " +
+                    "(client: ${clientVersion.version}, daemon: ${daemonVersion.version})"
+        )
+    }
+
+    @DisplayName("daemon running on the same JVM version is reused on reconnect")
+    @Test
+    fun testDaemonIsReusedWithCompatibleJavaVersion() {
+        leaseSession()
+
+        val messagesOnSecondLease = mutableListOf<DaemonReportMessage>()
+        leaseSession(
+            clientMarkerFile = workingDirectory.resolve("client2.alive"),
+            sessionMarkerFile = workingDirectory.resolve("session2.alive"),
+            daemonMessagesCollector = messagesOnSecondLease,
+        )
+
+        val startupMessages = messagesOnSecondLease.filter { "starting the daemon" in it.message.lowercase() }
+        assertTrue(
+            startupMessages.isEmpty(),
+            "Expected daemon to be reused (no new startup), but got: $startupMessages"
+        )
+    }
+}

--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/DaemonJavaLanguageVersionTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/DaemonJavaLanguageVersionTest.kt
@@ -5,10 +5,7 @@
 
 package org.jetbrains.kotlin.daemon
 
-import org.jetbrains.kotlin.cli.common.CompilerSystemProperties
 import org.jetbrains.kotlin.daemon.client.DaemonReportMessage
-import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -16,34 +13,6 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("Kotlin daemon Java language version compatibility (KT-71048)")
 class DaemonJavaLanguageVersionTest : BaseDaemonSessionTest() {
-
-    @DisplayName("getJavaLanguageVersion() returns a known (non-unknown) language version over RMI")
-    @Test
-    fun testGetJavaLanguageVersionReturnsKnownVersion() {
-        val (compileService, _) = leaseSession()
-        val result = compileService.getJavaLanguageVersion()
-        assertTrue(result.isGood, "getJavaLanguageVersion() RMI call must succeed")
-        val version = result.get()
-        assertTrue(
-            version.version > 0,
-            "Daemon must report a real Java major language version (> 0), got ${version.version}"
-        )
-    }
-
-    @DisplayName("getJavaLanguageVersion() reports the same major language version as the client JVM")
-    @Test
-    fun testDaemonVersionMatchesClientJvm() {
-        val clientVersion = JavaLanguageVersion.parse(CompilerSystemProperties.JAVA_VERSION.value)
-        val (compileService, _) = leaseSession()
-
-        val daemonVersion = compileService.getJavaLanguageVersion().get()
-
-        assertEquals(
-            clientVersion.version, daemonVersion.version,
-            "Daemon Java major language version must equal the client JVM language version " +
-                    "(client: ${clientVersion.version}, daemon: ${daemonVersion.version})"
-        )
-    }
 
     @DisplayName("daemon running on the same JVM version is reused on reconnect")
     @Test

--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/JavaLanguageVersionTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/JavaLanguageVersionTest.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.daemon
+
+import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class JavaLanguageVersionTest {
+
+    @Test
+    @DisplayName("null produces unknown language version")
+    fun parseNull() {
+        assertUnknown(JavaLanguageVersion.parse(null))
+    }
+
+    @Test
+    @DisplayName("empty string produces unknown language version")
+    fun parseEmpty() {
+        assertUnknown(JavaLanguageVersion.parse(""))
+    }
+
+    @Test
+    @DisplayName("blank string produces unknown language version after trimming")
+    fun parseBlank() {
+        assertUnknown(JavaLanguageVersion.parse("   "))
+    }
+
+    @Test
+    @DisplayName("non-numeric string produces unknown language version")
+    fun parseNonNumeric() {
+        assertUnknown(JavaLanguageVersion.parse("abc"))
+    }
+
+    @Test
+    @DisplayName("string starting with '-' produces unknown language version")
+    fun parseNegativeSign() {
+        assertUnknown(JavaLanguageVersion.parse("-17"))
+    }
+
+    @Test
+    @DisplayName("'1.8' parses to language version 8")
+    fun parseLegacyShort() {
+        assertEquals(8, JavaLanguageVersion.parse("1.8").version)
+    }
+
+    @Test
+    @DisplayName("'1.8.0' parses to language version 8 — java.version patch suffix is also accepted")
+    fun parseLegacyWithPatch() {
+        assertEquals(8, JavaLanguageVersion.parse("1.8.0").version)
+    }
+
+    @Test
+    @DisplayName("'1.8.0_292' parses to language version 8 — java.version update suffix is also accepted")
+    fun parseLegacyFull() {
+        assertEquals(8, JavaLanguageVersion.parse("1.8.0_292").version)
+    }
+
+    @Test
+    @DisplayName("'1.6' parses to language version 6")
+    fun parseLegacyJava6() {
+        assertEquals(6, JavaLanguageVersion.parse("1.6").version)
+    }
+
+    @Test
+    @DisplayName("'1.' with no minor version produces unknown language version")
+    fun parseLegacyMissingMinor() {
+        assertUnknown(JavaLanguageVersion.parse("1."))
+    }
+
+    @Test
+    @DisplayName("'1.a' with non-numeric minor produces unknown language version")
+    fun parseLegacyNonNumericMinor() {
+        assertUnknown(JavaLanguageVersion.parse("1.a"))
+    }
+
+    @Test
+    @DisplayName("legacy string with surrounding whitespace is trimmed before parsing")
+    fun parseLegacyWhitespaceTrimmed() {
+        assertEquals(8, JavaLanguageVersion.parse("  1.8  ").version)
+    }
+
+    @Test
+    @DisplayName("'11' parses to language version 11")
+    fun parseModernJava11() {
+        assertEquals(11, JavaLanguageVersion.parse("11").version)
+    }
+
+    @Test
+    @DisplayName("'17' parses to language version 17")
+    fun parseModernJava17() {
+        assertEquals(17, JavaLanguageVersion.parse("17").version)
+    }
+
+    @Test
+    @DisplayName("'21' parses to language version 21")
+    fun parseModernJava21() {
+        assertEquals(21, JavaLanguageVersion.parse("21").version)
+    }
+
+    @Test
+    @DisplayName("'17.0.1' parses to language version 17 — java.version minor/patch suffix is also accepted")
+    fun parseModernWithMinorAndPatch() {
+        assertEquals(17, JavaLanguageVersion.parse("17.0.1").version)
+    }
+
+    @Test
+    @DisplayName("'17.0.1+12-LTS' parses to language version 17 — java.version build qualifier is also accepted")
+    fun parseModernWithBuildQualifier() {
+        assertEquals(17, JavaLanguageVersion.parse("17.0.1+12-LTS").version)
+    }
+
+    @Test
+    @DisplayName("modern string with surrounding whitespace is trimmed before parsing")
+    fun parseModernWhitespaceTrimmed() {
+        assertEquals(21, JavaLanguageVersion.parse("  21  ").version)
+    }
+
+    @Test
+    @DisplayName("language version 8 compares less than language version 11")
+    fun compareVersionLess() {
+        val java8 = JavaLanguageVersion.parse("1.8")
+        val java11 = JavaLanguageVersion.parse("11")
+        assertTrue(java8 < java11)
+    }
+
+    @Test
+    @DisplayName("language version 21 compares greater than language version 17")
+    fun compareVersionGreater() {
+        val java21 = JavaLanguageVersion.parse("21")
+        val java17 = JavaLanguageVersion.parse("17")
+        assertTrue(java21 > java17)
+    }
+
+    @Test
+    @DisplayName("equal major language versions compare as equal regardless of minor/patch")
+    fun compareVersionEqual() {
+        val java17a = JavaLanguageVersion.parse("17")
+        val java17b = JavaLanguageVersion.parse("17.0.1")
+        assertEquals(0, java17a.compareTo(java17b))
+    }
+
+    @Test
+    @DisplayName("'1.5' parses to language version 5")
+    fun parseLegacyJava5() {
+        assertEquals(5, JavaLanguageVersion.parse("1.5").version)
+    }
+
+    @Test
+    @DisplayName("'1.7' parses to language version 7")
+    fun parseLegacyJava7() {
+        assertEquals(7, JavaLanguageVersion.parse("1.7").version)
+    }
+
+    @Test
+    @DisplayName("'10' parses to language version 10 — first version to drop the legacy 1.x prefix")
+    fun parseModernJava10() {
+        assertEquals(10, JavaLanguageVersion.parse("10").version)
+    }
+
+    @Test
+    @DisplayName("'11.0.2-openj9' parses to language version 11 — hyphen-separated qualifier is ignored")
+    fun parseModernWithHyphenQualifier() {
+        assertEquals(11, JavaLanguageVersion.parse("11.0.2-openj9").version)
+    }
+
+    @Test
+    @DisplayName("a known language version compares greater than unknown language version, since unknown.version == -1")
+    fun knownVersionComparesToUnknownAsGreater() {
+        val java8 = JavaLanguageVersion.parse("1.8")
+        val unknown = JavaLanguageVersion.parse(null)
+        assertTrue(java8 > unknown)
+    }
+
+    @Test
+    @DisplayName("JavaLanguageVersion is serializable for RMI transport")
+    fun javaLanguageVersionIsSerializable() {
+        val original = JavaLanguageVersion.parse("17")
+        val baos = java.io.ByteArrayOutputStream()
+        java.io.ObjectOutputStream(baos).use { it.writeObject(original) }
+        val restored = java.io.ObjectInputStream(java.io.ByteArrayInputStream(baos.toByteArray())).use {
+            it.readObject() as JavaLanguageVersion
+        }
+        assertEquals(original.version, restored.version)
+        assertTrue(restored >= JavaLanguageVersion.parse("11"))
+        assertFalse(restored >= JavaLanguageVersion.parse("21"))
+    }
+
+    @Test
+    @DisplayName("unknown JavaLanguageVersion is serializable for RMI transport")
+    fun unknownJavaLanguageVersionIsSerializable() {
+        val original = JavaLanguageVersion.parse(null)
+        val baos = java.io.ByteArrayOutputStream()
+        java.io.ObjectOutputStream(baos).use { it.writeObject(original) }
+        val restored = java.io.ObjectInputStream(java.io.ByteArrayInputStream(baos.toByteArray())).use {
+            it.readObject() as JavaLanguageVersion
+        }
+        assertEquals(-1, restored.version)
+        assertTrue(restored < JavaLanguageVersion.of(8))
+    }
+
+    @Test
+    @DisplayName("of(17) returns a known language version with version == 17")
+    fun ofKnownVersion() {
+        assertEquals(17, JavaLanguageVersion.of(17).version)
+    }
+
+    @Test
+    @DisplayName("of(8) returns the same language version as parse(\"1.8\")")
+    fun ofEqualsParseForLegacyVersion() {
+        assertEquals(JavaLanguageVersion.parse("1.8").version, JavaLanguageVersion.of(8).version)
+    }
+
+    @Test
+    @DisplayName("of(17) and parse(\"17\") are structurally equal")
+    fun ofEqualsParseStructurally() {
+        assertEquals(JavaLanguageVersion.of(17), JavaLanguageVersion.parse("17"))
+    }
+
+    @Test
+    @DisplayName("of(0) throws IllegalArgumentException")
+    fun ofZeroThrows() {
+        assertThrows(IllegalArgumentException::class.java) { JavaLanguageVersion.of(0) }
+    }
+
+    @Test
+    @DisplayName("of(-1) throws IllegalArgumentException, preventing confusion with unknown language version")
+    fun ofNegativeThrows() {
+        assertThrows(IllegalArgumentException::class.java) { JavaLanguageVersion.of(-1) }
+    }
+
+    @Test
+    @DisplayName("of(17) is serializable for RMI transport")
+    fun ofIsSerializable() {
+        val original = JavaLanguageVersion.of(17)
+        val baos = java.io.ByteArrayOutputStream()
+        java.io.ObjectOutputStream(baos).use { it.writeObject(original) }
+        val restored = java.io.ObjectInputStream(java.io.ByteArrayInputStream(baos.toByteArray())).use {
+            it.readObject() as JavaLanguageVersion
+        }
+        assertEquals(original, restored)
+    }
+
+    private fun assertUnknown(version: JavaLanguageVersion) {
+        assertEquals(-1, version.version, "Expected unknown language version to have version == -1")
+        assertTrue(version < JavaLanguageVersion.of(8), "Unknown language version must compare less than any known language version")
+    }
+}

--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/MakeRunFileDigestTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/MakeRunFileDigestTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.daemon
+
+import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion
+import org.jetbrains.kotlin.daemon.common.makeRunFileDigest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+
+class MakeRunFileDigestTest {
+
+    private val classpath
+        get() = listOf("/a/kotlin-compiler.jar").map { Path(it) }
+
+    @Test
+    @DisplayName("same inputs produce the same digest")
+    fun sameInputsProduceSameDigest() {
+        assertEquals(
+            makeRunFileDigest(JavaLanguageVersion.of(17), classpath),
+            makeRunFileDigest(JavaLanguageVersion.of(17), classpath)
+        )
+    }
+
+    @Test
+    @DisplayName("different JVM versions produce different digests")
+    fun differentJvmVersionsProduceDifferentDigests() {
+        assertNotEquals(
+            makeRunFileDigest(JavaLanguageVersion.of(17), classpath),
+            makeRunFileDigest(JavaLanguageVersion.of(21), classpath)
+        )
+    }
+
+    @Test
+    @DisplayName("different classpaths produce different digests")
+    fun differentClasspathsProduceDifferentDigests() {
+        val other = listOf("/b/kotlin-compiler.jar").map { Path(it) }
+        assertNotEquals(
+            makeRunFileDigest(JavaLanguageVersion.of(17), classpath),
+            makeRunFileDigest(JavaLanguageVersion.of(17), other)
+        )
+    }
+
+    @Test
+    @DisplayName("classpath is normalised: duplicates and ordering do not affect the digest")
+    fun classpathIsNormalisedBeforeDigesting() {
+        val withDuplicatesAndDifferentOrder = listOf(
+            "/a/kotlin-compiler.jar",
+            "/a/kotlin-compiler.jar",
+            "/b/scripting.jar",
+        ).map { Path(it) }
+        val canonical = listOf("/b/scripting.jar", "/a/kotlin-compiler.jar").map { Path(it) }
+        assertEquals(
+            makeRunFileDigest(JavaLanguageVersion.of(17), canonical),
+            makeRunFileDigest(JavaLanguageVersion.of(17), withDuplicatesAndDifferentOrder)
+        )
+    }
+}

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -816,6 +816,7 @@ class CompileServiceImpl(
     compilerId: CompilerId,
     daemonOptions: DaemonOptions,
     val daemonJVMOptions: DaemonJVMOptions,
+    val javaLanguageVersion: JavaLanguageVersion,
     port: Int,
     timer: Timer,
     onShutdown: () -> Unit,
@@ -844,6 +845,10 @@ class CompileServiceImpl(
         } catch (e: Exception) {
             CompileService.CallResult.Error("Unknown Kotlin version")
         }
+    }
+
+    override fun getJavaLanguageVersion(): CompileService.CallResult<JavaLanguageVersion> = ifAlive {
+        CompileService.CallResult.Good(javaLanguageVersion)
     }
 
     override fun getDaemonOptions(): CompileService.CallResult<DaemonOptions> = ifAlive {
@@ -1120,16 +1125,19 @@ class CompileServiceImpl(
                 compilerId,
                 runFile,
                 filter = { _, p -> p != port },
-                report = { _, msg -> log.info(msg) }).toList().sortedWith(comparator)
-
-            fun hasLowerPriorityThan(other: DaemonWithMetadata): Boolean =
-                daemonJVMOptions memorywiseFitsInto other.jvmOptions && FileAgeComparator().compare(other.runFile, runFile) > 0
+                report = { _, msg -> log.info(msg) }
+            ).toList()
+                .filter { it.javaLanguageVersion == javaLanguageVersion }
+                .sortedWith(comparator)
 
             fun hasHigherPriorityThan(other: DaemonWithMetadata): Boolean =
                 other.jvmOptions memorywiseFitsInto daemonJVMOptions && FileAgeComparator().compare(
                     other.runFile,
                     runFile
                 ) < 0
+
+            fun hasLowerPriorityThan(other: DaemonWithMetadata): Boolean =
+                daemonJVMOptions memorywiseFitsInto other.jvmOptions && FileAgeComparator().compare(other.runFile, runFile) > 0
 
             var bestDaemonWithMetadata = aliveWithOpts.firstOrNull() ?: return@ifAliveUnit
 
@@ -1167,9 +1175,9 @@ class CompileServiceImpl(
             //    C performs election: (1) is false because B is better than A and B does not fit into C, (2) is false C does not fit into neither A nor B.
             //    Result: all daemons are alive and well.
             for (i in 0 until aliveWithOpts.size) {
-                // there is at least one bigger, try to handover my clients to it and shutdown
                 bestDaemonWithMetadata = aliveWithOpts[i]
                 if (hasLowerPriorityThan(bestDaemonWithMetadata)) {
+                    // there is at least one bigger, try to handover my clients to it and shutdown
                     log.info("$LOG_PREFIX_ASSUMING_OTHER_DAEMONS_HAVE higher prio, try to handover clients to it and schedule shutdown: my runfile: ${runFile.name} (${runFile.lastModified()}) vs best other runfile: ${bestDaemonWithMetadata.runFile.name} (${bestDaemonWithMetadata.runFile.lastModified()})")
                     val clients = getClients().takeIf { it.isGood }?.get() ?: emptyList()
                     val handoverSuccessful = clients

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -100,6 +100,7 @@ class EventManagerImpl : EventManager {
 abstract class CompileServiceImplBase(
     val daemonOptions: DaemonOptions,
     val compilerId: CompilerId,
+    val javaLanguageVersion: JavaLanguageVersion,
     val port: Int,
     val timer: Timer,
     val onShutdown: () -> Unit,
@@ -248,7 +249,7 @@ abstract class CompileServiceImplBase(
             runFileDir,
             makeRunFilenameString(
                 timestamp = "%tFT%<tH-%<tM-%<tS.%<tLZ".format(Calendar.getInstance(TimeZone.getTimeZone("Z"))),
-                digest = compilerId.digest(),
+                digest = makeRunFileDigest(javaLanguageVersion, compilerId.compilerClasspath.map { Path(it) }),
                 port = port.toString()
             )
         )
@@ -682,7 +683,7 @@ abstract class CompileServiceImplBase(
         incrementalCompilationOptions: IncrementalCompilationOptions,
         compilerMessageCollector: MessageCollector,
         reporter: RemoteBuildReporter<BuildTimeMetric, BuildPerformanceMetric>,
-        configurationInputs: ConfigurationInputs? = null
+        configurationInputs: ConfigurationInputs? = null,
     ): ExitCode {
         reporter.startMeasureGc()
         @Suppress("DEPRECATION") // TODO: get rid of that parsing KT-62759
@@ -816,11 +817,11 @@ class CompileServiceImpl(
     compilerId: CompilerId,
     daemonOptions: DaemonOptions,
     val daemonJVMOptions: DaemonJVMOptions,
-    val javaLanguageVersion: JavaLanguageVersion,
+    javaLanguageVersion: JavaLanguageVersion,
     port: Int,
     timer: Timer,
     onShutdown: () -> Unit,
-) : CompileService, CompileServiceImplBase(daemonOptions, compilerId, port, timer, onShutdown) {
+) : CompileService, CompileServiceImplBase(daemonOptions, compilerId, javaLanguageVersion, port, timer, onShutdown) {
 
     private inline fun <R> withValidRepl(
         sessionId: Int,
@@ -845,10 +846,6 @@ class CompileServiceImpl(
         } catch (e: Exception) {
             CompileService.CallResult.Error("Unknown Kotlin version")
         }
-    }
-
-    override fun getJavaLanguageVersion(): CompileService.CallResult<JavaLanguageVersion> = ifAlive {
-        CompileService.CallResult.Good(javaLanguageVersion)
     }
 
     override fun getDaemonOptions(): CompileService.CallResult<DaemonOptions> = ifAlive {
@@ -1123,11 +1120,11 @@ class CompileServiceImpl(
             val aliveWithOpts = walkDaemons(
                 File(daemonOptions.runFilesPathOrDefault),
                 compilerId,
+                javaLanguageVersion,
                 runFile,
                 filter = { _, p -> p != port },
                 report = { _, msg -> log.info(msg) }
             ).toList()
-                .filter { it.javaLanguageVersion == javaLanguageVersion }
                 .sortedWith(comparator)
 
             fun hasHigherPriorityThan(other: DaemonWithMetadata): Boolean =

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt
@@ -22,7 +22,9 @@ import java.lang.management.ManagementFactory
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.jar.Manifest
-import java.util.logging.*
+import java.util.logging.Level
+import java.util.logging.LogManager
+import java.util.logging.Logger
 import kotlin.concurrent.schedule
 import kotlin.system.exitProcess
 
@@ -64,9 +66,10 @@ abstract class KotlinCompileDaemonBase {
     protected abstract fun getCompileServiceAndPort(
         compilerSelector: CompilerSelector,
         compilerId: CompilerId,
+        javaLanguageVersion: JavaLanguageVersion,
         daemonOptions: DaemonOptions,
         daemonJVMOptions: DaemonJVMOptions,
-        timer: Timer
+        timer: Timer,
     ) : Pair<CompileServiceImplBase, Int>
 
     protected open fun runCompileService(compileService: CompileServiceImplBase) : Any? = null
@@ -115,6 +118,7 @@ abstract class KotlinCompileDaemonBase {
     protected fun mainImpl(args: Array<String>) {
         val compilerId = CompilerId()
         val daemonOptions = DaemonOptions()
+        val javaLanguageVersion = JavaLanguageVersion.parse(CompilerSystemProperties.JAVA_VERSION.value)
         DaemonLogOptions().run {
             val unknownArgs = args.asIterable().filterExtractProps(compilerId, daemonOptions, this, prefix = COMPILE_DAEMON_CMDLINE_OPTIONS_PREFIX)
             setupLogging(this)
@@ -164,7 +168,14 @@ abstract class KotlinCompileDaemonBase {
                 }
                 // timer with a daemon thread, meaning it should not prevent JVM to exit normally
                 val timer = Timer(true)
-                val (compilerService, port) = getCompileServiceAndPort(compilerSelector, compilerId, daemonOptions, daemonJVMOptions, timer)
+                val (compilerService, port) = getCompileServiceAndPort(
+                    compilerSelector,
+                    compilerId,
+                    javaLanguageVersion,
+                    daemonOptions,
+                    daemonJVMOptions,
+                    timer
+                )
                 compilerService.startDaemonElections()
                 compilerService.registerInitialClient(initialClientInfo)
                 compilerService.configurePeriodicActivities()
@@ -210,9 +221,10 @@ object KotlinCompileDaemon : KotlinCompileDaemonBase() {
     override fun getCompileServiceAndPort(
         compilerSelector: CompilerSelector,
         compilerId: CompilerId,
+        javaLanguageVersion: JavaLanguageVersion,
         daemonOptions: DaemonOptions,
         daemonJVMOptions: DaemonJVMOptions,
-        timer: Timer
+        timer: Timer,
     ) = run {
         val (registry, port) = findPortAndCreateRegistry(COMPILE_DAEMON_FIND_PORT_ATTEMPTS, COMPILE_DAEMON_PORTS_RANGE_START, COMPILE_DAEMON_PORTS_RANGE_END)
         val compilerService = CompileServiceImpl(registry = registry,
@@ -220,6 +232,7 @@ object KotlinCompileDaemon : KotlinCompileDaemonBase() {
                                                  compilerId = compilerId,
                                                  daemonOptions = daemonOptions,
                                                  daemonJVMOptions = daemonJVMOptions,
+                                                 javaLanguageVersion = javaLanguageVersion,
                                                  port = port,
                                                  timer = timer,
                                                  onShutdown = {


### PR DESCRIPTION
# Manual testing

## Before

### 1. Build with Java 17 — starts a Java 17 Kotlin daemon
```
jps -v | grep Kotlin 
// empty

ls /…/kotlin/daemon
//empty

./gradlew —stop

JAVA_HOME=~/.../temurin-17.jdk/Contents/Home ./gradlew compileKotlin --info --rerun

i: A compatible daemon not found
i: trying to start a new compiler daemon
i: starting the daemon as: /.../temurin-17.jdk/Contents/Home/bin/java, …
….
i: new compiler daemon started, trying to find it
i: A compatible daemon found: javaVersion=17, runFileMarker=/.../kotlin-daemon.2026-04-24T09-27-05.104Z.2b82c4c86a81da7ce59b4c72db395e33.17219.run
```

**Additional entries**
```
jps -v | grep Kotlin 
20078 KotlinCompileDaemon ...

ls /.../kotlin/daemon                                            
kotlin-daemon.2026-04-24T09-27-05.104Z.2b82c4c86a81da7ce59b4c72db395e33.17219.run
```

### 2. Build with Java 24 without stopping daemons — reuses the Java 17 Kotlin daemon
```
JAVA_HOME=~/.../temurin-24.0.2/Contents/Home ./gradlew compileKotlin --info --rerun

i: A compatible daemon found: javaVersion=17, runFileMarker=/.../kotlin-daemon.2026-04-24T09-27-05.104Z.2b82c4c86a81da7ce59b4c72db395e33.17219.run
```

**Additional entries**
```
jps -v | grep Kotlin 
20078 KotlinCompileDaemon ...

ls /.../kotlin/daemon                                            
kotlin-daemon.2026-04-24T09-27-05.104Z.2b82c4c86a81da7ce59b4c72db395e33.17219.run
```

## After

### 1. Build with Java 17 — starts a Java 17 Kotlin daemon

```
jps -v | grep Kotlin 
// empty

ls /…/kotlin/daemon
//empty

./gradlew —stop

JAVA_HOME=~/.../temurin-17.jdk/Contents/Home ./gradlew compileKotlin --info --rerun

i: A compatible daemon not found
i: trying to start a new compiler daemon
i: starting the daemon as: /.../temurin-17.jdk/Contents/Home/bin/java, …
….
i: new compiler daemon started, trying to find it
i: A compatible daemon found: javaVersion=17, runFileMarker=/.../kotlin-daemon.2026-04-24T09-21-17.423Z.2b82c4c86a81da7ce59b4c72db395e33.17712.run
```

**Additional entries**
```
jps -v | grep Kotlin 
19439 KotlinCompileDaemon...

ls /.../kotlin/daemon                                            
kotlin-daemon.2026-04-24T09-21-17.423Z.2b82c4c86a81da7ce59b4c72db395e33.17712.run
```
### 2. Build with Java 24 without stopping daemons — starts a Java 24 Kotlin daemon

```
JAVA_HOME=~/.../temurin-24.0.2/Contents/Home ./gradlew compileKotlin --info --rerun

i: A compatible daemon not found
i: trying to start a new compiler daemon
i: starting the daemon as: /.../temurin-24.0.2/Contents/Home/bin/java, …
…
i: new compiler daemon started, trying to find it
i: A compatible daemon found: javaVersion=24, runFileMarker=/.../kotlin-daemon.2026-04-24T09-23-23.942Z.2b82c4c86a81da7ce59b4c72db395e33.17792.run
```
**Additional entries**
```
jps -v | grep Kotlin 
19554 KotlinCompileDaemon ...
19439 KotlinCompileDaemon ...

ls /.../kotlin/daemon    
kotlin-daemon.2026-04-24T09-21-17.423Z.2b82c4c86a81da7ce59b4c72db395e33.17712.run 
kotlin-daemon.2026-04-24T09-23-23.942Z.2b82c4c86a81da7ce59b4c72db395e33.17792.run
```