### PR TITLE
[KT-85690] Remove dependencies on jvm's kotlin-stdlib.jar from jklib test infra

### DIFF
--- a/compiler/jklib.tests/testFixtures/org/jetbrains/kotlin/jklib/test/irText/AbstractFirJKlibIrTextTest.kt
+++ b/compiler/jklib.tests/testFixtures/org/jetbrains/kotlin/jklib/test/irText/AbstractFirJKlibIrTextTest.kt
@@ -72,6 +72,7 @@ abstract class AbstractFirJKlibIrTextTest : AbstractKotlinCompilerWithTargetBack
         setupDefaultDirectivesForIrTextTest()
         defaultDirectives {
             +CodegenTestDirectives.IGNORE_IR_EXPECT_FLAG
+            +JvmEnvironmentConfigurationDirectives.NO_RUNTIME
         }
 
         useFailureSuppressors(

--- a/compiler/testData/ir/irText/expressions/breakContinueInWhen.kt
+++ b/compiler/testData/ir/irText/expressions/breakContinueInWhen.kt
@@ -1,5 +1,4 @@
 // IGNORE_BACKEND: JS_IR, WASM_JS
-// IGNORE_BACKEND: JKLIB
 
 // KT-61141: throws kotlin.AssertionError instead of java.lang.AssertionError
 // IGNORE_BACKEND: NATIVE

--- a/compiler/testData/ir/irText/expressions/callableReferences/withVarargViewedAsArray.kt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/withVarargViewedAsArray.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JKLIB
 fun sum(vararg args: Int): Int {
     var result = 0
     for (arg in args)

--- a/compiler/testData/ir/irText/expressions/ifWithLoop.kt
+++ b/compiler/testData/ir/irText/expressions/ifWithLoop.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JKLIB
 fun topLevelMethod() {
     var z = 1
 

--- a/compiler/testData/ir/irText/expressions/kt47245.kt
+++ b/compiler/testData/ir/irText/expressions/kt47245.kt
@@ -1,5 +1,4 @@
 // SKIP_KT_DUMP
-// IGNORE_BACKEND: JKLIB
 
 fun test() {
     for (i in 0..0) fun () {}

--- a/compiler/testData/ir/irText/expressions/simpleOperators.kt
+++ b/compiler/testData/ir/irText/expressions/simpleOperators.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JKLIB
 fun test1(a: Int, b: Int) = a + b
 fun test2(a: Int, b: Int) = a - b
 fun test3(a: Int, b: Int) = a * b

--- a/compiler/testData/ir/irText/regressions/coercionInLoop.kt
+++ b/compiler/testData/ir/irText/regressions/coercionInLoop.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: JKLIB
 fun box(): String {
     val a = DoubleArray(5)
     val x = a.iterator()

--- a/compiler/testData/ir/irText/stubs/arraysFromBuiltins.kt
+++ b/compiler/testData/ir/irText/stubs/arraysFromBuiltins.kt
@@ -2,6 +2,5 @@
 // DUMP_EXTERNAL_CLASS: kotlin/IntArray
 // DUMP_EXTERNAL_CLASS: kotlin/collections/IntIterator
 // TARGET_BACKEND: JVM_IR
-// IGNORE_BACKEND: JKLIB
 
 val test = IntArray(1).iterator()

--- a/libraries/stdlib/jklib-for-test/build.gradle.kts
+++ b/libraries/stdlib/jklib-for-test/build.gradle.kts
@@ -19,16 +19,6 @@ val substrateStdlibCompilerDependencies by configurations.creating {
     isCanBeResolved = true
 }
 
-val klibCompileClasspath by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-    }
-}
-
 dependencies {
     // 1. Dependencies to RUN the JKlib Compiler
     jklibCompilerClasspath(project(":compiler:cli-jklib"))
@@ -43,12 +33,6 @@ dependencies {
     // Used to read XML metadata files inside META-INF
     substrateStdlibCompilerDependencies(commonDependency("org.codehaus.woodstox:stax2-api"))
     substrateStdlibCompilerDependencies(commonDependency("com.fasterxml:aalto-xml"))
-
-    // 2. Dependencies to COMPILE the minimal stdlib KLIB
-    klibCompileClasspath(project(":kotlin-stdlib"))
-    klibCompileClasspath(commonDependency("org.jetbrains.kotlin:kotlin-reflect")) {
-        isTransitive = false
-    }
 }
 
 val outputKlib = layout.buildDirectory.file("libs/kotlin-stdlib-jvm-ir.klib")
@@ -75,6 +59,7 @@ val copyMinimalSources by tasks.registering(Sync::class) {
         include(
             "kotlin/Annotation.kt",
             "kotlin/Annotations.kt",
+            "kotlin/collections/PrimitiveIterators.kt",
             "kotlin/Any.kt",
             "kotlin/Array.kt",
             "kotlin/ArrayIntrinsics.kt",
@@ -95,6 +80,7 @@ val copyMinimalSources by tasks.registering(Sync::class) {
             "kotlin/Primitives.kt",
             "kotlin/Unit.kt",
             "kotlin/annotation/Annotations.kt",
+            "kotlin/annotations/OptIn.kt",
             "kotlin/annotations/Multiplatform.kt",
             "kotlin/annotations/WasExperimental.kt",
             "kotlin/annotations/ReturnValue.kt",
@@ -164,7 +150,6 @@ val copyMinimalSources by tasks.registering(Sync::class) {
 fun JavaExec.configureJklibCompilation(
     sourceTask: TaskProvider<Sync>,
     klibOutput: Provider<RegularFile>,
-    klibCompileClasspath: FileCollection,
 ) {
     dependsOn(sourceTask)
 
@@ -177,7 +162,6 @@ fun JavaExec.configureJklibCompilation(
         include("**/*.kt")
     }
     inputs.files(sourceTree)
-    inputs.files(klibCompileClasspath)
     outputs.file(klibOutput)
 
     doFirst {
@@ -208,9 +192,6 @@ fun JavaExec.configureJklibCompilation(
             "-Xcommon-sources=${(commonSourceFiles).joinToString(",")}",
         )
 
-        val fullClasspath = klibCompileClasspath.asPath
-        
-        args("-classpath", fullClasspath)
         args(jvmSourceFiles)
         args(commonSourceFiles)
     }
@@ -223,7 +204,7 @@ val compileStdlib by tasks.registering(JavaExec::class) {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(8))
     })
-    configureJklibCompilation(copyMinimalSources, outputKlib, klibCompileClasspath)
+    configureJklibCompilation(copyMinimalSources, outputKlib)
 
     args("-nowarn")
 }

--- a/libraries/stdlib/jklib-for-test/src/stubs/jvm/builtins/stubs.kt
+++ b/libraries/stdlib/jklib-for-test/src/stubs/jvm/builtins/stubs.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.jvm.internal
+
+public object Reflection {
+    public fun renderLambdaToString(lambda: Lambda<*>): String {
+        TODO("stub")
+    }
+}

--- a/libraries/stdlib/jklib-for-test/src/stubs/kotlin/collections/stubs.kt
+++ b/libraries/stdlib/jklib-for-test/src/stubs/kotlin/collections/stubs.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.collections
+
+public fun <T> Array<out T>.asList(): List<T> {
+    TODO("stub")
+}
+
+public fun <T> List<T>.getOrNull(index: Int): T? {
+    TODO("stub")
+}

--- a/libraries/stdlib/jklib-for-test/src/stubs/kotlin/jvm/internal/stubs.kt
+++ b/libraries/stdlib/jklib-for-test/src/stubs/kotlin/jvm/internal/stubs.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.jvm.internal
+
+public fun collectionToArray(collection: Collection<*>): Array<Any?> {
+    TODO("stub")
+}
+
+public fun <T> collectionToArray(collection: Collection<*>, array: Array<T>): Array<T> {
+    TODO("stub")
+}

--- a/libraries/stdlib/jklib-for-test/src/stubs/kotlin/ranges/stubs.kt
+++ b/libraries/stdlib/jklib-for-test/src/stubs/kotlin/ranges/stubs.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.ranges
+
+public infix fun Int.until(to: Int): IntRange {
+    TODO("stub")
+}
+
+public class IntRange(public val start: Int, public val endInclusive: Int) {
+    public operator fun iterator(): Iterator<Int> {
+        TODO("stub")
+    }
+}

--- a/libraries/stdlib/jklib-for-test/src/stubs/kotlin/stubs.kt
+++ b/libraries/stdlib/jklib-for-test/src/stubs/kotlin/stubs.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin
+
+public fun error(message: Any): Nothing {
+    TODO("stub")
+}


### PR DESCRIPTION
Two changes are done here:
1- Make the jklib-for-test stdlib self dependent which removes its dependency on jvm's kotlin-stdlib.jar
   1.1 - Adding missing stubs
   1.2 - Unmute tests that depended on missing symbols not present during the test run
2- Remove the presence of kotlin-stdlib.jar and kotlin-reflect from the jklib.tests

These allow the IR linking inside the IR deserialization phase 
to only handle the linking required for a self contained stdlib + the tests without any other leaks.

For #1 This also required adding stubs,
Which have todos in their implementation to avoid introducing more dependencies

The jklib-for-test stdlib is based off jvm minimal stdlib for tests
In order to keep compatibility with tests not using the full stdlib
The jvm minimal stdlib pulls some symbols from the bultins metadata it copies from kotlin-stdlib.jar which can't be done into a klib.
