### PR TITLE
[DO NOT MERGE] Cherry-pick "Do not generate groups in inline lambdas without `@Composable` calls" to 2.3.20

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ComposeCrossModuleTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ComposeCrossModuleTests.kt
@@ -1538,6 +1538,47 @@ class ComposeCrossModuleTests(useFir: Boolean) : AbstractCodegenTest(useFir) {
         )
     }
 
+    @Test
+    fun openFunctionDefaultParameterCrossModule() {
+        assumeTrue(useFir)
+        compile(
+            mapOf(
+                "Base" to mapOf(
+                    "base/Base.kt" to """
+                    package base
+
+                    import androidx.compose.runtime.Composable
+
+                    open class Test {
+                        @Composable open fun Test(int: Int = 0) = int
+                    }
+                    """
+                ),
+                "Main" to mapOf(
+                    "Main.kt" to """
+                    package main
+
+                    import base.Test
+                    import androidx.compose.runtime.Composable
+                    
+                    class TestImpl : Test() {
+                        @Composable override fun Test(int: Int) = -1
+                    }
+                    """
+                )
+            ),
+            validate = { bytecode ->
+                val matcher = Regex("public Test\\(ILandroidx/compose/runtime/Composer;I\\)I")
+                val methodCount = matcher.findAll(bytecode).count()
+                assertEquals(
+                    "Expected exactly 2 methods with that signature, one for definition, one for override",
+                    2,
+                    methodCount
+                )
+            }
+        )
+    }
+
     private fun compile(
         modules: Map<String, Map<String, String>>,
         dumpClasses: Boolean = false,

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
@@ -2707,4 +2707,35 @@ class ControlFlowTransformTests(useFir: Boolean) : AbstractControlFlowTransformT
             fun Modifier.clickable(f: () -> Unit): Modifier = this
         """
     )
+
+    // Regression test for b/509945632
+    @Test
+    fun testInlineSwitchNoComposables() = verifyGoldenComposeIrTransform(
+        source = """
+            import androidx.compose.runtime.*
+
+            @Composable fun Test(clicked: Boolean) {
+                thenIf(
+                    condition = clicked,
+                    ifTrue = {
+                        "true"
+                    },
+                    ifFalse = {
+                        "false"
+                    },
+                )
+            }
+        """,
+        extra = """
+            inline fun thenIf(
+                condition: Boolean,
+                ifFalse: () -> Unit,
+                ifTrue: () -> Unit,
+            ) = if (condition) {
+                ifTrue()
+            } else {
+                ifFalse()
+            }
+        """
+    )
 }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchNoComposables[useFir = false].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchNoComposables[useFir = false].txt
@@ -8,11 +8,10 @@ import androidx.compose.runtime.*
     thenIf(
         condition = clicked,
         ifTrue = {
-            val lambdaTrue = { }
+            "true"
         },
         ifFalse = {
-            remember { mutableStateOf(value = "Mock") }
-            val lambdaFalse = { }
+            "false"
         },
     )
 }
@@ -34,23 +33,10 @@ fun Test(clicked: Boolean, %composer: Composer?, %changed: Int) {
       traceEventStart(<>, %dirty, -1, <>)
     }
     thenIf(clicked, {
-      %composer.startReplaceGroup(<>)
-      sourceInformation(%composer, "C*<rememb...>:Test.kt")
-      sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-      val tmp0_group = %composer.cache(false) {
-        mutableStateOf(
-          value = "Mock"
-        )
-      }
-      sourceInformationMarkerEnd(%composer)
-      tmp0_group
-      val lambdaFalse = {
-      }
-      %composer.endReplaceGroup()
+      "false"
     }
     ) {
-      val lambdaTrue = {
-      }
+      "true"
     }
     if (isTraceInProgress()) {
       traceEventEnd()

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchNoComposables[useFir = true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchNoComposables[useFir = true].txt
@@ -8,11 +8,10 @@ import androidx.compose.runtime.*
     thenIf(
         condition = clicked,
         ifTrue = {
-            val lambdaTrue = { }
+            "true"
         },
         ifFalse = {
-            remember { mutableStateOf(value = "Mock") }
-            val lambdaFalse = { }
+            "false"
         },
     )
 }
@@ -24,7 +23,7 @@ import androidx.compose.runtime.*
 @Composable
 fun Test(clicked: Boolean, %composer: Composer?, %changed: Int) {
   %composer = %composer.startRestartGroup(<>)
-  sourceInformation(%composer, "C(Test):Test.kt")
+  sourceInformation(%composer, "C(Test)N(clicked):Test.kt")
   val %dirty = %changed
   if (%changed and 0b0110 == 0) {
     %dirty = %dirty or if (%composer.changed(clicked)) 0b0100 else 0b0010
@@ -34,23 +33,10 @@ fun Test(clicked: Boolean, %composer: Composer?, %changed: Int) {
       traceEventStart(<>, %dirty, -1, <>)
     }
     thenIf(clicked, {
-      %composer.startReplaceGroup(<>)
-      sourceInformation(%composer, "C*<rememb...>:Test.kt")
-      sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-      val tmp0_group = %composer.cache(false) {
-        mutableStateOf(
-          value = "Mock"
-        )
-      }
-      sourceInformationMarkerEnd(%composer)
-      tmp0_group
-      val lambdaFalse = {
-      }
-      %composer.endReplaceGroup()
+      "false"
     }
     ) {
-      val lambdaTrue = {
-      }
+      "true"
     }
     if (isTraceInProgress()) {
       traceEventEnd()

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
@@ -468,6 +468,22 @@ class CompositionTests {
         clicked = !clicked
         advance()
     }
+
+    // Regression test for b/509945632
+    @Test
+    fun testInlineFunctionWith2Lambdas() = compositionTest {
+        var elements by mutableStateOf(emptyList<String>())
+        var counter = 0
+        compose {
+            // if lambdas introduce a group, `ReceiveValueGroup` is removed after update
+            elements.associateBy({ it }, { it.length })
+            ReceiveValueGroup(counter)
+        }
+
+        elements = List(100) { "$it" }
+        counter += 10
+        advance()
+    }
 }
 
 @Composable
@@ -479,6 +495,12 @@ fun getCondition() = remember { false }
 @NonRestartableComposable
 @Composable
 fun ReceiveValue(value: Int) {
+    val string = remember { "$value" }
+    assertEquals(1, string.length)
+}
+
+@Composable
+fun ReceiveValueGroup(value: Int) {
     val string = remember { "$value" }
     assertEquals(1, string.length)
 }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -1564,11 +1564,15 @@ abstract class AbstractComposeLowering(
     }
 
     protected var IrDeclaration.composeMetadata: ComposeMetadata?
-        get() = context.metadataDeclarationRegistrar.getCustomMetadataExtension(this, COMPOSE_PLUGIN_ID)
-            ?.let { ComposeMetadata(it) }
+        get() {
+            val attributeOwner = attributeOwnerId as? IrDeclaration ?: return null
+            return context.metadataDeclarationRegistrar.getCustomMetadataExtension(attributeOwner, COMPOSE_PLUGIN_ID)
+                ?.let { ComposeMetadata(it) }
+        }
         set(value) {
-            if (value != null && this.hasFirDeclaration()) {
-                context.metadataDeclarationRegistrar.addCustomMetadataExtension(this, COMPOSE_PLUGIN_ID, value.data)
+            val attributeOwner = attributeOwnerId as? IrDeclaration ?: return
+            if (value != null && attributeOwner.hasFirDeclaration()) {
+                context.metadataDeclarationRegistrar.addCustomMetadataExtension(attributeOwner, COMPOSE_PLUGIN_ID, value.data)
             }
         }
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -1286,19 +1286,24 @@ class ComposableFunctionBodyTransformer(
     private fun visitInlinedLambdaInComposableScope(declaration: IrFunction): IrStatement {
         val scope = currentFunctionScope
         val parentScope = scope.parent
-        val outerGroupRequired = parentScope is Scope.CaptureScope && parentScope.forceInlinedLambdaGroup
+        val forceInlineLambdaGroup = parentScope is Scope.CaptureScope && parentScope.forceInlinedLambdaGroup
 
-        if (!outerGroupRequired) {
-            val result = super.visitFunction(declaration)
+        if (!forceInlineLambdaGroup) {
+            val transformed = super.visitFunction(declaration)
             if (scope.hasComposableCalls) {
                 encounteredCapturedComposableCall()
             }
-            return result
+            return transformed
         }
 
         val originalBody = declaration.body ?: return super.visitFunction(declaration)
         val (body, returnVar) = originalBody.asBodyAndResultVar()
         body.transformChildrenVoid()
+
+        // Avoid transforming functions that are not referencing anything composable, as they cannot use slots.
+        if (!scope.hasComposableCalls) {
+            return super.visitFunction(declaration)
+        }
 
         scope.realizeGroup {
             irEndReplaceGroup(scope = scope, startOffset = body.endOffset, endOffset = body.endOffset)


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/commit/639c9b39ef3543e46732a6aa66822916f6663555 introduced a regression that causes every inline lambda to generate a group in cases when function has two or more inline parameters. The groups are only required for lambdas with the `@Composable` calls inside.

Test: Compiler tests
Fixes: 509945632