### PR TITLE
[JKLIB] Fix builtins initialization and JVM signature computation

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -21,20 +21,18 @@ import org.jetbrains.kotlin.cli.jvm.compiler.VfsBasedProjectEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.toAbstractProjectFileSearchScope
 import org.jetbrains.kotlin.cli.pipeline.CheckCompilationErrors
 import org.jetbrains.kotlin.cli.pipeline.PipelinePhase
+import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.config.CommonConfigurationKeys.MODULE_NAME
-import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import org.jetbrains.kotlin.config.MessageCollectorAccess
-import org.jetbrains.kotlin.config.languageVersionSettings
-import org.jetbrains.kotlin.config.messageCollector
 import org.jetbrains.kotlin.container.get
 import org.jetbrains.kotlin.context.ContextForNewModule
 import org.jetbrains.kotlin.context.ProjectContext
+import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
+import org.jetbrains.kotlin.descriptors.deserialization.AdditionalClassPartsProvider
 import org.jetbrains.kotlin.descriptors.impl.CompositePackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.frontend.java.di.createContainerForLazyResolveWithJava
-import org.jetbrains.kotlin.frontend.java.di.initialize
 import org.jetbrains.kotlin.idea.MainFunctionDetector
 import org.jetbrains.kotlin.incremental.components.EnumWhenTracker
 import org.jetbrains.kotlin.incremental.components.ExpectActualTracker
@@ -47,6 +45,7 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.descriptors.IrDescriptorBasedFunctionFactory
 import org.jetbrains.kotlin.ir.util.ExternalDependenciesGenerator
+import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.library.KotlinLibrary
@@ -67,6 +66,8 @@ import org.jetbrains.kotlin.resolve.CompilerEnvironment
 import org.jetbrains.kotlin.resolve.jvm.JavaDescriptorResolver
 import org.jetbrains.kotlin.resolve.jvm.multiplatform.OptionalAnnotationPackageFragmentProvider
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactory
+import org.jetbrains.kotlin.storage.StorageManager
+import org.jetbrains.kotlin.types.KotlinType
 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
 object JKlibIrCompilationPhase :
@@ -85,29 +86,23 @@ object JKlibIrCompilationPhase :
         val projectContext = ProjectContext(projectEnvironment.project, "TopDownAnalyzer for JKlib")
         val storageManager = projectContext.storageManager
         val builtIns = JvmBuiltIns(projectContext.storageManager, JvmBuiltIns.Kind.FROM_DEPENDENCIES)
-
-        val klibFactories = KlibMetadataFactories({ builtIns }, JavaFlexibleTypeDeserializer)
-        val trace = BindingTraceContext(projectContext.project)
-
         val sortedDependencies = loadLibraries(klibFiles, configuration)
 
-        val jarDepsModuleDescriptor = createJarDependenciesModuleDescriptor(projectEnvironment, projectContext, configuration)
-        
-        val dependencyDescriptorsByKlib = sortedDependencies.associateWith { klib ->
-            klibFactories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
-                klib,
-                configuration.languageVersionSettings,
-                storageManager,
-                if (klib.isJklibStdlib) null else builtIns,
-                lookupTracker = LookupTracker.DO_NOTHING,
-            )
-        }
+        val dependencyDescriptorsByKlib = createKlibDescriptors(sortedDependencies, configuration, storageManager, builtIns)
+
+        val jarDepsModuleDescriptor = createJarDependenciesModuleDescriptor(
+            projectEnvironment,
+            projectContext,
+            configuration,
+            builtIns,
+        )
 
         val descriptors = dependencyDescriptorsByKlib.values + jarDepsModuleDescriptor
         descriptors.forEach { if (it != jarDepsModuleDescriptor) it.setDependencies(descriptors) }
 
         val mainModule = dependencyDescriptorsByKlib.getValue(sortedDependencies.single { it.libraryFile == klib })
 
+        val trace = BindingTraceContext(projectContext.project)
         val mangler = JKlibDescriptorMangler(
             MainFunctionDetector(trace.bindingContext, configuration.languageVersionSettings)
         )
@@ -172,6 +167,12 @@ object JKlibIrCompilationPhase :
         ExternalDependenciesGenerator(symbolTable, listOf(linker)).generateUnboundSymbolsAsDependencies()
         linker.postProcess(inOrAfterLinkageStep = true)
 
+        // TODO(KT-86160): remove this when we have a proper solution for this issue.
+        symbolTable
+            .referenceClass(IdSignature.CommonSignature("kotlin", "Int", null, 0, null))
+            .owner
+            .declarations
+
         linker.checkNoUnboundSymbols(symbolTable, "Found unbound symbol")
 
         return JKlibIrCompilationArtifact(
@@ -185,17 +186,14 @@ object JKlibIrCompilationPhase :
         projectEnvironment: VfsBasedProjectEnvironment,
         projectContext: ProjectContext,
         configuration: CompilerConfiguration,
+        builtIns: JvmBuiltIns,
     ): ModuleDescriptorImpl {
         val languageVersionSettings = configuration.languageVersionSettings
-        val fallbackBuiltIns = JvmBuiltIns(projectContext.storageManager, JvmBuiltIns.Kind.FALLBACK).apply {
-            initialize(builtInsModule, languageVersionSettings)
-        }
-
         val platform = JvmPlatforms.defaultJvmPlatform
         val dependenciesContext = ContextForNewModule(
             projectContext,
             Name.special("<dependencies of ${configuration.getNotNull(MODULE_NAME)}>"),
-            fallbackBuiltIns,
+            builtIns,
             platform,
         )
 
@@ -236,7 +234,7 @@ object JKlibIrCompilationPhase :
         moduleClassResolver.compiledCodeResolver = dependenciesContainer.get()
 
         dependenciesContext.setDependencies(
-            listOf(dependenciesContext.module, fallbackBuiltIns.builtInsModule)
+            listOf(dependenciesContext.module, builtIns.builtInsModule)
         )
         dependenciesContext.initializeModuleContents(
             CompositePackageFragmentProvider(
@@ -249,6 +247,55 @@ object JKlibIrCompilationPhase :
             )
         )
         return dependenciesContext.module
+    }
+
+    private fun createKlibDescriptors(
+        sortedDependencies: List<KotlinLibrary>,
+        configuration: CompilerConfiguration,
+        storageManager: StorageManager,
+        builtIns: JvmBuiltIns,
+    ): Map<KotlinLibrary, ModuleDescriptorImpl> {
+        val klibFactories = KlibMetadataFactories(
+            { builtIns },
+            JavaFlexibleTypeDeserializer,
+            // We need to wire the JvmBuiltInsCustomizer instance to the KlibMetadataFactories. This allows resolving APIs that are not part
+            // of the original builtins classes but are present in the mapped Java classes.
+            // We cannot directly pass builtIns.customizer because it's a lazy property. It can only be accessed after builtIns has been
+            // fully initialized. By the time the deserializer queries this provider, `builtIns` will have been fully initialized.
+            additionalClassPartsProvider = object : AdditionalClassPartsProvider {
+                private val delegate by lazy { builtIns.customizer }
+
+                override fun getSupertypes(classDescriptor: ClassDescriptor): Collection<KotlinType> =
+                    delegate.getSupertypes(classDescriptor)
+
+                override fun getFunctions(name: Name, classDescriptor: ClassDescriptor): Collection<SimpleFunctionDescriptor> =
+                    delegate.getFunctions(name, classDescriptor)
+
+                override fun getConstructors(classDescriptor: ClassDescriptor): Collection<ClassConstructorDescriptor> =
+                    delegate.getConstructors(classDescriptor)
+
+                override fun getFunctionsNames(classDescriptor: ClassDescriptor): Collection<Name> =
+                    delegate.getFunctionsNames(classDescriptor)
+            }
+        )
+
+        val dependencyDescriptorsByKlib = sortedDependencies.associateWith { klib ->
+            val descriptor = klibFactories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
+                klib,
+                configuration.languageVersionSettings,
+                storageManager,
+                if (klib.isJklibStdlib) null else builtIns,
+                lookupTracker = LookupTracker.DO_NOTHING,
+            )
+
+            if (klib.isJklibStdlib) {
+                builtIns.initialize(descriptor, true)
+            }
+
+            descriptor
+        }
+
+        return dependencyDescriptorsByKlib
     }
 
     private fun loadLibraries(klibFiles: List<String>, configuration: CompilerConfiguration): List<KotlinLibrary> {

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
@@ -300,7 +300,7 @@ object JKlibKlibSerializationPhase : PipelinePhase<JKlibFir2IrPipelineArtifact, 
             cleanFiles = emptyList(),
             dependencies = emptyList(),
             createModuleSerializer = { irDiagnosticReporter: IrDiagnosticReporter ->
-                JKlibModuleSerializer(IrSerializationSettings(configuration), irDiagnosticReporter)
+                JKlibModuleSerializer(IrSerializationSettings(configuration), irDiagnosticReporter, fir2IrResult.irBuiltIns)
             },
             metadataSerializer = Fir2KlibMetadataSerializer(
                 configuration,

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -6,34 +6,27 @@
 package org.jetbrains.kotlin.ir.backend.jklib
 
 
+import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideClassFilter
 import org.jetbrains.kotlin.backend.common.overrides.IrLinkerFakeOverrideProvider
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.backend.common.serialization.encodings.BinarySymbolData
-import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
-import org.jetbrains.kotlin.builtins.jvm.JvmBuiltInsSignatures
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
-import org.jetbrains.kotlin.ir.declarations.IrField
-import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
-import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
+import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
-import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFieldSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContextImpl
 import org.jetbrains.kotlin.ir.util.DeclarationStubGenerator
 import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.SymbolTable
-import org.jetbrains.kotlin.ir.util.getNameWithAssert
 import org.jetbrains.kotlin.library.KotlinAbiVersion
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.load.java.descriptors.JavaCallableMemberDescriptor
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageFragment
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
@@ -69,6 +62,16 @@ class JKlibIrLinker(
         typeSystem = IrTypeSystemContextImpl(builtIns),
         friendModules = emptyMap(),
         partialLinkageSupport = partialLinkageSupport,
+        // Do not construct fake overrides for Java classes. These classes are created with the
+        // stub generator and are already complete. Building fake overrides for them will throw
+        // an IllegalStateException as class declarations symbols are already bound
+        // Note: We use an origin check instead of `clazz.isFromJava()` because parents might
+        // not be initialized yet, and `isFromJava()` attempts to access the parent.
+        // TODO(KT-86172): Investigate the issue around property fake override and remove this filter.
+        platformSpecificClassFilter = object : FakeOverrideClassFilter {
+            override fun needToConstructFakeOverrides(clazz: IrClass): Boolean =
+                clazz.origin != IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB
+        },
     )
 
     override fun isBuiltInModule(moduleDescriptor: ModuleDescriptor): Boolean =
@@ -90,57 +93,6 @@ class JKlibIrLinker(
             strategyResolver,
             libraryAbiVersion,
         )
-    }
-
-    private val mappedClassSymbols = mutableMapOf<FqName, IrClassSymbol>()
-
-    private fun FqName.isMappedType(): Boolean {
-        return (JavaToKotlinClassMap.mapJavaToKotlin(this) ?: JavaToKotlinClassMap.mapKotlinToJava(toUnsafe())) != null
-    }
-
-    private val mappedClassFqnByFunctionName: Map<String, FqName> =
-        JvmBuiltInsSignatures.VISIBLE_METHOD_SIGNATURES.associate { signature ->
-            val dotIndex = signature.indexOf('.')
-            val parenthesisIndex = signature.indexOf('(')
-            val classInternalName = signature.substring(0, dotIndex)
-            val funName = signature.substring(dotIndex + 1, parenthesisIndex)
-            val javaFqName = FqName(classInternalName.replace('/', '.'))
-            funName to javaFqName
-        }
-
-    /**
-     * A hack to resolve methods from Java-to-Kotlin mapped types that are only defined on the Java
-     * type but visible from the Kotlin type (e.g., java.lang.Throwable.getSuppressed). Those methods
-     * are not available from the kotlin type during early linkage.
-     */
-    // TODO(KT-84877): remove this hack when we have a proper way to map Java APIs not present in klib
-    // to Kotlin.
-    private fun withKotlinBuiltinsHack(idSig: IdSignature, f: () -> IrSymbol?): IrSymbol? {
-        val symbol = f()
-        if (idSig is IdSignature.CommonSignature) {
-            val fqName = FqName("${idSig.packageFqName}.${idSig.declarationFqName}")
-            if (symbol != null) {
-                if (symbol is IrClassSymbol && fqName.isMappedType() && fqName !in mappedClassSymbols) {
-                    mappedClassSymbols[fqName] = symbol
-                }
-                return symbol
-            }
-
-            // This is needed to avoid unbound symbols for some kotlin.Int functions.
-            mappedClassSymbols[FqName("kotlin.Int")]?.owner?.declarations
-
-            val funName = idSig.nameSegments.last()
-            val mappedClassFqn = mappedClassFqnByFunctionName[funName] ?: return null
-            val mappedClassSymbol = mappedClassSymbols[mappedClassFqn] ?: return null
-
-            for (declaration in mappedClassSymbol.owner.declarations) {
-                if (declaration.getNameWithAssert().asString() == funName) {
-                    return declaration.symbol
-                }
-            }
-            return null
-        }
-        return symbol
     }
 
     private fun declareJavaFieldStub(symbol: IrFieldSymbol): IrField {
@@ -173,8 +125,8 @@ class JKlibIrLinker(
         override fun tryDeserializeIrSymbol(
             idSig: IdSignature,
             symbolKind: BinarySymbolData.SymbolKind,
-        ): IrSymbol? = withKotlinBuiltinsHack(idSig) {
-            val descriptor = resolveDescriptor(idSig) ?: return@withKotlinBuiltinsHack null
+        ): IrSymbol? {
+            val descriptor = resolveDescriptor(idSig) ?: return null
 
             val declaration = stubGenerator.run {
                 when (symbolKind) {
@@ -189,7 +141,7 @@ class JKlibIrLinker(
                 }
             }
 
-            return@withKotlinBuiltinsHack declaration.symbol
+            return declaration.symbol
         }
 
         override fun deserializedSymbolNotFound(idSig: IdSignature): Nothing = error("No descriptor found for $idSig")
@@ -230,17 +182,17 @@ class JKlibIrLinker(
         override fun tryDeserializeIrSymbol(
             idSig: IdSignature,
             symbolKind: BinarySymbolData.SymbolKind,
-        ): IrSymbol? = withKotlinBuiltinsHack(idSig) {
+        ): IrSymbol? {
             super.tryDeserializeIrSymbol(idSig, symbolKind)?.let {
-                return@withKotlinBuiltinsHack it
+                return it
             }
             deserializedSymbols[idSig]?.let {
-                return@withKotlinBuiltinsHack it
+                return it
             }
-            val descriptor = descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) ?: return@withKotlinBuiltinsHack null
+            val descriptor = descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) ?: return null
             val symbol = (stubGenerator.generateMemberStub(descriptor) as IrSymbolOwner).symbol
             deserializedSymbols[idSig] = symbol
-            return@withKotlinBuiltinsHack symbol
+            return symbol
         }
     }
 

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.backend.common.serialization.mangle.descriptor.Descr
 import org.jetbrains.kotlin.backend.common.serialization.mangle.ir.IrMangleComputer
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.descriptors.annotations.CompositeAnnotations
+import org.jetbrains.kotlin.descriptors.annotations.Annotations
 import org.jetbrains.kotlin.idea.MainFunctionDetector
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.backend.jvm.serialization.BaseJvmIrMangler
@@ -24,18 +24,13 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
-import org.jetbrains.kotlin.load.java.JSPECIFY_NULL_MARKED_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
 import org.jetbrains.kotlin.load.java.descriptors.JavaCallableMemberDescriptor
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
-import org.jetbrains.kotlin.load.java.typeEnhancement.ENHANCED_NULLABILITY_ANNOTATIONS
 import org.jetbrains.kotlin.load.java.typeEnhancement.hasEnhancedNullability
 import org.jetbrains.kotlin.load.kotlin.*
 import org.jetbrains.kotlin.resolve.DescriptorUtils
-import org.jetbrains.kotlin.types.AbstractTypeChecker
-import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.SimpleType
-import org.jetbrains.kotlin.types.TypeUtils
+import org.jetbrains.kotlin.types.*
 import org.jetbrains.kotlin.types.model.TypeArgumentMarker
 import org.jetbrains.kotlin.types.model.TypeParameterMarker
 import org.jetbrains.kotlin.types.model.TypeSystemContext
@@ -138,8 +133,39 @@ private fun StringBuilder.appendErasedType(type: KotlinType) {
     append(type.mapToJvmType())
 }
 
-private fun KotlinType.mapToJvmType(): JvmType =
-    mapType(this, JvmTypeFactoryImpl, TypeMappingMode.DEFAULT, TypeMappingConfigurationImpl, descriptorTypeWriter = null)
+private fun KotlinType.mapToJvmType(): JvmType {
+    var type = this
+    // Under JSpecify strict mode, Kotlinc loads non-nullable enhanced Java boxed types (like `@NonNull Integer` or `@NullMarked` Java
+    // `Boolean`) as non-nullable Kotlin primitive types (`kotlin.Int`, `kotlin.Boolean`) with a `@EnhancedNullability` annotation.
+    //
+    // However, K2's IR-backed descriptors used during Klib serialization lose this `@EnhancedNullability` annotation. Consequently, the
+    // `mapType()` call below maps them to primitive JVM types (`I`, `Z`) in Klib metadata signatures instead of boxed types.
+    //
+    // The Klib deserialization process using K1 does not have this issue and correctly maps the type leading to some signature mismatches
+    // during the IR linking.
+    //
+    // To resolve this discrepancy, we strip the `hasEnhancedNullability` annotations in J2CL's mangler. This matches K2's "stripped"
+    // behavior, forcing `mapType` to map them to primitive descriptors (`I`, `Z`) to ensure they link successfully. True Java primitives
+    // (which never had `@EnhancedNullability`) are unaffected.
+    // TODO(KT-86165): A proper long-term solution would be to avoid using IrBasedDescriptors at all in K2 and compute the JVM signature
+    //  from the IR.
+    if (
+        type is SimpleType &&
+        KotlinBuiltIns.isPrimitiveType(type) &&
+        !type.isNullable() &&
+        type.hasEnhancedNullability()
+    ) {
+        type = type.replaceAnnotations(Annotations.EMPTY)
+    }
+
+    return mapType(
+        type,
+        JvmTypeFactoryImpl,
+        TypeMappingMode.DEFAULT,
+        TypeMappingConfigurationImpl,
+        descriptorTypeWriter = null,
+    )
+}
 
 private fun hasVoidReturnType(descriptor: CallableDescriptor): Boolean {
     if (descriptor is ConstructorDescriptor) return true
@@ -168,31 +194,7 @@ private fun FunctionDescriptor.computeJvmDescriptor(withReturnType: Boolean = tr
         if (hasVoidReturnType(this@computeJvmDescriptor)) {
             append("V")
         } else {
-            val returnType = returnType!!
-            // Given a class annotated with `@NullMarked`, there will be such difference between K1 and K2 signatures for
-            // functions containing primitive types in arguments/return value:
-            // ```
-            // kotlinjavainterop/NullMarkedClass.getNonNullInteger()I // K2
-            // kotlinjavainterop/NullMarkedClass.getNonNullInteger()Ljava/lang/Integer; // K1
-            // ```
-            // The reason is that in K1 the return type is annotated with `@EnhancedNullability`, but in K2 it isn't.
-            // The workaround forces adding `@EnhancedNullability` for such types so that they are always boxed
-            // when computing function's signature.
-            if (returnType is SimpleType &&
-                KotlinBuiltIns.isPrimitiveType(returnType) &&
-                !returnType.hasEnhancedNullability() &&
-                containingDeclaration.annotations.hasAnnotation(JSPECIFY_NULL_MARKED_ANNOTATION_FQ_NAME)
-            ) {
-                val newType = returnType.replaceAnnotations(
-                    CompositeAnnotations(
-                        returnType.annotations,
-                        ENHANCED_NULLABILITY_ANNOTATIONS
-                    )
-                )
-                appendErasedType(newType)
-            } else {
-                appendErasedType(returnType)
-            }
+            appendErasedType(returnType!!)
         }
     }
 }

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibModuleSerializer.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibModuleSerializer.kt
@@ -6,18 +6,21 @@
 package org.jetbrains.kotlin.ir.backend.jklib
 
 import org.jetbrains.kotlin.backend.common.serialization.*
+import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 
-class JKlibGlobalDeclarationTable : GlobalDeclarationTable(JKlibIrMangler())
+class JKlibGlobalDeclarationTable(builtIns: IrBuiltIns) : GlobalDeclarationTable(JKlibIrMangler()) {
+    init {
+        loadKnownBuiltins(builtIns)
+    }
+}
 
 class JKlibModuleSerializer(
     settings: IrSerializationSettings,
     diagnosticReporter: IrDiagnosticReporter,
-) : IrModuleSerializer<IrFileSerializer>(
-    settings, diagnosticReporter
-) {
-    override val globalDeclarationTable = JKlibGlobalDeclarationTable()
-
+    builtIns: IrBuiltIns,
+) : IrModuleSerializer<IrFileSerializer>(settings, diagnosticReporter) {
+    override val globalDeclarationTable = JKlibGlobalDeclarationTable(builtIns)
 
     override fun createFileSerializer(settings: IrSerializationSettings): IrFileSerializer =
         IrFileSerializer(settings, DeclarationTable.Default(globalDeclarationTable))

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataFactories.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataFactories.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.library.metadata
 
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
-import org.jetbrains.kotlin.descriptors.deserialization.*
+import org.jetbrains.kotlin.descriptors.deserialization.AdditionalClassPartsProvider
 import org.jetbrains.kotlin.library.metadata.impl.KlibMetadataDeserializedPackageFragmentsFactoryImpl
 import org.jetbrains.kotlin.library.metadata.impl.KlibMetadataModuleDescriptorFactoryImpl
 import org.jetbrains.kotlin.library.metadata.impl.KlibModuleDescriptorFactoryImpl
@@ -19,8 +19,14 @@ import org.jetbrains.kotlin.storage.StorageManager
  */
 class KlibMetadataFactories(
     createBuiltIns: (StorageManager) -> KotlinBuiltIns,
-    val flexibleTypeDeserializer: FlexibleTypeDeserializer
+    val flexibleTypeDeserializer: FlexibleTypeDeserializer,
+    val additionalClassPartsProvider: AdditionalClassPartsProvider,
 ) {
+    constructor(
+        createBuiltIns: (StorageManager) -> KotlinBuiltIns,
+        flexibleTypeDeserializer: FlexibleTypeDeserializer,
+    ) : this(createBuiltIns, flexibleTypeDeserializer, AdditionalClassPartsProvider.None)
+
     /**
      * The default [KlibModuleDescriptorFactory] factory instance.
      */
@@ -53,7 +59,8 @@ class KlibMetadataFactories(
         KlibMetadataModuleDescriptorFactoryImpl(
             descriptorFactory,
             packageFragmentsFactory,
-            flexibleTypeDeserializer
+            flexibleTypeDeserializer,
+            additionalClassPartsProvider,
         )
 
     fun createDefaultKonanResolvedModuleDescriptorsFactory(

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.builtins.functions.functionInterfacePackageFragmentP
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.contracts.ContractDeserializerImpl
 import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.deserialization.AdditionalClassPartsProvider
 import org.jetbrains.kotlin.descriptors.impl.CompositePackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.EmptyPackageFragmentDescriptor
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
@@ -18,7 +19,9 @@ import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.components.metadata
 import org.jetbrains.kotlin.library.isAnyPlatformStdlib
 import org.jetbrains.kotlin.library.metadata.*
-import org.jetbrains.kotlin.name.*
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.NativeForwardDeclarationKind
+import org.jetbrains.kotlin.name.parentOrNull
 import org.jetbrains.kotlin.platform.jvm.isJvm
 import org.jetbrains.kotlin.resolve.CommonCompilerDeserializationConfiguration
 import org.jetbrains.kotlin.resolve.sam.SamConversionResolverImpl
@@ -29,7 +32,8 @@ import org.jetbrains.kotlin.utils.addToStdlib.runIf
 class KlibMetadataModuleDescriptorFactoryImpl(
     override val descriptorFactory: KlibModuleDescriptorFactory,
     override val packageFragmentsFactory: KlibMetadataDeserializedPackageFragmentsFactory,
-    override val flexibleTypeDeserializer: FlexibleTypeDeserializer
+    override val flexibleTypeDeserializer: FlexibleTypeDeserializer,
+    val additionalClassPartsProvider: AdditionalClassPartsProvider = AdditionalClassPartsProvider.None,
 ) : KlibMetadataModuleDescriptorFactory {
 
     override fun createDescriptorOptionalBuiltIns(
@@ -157,6 +161,7 @@ class KlibMetadataModuleDescriptorFactoryImpl(
             emptyList(),
             notFoundClasses,
             ContractDeserializerImpl(configuration, storageManager),
+            additionalClassPartsProvider = additionalClassPartsProvider,
             extensionRegistryLite = KlibMetadataSerializerProtocol.extensionRegistry,
             samConversionResolver = SamConversionResolverImpl(storageManager, samWithReceiverResolvers = emptyList()),
             enumEntriesDeserializationSupport = enumEntriesDeserializationSupport,


### PR DESCRIPTION
This commit fixes several issues in the JKlib compiler:
- JvmBuiltins were not correctly initialized
- Correctly wire up the JvmBuiltInsCustomizer in the KlibMetadataModuleDescriptorFactory. This customizer is needed to augments the Kotlin builtin types by adding Java methods into the scope of those types.
- Fix the discrepancy between K1 and K2 when computing JVM signature of function with enhanced nullability annotations.
- Bypassed fake override construction for Java stub declarations to prevent linkage conflicts.
 - Remove the withKotlinBuiltinsHack now everything is resolved correctly

 ^KT-84877 Fixed
 ^KT-85846 Fixed
 ^KT-85717 Fixed