### PR TITLE
Always wrap inline lambdas with a composable group with a group

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ControlFlowTransformTests.kt
@@ -2738,4 +2738,37 @@ class ControlFlowTransformTests : AbstractControlFlowTransformTests() {
             }
         """
     )
+
+    // Regression test for b/509945632
+    @Test
+    fun testInlineSwitchReadOnly() = verifyGoldenComposeIrTransform(
+        source = """
+            import androidx.compose.runtime.*
+
+            val Local = staticCompositionLocalOf { null }
+
+            @Composable fun Test(clicked: Boolean) {
+                thenIf(
+                    condition = clicked,
+                    ifTrue = {
+                        Local.current
+                    },
+                    ifFalse = {
+                        Local.current
+                    },
+                )
+            }
+        """,
+        extra = """
+            inline fun thenIf(
+                condition: Boolean,
+                ifFalse: () -> Unit,
+                ifTrue: () -> Unit,
+            ) = if (condition) {
+                ifTrue()
+            } else {
+                ifFalse()
+            }
+        """
+    )
 }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchReadOnly.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchReadOnly.txt
@@ -1,0 +1,55 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.*
+
+val Local = staticCompositionLocalOf { null }
+
+@Composable fun Test(clicked: Boolean) {
+    thenIf(
+        condition = clicked,
+        ifTrue = {
+            Local.current
+        },
+        ifFalse = {
+            Local.current
+        },
+    )
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+val Local: ProvidableCompositionLocal<Nothing?> = staticCompositionLocalOf {
+  null
+}
+@Composable
+fun Test(clicked: Boolean, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(Test)N(clicked)*<curren...>,<curren...>,<curren...>,<curren...>:Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (%composer.changed(clicked)) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    thenIf(clicked, {
+      Local.<get-current>(%composer, 0b0110)
+    }
+    ) {
+      Local.<get-current>(%composer, 0b0110)
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Test(clicked, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchingEarlyReturn.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testInlineSwitchingEarlyReturn.txt
@@ -36,7 +36,7 @@ fun Test(clicked: Boolean, %composer: Composer?, %changed: Int) {
     if (isTraceInProgress()) {
       traceEventStart(<>, %dirty, -1, <>)
     }
-    Modifier.thenIf(clicked, {
+    val tmp0_group = Modifier.thenIf(clicked, {
       %composer.startReplaceGroup(<>)
       sourceInformation(%composer, "C*<rememb...>,<{>:Test.kt")
       sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
@@ -86,6 +86,7 @@ fun Test(clicked: Boolean, %composer: Composer?, %changed: Int) {
       %composer.endReplaceGroup()
       tmp0
     }
+    tmp0_group
     if (isTraceInProgress()) {
       traceEventEnd()
     }

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
@@ -496,6 +496,26 @@ class CompositionTests {
         counter += 10
         advance()
     }
+
+    // Regression test for b/509945632
+    @Test
+    fun testInlineFunctionWith2LambdasComposable() = compositionTest {
+        var elements by mutableStateOf(emptyList<String>())
+        var counter = 0
+        compose {
+            // if not wrapped with a group, `ReceiveValueGroup` is removed after update
+            elements.associateBy({
+                remember { it }
+            }, {
+                it.length
+            })
+            ReceiveValueGroup(counter)
+        }
+
+        elements = List(100) { "$it" }
+        counter += 10
+        advance()
+    }
 }
 
 @Composable

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -1301,7 +1301,7 @@ class ComposableFunctionBodyTransformer(
 
         if (!forceInlineLambdaGroup) {
             val transformed = super.visitFunction(declaration)
-            if (scope.hasComposableCalls) {
+            if (scope.hasComposableCallsWithGroups) {
                 encounteredCapturedComposableCall()
             }
             return transformed
@@ -1311,10 +1311,11 @@ class ComposableFunctionBodyTransformer(
         val (body, returnVar) = originalBody.asBodyAndResultVar()
         body.transformChildrenVoid()
 
-        // Avoid transforming functions that are not referencing anything composable, as they cannot use slots.
-        if (!scope.hasComposableCalls) {
+        // Avoid transforming functions that are not referencing anything composable, as they cannot use slots (read-only is fine).
+        if (!scope.hasComposableCallsWithGroups) {
             return super.visitFunction(declaration)
         }
+        encounteredCapturedComposableCall()
 
         scope.realizeGroup {
             irEndReplaceGroup(scope = scope, startOffset = body.endOffset, endOffset = body.endOffset)
@@ -3065,9 +3066,7 @@ class ComposableFunctionBodyTransformer(
                         expression.arguments[index] = transformed
                     }
                 }
-                return if (captureScope.hasCapturedComposableCall && !captureScope.forceInlinedLambdaGroup) {
-                    // the outer group around the call is only required when the inline function body is not
-                    // wrapped with a group.
+                return if (captureScope.hasCapturedComposableCall) {
                     captureScope.realizeAllDirectChildren()
                     expression.asCoalescableGroup(captureScope)
                 } else {


### PR DESCRIPTION
Variable amount of groups can potentially remove later content. We can also skip groups for read only composables, since they don't introduce slot access.

Test: Compiler tests
Bug: 509945632