### PR TITLE
[Build] Align Kotlin daemon classpaths

### DIFF
--- a/repo/gradle-settings-conventions/kotlin-bootstrap/src/main/kotlin/kotlin-bootstrap.settings.gradle.kts
+++ b/repo/gradle-settings-conventions/kotlin-bootstrap/src/main/kotlin/kotlin-bootstrap.settings.gradle.kts
@@ -230,10 +230,13 @@ private fun Settings.applyBootstrapConfiguration(
             if (name == "kotlinCompilerClasspath") {
                 val compilerClasspathSubstituteReason = "Override Kotlin compiler classpath with bootstrap"
                 dependencies.add(
-                    project.dependencies.enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:$bootstrapVersion")
+                    project.dependencies.create("org.jetbrains.kotlin:kotlin-compiler-embeddable:$bootstrapVersion")
                 )
                 dependencies.add(
-                    project.dependencies.create("org.jetbrains.kotlin:kotlin-compiler-embeddable:$bootstrapVersion")
+                    project.dependencies.create("org.jetbrains.kotlin:kotlin-build-tools-compat:$bootstrapVersion")
+                )
+                dependencies.add(
+                    project.dependencies.create("org.jetbrains.kotlin:kotlin-build-tools-impl:$bootstrapVersion")
                 )
                 dependencyConstraints.add(
                     project.dependencies.constraints.create("org.jetbrains.kotlin:kotlin-compiler-embeddable") {


### PR DESCRIPTION
To be able to reuse daemons between BTA and non-BTA modes, the classpaths should match. This change adds BTA implementation artifacts to the non-BTA configuration and also removes platform dependency on kotlin-bom which bumps kotlin-reflect from the predefined version 1.6.10. This matches with the default dependencies in KGP. KGP adds those dependencies into `defaultDependencies`, but since this hack with subtitution is present here, it removes the 'default dependencies' and those should be re-added back. Relates to KTI-2475