### PR TITLE
[K/N][tests] Filter testDependencyKlibs by filename, not full path

### DIFF
--- a/native/external-projects-test-utils/src/org/jetbrains/kotlin/konan/test/testDependencies.kt
+++ b/native/external-projects-test-utils/src/org/jetbrains/kotlin/konan/test/testDependencies.kt
@@ -34,8 +34,8 @@ private val testDependencyKlibs = System.getProperty("testDependencyKlibs").orEm
 
 private fun getLibrary(name: String): Library {
     val (cinteropKlibs, regularKlibs) = testDependencyKlibs
-        .filter { it.pathString.contains(name) }
-        .partition { it.pathString.contains("interop") }
+        .filter { it.fileName.pathString.contains(name) }
+        .partition { it.fileName.pathString.contains("interop") }
 
     return Library(
         mainKlib = regularKlibs.singleOrNull() ?: error("Missing '$name' in 'testDependencyKlibs' System Property"),


### PR DESCRIPTION
`getLibrary(name)` in `testDependencies.kt` partitioned cinterop vs regular klibs with `pathString.contains("interop")` on the absolute path. Any workspace whose path contains the substring `interop` (e.g. a checkout under `~/jb/kt_cinterop_lib` — `cinterop` contains `interop`) caused every project-built klib to land in the cinterop bucket, leaving `regularKlibs` empty and failing the `singleOrNull()` check with
"Missing '<name>' in 'testDependencyKlibs' System Property". Tests routed through kotlinx-* klibs were unaffected because those resolve to paths under `~/.gradle/caches/…` which don't contain `interop`.

Restrict both the name filter and the cinterop partition to the klib `fileName.pathString` so the substring match is applied only to the klib filename (where the `interop` marker actually lives, e.g. `atomicfu-cinterop-interop.klib`), making the lookup independent of the absolute workspace path.