### PR TITLE
Hoist `kotlin.*` gradle property reads to `BuildService` scope

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/properties/PropertiesBuildService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/properties/PropertiesBuildService.kt
@@ -11,8 +11,10 @@ import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
+import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnosticOncePerBuild
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
@@ -38,6 +40,30 @@ internal abstract class PropertiesBuildService @Inject constructor(
 
     interface Params : BuildServiceParameters {
         val localProperties: MapProperty<String, String>
+
+        /**
+         * Snapshot of the values of every `kotlin.*` Gradle property known to the
+         * Kotlin Gradle Plugin (see [PropertiesProvider.PropertyNames.allProperties]),
+         * resolved once at BuildService registration time.
+         *
+         * Reading these values through this map (a BuildService parameter) makes the
+         * configuration-cache fingerprint inputs build-scoped instead of project-scoped,
+         * which is critical with Isolated Projects: in a build with N projects applying
+         * the Kotlin plugin, this turns ~M*N project-scope property reads into ~M
+         * build-scope reads (where M is the number of `kotlin.*` properties).
+         *
+         * Only entries with an actual value are present; absence here means the
+         * property was not set as a Gradle property (the lookup will fall back to
+         * project extra properties and `local.properties`).
+         */
+        val gradleProperties: MapProperty<String, String>
+
+        /**
+         * The set of property names that were pre-scanned into [gradleProperties].
+         * Used to distinguish "known property, absent value" (use the snapshot) from
+         * "unknown property" (fall back to a per-project `gradleProperty()` lookup).
+         */
+        val knownPropertyNames: SetProperty<String>
     }
 
     /**
@@ -46,6 +72,8 @@ internal abstract class PropertiesBuildService @Inject constructor(
     private val propertiesPerProject = ConcurrentHashMap<String, Provider<String>>()
 
     private val localProperties by lazy { parameters.localProperties.get() }
+    private val gradleProperties by lazy { parameters.gradleProperties.get() }
+    private val knownPropertyNames by lazy { parameters.knownPropertyNames.get() }
     private val logger = Logging.getLogger(this::class.java)
 
     /**
@@ -66,10 +94,27 @@ internal abstract class PropertiesBuildService @Inject constructor(
             // MemoizedCallable.
             val valueFromGradleAndLocalProperties = MemoizedCallable {
                 extraPropertiesExtension.getOrNull(propertyName)?.toString()
-                    ?: providerFactory.gradleProperty(propertyName).orNull
+                    ?: gradlePropertyValue(propertyName)
                     ?: localProperties[propertyName]
             }
             providerFactory.provider { valueFromGradleAndLocalProperties.call() }
+        }
+    }
+
+    /**
+     * Look up [propertyName] as a Gradle property, going through the build-scoped
+     * snapshot in [Params.gradleProperties] when possible to avoid registering a
+     * project-scope configuration-cache fingerprint input on every project that
+     * applies the Kotlin plugin (see [Params.gradleProperties] for context).
+     *
+     * Falls back to [providerFactory] for property names that were not part of the
+     * pre-scan (e.g. dynamic `kotlin.native.binary.*` keys).
+     */
+    private fun gradlePropertyValue(propertyName: String): String? {
+        return if (knownPropertyNames.contains(propertyName)) {
+            gradleProperties[propertyName]
+        } else {
+            providerFactory.gradleProperty(propertyName).orNull
         }
     }
 
@@ -160,6 +205,27 @@ internal abstract class PropertiesBuildService @Inject constructor(
         fun registerIfAbsent(project: Project): Provider<PropertiesBuildService> =
             project.gradle.registerClassLoaderScopedBuildService(PropertiesBuildService::class) {
                 it.parameters.localProperties.set(project.localProperties)
+
+                // Pre-scan every kotlin.* Gradle property the plugin knows about and route
+                // the reads through a BuildService parameter rather than a per-project
+                // providerFactory call. This makes the configuration-cache fingerprint input
+                // build-scoped instead of project-scoped, so the cost is paid once per build
+                // instead of once per project that applies the Kotlin plugin. With Isolated
+                // Projects this is the difference between ~30 and ~30 * (#kotlin-projects)
+                // CC inputs.
+                //
+                // Resolve each provider eagerly here so we can put plain `String` values
+                // into the MapProperty: putting an absent-value `Provider` would make the
+                // whole MapProperty "missing" (see https://github.com/gradle/gradle/issues/13364
+                // and the MapProperty.put(K, Provider) javadoc), which would break every
+                // build that doesn't explicitly set every known kotlin.* property.
+                val knownNames = PropertiesProvider.PropertyNames.allProperties()
+                it.parameters.knownPropertyNames.set(knownNames)
+                it.parameters.gradleProperties.set(
+                    knownNames.mapNotNull { name ->
+                        project.providers.gradleProperty(name).orNull?.let { value -> name to value }
+                    }.toMap()
+                )
             }
     }
 


### PR DESCRIPTION
Fully resolves [KT-62496](https://youtrack.jetbrains.com/issues/KT-62496)

The `PropertiesBuildService` cache key includes project path, so each of N projects that apply the Kotlin plugin independently invokes `providerFactory.gradleProperty(name).orNull` for the same `kotlin.*` property name. With Gradle's configuration cache (especially Isolated Projects), each call attributes a project-scoped fingerprint input, multiplying the cost by N.

Pre-scan every property name advertised by
`PropertiesProvider.PropertyNames.allProperties()` at `BuildService` registration time and pass the values through `Params.gradleProperties` (a `MapProperty`). Reading values via the `BuildService` parameter, like the existing `localProperties`, makes the CC fingerprint input build-scoped, so the cost is paid once per build instead of once per project.

Property names not in the pre-scanned set (e.g. dynamic `kotlin.native.binary.*` keys) still fall back to `providerFactory`.
