### PR TITLE
[CFG] Only visit receiver expressions once when analyzing calls

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirLocalVariableAssignmentAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/dfa/FirLocalVariableAssignmentAnalyzer.kt
@@ -578,8 +578,12 @@ class FirLocalVariableAssignmentAnalyzer private constructor(
 
         override fun visitFunctionCall(functionCall: FirFunctionCall, data: MiniCfgData) {
             functionCall.explicitReceiver?.accept(this, data)
-            functionCall.dispatchReceiver?.accept(this, data)
-            functionCall.extensionReceiver?.accept(this, data)
+            if (functionCall.dispatchReceiver !== functionCall.explicitReceiver) {
+                functionCall.dispatchReceiver?.accept(this, data)
+            }
+            if (functionCall.extensionReceiver !== functionCall.explicitReceiver && functionCall.extensionReceiver !== functionCall.dispatchReceiver) {
+                functionCall.extensionReceiver?.accept(this, data)
+            }
             // Delay processing of lambda args because lambda body are evaluated after all arguments have been evaluated.
             // TODO: this is not entirely correct (the lambda might be nested deep inside an expression), but also this
             //  entire override should be unnecessary as long as the full CFG builder visits everything in the right order. KT-59691


### PR DESCRIPTION
A performance regression was introduced when attempting to simplify some unrelated code while fixing another performance regression in `FirLocalVariableAssignmentAnalyzer`. This caused all receiver property expressions of a `FirFunctionCall` to be visited even if there were repeated references to the same FIR element. To avoid creation of a Set and looping mechanism, instead, check that each receiver expression is unique among the other receivers and only visit unique expressions.

^KT-86006