### PR TITLE
KT-85614: copyToRecursively's error handler should not throw on its own

### DIFF
--- a/libraries/stdlib/jdk7/src/kotlin/io/path/PathRecursiveFunctions.kt
+++ b/libraries/stdlib/jdk7/src/kotlin/io/path/PathRecursiveFunctions.kt
@@ -202,9 +202,13 @@ public fun Path.copyToRecursively(
 
     val normalizedTarget = target.normalize()
 
-    fun destination(source: Path): Path {
+    fun destinationUnchecked(source: Path): Path {
         val relativePath = source.relativeTo(this@copyToRecursively)
-        val destination = target.resolve(relativePath.pathString)
+        return target.resolve(relativePath.pathString)
+    }
+
+    fun destination(source: Path): Path {
+        val destination = destinationUnchecked(source)
         if (!destination.normalize().startsWith(normalizedTarget)) {
             throw IllegalFileNameException(
                 source,
@@ -216,7 +220,7 @@ public fun Path.copyToRecursively(
     }
 
     fun error(source: Path, exception: Exception): FileVisitResult {
-        return onError(source, destination(source), exception).toFileVisitResult()
+        return onError(source, destinationUnchecked(source), exception).toFileVisitResult()
     }
 
     val stack = arrayListOf<Path>()

--- a/libraries/stdlib/jdk7/src/kotlin/io/path/PathRecursiveFunctions.kt
+++ b/libraries/stdlib/jdk7/src/kotlin/io/path/PathRecursiveFunctions.kt
@@ -202,14 +202,10 @@ public fun Path.copyToRecursively(
 
     val normalizedTarget = target.normalize()
 
-    fun destinationUnchecked(source: Path): Path {
+    fun destination(source: Path, validatePath: Boolean = true): Path {
         val relativePath = source.relativeTo(this@copyToRecursively)
-        return target.resolve(relativePath.pathString)
-    }
-
-    fun destination(source: Path): Path {
-        val destination = destinationUnchecked(source)
-        if (!destination.normalize().startsWith(normalizedTarget)) {
+        val destination = target.resolve(relativePath.pathString)
+        if (validatePath && !destination.normalize().startsWith(normalizedTarget)) {
             throw IllegalFileNameException(
                 source,
                 destination,
@@ -220,7 +216,12 @@ public fun Path.copyToRecursively(
     }
 
     fun error(source: Path, exception: Exception): FileVisitResult {
-        return onError(source, destinationUnchecked(source), exception).toFileVisitResult()
+        // destination, when invoked with default validatePath value (true) may throw an exception.
+        // If this function was invoked to handle such an exception thrown elsewhere,
+        // there is no way to deliver exception to onError other than bypassing the validation.
+        // Thus, we call destination w/ validatePath = false.
+        val destinationPath = destination(source, validatePath = false)
+        return onError(source, destinationPath, exception).toFileVisitResult()
     }
 
     val stack = arrayListOf<Path>()

--- a/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
+++ b/libraries/stdlib/jdk7/test/PathRecursiveFunctionsZipTest.kt
@@ -515,6 +515,16 @@ class PathRecursiveFunctionsZipTest : AbstractPathTest() {
             })
             assertTrue(failed)
         }
+        withZip("Archive4.zip", listOf("normal", "../../../../../test")) { root, zipRoot ->
+            val target = root.resolve("UnzipArchive4")
+            var failed = false
+            zipRoot.copyToRecursively(target, followLinks = false, onError = { _, _, exception ->
+                failed = true
+                assertIs<IllegalFileNameException>(exception)
+                OnErrorResult.SKIP_SUBTREE
+            })
+            assertTrue(failed)
+        }
     }
 
     // To demonstrate how recursive functions behave when the traversal starting path ends with "." or ".."


### PR DESCRIPTION
`Path.copyToRecursively` accepts error handler and it catches and delegates all errors thrown during traversal and copying to that hander. The handler accepts resolved destination path, but destination path resolution can throw an exception. As a result, such exceptions were never delivered to the handler.

^KT-85614 fixed