### PR TITLE
[Gradle] Don't fail the integration test if no compatible JDK could be found

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/KotlinNativeIsolatedClassloaderIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/KotlinNativeIsolatedClassloaderIT.kt
@@ -7,11 +7,9 @@ package org.jetbrains.kotlin.gradle.native
 
 import org.gradle.api.JavaVersion
 import org.gradle.util.GradleVersion
-import org.jetbrains.kotlin.gradle.dsl.NativeCacheKind
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.condition.OS
-import kotlin.io.path.appendText
 
 @DisplayName("KotlinNative isolated class loader test")
 @NativeGradlePluginTests

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/argumentProviders.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/argumentProviders.kt
@@ -262,9 +262,10 @@ class GradleAndJdkArgumentsProvider : GradleArgumentsProvider() {
             // All Gradle versions fit
             filteredVersions.count() == initialVersionsCount -> this
             // No Gradle versions fit
-            filteredVersions.count() == 0 -> error(
-                "Requested Gradle versions ${this.joinToString()} are not compatible with JDK ${requestedJdk.version}."
-            )
+            filteredVersions.isEmpty() -> {
+                println("Requested Gradle versions ${this.joinToString()} are not compatible with JDK ${requestedJdk.version}.")
+                emptySet()
+            }
             // Some Gradle versions fit
             filteredVersions.count() <= initialVersionsCount -> {
                 filteredVersions.toSet()


### PR DESCRIPTION
On CI our tests are running per-Gradle release and in such case previous logic fails the test as it could not find the compatible requested JDK and Gradle versions. Updated the logic to return empty set to avoid such incompatibility and still allow to run tests.
