### PR TITLE
[CFG] Only visit delegate expression once when analyzing local variables 

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirLocalVariableAssignmentAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirLocalVariableAssignmentAnalyzer.kt
@@ -577,17 +577,16 @@ class FirLocalVariableAssignmentAnalyzer private constructor(
         //   control flow structures can cause incorrect smartcasts. KT-59691
 
         override fun visitFunctionCall(functionCall: FirFunctionCall, data: MiniCfgData) {
-            val visitor = this
-            with(functionCall) {
-                setOfNotNull(explicitReceiver, dispatchReceiver, extensionReceiver).forEach { it.accept(visitor, data) }
-                // Delay processing of lambda args because lambda body are evaluated after all arguments have been evaluated.
-                // TODO: this is not entirely correct (the lambda might be nested deep inside an expression), but also this
-                //  entire override should be unnecessary as long as the full CFG builder visits everything in the right order. KT-59691
-                val (postponedFunctionArgs, normalArgs) = argumentList.arguments.partition { it is FirAnonymousFunctionExpression }
-                normalArgs.forEach { it.accept(visitor, data) }
-                postponedFunctionArgs.forEach { it.accept(visitor, data) }
-                calleeReference.accept(visitor, data)
-            }
+            functionCall.explicitReceiver?.accept(this, data)
+            functionCall.dispatchReceiver?.accept(this, data)
+            functionCall.extensionReceiver?.accept(this, data)
+            // Delay processing of lambda args because lambda body are evaluated after all arguments have been evaluated.
+            // TODO: this is not entirely correct (the lambda might be nested deep inside an expression), but also this
+            //  entire override should be unnecessary as long as the full CFG builder visits everything in the right order. KT-59691
+            val (postponedFunctionArgs, normalArgs) = functionCall.argumentList.arguments.partition { it is FirAnonymousFunctionExpression }
+            normalArgs.forEach { it.accept(this, data) }
+            postponedFunctionArgs.forEach { it.accept(this, data) }
+            functionCall.calleeReference.accept(this, data)
         }
 
         override fun visitBlock(block: FirBlock, data: MiniCfgData) {
@@ -601,6 +600,14 @@ class FirLocalVariableAssignmentAnalyzer private constructor(
             if (property.isEffectivelyLocal) {
                 data.variableDeclarations.last()[property.name] = property
             }
+        }
+
+        override fun visitWrappedDelegateExpression(wrappedDelegateExpression: FirWrappedDelegateExpression, data: MiniCfgData) {
+            // An FirWrappedDelegateExpression contains the same expression twice for delegate creation:
+            // 'provideDelegateCall' contains 'expression' as its explicit receiver in a 'providedDelegate()' call.
+            // This causes 'expression' to be visited twice, thus an exponential growth in the number of expressions being analyzed.
+            // So, only visit 'expression', as the local variable analysis will be the same.
+            wrappedDelegateExpression.expression.accept(this, data)
         }
 
         override fun visitReplDeclarationReference(replDeclarationReference: FirReplDeclarationReference, data: MiniCfgData) {

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirLocalVariableAssignmentAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirLocalVariableAssignmentAnalyzer.kt
@@ -332,335 +332,333 @@ class FirLocalVariableAssignmentAnalyzer private constructor(
         assignment.type = type
     }
 
-    companion object {
-        /**
-         * Computes assigned local variables in each execution path. This analyzer runs before BODY_RESOLVE. Hence, it works on
-         * syntactical information only.
-         *
-         * # Note on implementation detail
-         *
-         * The analyzer constructs a mini control flow graph that captures forking of execution path. The only information it cares about,
-         * though, is which variables are assigned in a given node or any transitive successor; thus nodes which add no extra information
-         * and have only one predecessor are elided from the resulting graph.
-         *
-         * For example, consider the following code.
-         *
-         * ```
-         * fun test() {
-         *   var x: Int = 0
-         *   var y: Int = 0
-         *   var z: Int = 0
-         *   if (true) {
-         *     run {
-         *       x = 1
-         *       var a = 1
-         *       a = 2
-         *     }
-         *   } else {
-         *     x = 2
-         *     y = 2
-         *   }
-         *   z = 3
-         * }
-         * ```
-         *
-         * The generated mini CFG looks like the following, with assigned local variables annotated after each node in curly brackets.
-         *
-         *     ┌───────┐
-         *     │ entry │ {x y z}
-         *     └─┬─┬─┬─┘
-         *       │ │ │ fallback
-         *       │ │ └─────────────────────────────┐
-         *       │ │ false                         │
-         *       │ └─────────────────────────┐     │
-         *       │ true                      │     │
-         *     ┌ ┴ ─ ─ ┐                 ┌ ─ ┴ ─ ┐ │
-         *     │ then  │                 │ else  │ │
-         *     └ ┬ ─ ┬ ┘                 └ ─ ┬ ─ ┘ │
-         *       │   │ normal execution      │     │
-         *       │   └─────────────┐         │     │
-         *       │ lambda arg      │         │     │
-         *     ┌─┴──────┐      ┌───┴───┐     │     │
-         *     │ lambda │ {x}  │ empty │ {z} │     │
-         *     └────────┘      └───┬───┘     │     │
-         *       ┌─────────────────┘         │     │
-         *       │ ┌─────────────────────────┘     │
-         *       │ │ ┌─────────────────────────────┘
-         *     ┌─┴─┴─┴─┐
-         *     │ after │ {z}
-         *     │  if   │
-         *     └───────┘
-         *
-         * Some notes on why each node contains what it contains:
-         * - the nodes with the dashed outline and no associated set, "then" and "else", are elided, as they are neither merge points
-         *   nor do they have any useful information - we will never need to know which variables are assigned to after entering the
-         *   "else" branch, for example, because that code path will encounter no lambdas. Instead, any assignments done in elided
-         *   blocks are immediately propagated to the parents, which is why the "entry" node contains `y`.
-         *
-         * - the "lambda" and "empty" nodes are not merge points, but they are what the CFG is for: if the lambda is not called-in-place,
-         *   then all variables it assigns to cannot be smartcasted in "empty" or its successors and vice versa, as the body of the lambda
-         *   can be executed at arbitrary points on that path.
-         *
-         * - changes to `z` is captured and back-propagated to all earlier nodes as desired.
-         *
-         * - `a` is not recorded anywhere because it's declared inside the lambda, and no statement needed a new block after
-         *   the declaration.
-         *
-         * Because names are not resolved at this point, we manually track local variable declarations and resolve them along the way
-         * so that shadowed names are handled correctly. This works because local variables at any scope have higher priority
-         * than members on implicit receivers, even if the implicit receiver is introduced by a later scope.
-         */
-        private class Fork(
-            val assignedLater: VariableAssignments,
-            val assignedInside: VariableAssignments,
-        ) {
-            @CfgInternals
-            fun createSnapshot(firMapper: SnapshotFirMapper): Fork {
-                return Fork(assignedLater.createSnapshot(firMapper), assignedInside.createSnapshot(firMapper))
-            }
+    /**
+     * Computes assigned local variables in each execution path. This analyzer runs before BODY_RESOLVE. Hence, it works on
+     * syntactical information only.
+     *
+     * # Note on implementation detail
+     *
+     * The analyzer constructs a mini control flow graph that captures forking of execution path. The only information it cares about,
+     * though, is which variables are assigned in a given node or any transitive successor; thus nodes which add no extra information
+     * and have only one predecessor are elided from the resulting graph.
+     *
+     * For example, consider the following code.
+     *
+     * ```
+     * fun test() {
+     *   var x: Int = 0
+     *   var y: Int = 0
+     *   var z: Int = 0
+     *   if (true) {
+     *     run {
+     *       x = 1
+     *       var a = 1
+     *       a = 2
+     *     }
+     *   } else {
+     *     x = 2
+     *     y = 2
+     *   }
+     *   z = 3
+     * }
+     * ```
+     *
+     * The generated mini CFG looks like the following, with assigned local variables annotated after each node in curly brackets.
+     *
+     *     ┌───────┐
+     *     │ entry │ {x y z}
+     *     └─┬─┬─┬─┘
+     *       │ │ │ fallback
+     *       │ │ └─────────────────────────────┐
+     *       │ │ false                         │
+     *       │ └─────────────────────────┐     │
+     *       │ true                      │     │
+     *     ┌ ┴ ─ ─ ┐                 ┌ ─ ┴ ─ ┐ │
+     *     │ then  │                 │ else  │ │
+     *     └ ┬ ─ ┬ ┘                 └ ─ ┬ ─ ┘ │
+     *       │   │ normal execution      │     │
+     *       │   └─────────────┐         │     │
+     *       │ lambda arg      │         │     │
+     *     ┌─┴──────┐      ┌───┴───┐     │     │
+     *     │ lambda │ {x}  │ empty │ {z} │     │
+     *     └────────┘      └───┬───┘     │     │
+     *       ┌─────────────────┘         │     │
+     *       │ ┌─────────────────────────┘     │
+     *       │ │ ┌─────────────────────────────┘
+     *     ┌─┴─┴─┴─┐
+     *     │ after │ {z}
+     *     │  if   │
+     *     └───────┘
+     *
+     * Some notes on why each node contains what it contains:
+     * - the nodes with the dashed outline and no associated set, "then" and "else", are elided, as they are neither merge points
+     *   nor do they have any useful information - we will never need to know which variables are assigned to after entering the
+     *   "else" branch, for example, because that code path will encounter no lambdas. Instead, any assignments done in elided
+     *   blocks are immediately propagated to the parents, which is why the "entry" node contains `y`.
+     *
+     * - the "lambda" and "empty" nodes are not merge points, but they are what the CFG is for: if the lambda is not called-in-place,
+     *   then all variables it assigns to cannot be smartcasted in "empty" or its successors and vice versa, as the body of the lambda
+     *   can be executed at arbitrary points on that path.
+     *
+     * - changes to `z` is captured and back-propagated to all earlier nodes as desired.
+     *
+     * - `a` is not recorded anywhere because it's declared inside the lambda, and no statement needed a new block after
+     *   the declaration.
+     *
+     * Because names are not resolved at this point, we manually track local variable declarations and resolve them along the way
+     * so that shadowed names are handled correctly. This works because local variables at any scope have higher priority
+     * than members on implicit receivers, even if the implicit receiver is introduced by a later scope.
+     */
+    private class Fork(
+        val assignedLater: VariableAssignments,
+        val assignedInside: VariableAssignments,
+    ) {
+        @CfgInternals
+        fun createSnapshot(firMapper: SnapshotFirMapper): Fork {
+            return Fork(assignedLater.createSnapshot(firMapper), assignedInside.createSnapshot(firMapper))
+        }
+    }
+
+    private class Assignment(
+        val operatorAssignment: Boolean,
+        var type: ConeKotlinType? = null,
+    )
+
+    private class VariableAssignments {
+        private val assignments: MutableMap<FirProperty, MutableSet<Assignment>> = mutableMapOf()
+
+        operator fun get(property: FirProperty): Set<Assignment>? {
+            return assignments[property]
         }
 
-        private class Assignment(
-            val operatorAssignment: Boolean,
-            var type: ConeKotlinType? = null,
-        )
-
-        private class VariableAssignments {
-            private val assignments: MutableMap<FirProperty, MutableSet<Assignment>> = mutableMapOf()
-
-            operator fun get(property: FirProperty): Set<Assignment>? {
-                return assignments[property]
-            }
-
-            operator fun contains(property: FirProperty): Boolean {
-                return property in assignments
-            }
-
-            fun add(property: FirProperty, assignment: Assignment): Boolean {
-                return assignments.getOrPut(property) { mutableSetOf() }.add(assignment)
-            }
-
-            @CfgInternals
-            fun createSnapshot(firMapper: SnapshotFirMapper): VariableAssignments {
-                val copy = VariableAssignments()
-                for ((key, value) in assignments) {
-                    copy.assignments.put(firMapper.mapElement(key), value)
-                }
-                return copy
-            }
-
-            fun copy(): VariableAssignments {
-                val copy = VariableAssignments()
-                copy.assignments += this.assignments
-                return copy
-            }
-
-            fun merge(other: VariableAssignments?): Boolean {
-                if (other == null || other.assignments.isEmpty()) return false
-
-                var modified = false
-                for ((property, values) in other.assignments) {
-                    modified = modified or assignments.getOrPut(property) { mutableSetOf() }.addAll(values)
-                }
-                return modified
-            }
-
-            fun retain(properties: Set<FirProperty>) {
-                assignments.keys.retainAll(properties)
-            }
-
-            fun getAssignedProperties(): Set<FirPropertySymbol> {
-                return assignments.entries
-                    // TODO(KT-57563): Operator assignments should be treated just like any other assignment.
-                    .filter { (_, v) -> v.any { !it.operatorAssignment } }
-                    .mapTo(mutableSetOf()) { (k, _) -> k.symbol }
-            }
+        operator fun contains(property: FirProperty): Boolean {
+            return property in assignments
         }
 
-        private class MiniFlow(val parents: Set<MiniFlow>) {
-            val assignedLater = VariableAssignments()
-
-            fun fork(): MiniFlow = MiniFlow(setOf(this))
-
-            companion object {
-                fun start() = MiniFlow(emptySet())
-            }
+        fun add(property: FirProperty, assignment: Assignment): Boolean {
+            return assignments.getOrPut(property) { mutableSetOf() }.add(assignment)
         }
 
-        private class MiniCfgBuilder : FirVisitor<Unit, MiniCfgBuilder.MiniCfgData>() {
-            override fun visitElement(element: FirElement, data: MiniCfgData) {
-                element.acceptChildren(this, data)
+        @CfgInternals
+        fun createSnapshot(firMapper: SnapshotFirMapper): VariableAssignments {
+            val copy = VariableAssignments()
+            for ((key, value) in assignments) {
+                copy.assignments.put(firMapper.mapElement(key), value)
             }
+            return copy
+        }
 
-            private fun visitElementWithLexicalScope(element: FirElement, data: MiniCfgData): VariableAssignments {
-                // Detach the flow so that variables declared inside the structure do not leak into the outside.
-                val flow = MiniFlow.start()
-                val freeVariables = data.variableDeclarations.flatMapTo(mutableSetOf()) { it.values }
+        fun copy(): VariableAssignments {
+            val copy = VariableAssignments()
+            copy.assignments += this.assignments
+            return copy
+        }
+
+        fun merge(other: VariableAssignments?): Boolean {
+            if (other == null || other.assignments.isEmpty()) return false
+
+            var modified = false
+            for ((property, values) in other.assignments) {
+                modified = modified or assignments.getOrPut(property) { mutableSetOf() }.addAll(values)
+            }
+            return modified
+        }
+
+        fun retain(properties: Set<FirProperty>) {
+            assignments.keys.retainAll(properties)
+        }
+
+        fun getAssignedProperties(): Set<FirPropertySymbol> {
+            return assignments.entries
+                // TODO(KT-57563): Operator assignments should be treated just like any other assignment.
+                .filter { (_, v) -> v.any { !it.operatorAssignment } }
+                .mapTo(mutableSetOf()) { (k, _) -> k.symbol }
+        }
+    }
+
+    private class MiniFlow(val parents: Set<MiniFlow>) {
+        val assignedLater = VariableAssignments()
+
+        fun fork(): MiniFlow = MiniFlow(setOf(this))
+
+        companion object {
+            fun start() = MiniFlow(emptySet())
+        }
+    }
+
+    private class MiniCfgBuilder : FirVisitor<Unit, MiniCfgBuilder.MiniCfgData>() {
+        override fun visitElement(element: FirElement, data: MiniCfgData) {
+            element.acceptChildren(this, data)
+        }
+
+        private fun visitElementWithLexicalScope(element: FirElement, data: MiniCfgData): VariableAssignments {
+            // Detach the flow so that variables declared inside the structure do not leak into the outside.
+            val flow = MiniFlow.start()
+            val freeVariables = data.variableDeclarations.flatMapTo(mutableSetOf()) { it.values }
+            data.flow = flow
+            element.acceptChildren(this, data)
+            return flow.assignedLater.apply { retain(freeVariables) }
+        }
+
+        override fun visitAnonymousInitializer(anonymousInitializer: FirAnonymousInitializer, data: MiniCfgData) {
+            visitLocalDeclaration(anonymousInitializer, data)
+        }
+
+        override fun visitAnonymousFunction(anonymousFunction: FirAnonymousFunction, data: MiniCfgData) =
+            visitLocalDeclaration(anonymousFunction, data)
+
+        override fun visitNamedFunction(namedFunction: FirNamedFunction, data: MiniCfgData) =
+            visitLocalDeclaration(namedFunction, data)
+
+        override fun visitRegularClass(regularClass: FirRegularClass, data: MiniCfgData) =
+            visitLocalDeclaration(regularClass, data)
+
+        override fun visitAnonymousObject(anonymousObject: FirAnonymousObject, data: MiniCfgData) =
+            visitLocalDeclaration(anonymousObject, data)
+
+        private fun visitLocalDeclaration(declaration: FirDeclaration, data: MiniCfgData) {
+            val flow = data.flow
+            val assignedInside = visitElementWithLexicalScope(declaration, data)
+            // Now that the inner variables have been discarded, the rest can be propagated to prevent smartcasts
+            // in declarations that came before this one.
+            flow.recordAssignments(assignedInside)
+            data.flow = flow.fork()
+            data.forks[declaration.symbol] = Fork(data.flow.assignedLater, assignedInside)
+        }
+
+        override fun visitWhenExpression(whenExpression: FirWhenExpression, data: MiniCfgData) {
+            whenExpression.subjectVariable?.accept(this, data)
+            val flow = data.flow
+            // Also collect `flow` here for the case when none of the branches execute.
+            data.flow = whenExpression.branches.mapTo(mutableSetOf(flow)) {
+                // No need to create a fork - it'll not be observed anywhere anyway.
                 data.flow = flow
-                element.acceptChildren(this, data)
-                return flow.assignedLater.apply { retain(freeVariables) }
+                it.accept(this, data)
+                data.flow
+            }.join()
+        }
+
+        override fun visitTryExpression(tryExpression: FirTryExpression, data: MiniCfgData) {
+            tryExpression.tryBlock.accept(this, data)
+            val flow = data.flow
+            data.flow = tryExpression.catches.mapTo(mutableSetOf(flow)) {
+                data.flow = flow
+                it.accept(this, data)
+                data.flow
+            }.join()
+            tryExpression.finallyBlock?.accept(this, data)
+        }
+
+        private fun Set<MiniFlow>.join(): MiniFlow =
+            singleOrNull() ?: MiniFlow(this)
+
+        override fun visitLoop(loop: FirLoop, data: MiniCfgData) {
+            val entry = data.flow
+            val assignedInside = visitElementWithLexicalScope(loop, data)
+            // Now that the inner variables have been discarded, the rest can be propagated to prevent smartcasts
+            // in declarations that came before this loop.
+            entry.recordAssignments(assignedInside)
+            // All forks in the loop should have the same set of variables assigned later, equal to the set
+            // at the start of the loop.
+            data.flow.recordAssignments(assignedInside)
+            data.flow = entry.fork()
+            data.forks[loop] = Fork(data.flow.assignedLater, assignedInside)
+        }
+
+        override fun visitWhileLoop(whileLoop: FirWhileLoop, data: MiniCfgData) =
+            visitLoop(whileLoop, data)
+
+        override fun visitDoWhileLoop(doWhileLoop: FirDoWhileLoop, data: MiniCfgData) =
+            visitLoop(doWhileLoop, data)
+
+        // TODO: liveness analysis - return/throw/break/continue terminate the flow.
+        //   This is somewhat problematic though because try-catch and loops can restore it.
+        //   It is not possible to implement liveness analysis partially - otherwise combinations of
+        //   control flow structures can cause incorrect smartcasts. KT-59691
+
+        override fun visitFunctionCall(functionCall: FirFunctionCall, data: MiniCfgData) {
+            val visitor = this
+            with(functionCall) {
+                setOfNotNull(explicitReceiver, dispatchReceiver, extensionReceiver).forEach { it.accept(visitor, data) }
+                // Delay processing of lambda args because lambda body are evaluated after all arguments have been evaluated.
+                // TODO: this is not entirely correct (the lambda might be nested deep inside an expression), but also this
+                //  entire override should be unnecessary as long as the full CFG builder visits everything in the right order. KT-59691
+                val (postponedFunctionArgs, normalArgs) = argumentList.arguments.partition { it is FirAnonymousFunctionExpression }
+                normalArgs.forEach { it.accept(visitor, data) }
+                postponedFunctionArgs.forEach { it.accept(visitor, data) }
+                calleeReference.accept(visitor, data)
             }
+        }
 
-            override fun visitAnonymousInitializer(anonymousInitializer: FirAnonymousInitializer, data: MiniCfgData) {
-                visitLocalDeclaration(anonymousInitializer, data)
+        override fun visitBlock(block: FirBlock, data: MiniCfgData) {
+            data.variableDeclarations.addLast(mutableMapOf())
+            visitElement(block, data)
+            data.variableDeclarations.removeLast()
+        }
+
+        override fun visitProperty(property: FirProperty, data: MiniCfgData) {
+            visitElement(property, data)
+            if (property.isEffectivelyLocal) {
+                data.variableDeclarations.last()[property.name] = property
             }
+        }
 
-            override fun visitAnonymousFunction(anonymousFunction: FirAnonymousFunction, data: MiniCfgData) =
-                visitLocalDeclaration(anonymousFunction, data)
+        override fun visitReplDeclarationReference(replDeclarationReference: FirReplDeclarationReference, data: MiniCfgData) {
+            replDeclarationReference.symbol.fir.accept(this, data)
+        }
 
-            override fun visitNamedFunction(namedFunction: FirNamedFunction, data: MiniCfgData) =
-                visitLocalDeclaration(namedFunction, data)
+        override fun visitReplPropertyInitializer(replPropertyInitializer: FirReplPropertyInitializer, data: MiniCfgData) {
+            replPropertyInitializer.propertySymbol.fir.accept(this, data)
+        }
 
-            override fun visitRegularClass(regularClass: FirRegularClass, data: MiniCfgData) =
-                visitLocalDeclaration(regularClass, data)
+        override fun visitReplPropertyDelegate(replPropertyDelegate: FirReplPropertyDelegate, data: MiniCfgData) {
+            replPropertyDelegate.propertySymbol.fir.accept(this, data)
+        }
 
-            override fun visitAnonymousObject(anonymousObject: FirAnonymousObject, data: MiniCfgData) =
-                visitLocalDeclaration(anonymousObject, data)
+        override fun visitReplExpressionReference(replExpressionReference: FirReplExpressionReference, data: MiniCfgData) {
+            replExpressionReference.expressionRef.value.accept(this, data)
+        }
 
-            private fun visitLocalDeclaration(declaration: FirDeclaration, data: MiniCfgData) {
-                val flow = data.flow
-                val assignedInside = visitElementWithLexicalScope(declaration, data)
-                // Now that the inner variables have been discarded, the rest can be propagated to prevent smartcasts
-                // in declarations that came before this one.
-                flow.recordAssignments(assignedInside)
-                data.flow = flow.fork()
-                data.forks[declaration.symbol] = Fork(data.flow.assignedLater, assignedInside)
+        override fun visitVariableAssignment(variableAssignment: FirVariableAssignment, data: MiniCfgData) {
+            visitElement(variableAssignment, data)
+            if (variableAssignment.explicitReceiver != null) return
+            variableAssignment.calleeReference?.let {
+                val operatorAssignment = variableAssignment.source?.kind is KtFakeSourceElementKind.DesugaredIncrementOrDecrement
+                data.recordAssignment(it, operatorAssignment)
             }
+        }
 
-            override fun visitWhenExpression(whenExpression: FirWhenExpression, data: MiniCfgData) {
-                whenExpression.subjectVariable?.accept(this, data)
-                val flow = data.flow
-                // Also collect `flow` here for the case when none of the branches execute.
-                data.flow = whenExpression.branches.mapTo(mutableSetOf(flow)) {
-                    // No need to create a fork - it'll not be observed anywhere anyway.
-                    data.flow = flow
-                    it.accept(this, data)
-                    data.flow
-                }.join()
-            }
+        override fun visitAugmentedAssignment(augmentedAssignment: FirAugmentedAssignment, data: MiniCfgData) {
+            visitElement(augmentedAssignment, data)
+            val lhs = augmentedAssignment.leftArgument as? FirQualifiedAccessExpression ?: return
+            if (lhs.explicitReceiver != null) return
+            data.recordAssignment(lhs.calleeReference, operatorAssignment = true)
+        }
 
-            override fun visitTryExpression(tryExpression: FirTryExpression, data: MiniCfgData) {
-                tryExpression.tryBlock.accept(this, data)
-                val flow = data.flow
-                data.flow = tryExpression.catches.mapTo(mutableSetOf(flow)) {
-                    data.flow = flow
-                    it.accept(this, data)
-                    data.flow
-                }.join()
-                tryExpression.finallyBlock?.accept(this, data)
-            }
+        private fun MiniCfgData.recordAssignment(reference: FirReference, operatorAssignment: Boolean) {
+            val name = (reference as? FirNamedReference)?.name ?: return
+            val property = variableDeclarations.lastOrNull { name in it }?.get(name) ?: return
 
-            private fun Set<MiniFlow>.join(): MiniFlow =
-                singleOrNull() ?: MiniFlow(this)
+            val assignment = Assignment(operatorAssignment)
+            assignments.getOrPut(property) { mutableListOf() }.add(assignment)
+            flow.recordAssignment(property, assignment)
+        }
 
-            override fun visitLoop(loop: FirLoop, data: MiniCfgData) {
-                val entry = data.flow
-                val assignedInside = visitElementWithLexicalScope(loop, data)
-                // Now that the inner variables have been discarded, the rest can be propagated to prevent smartcasts
-                // in declarations that came before this loop.
-                entry.recordAssignments(assignedInside)
-                // All forks in the loop should have the same set of variables assigned later, equal to the set
-                // at the start of the loop.
-                data.flow.recordAssignments(assignedInside)
-                data.flow = entry.fork()
-                data.forks[loop] = Fork(data.flow.assignedLater, assignedInside)
-            }
+        private fun MiniFlow.recordAssignment(property: FirProperty, assignment: Assignment) {
+            if (!assignedLater.add(property, assignment)) return // Parents do not need to be updated if this flow is not updated.
+            parents.forEach { it.recordAssignment(property, assignment) }
+        }
 
-            override fun visitWhileLoop(whileLoop: FirWhileLoop, data: MiniCfgData) =
-                visitLoop(whileLoop, data)
+        private fun MiniFlow.recordAssignments(properties: VariableAssignments) {
+            if (!assignedLater.merge(properties)) return // Parents do not need to be updated if this flow is not updated.
+            parents.forEach { it.recordAssignments(properties) }
+        }
 
-            override fun visitDoWhileLoop(doWhileLoop: FirDoWhileLoop, data: MiniCfgData) =
-                visitLoop(doWhileLoop, data)
-
-            // TODO: liveness analysis - return/throw/break/continue terminate the flow.
-            //   This is somewhat problematic though because try-catch and loops can restore it.
-            //   It is not possible to implement liveness analysis partially - otherwise combinations of
-            //   control flow structures can cause incorrect smartcasts. KT-59691
-
-            override fun visitFunctionCall(functionCall: FirFunctionCall, data: MiniCfgData) {
-                val visitor = this
-                with(functionCall) {
-                    setOfNotNull(explicitReceiver, dispatchReceiver, extensionReceiver).forEach { it.accept(visitor, data) }
-                    // Delay processing of lambda args because lambda body are evaluated after all arguments have been evaluated.
-                    // TODO: this is not entirely correct (the lambda might be nested deep inside an expression), but also this
-                    //  entire override should be unnecessary as long as the full CFG builder visits everything in the right order. KT-59691
-                    val (postponedFunctionArgs, normalArgs) = argumentList.arguments.partition { it is FirAnonymousFunctionExpression }
-                    normalArgs.forEach { it.accept(visitor, data) }
-                    postponedFunctionArgs.forEach { it.accept(visitor, data) }
-                    calleeReference.accept(visitor, data)
-                }
-            }
-
-            override fun visitBlock(block: FirBlock, data: MiniCfgData) {
-                data.variableDeclarations.addLast(mutableMapOf())
-                visitElement(block, data)
-                data.variableDeclarations.removeLast()
-            }
-
-            override fun visitProperty(property: FirProperty, data: MiniCfgData) {
-                visitElement(property, data)
-                if (property.isEffectivelyLocal) {
-                    data.variableDeclarations.last()[property.name] = property
-                }
-            }
-
-            override fun visitReplDeclarationReference(replDeclarationReference: FirReplDeclarationReference, data: MiniCfgData) {
-                replDeclarationReference.symbol.fir.accept(this, data)
-            }
-
-            override fun visitReplPropertyInitializer(replPropertyInitializer: FirReplPropertyInitializer, data: MiniCfgData) {
-                replPropertyInitializer.propertySymbol.fir.accept(this, data)
-            }
-
-            override fun visitReplPropertyDelegate(replPropertyDelegate: FirReplPropertyDelegate, data: MiniCfgData) {
-                replPropertyDelegate.propertySymbol.fir.accept(this, data)
-            }
-
-            override fun visitReplExpressionReference(replExpressionReference: FirReplExpressionReference, data: MiniCfgData) {
-                replExpressionReference.expressionRef.value.accept(this, data)
-            }
-
-            override fun visitVariableAssignment(variableAssignment: FirVariableAssignment, data: MiniCfgData) {
-                visitElement(variableAssignment, data)
-                if (variableAssignment.explicitReceiver != null) return
-                variableAssignment.calleeReference?.let {
-                    val operatorAssignment = variableAssignment.source?.kind is KtFakeSourceElementKind.DesugaredIncrementOrDecrement
-                    data.recordAssignment(it, operatorAssignment)
-                }
-            }
-
-            override fun visitAugmentedAssignment(augmentedAssignment: FirAugmentedAssignment, data: MiniCfgData) {
-                visitElement(augmentedAssignment, data)
-                val lhs = augmentedAssignment.leftArgument as? FirQualifiedAccessExpression ?: return
-                if (lhs.explicitReceiver != null) return
-                data.recordAssignment(lhs.calleeReference, operatorAssignment = true)
-            }
-
-            private fun MiniCfgData.recordAssignment(reference: FirReference, operatorAssignment: Boolean) {
-                val name = (reference as? FirNamedReference)?.name ?: return
-                val property = variableDeclarations.lastOrNull { name in it }?.get(name) ?: return
-
-                val assignment = Assignment(operatorAssignment)
-                assignments.getOrPut(property) { mutableListOf() }.add(assignment)
-                flow.recordAssignment(property, assignment)
-            }
-
-            private fun MiniFlow.recordAssignment(property: FirProperty, assignment: Assignment) {
-                if (!assignedLater.add(property, assignment)) return // Parents do not need to be updated if this flow is not updated.
-                parents.forEach { it.recordAssignment(property, assignment) }
-            }
-
-            private fun MiniFlow.recordAssignments(properties: VariableAssignments) {
-                if (!assignedLater.merge(properties)) return // Parents do not need to be updated if this flow is not updated.
-                parents.forEach { it.recordAssignments(properties) }
-            }
-
-            class MiniCfgData {
-                var flow: MiniFlow = MiniFlow.start()
-                val variableDeclarations: ArrayDeque<MutableMap<Name, FirProperty>> = ArrayDeque(listOf(mutableMapOf()))
-                val assignments: MutableMap<FirProperty, MutableList<Assignment>> = mutableMapOf()
-                val forks: MutableMap<Any /* FirBasedSymbol<*> | FirLoop */, Fork> = mutableMapOf()
-            }
+        class MiniCfgData {
+            var flow: MiniFlow = MiniFlow.start()
+            val variableDeclarations: ArrayDeque<MutableMap<Name, FirProperty>> = ArrayDeque(listOf(mutableMapOf()))
+            val assignments: MutableMap<FirProperty, MutableList<Assignment>> = mutableMapOf()
+            val forks: MutableMap<Any /* FirBasedSymbol<*> | FirLoop */, Fork> = mutableMapOf()
         }
     }
 }

--- a/compiler/testData/diagnostics/tests/smartCasts/variables/nestedDelegatesStress.kt
+++ b/compiler/testData/diagnostics/tests/smartCasts/variables/nestedDelegatesStress.kt
@@ -1,0 +1,36 @@
+// RUN_PIPELINE_TILL: BACKEND
+// WITH_STDLIB
+// ISSUE: KT-66451
+
+object Foo {
+    val a by lazy {
+    val b by lazy {
+    val c by lazy {
+    val d by lazy {
+    val e by lazy {
+    val f by lazy {
+    val g by lazy {
+    val h by lazy {
+    val i by lazy {
+    val j by lazy {
+    val k by lazy {
+    val l by lazy {
+    val m by lazy {
+    val n by lazy {
+    val o by lazy {
+    val p by lazy {
+    val q by lazy {
+    val r by lazy {
+    val s by lazy {
+    val t by lazy {
+    val u by lazy {
+    val v by lazy {
+    val w by lazy {
+    val x by lazy {
+    val y by lazy {
+    val z by lazy {
+    }}}}}}}}}}}}}}}}}}}}}}}}}}
+}
+
+/* GENERATED_FIR_TAGS: lambdaLiteral, localProperty, nullableType, objectDeclaration, propertyDeclaration,
+propertyDelegate, starProjection */


### PR DESCRIPTION
When visiting delegate properties in FirLocalVariableAssignmentAnalyzer,
the delegate expression is actually visited twice due to
`FirWrappedDelegateExpression` having both `expression` and
`provideDelegateCall`. The `expression` element is part of the FIR tree
twice, directly as `expression` but also as the explicit receiver in
`provideDelegateCall`. Navigating `provideDelegateCall` is redundant and
leads to an exponential increase in analysis time. So only visit
`expression` from `FirWrappedDelegateExpression` to avoid this
exponential increase.