### PR TITLE
fix: exclude `slf4j-simple` from the `kotlin-main-kts` fat jar

### DIFF
--- a/libraries/tools/kotlin-main-kts/build.gradle.kts
+++ b/libraries/tools/kotlin-main-kts/build.gradle.kts
@@ -33,8 +33,7 @@ dependencies {
     embedded(project(":kotlin-scripting-jvm-host-unshaded")) { isTransitive = false }
     embedded(project(":kotlin-scripting-dependencies")) { isTransitive = false }
     embedded(project(":kotlin-scripting-dependencies-maven-all")) { isTransitive = false }
-    embedded("org.slf4j:slf4j-api:1.7.36")
-    embedded("org.slf4j:slf4j-simple:1.7.36")
+    embedded("org.slf4j:slf4j-api:2.0.18")
     embedded(commonDependency("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm")) {
         isTransitive = false
         attributes {


### PR DESCRIPTION
fixes [KT-81943](https://youtrack.jetbrains.com/issue/KT-81943) kotlin-main-kts includes org.slf4j.impl.SimpleLogger causing SLF4J implementation conflicts

Add separate `resultJar` (for Maven publish) and `distJar` (For kotlinc MainKts).