### PR TITLE
[kx.serialization] Avoid IR properties without receivers

### DIFF
--- a/plugins/compose/compiler-hosted/build.gradle.kts
+++ b/plugins/compose/compiler-hosted/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":kotlinx-serialization-compiler-plugin")))
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.7.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.0")
 
     // compose runtime for tests
     testImplementation(composeRuntime()) { isTransitive = false }

--- a/plugins/compose/compiler-hosted/testData/withSerialization/basic.kt
+++ b/plugins/compose/compiler-hosted/testData/withSerialization/basic.kt
@@ -1,10 +1,14 @@
 import androidx.compose.runtime.Composable
 import androidx.compose.foundation.text.BasicText
 import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 import kotlinx.serialization.descriptors.*
 
 @Serializable
-data class Data(val ok: String)
+data class Data(val ok: String) {
+    @Transient
+    val trans = "ok"
+}
 
 @Composable
 fun ClickCounter(clicks: Int) {
@@ -12,5 +16,11 @@ fun ClickCounter(clicks: Int) {
 }
 
 fun box(): String {
-    return Data.serializer().descriptor.elementNames.single().uppercase()
+    val data = Data("ok")
+    val encoded = Json.encodeToString(data)
+    val decoded = Json.decodeFromString<Data>(encoded)
+    if (decoded.ok != "ok") return "FAIL instance"
+    if (decoded.trans != "ok") return "FAIL transient"
+    if (Data.serializer().descriptor.elementNames.single() != "ok") return "FAIL descriptor"
+    return "OK"
 }

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/DefaultValuesUtils.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/DefaultValuesUtils.kt
@@ -55,7 +55,7 @@ fun IrBuilderWithScope.createPropertyByParamReplacer(
     val transientPropertiesSet =
         irClass.declarations.asSequence()
             .filterIsInstance<IrProperty>()
-            .filter { it.backingField != null }
+            .filter { it.isNonStaticWithField }
             .filter { !serialPropertiesMap.containsKey(it) }
             .toSet()
 

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/IrGeneratorUtils.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/IrGeneratorUtils.kt
@@ -165,3 +165,5 @@ internal fun IrProperty.isJvmOptimizableDelegate(): Boolean =
     isDelegated && !isFakeOverride && backingField != null && // fast path
             (getPropertyReferenceForOptimizableDelegatedProperty() != null || getSingletonOrConstantForOptimizableDelegatedProperty() != null)
 
+
+internal val IrProperty.isNonStaticWithField get() = backingField != null && getter?.dispatchReceiverParameter != null

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/IrSerializableProperties.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/IrSerializableProperties.kt
@@ -120,7 +120,7 @@ internal fun serializablePropertiesForIrBackend(
     val (primaryCtorSerializableProps, bodySerializableProps) = properties
         .asSequence()
         .filter { !it.isFakeOverride && !it.isDelegated && it.origin != IrDeclarationOrigin.DELEGATED_MEMBER }
-        .filter { it.getter?.parameters?.isNotEmpty() == true /* Compose plugin may generate static properties. Also, we are having companion blocks soon. */ }
+        .filter { it.isNonStaticWithField /* Compose plugin may generate static properties. Also, we are having companion blocks soon. */ }
         .filter(::isPropSerializable)
         .map {
             val isConstructorParameterWithDefault = primaryParamsAsProps[it] ?: false

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializableIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializableIrGenerator.kt
@@ -83,7 +83,7 @@ class SerializableIrGenerator(
             irClass.declarations.asSequence().forEach {
                 when {
                     // only properties with backing field
-                    it is IrProperty && it.backingField != null -> {
+                    it is IrProperty && it.isNonStaticWithField -> {
                         if (it in serialDescs) {
                             current = it
                         } else if (it.backingField?.initializer != null &&

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerIrGenerator.kt
@@ -396,7 +396,7 @@ open class SerializerIrGenerator(
         val transients = serializableIrClass.declarations.asSequence()
             .filterIsInstance<IrProperty>()
             .filter { !serialPropertiesIndexes.contains(it) }
-            .filter { it.backingField != null }
+            .filter { it.isNonStaticWithField }
 
         // var bitMask0 = 0, bitMask1 = 0...
         val bitMasks = (0 until blocksCnt).map { irTemporary(irInt(0), "bitMask$it", isMutable = true) }


### PR DESCRIPTION
Follow-up for KT-85554:

While Kotlin does not have static properties, they still may be encountered in IR. Notably, Compose plugin produces synthetic static `$stable` property.

#KT-85963 Fixed