### PR TITLE
[NI] Add a native image distribution of Kotlin compiler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -874,6 +874,10 @@ tasks {
         )
     }
 
+    testLifecycleTask("nativeImageCompilerTest") {
+        dependsOn(":kotlin-compiler-native-image:nativeImageBoxTest")
+    }
+
     testLifecycleTask("jsCompilerTest") {
         dependsOn(":js:js.tests:jsTest")
     }

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
@@ -88,6 +88,7 @@ import org.jetbrains.kotlin.resolve.jvm.modules.JavaModuleResolver
 import org.jetbrains.kotlin.resolve.lazy.declarations.CliDeclarationProviderFactoryService
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactoryService
 import org.jetbrains.kotlin.serialization.DescriptorSerializerPlugin
+import org.jetbrains.kotlin.utils.isGraalNativeImageRuntime
 import java.io.File
 
 class KotlinCoreEnvironment private constructor(
@@ -172,8 +173,11 @@ class KotlinCoreEnvironment private constructor(
 
         fun registerExtensionsFromPlugins(configuration: CompilerConfiguration) {
             if (!extensionRegistered) {
-                registerPluginExtensionPoints(project)
-                registerExtensionsFromPlugins(project, configuration)
+                if (!isGraalNativeImageRuntime) {
+                    // native image currently does not support dynamic class loading
+                    registerPluginExtensionPoints(project)
+                    registerExtensionsFromPlugins(project, configuration)
+                }
                 extensionRegistered = true
             }
         }

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
@@ -195,6 +195,11 @@ public class ForTestCompileRuntime {
     }
 
     @NotNull
+    public static File kotlinNativeImageDistForTests() {
+        return getFileFromProperty(KOTLIN_NATIVE_IMAGE_DIST_PATH);
+    }
+
+    @NotNull
     public static synchronized ClassLoader runtimeAndReflectJarClassLoader() {
         ClassLoader loader = reflectJarClassLoader.get();
         if (loader == null) {

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
@@ -24,6 +24,7 @@ object TestCompilePaths {
     const val KOTLIN_SCRIPTING_PLUGIN_CLASSPATH = "kotlin.scriptingPlugin.classpath"
     const val KOTLIN_TEST_SCRIPT_DEFINITION_CLASSPATH = "kotlin.script.test.script.definition.classpath"
     const val KOTLIN_DIST_PATH = "kotlin.dist.path"
+    const val KOTLIN_NATIVE_IMAGE_DIST_PATH = "kotlin.native-image.dist.path"
     const val KOTLIN_MOCKJDK_RUNTIME_PATH = "kotlin.mockJDK.runtime.path"
     const val KOTLIN_MOCKJDKMODIFIED_RUNTIME_PATH = "kotlin.mockJDKModified.runtime.path"
     const val KOTLIN_MOCKJDK_ANNOTATIONS_PATH = "kotlin.mockJDK.annotations.path"

--- a/compiler/util/src/org/jetbrains/kotlin/utils/graalvm.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/graalvm.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.utils
+
+val isGraalNativeImageRuntime: Boolean by lazy {
+    System.getProperty("org.graalvm.nativeimage.runtime")?.toBooleanStrictOrNull() == true
+}

--- a/prepare/compiler-native-image/README.md
+++ b/prepare/compiler-native-image/README.md
@@ -1,0 +1,114 @@
+# Kotlin Compiler Embeddable Native Image distribution
+
+A GraalVM-compiled native image of `kotlin-compiler-embeddable` that runs as a
+standalone executable. Behaves like the regular `kotlinc` but with some limitations &mdash;
+mainly, no support for plugins. Produces a native image distribution which is similar
+in its structure to the standard `kotlinc` distribution.
+
+## Distribution layout
+
+The distribution is produced in [prepare/compiler-native-image/build/dist/kotlinc-native-image](build/dist/kotlinc-native-image) directory and
+has the following structure:
+
+* `bin/kotlinc-native-image[.exe]` &mdash; native binary;
+* `bin/kotlinc-native-image.[sh|bat]` &mdash; launcher wrappers;
+* `lib/` &mdash; runtime classpath jars;
+* `license/` &mdash; license information.
+
+## Building
+
+Produce a native image binary:
+```
+./gradlew :kotlin-compiler-native-image:kotlincNativeImage
+```
+
+The task requires a GraalVM JDK 25 toolchain, which is automatically resolved via Gradle.
+
+Produce a native image distribution:
+```
+./gradlew :kotlin-compiler-native-image:kotlincNativeImageDist
+```
+
+
+## Running
+
+Similar to JVM `kotlinc`, the native image binary requires some configuration. To simplify
+the user experience, the distribution also provides `kotlinc-native-image.[sh|bat]` wrapper scripts
+that do all the necessary configuration of the binary. Namely, they configure:
+
+* `-Djava.home` &mdash; resolved to the `JAVA_HOME` environment variable;
+* `-Dkotlin.home` &mdash; resolved to the location of the distribution root.
+
+These wrapper scripts may be used as a drop-in replacement for the JVM `kotlinc`:
+
+```bash
+dist/kotlinc-native-image/bin/kotlinc-native-image.sh path/to/Foo.kt -d out/
+```
+
+## Tests
+
+Run the test suite with:
+```
+./gradlew :kotlin-compiler-native-image:nativeImageBoxTest
+```
+
+The test suite mirrors the compiler's JVM box-codegen tests: it is
+generated from the same test data under [compiler/testData/codegen/box](../../compiler/testData/codegen/box)
+and behaves similarly to the JVM tests. The goal is to ensure that the behavior of the native image
+compiler is the same as its JVM counterpart.
+
+The current setup is quite ad-hoc:
+
+* tests are excluded from the default `compilerTest` aggregate and run only via
+  the dedicated `nativeImageBoxTest` task; the main goal is to not intervene with
+  pre-existing workflows while still ensuring that the native image works correctly;
+* test setup manually performs the source code preprocessing and directives handling;
+* `JVM_IR` is treated as the target backend, so a test is skipped if it contains 
+  `// IGNORE_BACKEND: JVM_IR` directive (or its equivalent);
+* multifile tests are not supported;
+* tests that use helper functions (`helpers.*`) are skipped.
+
+
+## Reachability metadata
+
+GraalVM reachability metadata is stored in [prepare/compiler-native-image/resources/META-INF/native-image](resources/META-INF/native-image).
+
+Initial metadata was collected by running the Kotlin Compiler Embeddable JAR with the [GraalVM Tracing Agent](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/)
+on the same set of compiler box tests [compiler/testData/codegen/box](../../compiler/testData/codegen/box).
+
+Metadata can be updated manually when necessary. You can use this script template:
+
+```bash
+#!/bin/bash
+
+GRAAL_HOME=$JAVA_HOME
+UPDATE_REACHABILITY_METADATA=false
+NATIVE_IMAGE_BIN=$GRAAL_HOME/bin/native-image
+
+echo '--- Building kotlin compiler dist ---'
+./gradlew -q :dist
+
+echo '--- Building kotlin compiler embeddable ---'
+./gradlew -q :kotlin-compiler-embeddable:embeddable
+
+EMBEDDABLE_JAR=$(find prepare/compiler-embeddable -name 'kotlin-compiler-embeddable-*.jar')
+STDLIB_JAR='dist/kotlinc/lib/kotlin-stdlib.jar'
+REFLECT_JAR='dist/kotlinc/lib/kotlin-reflect.jar'
+COROUTINES_JAR='dist/kotlinc/lib/kotlin-coroutines-core-jvm.jar'
+ANNOTATIONS_JAR=$(find dist/kotlinc/lib/ -name 'annotations-*.jar')
+
+CLASSPATH=$EMBEDDABLE_JAR:$STDLIB_JAR:$REFLECT_JAR:$COROUTINES_JAR:$ANNOTATIONS_JAR
+
+$GRAAL_HOME/bin/java \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-opens java.base/java.io=ALL-UNNAMED \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens java.desktop/javax.swing=ALL-UNNAMED \
+  -cp $CLASSPATH \
+  -Dkotlin.home=dist/kotlinc \
+  -Djava.home=$GRAAL_HOME \
+  -agentlib:native-image-agent=config-merge-dir=prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable \
+  org.jetbrains.kotlin.cli.jvm.K2JVMCompiler \
+  $@
+```

--- a/prepare/compiler-native-image/bin/kotlinc-native-image.bat
+++ b/prepare/compiler-native-image/bin/kotlinc-native-image.bat
@@ -1,0 +1,15 @@
+@echo off
+
+setlocal
+set _BIN_DIR=%~dp0
+set _KOTLIN_HOME=%_BIN_DIR%..
+
+if "%JAVA_HOME%"=="" (
+  echo error: JAVA_HOME is not set; kotlinc-native-image requires JAVA_HOME environment variable 1>&2
+  exit /b 1
+)
+
+"%_BIN_DIR%kotlinc-native-image.exe" ^
+  "-Djava.home=%JAVA_HOME%" ^
+  "-Dkotlin.home=%_KOTLIN_HOME%" ^
+  %*

--- a/prepare/compiler-native-image/bin/kotlinc-native-image.sh
+++ b/prepare/compiler-native-image/bin/kotlinc-native-image.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Based on scalac from the Scala distribution
+# Copyright 2002-2011, LAMP/EPFL
+# Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+# Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+
+KOTLINC_BINARY_NAME=kotlinc-native-image
+
+# Based on findScalaHome() from scalac script
+findKotlinHome() {
+    local source="${BASH_SOURCE[0]}"
+    while [ -h "$source" ] ; do
+        local linked="$(readlink "$source")"
+        local dir="$(cd -P $(dirname "$source") && cd -P $(dirname "$linked") && pwd)"
+        source="$dir/$(basename "$linked")"
+    done
+    (cd -P "$(dirname "$source")/.." && pwd)
+}
+
+KOTLINC_HOME_DIR="$(findKotlinHome)"
+KOTLINC_BINARY_DIR="${KOTLINC_HOME_DIR}/bin"
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "error: JAVA_HOME is not set; ${KOTLINC_BINARY_NAME} requires JAVA_HOME environment variable" >&2
+  exit 1
+fi
+
+exec "${KOTLINC_BINARY_DIR}/${KOTLINC_BINARY_NAME}" \
+  -Djava.home="${JAVA_HOME}" \
+  -Dkotlin.home="${KOTLINC_HOME_DIR}" \
+  "$@"

--- a/prepare/compiler-native-image/build.gradle.kts
+++ b/prepare/compiler-native-image/build.gradle.kts
@@ -1,0 +1,140 @@
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.kotlin.dsl.register
+import java.util.regex.Pattern.quote
+import kotlin.io.path.exists
+
+description = "Kotlin Compiler (Native Image)"
+
+plugins {
+    kotlin("jvm")
+    id("java-test-fixtures")
+    id("project-tests-convention")
+    id("test-inputs-check")
+}
+
+val nativeImageClasspath by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    nativeImageClasspath(project(":kotlin-compiler-embeddable", configuration = "runtimeElements"))
+
+    testFixturesApi(libs.junit.jupiter.api)
+    testFixturesApi(testFixtures(project(":compiler:test-infrastructure")))
+    testFixturesApi(testFixtures(project(":compiler:tests-common-new")))
+    testFixturesApi(testFixtures(project(":generators:test-generator")))
+
+    testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+sourceSets {
+    "main" { none() }
+    "test" { projectDefault() }
+    "testFixtures" { projectDefault() }
+}
+
+projectTests {
+    testData(project(":compiler").isolated, "testData/codegen")
+
+    testGenerator(
+        "org.jetbrains.kotlin.compiler.nativeimage.GenerateNativeImageTestsKt",
+        generateTestsInBuildDirectory = true,
+    )
+
+    testTask(
+        taskName = "nativeImageBoxTest",
+        jUnitMode = JUnitMode.JUnit5,
+        skipInLocalBuild = false,
+    ) {
+        description = "Compares native-image kotlinc against default kotlinc on " +
+                "compiler/testData/codegen/box."
+        addClasspathProperty(
+            kotlincNativeImageDist.map { layout.files(it.destinationDir) },
+            "kotlin.native-image.dist.path"
+        )
+    }
+
+    withJvmStdlibAndReflect()
+    withTestJar()
+    withMockJdkRuntime()
+}
+
+val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
+    description = "Build a native image of the kotlin-compiler-embeddable"
+
+    val resources = layout.projectDirectory.dir("resources")
+    val classpathFiles = files(nativeImageClasspath, resources)
+    inputs.files(nativeImageClasspath, resources)
+        .withNormalizer(ClasspathNormalizer::class)
+        .withPropertyName("nativeImageClasspath")
+
+    val isWindows = OperatingSystem.current().isWindows
+    val mainClass = "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler"
+    val executableExtension = if (isWindows) ".exe" else ""
+    val outputFile = layout.buildDirectory.file("bin/kotlinc-native-image$executableExtension")
+    outputs.file(outputFile)
+
+    val javaLauncher = javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(JdkMajorVersion.JDK_25_0.targetName))
+        vendor.set(JvmVendorSpec.GRAAL_VM)
+    }
+
+    doFirst {
+        val javaHome = javaLauncher.get().executablePath.asFile.toPath().parent.parent
+
+        val nativeImageName = if (isWindows) "native-image.cmd" else "native-image"
+        val nativeImageBin = javaHome.resolve("lib/svm/bin/$nativeImageName")
+        if (!nativeImageBin.exists()) {
+            throw GradleException("native-image not found at ${nativeImageBin.toAbsolutePath()} (JAVA_HOME=${javaHome.toAbsolutePath()})")
+        }
+        val fullClasspath = classpathFiles.joinToString(File.pathSeparator) { it.absolutePath }
+        commandLine(
+            nativeImageBin,
+            "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+            "--add-opens", "java.base/java.io=ALL-UNNAMED",
+            "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+            "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-opens", "java.desktop/javax.swing=ALL-UNNAMED",
+            "-H:+AddAllCharsets",
+            "-H:+UnlockExperimentalVMOptions",
+            "-H:+AllowJRTFileSystem",
+            "-cp", fullClasspath,
+            "-o", outputFile.get().asFile.absolutePath,
+            mainClass,
+        )
+    }
+}
+
+val kotlincNativeImageDist = tasks.register<Copy>("kotlincNativeImageDist") {
+    description = "Build the kotlin-compiler-embeddable native distribution"
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    rename(quote("-${version}"), "")
+    rename(quote("-${bootstrapKotlinVersion}"), "")
+    destinationDir = layout.buildDirectory.dir("dist/kotlinc-native-image").get().asFile
+    val wrapperScriptFiles = files("bin/kotlinc-native-image.sh", "bin/kotlinc-native-image.bat")
+    into("bin") {
+        from(kotlincNativeImageTask)
+        from(wrapperScriptFiles) {
+            filePermissions {
+                unix("rwxr-xr-x")
+            }
+        }
+    }
+    val licenseFiles = files("$rootDir/license")
+    into("license") {
+        from(licenseFiles)
+    }
+    val librariesStripVersionFiles = files(nativeImageClasspath)
+    into("lib") {
+        from(librariesStripVersionFiles) {
+            rename {
+                it.replace(Regex("-\\d.*\\.jar\$"), ".jar")
+            }
+        }
+        filePermissions {
+            unix("rw-r--r--")
+        }
+    }
+}

--- a/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
+++ b/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
@@ -1,0 +1,1047 @@
+{
+  "reflection": [
+    {
+      "type": "gnu.trove.TObjectHashingStrategy"
+    },
+    {
+      "type": "java.io.Serializable"
+    },
+    {
+      "type": "java.lang.Boolean"
+    },
+    {
+      "type": "java.lang.Byte"
+    },
+    {
+      "type": "java.lang.CharSequence"
+    },
+    {
+      "type": "java.lang.Character"
+    },
+    {
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "getRecordComponents",
+          "parameterTypes": []
+        },
+        {
+          "name": "isSealed",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.ClassValue"
+    },
+    {
+      "type": "java.lang.Cloneable"
+    },
+    {
+      "type": "java.lang.Comparable"
+    },
+    {
+      "type": "java.lang.Double"
+    },
+    {
+      "type": "java.lang.Enum"
+    },
+    {
+      "type": "java.lang.Float"
+    },
+    {
+      "type": "java.lang.Integer"
+    },
+    {
+      "type": "java.lang.Iterable"
+    },
+    {
+      "type": "java.lang.Long"
+    },
+    {
+      "type": "java.lang.Number"
+    },
+    {
+      "type": "java.lang.Object"
+    },
+    {
+      "type": "java.lang.Runtime",
+      "methods": [
+        {
+          "name": "version",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Runtime$Version",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "major",
+          "parameterTypes": []
+        },
+        {
+          "name": "minor",
+          "parameterTypes": []
+        },
+        {
+          "name": "pre",
+          "parameterTypes": []
+        },
+        {
+          "name": "security",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Short"
+    },
+    {
+      "type": "java.lang.String"
+    },
+    {
+      "type": "java.lang.Throwable"
+    },
+    {
+      "type": "java.lang.Void"
+    },
+    {
+      "type": "java.lang.annotation.Annotation"
+    },
+    {
+      "type": "java.util.Collection"
+    },
+    {
+      "type": "java.util.Iterator"
+    },
+    {
+      "type": "java.util.List"
+    },
+    {
+      "type": "java.util.ListIterator"
+    },
+    {
+      "type": "java.util.Map"
+    },
+    {
+      "type": "java.util.Map.Entry"
+    },
+    {
+      "type": "java.util.Optional",
+      "methods": [
+        {
+          "name": "isPresent",
+          "parameterTypes": []
+        },
+        {
+          "name": "orElse",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.util.Set"
+    },
+    {
+      "type": "jdk.internal.jrtfs.JrtFileSystemProvider"
+    },
+    {
+      "type": "kotlin.Any"
+    },
+    {
+      "type": "kotlin.Array"
+    },
+    {
+      "type": "kotlin.Metadata",
+      "methods": [
+        {
+          "name": "bv",
+          "parameterTypes": []
+        },
+        {
+          "name": "d1",
+          "parameterTypes": []
+        },
+        {
+          "name": "d2",
+          "parameterTypes": []
+        },
+        {
+          "name": "k",
+          "parameterTypes": []
+        },
+        {
+          "name": "mv",
+          "parameterTypes": []
+        },
+        {
+          "name": "pn",
+          "parameterTypes": []
+        },
+        {
+          "name": "xi",
+          "parameterTypes": []
+        },
+        {
+          "name": "xs",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "kotlin.SafePublicationLazyImpl"
+    },
+    {
+      "type": "kotlin.String"
+    },
+    {
+      "type": "kotlin.jvm.internal.BooleanCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.ByteCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.CharCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.DefaultConstructorMarker"
+    },
+    {
+      "type": "kotlin.jvm.internal.DoubleCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.EnumCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.FloatCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.IntCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.LongCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.ShortCompanionObject"
+    },
+    {
+      "type": "kotlin.jvm.internal.StringCompanionObject"
+    },
+    {
+      "type": "kotlin.reflect.KCallable",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "kotlin.reflect.jvm.internal.ReflectionFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition"
+    },
+    {
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition"
+    },
+    {
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition"
+    },
+    {
+      "type": "kotlin.reflect.jvm.internal.impl.resolve.scopes.DescriptorKindFilter",
+      "fields": [
+        {
+          "name": "ALL"
+        },
+        {
+          "name": "CALLABLES"
+        },
+        {
+          "name": "CLASSIFIERS"
+        },
+        {
+          "name": "Companion"
+        },
+        {
+          "name": "FUNCTIONS"
+        },
+        {
+          "name": "NON_SINGLETON_CLASSIFIERS"
+        },
+        {
+          "name": "PACKAGES"
+        },
+        {
+          "name": "SINGLETON_CLASSIFIERS"
+        },
+        {
+          "name": "TYPE_ALIASES"
+        },
+        {
+          "name": "VALUES"
+        },
+        {
+          "name": "VARIABLES"
+        }
+      ]
+    },
+    {
+      "type": "kotlinx.coroutines.CancellableContinuationImpl"
+    },
+    {
+      "type": "kotlinx.coroutines.CompletedExceptionally"
+    },
+    {
+      "type": "kotlinx.coroutines.EventLoopImplBase"
+    },
+    {
+      "type": "kotlinx.coroutines.JobSupport"
+    },
+    {
+      "type": "kotlinx.coroutines.JobSupport$Finishing"
+    },
+    {
+      "type": "kotlinx.coroutines.channels.BufferedChannel"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.AtomicOp"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.ConcurrentLinkedListNode"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.DispatchedContinuation"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.LimitedDispatcher"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.LockFreeLinkedListNode"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.LockFreeTaskQueue"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.LockFreeTaskQueueCore"
+    },
+    {
+      "type": "kotlinx.coroutines.internal.Segment"
+    },
+    {
+      "type": "kotlinx.coroutines.scheduling.CoroutineScheduler"
+    },
+    {
+      "type": "org.jetbrains.kotlin.backend.jvm.extensions.ClassBuilderExtensionAdapter",
+      "methods": [
+        {
+          "name": "getExtensions",
+          "parameterTypes": [
+            "org.jetbrains.kotlin.config.CompilerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.cli.common.ModuleVisibilityHelperImpl"
+    },
+    {
+      "type": "org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.jetbrains.kotlin.cli.common.arguments.CommonToolArguments",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.jetbrains.kotlin.cli.common.arguments.Freezable",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.jetbrains.kotlin.codegen.serialization.JvmSerializationBindings",
+      "fields": [
+        {
+          "name": "DELEGATE_METHOD_FOR_PROPERTY"
+        },
+        {
+          "name": "FIELD_FOR_PROPERTY"
+        },
+        {
+          "name": "METHOD_FOR_FUNCTION"
+        },
+        {
+          "name": "SYNTHETIC_METHOD_FOR_PROPERTY"
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.codeInsight.ContainerProvider"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.codeInsight.multiverse.CodeInsightContextProvider"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.codeInsight.multiverse.MultiverseEnabler"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.lang.jvm.facade.JvmElementProvider"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.openapi.application.ApplicationManager",
+      "fields": [
+        {
+          "name": "ourApplication"
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.openapi.extensions.impl.ExtensionPointImpl"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.openapi.fileTypes.BinaryFileTypeDecompilers",
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.openapi.util.SimpleModificationTracker"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.openapi.vfs.PersistentFSConstants",
+      "fields": [
+        {
+          "name": "ourMaxIntellisenseFileSize"
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.psi.PsiElementFinder"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.psi.compiled.ClassFileDecompilers",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.psi.compiled.ClassFileDecompilers$Decompiler"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.psi.impl.source.JavaFileElementType"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.util.KeyedLazyInstanceEP"
+    },
+    {
+      "type": "org.jetbrains.kotlin.com.intellij.util.QueryExecutor"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.CompilerConfigurationExtension"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.CompilerConfigurationExtension[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.PreprocessedVirtualFileFactoryExtension"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.PreprocessedVirtualFileFactoryExtension[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.load.java.ErasedOverridabilityCondition"
+    },
+    {
+      "type": "org.jetbrains.kotlin.load.java.FieldOverridabilityCondition"
+    },
+    {
+      "type": "org.jetbrains.kotlin.load.java.JavaIncompatibilityRulesOverridabilityCondition"
+    },
+    {
+      "type": "org.jetbrains.kotlin.load.java.structure.impl.source.JavaFixedElementSourceFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtAnnotation"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtAnnotationEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtAnnotationEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtAnnotationUseSiteTarget"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtAnnotationUseSiteTarget[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtAnnotation[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtBackingField"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtBackingField[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtCallExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtCallExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClass"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClassBody"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClassBody[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClassInitializer"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClassInitializer[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClassLiteralExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClassLiteralExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtClass[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtCollectionLiteralExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtCollectionLiteralExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtCompanionBlock"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtCompanionBlock[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtConstantExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtConstantExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtConstructorCalleeExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtConstructorCalleeExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContextReceiver"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContextReceiverList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContextReceiverList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContextReceiver[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContractEffect"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContractEffectList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContractEffectList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtContractEffect[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDeclarationModifierList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDeclarationModifierList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDotQualifiedExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDotQualifiedExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDynamicType"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDynamicType[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtEnumEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtEnumEntrySuperclassReferenceExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtEnumEntrySuperclassReferenceExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtEnumEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtFileAnnotationList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtFileAnnotationList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtFunctionType"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtFunctionTypeReceiver"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtFunctionTypeReceiver[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtFunctionType[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtImportAlias"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtImportAlias[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtImportDirective"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtImportDirective[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtImportList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtImportList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtInitializerList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtInitializerList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtIntersectionType"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtIntersectionType[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtLambdaArgument"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtLambdaArgument[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtNameReferenceExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtNameReferenceExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtNamedFunction"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtNamedFunction[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtNullableType"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtNullableType[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtObjectDeclaration"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtObjectDeclaration[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtPackageDirective"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtPackageDirective[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtParameter"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtParameterList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtParameterList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtParameter[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtPrimaryConstructor"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtPrimaryConstructor[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtProperty"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtPropertyAccessor"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtPropertyAccessor[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtProperty[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtScript"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtScriptInitializer"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtScriptInitializer[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtScript[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSecondaryConstructor"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSecondaryConstructor[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtStringInterpolationPrefix"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtStringInterpolationPrefix[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtStringTemplateExpression"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtStringTemplateExpression[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSuperTypeCallEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSuperTypeCallEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSuperTypeEntry"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSuperTypeEntry[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSuperTypeList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtSuperTypeList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeAlias"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeAlias[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeArgumentList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeArgumentList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeConstraint"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeConstraintList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeConstraintList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeConstraint[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeParameter"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeParameterList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeParameterList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeParameter[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeProjection"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeProjection[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeReference"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtTypeReference[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtUserType"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtUserType[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtValueArgument"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtValueArgumentList"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtValueArgumentList[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtValueArgumentName"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtValueArgumentName[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtValueArgument[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.impl.KotlinElementTypeProviderImpl",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.stubs.elements.KtFileElementType"
+    },
+    {
+      "type": "org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingCompilerConfigurationComponentRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingK2CompilerPluginRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInsLoaderImpl"
+    },
+    {
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jetbrains.kotlin.com.intellij.openapi.command.CommandListener"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileListener"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jetbrains.kotlin.com.intellij.psi.util.PsiModificationTracker$Listener"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/allow-configuring-from-environment"
+    },
+    {
+      "glob": "META-INF/compiler.version"
+    },
+    {
+      "glob": "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "glob": "META-INF/services/kotlin.reflect.jvm.internal.impl.resolve.ExternalOverridabilityCondition"
+    },
+    {
+      "glob": "META-INF/services/kotlin.reflect.jvm.internal.impl.util.ModuleVisibilityHelper"
+    },
+    {
+      "glob": "META-INF/services/org.jetbrains.kotlin.builtins.BuiltInsLoader"
+    },
+    {
+      "glob": "META-INF/services/org.jetbrains.kotlin.resolve.ExternalOverridabilityCondition"
+    },
+    {
+      "glob": "META-INF/services/org.jetbrains.kotlin.util.ModuleVisibilityHelper"
+    },
+    {
+      "glob": "kotlin/annotation/annotation.kotlin_builtins"
+    },
+    {
+      "glob": "kotlin/collections/collections.kotlin_builtins"
+    },
+    {
+      "glob": "kotlin/concurrent/atomics/atomics.kotlin_builtins"
+    },
+    {
+      "glob": "kotlin/coroutines/coroutines.kotlin_builtins"
+    },
+    {
+      "glob": "kotlin/internal/internal.kotlin_builtins"
+    },
+    {
+      "glob": "kotlin/kotlin.kotlin_builtins"
+    },
+    {
+      "glob": "kotlin/ranges/ranges.kotlin_builtins"
+    },
+    {
+      "glob": "kotlin/reflect/reflect.kotlin_builtins"
+    },
+    {
+      "glob": "org/jetbrains/kotlin/org/fusesource/jansi/internal/native/Mac/arm64/libjansi.jnilib"
+    },
+    {
+      "glob": "org/jetbrains/kotlin/org/fusesource/jansi/jansi.properties"
+    }
+  ]
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageBlackBoxCodegenTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageBlackBoxCodegenTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.jetbrains.kotlin.codeMetaInfo.clearTextFromDiagnosticMarkup
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.test.InTextDirectivesUtils
+import org.jetbrains.kotlin.test.TargetBackend
+import org.jetbrains.kotlin.test.directives.AdditionalFilesDirectives
+import org.jetbrains.kotlin.test.directives.AdditionalFilesDirectives.CHECK_STATE_MACHINE
+import org.jetbrains.kotlin.test.directives.AdditionalFilesDirectives.CHECK_TAIL_CALL_OPTIMIZATION
+import org.jetbrains.kotlin.test.directives.AdditionalFilesDirectives.CHECK_TYPE
+import org.jetbrains.kotlin.test.directives.AdditionalFilesDirectives.CHECK_TYPE_WITH_EXACT
+import org.jetbrains.kotlin.test.directives.AdditionalFilesDirectives.INFERENCE_HELPERS
+import org.jetbrains.kotlin.test.directives.AdditionalFilesDirectives.WITH_COROUTINES
+import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
+import org.jetbrains.kotlin.test.directives.ConfigurationDirectives
+import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
+import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives
+import org.jetbrains.kotlin.test.directives.model.ComposedDirectivesContainer
+import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
+import org.jetbrains.kotlin.test.directives.model.SimpleDirective
+import org.jetbrains.kotlin.test.directives.model.ValueDirective
+import org.jetbrains.kotlin.test.preprocessors.JvmInlineSourceTransformer
+import org.jetbrains.kotlin.test.services.JUnit5Assertions
+import org.jetbrains.kotlin.test.services.impl.RegisteredDirectivesParser
+import org.jetbrains.kotlin.test.util.KtTestUtil
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.lang.reflect.InvocationTargetException
+import java.net.URLClassLoader
+import java.util.concurrent.ConcurrentHashMap
+
+abstract class AbstractNativeImageBlackBoxCodegenTest {
+    @TempDir
+    lateinit var workingDir: File
+
+    private val nativeImageDist: File by lazy { ForTestCompileRuntime.kotlinNativeImageDistForTests() }
+
+    private val nativeImageExecutable: File by lazy {
+        val launcher = when {
+            System.getProperty("os.name").startsWith("windows", ignoreCase = true) -> "kotlinc-native-image.bat"
+            else -> "kotlinc-native-image.sh"
+        }
+        nativeImageDist.resolve("bin").resolve(launcher)
+    }
+
+    private val javaHome: String = System.getProperty("java.home")
+
+    private val compilationClasspath: List<File> by lazy {
+        listOf(
+            ForTestCompileRuntime.runtimeJarForTests(),
+            ForTestCompileRuntime.kotlinTestJarForTests(),
+        )
+    }
+
+    private val reflectClasspath: File by lazy { ForTestCompileRuntime.reflectJarForTests() }
+
+    private val mockJdkRtJar: File by lazy { KtTestUtil.findMockJdkRtJar() }
+
+    open fun runTest(filePath: String) {
+        val testFile = ForTestCompileRuntime.transformTestDataPath(filePath)
+        val source = testFile.readText()
+        val directives = parseDirectives(source)
+
+        val skipReason = shouldSkip(source, directives)
+        assumeTrue(skipReason == null) { "skipped: $skipReason" }
+
+        val withReflect = JvmEnvironmentConfigurationDirectives.WITH_REFLECT in directives
+        val withFullJdk = JvmEnvironmentConfigurationDirectives.FULL_JDK in directives
+
+        val boxFile = File(workingDir, "box.kt").apply { writeText(prepareSource(source)) }
+        val outDir = File(workingDir, "ni-out").apply { mkdirs() }
+
+        val (exitCode, compilerStdout) = runNativeImageCompiler(
+            arguments = buildCompilerArgs(boxFile, outDir, directives, withFullJdk),
+            classpath = buildClasspath(withReflect, withFullJdk),
+        )
+        assertEquals(0, exitCode, "native-image compilation failed:\n$compilerStdout")
+
+        val result = invokeBox(outDir, boxClassName(source), withReflect)
+        assertEquals("OK", result, "box() != 'OK'")
+    }
+
+    private fun runNativeImageCompiler(
+        arguments: List<String>,
+        classpath: List<File>,
+    ): Pair<Int, String> {
+        val cmd = listOf(
+            nativeImageExecutable.absolutePath,
+            "-Dkotlinc.test.allow.testonly.language.features=true",
+            "-cp", classpath.joinToString(File.pathSeparator),
+        ) + arguments
+        val builder = ProcessBuilder(cmd).directory(workingDir).redirectErrorStream(true)
+        builder.environment().putIfAbsent("JAVA_HOME", javaHome)
+        val proc = builder.start()
+        val out = proc.inputStream.reader().use { it.readText() }
+        return proc.waitFor() to out
+    }
+
+    private fun buildCompilerArgs(
+        boxFile: File,
+        outDir: File,
+        directives: RegisteredDirectives,
+        withFullJdk: Boolean,
+    ): List<String> = buildList {
+        directives[LanguageSettingsDirectives.LANGUAGE].forEach { add("-XXLanguage:$it") }
+        addAll(directives.valueDirectiveFlags())
+        directives[LanguageSettingsDirectives.OPT_IN].forEach { add("-opt-in=$it") }
+        if (!withFullJdk) add("-no-jdk")
+        for ((directive, path) in HELPER_FILES) {
+            if (directive in directives) {
+                add(materializeHelperFile(path).absolutePath)
+            }
+        }
+        add(boxFile.absolutePath)
+        add("-d")
+        add(outDir.absolutePath)
+    }
+
+    private fun buildClasspath(withReflect: Boolean, withFullJdk: Boolean): List<File> = buildList {
+        addAll(compilationClasspath)
+        if (withReflect) add(reflectClasspath)
+        if (!withFullJdk) add(mockJdkRtJar)
+    }
+
+    private fun RegisteredDirectives.valueDirectiveFlags(): List<String> = listOfNotNull(
+        renderValueFlag(LanguageSettingsDirectives.RETURN_VALUE_CHECKER_MODE, "-Xreturn-value-checker") { it.state },
+        renderValueFlag(JvmEnvironmentConfigurationDirectives.ASSERTIONS_MODE, "-Xassertions") { it.description },
+        renderValueFlag(JvmEnvironmentConfigurationDirectives.LAMBDAS, "-Xlambdas") { it.description },
+        renderValueFlag(JvmEnvironmentConfigurationDirectives.SAM_CONVERSIONS, "-Xsam-conversions") { it.description },
+    )
+
+    private inline fun <T : Any> RegisteredDirectives.renderValueFlag(
+        directive: ValueDirective<T>,
+        flagPrefix: String,
+        render: (T) -> String,
+    ): String? = this[directive].singleOrNull()?.let { "$flagPrefix=${render(it)}" }
+
+    private fun invokeBox(classDir: File, boxClass: String, withReflect: Boolean): String? {
+        URLClassLoader(arrayOf(classDir.toURI().toURL()), sharedRuntimeLoader(withReflect)).use { loader ->
+            val method = loader.loadClass(boxClass).getMethod("box")
+            val thread = Thread.currentThread()
+            val previous = thread.contextClassLoader
+            thread.contextClassLoader = loader
+            return try {
+                method.invoke(null) as? String
+            } catch (e: InvocationTargetException) {
+                throw e.cause ?: e
+            } finally {
+                thread.contextClassLoader = previous
+            }
+        }
+    }
+
+    private fun materializeHelperFile(relativePath: String): File {
+        val resource = this::class.java.classLoader.getResource(relativePath)
+            ?: error("Helper file resource not found: $relativePath")
+        return workingDir.resolve(relativePath).also {
+            it.parentFile.mkdirs()
+            it.writeText(resource.readText())
+        }
+    }
+
+    private fun sharedRuntimeLoader(withReflect: Boolean): URLClassLoader =
+        sharedRuntimeLoaders.computeIfAbsent(withReflect) {
+            val cp = compilationClasspath + if (withReflect) listOf(reflectClasspath) else emptyList()
+            URLClassLoader(
+                cp.map { it.toURI().toURL() }.toTypedArray(),
+                ClassLoader.getSystemClassLoader().parent,
+            )
+        }
+
+    companion object {
+        private val BACKEND = TargetBackend.JVM_IR
+
+        private val sharedRuntimeLoaders = ConcurrentHashMap<Boolean, URLClassLoader>()
+
+        private const val HELPERS_PATH = "diagnostics/helpers"
+
+        private val HELPER_FILES: Map<SimpleDirective, String> = mapOf(
+            CHECK_TYPE to "${HELPERS_PATH}/types/checkType.kt",
+            CHECK_TYPE_WITH_EXACT to "${HELPERS_PATH}/types/checkTypeWithExact.kt",
+            INFERENCE_HELPERS to "${HELPERS_PATH}/inference/inferenceUtils.kt",
+            WITH_COROUTINES to "${HELPERS_PATH}/coroutines/CoroutineHelpers.kt",
+            CHECK_STATE_MACHINE to "${HELPERS_PATH}/coroutines/StateMachineChecker.kt",
+            CHECK_TAIL_CALL_OPTIMIZATION to "${HELPERS_PATH}/coroutines/TailCallOptimizationChecker.kt",
+        )
+
+        private val DIRECTIVES_CONTAINER = ComposedDirectivesContainer(
+            LanguageSettingsDirectives,
+            ConfigurationDirectives,
+            CodegenTestDirectives,
+            JvmEnvironmentConfigurationDirectives,
+            AdditionalFilesDirectives,
+        )
+
+        private val MULTI_FILE_MARKER = Regex("""(?m)^// FILE:""")
+        private val HELPERS_IMPORT = Regex("""(?m)^import helpers\.""")
+
+        private fun prepareSource(source: String): String =
+            clearTextFromDiagnosticMarkup(JvmInlineSourceTransformer.computeModifier(BACKEND).invoke(source))
+
+        private fun parseDirectives(source: String): RegisteredDirectives {
+            val parser = RegisteredDirectivesParser(DIRECTIVES_CONTAINER, JUnit5Assertions)
+            for (line in source.lineSequence()) {
+                if (line.startsWith("//")) parser.parse(line)
+            }
+            return parser.build()
+        }
+
+        private fun shouldSkip(source: String, directives: RegisteredDirectives): String? = when {
+            MULTI_FILE_MARKER.containsMatchIn(source) -> "multi-file (// FILE:) tests are not supported"
+            HELPERS_IMPORT.containsMatchIn(source) -> "tests importing helpers.* are not supported"
+            "+MultiPlatformProjects" in directives[LanguageSettingsDirectives.LANGUAGE] -> "multiplatform projects are not supported"
+            isBackendIgnored(directives) -> "ignored on $BACKEND via directive"
+            else -> null
+        }
+
+        private fun isBackendIgnored(directives: RegisteredDirectives): Boolean {
+            fun ValueDirective<TargetBackend>.matchesIgnore() =
+                directives[this].any { TargetBackend.ANY == it || BACKEND.isTransitivelyCompatibleWith(it) }
+            if (CodegenTestDirectives.IGNORE_BACKEND.matchesIgnore()) return true
+            if (CodegenTestDirectives.IGNORE_BACKEND_K2.matchesIgnore()) return true
+            return !InTextDirectivesUtils.isCompatibleTarget(
+                BACKEND,
+                directives[ConfigurationDirectives.TARGET_BACKEND],
+                directives[ConfigurationDirectives.DONT_TARGET_EXACT_BACKEND],
+            )
+        }
+
+        private const val BOX_FILE_CLASS = "BoxKt"
+
+        private fun boxClassName(source: String): String {
+            val pkg = source.lineSequence()
+                .firstOrNull { it.trimStart().startsWith("package ") }
+                ?.substringAfter("package ")
+                ?.trim()
+            return if (pkg.isNullOrBlank()) BOX_FILE_CLASS else "$pkg.$BOX_FILE_CLASS"
+        }
+    }
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/GenerateNativeImageTests.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/GenerateNativeImageTests.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.jetbrains.kotlin.generators.dsl.junit5.generateTestGroupSuiteWithJUnit5
+
+fun main(args: Array<String>) {
+    System.setProperty("java.awt.headless", "true")
+
+    generateTestGroupSuiteWithJUnit5(args) {
+        testGroup(testsRoot = args[0], testDataRoot = "compiler/testData/codegen") {
+            testClass<AbstractNativeImageBlackBoxCodegenTest> {
+                model("box")
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -329,6 +329,7 @@ include(
     ":kotlin-compiler",
     ":kotlin-compiler-embeddable",
     ":kotlin-compiler-client-embeddable",
+    ":kotlin-compiler-native-image",
     ":kotlin-klib-abi-reader",
     ":kotlin-reflect",
     ":compiler:tests-java8",
@@ -748,6 +749,7 @@ project(":kotlin-compiler").projectDir = File("$rootDir/prepare/compiler")
 project(":kotlin-jklib-compiler").projectDir = File("$rootDir/prepare/jklib-compiler")
 project(":kotlin-compiler-embeddable").projectDir = File("$rootDir/prepare/compiler-embeddable")
 project(":kotlin-compiler-client-embeddable").projectDir = File("$rootDir/prepare/compiler-client-embeddable")
+project(":kotlin-compiler-native-image").projectDir = File("$rootDir/prepare/compiler-native-image")
 project(":kotlin-klib-abi-reader").projectDir = File("$rootDir/libraries/tools/klib-abi-reader")
 project(":kotlin-preloader").projectDir = File("$rootDir/compiler/preloader")
 project(":kotlin-build-common").projectDir = File("$rootDir/build-common")


### PR DESCRIPTION
New `kotlin-compiler-native-image` module provides a native distribution of the kotlin-compiler-embeddable via GraalVM's native image. NI distribution mirrors the default kotlinc distribution in its structure, however it is currently only experimental and does not support compiler plugins. The new module also adds box tests for the native image dist.

KT-82373