### PR TITLE
[JKLIB] Allow private members of Java classes to propagate into the IR.

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
@@ -10,6 +10,9 @@ import org.jetbrains.kotlin.backend.common.linkage.partial.PartialLinkageDiagnos
 import org.jetbrains.kotlin.backend.common.serialization.IrSerializationSettings
 import org.jetbrains.kotlin.backend.common.serialization.serializeModuleIntoKlib
 import org.jetbrains.kotlin.backend.jvm.JvmBackendErrors
+import org.jetbrains.kotlin.backend.jvm.JvmIrSpecialAnnotationSymbolProvider
+import org.jetbrains.kotlin.backend.jvm.JvmIrTypeSystemContext
+import org.jetbrains.kotlin.builtins.DefaultBuiltIns
 import org.jetbrains.kotlin.cli.CliDiagnostics.CLASSPATH_RESOLUTION_ERROR
 import org.jetbrains.kotlin.cli.CliDiagnostics.COMPILER_ARGUMENTS_ERROR
 import org.jetbrains.kotlin.cli.common.*
@@ -18,7 +21,6 @@ import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoot
 import org.jetbrains.kotlin.cli.diagnosticFactoriesStorage
 import org.jetbrains.kotlin.cli.jklib.prepareJKlibSessions
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.convertToIrAndActualizeForJvm
 import org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.createProjectEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.*
 import org.jetbrains.kotlin.cli.jvm.configureJdkHomeFromSystemProperty
@@ -26,14 +28,20 @@ import org.jetbrains.kotlin.cli.pipeline.*
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.compiler.plugin.getCompilerExtensions
 import org.jetbrains.kotlin.config.*
+import org.jetbrains.kotlin.diagnostics.impl.BaseDiagnosticsCollector
 import org.jetbrains.kotlin.diagnostics.impl.deduplicating
 import org.jetbrains.kotlin.fir.DependencyListForCliModule
+import org.jetbrains.kotlin.fir.backend.Fir2IrConfiguration
+import org.jetbrains.kotlin.fir.backend.Fir2IrExtensions
+import org.jetbrains.kotlin.fir.backend.jvm.FirDirectJavaActualDeclarationExtractor
+import org.jetbrains.kotlin.fir.backend.jvm.FirJvmVisibilityConverter
 import org.jetbrains.kotlin.fir.backend.jvm.JvmFir2IrExtensions
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 import org.jetbrains.kotlin.fir.pipeline.*
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
 import org.jetbrains.kotlin.ir.backend.jklib.JKlibModuleSerializer
+import org.jetbrains.kotlin.ir.backend.jvm.serialization.JvmIrMangler
 import org.jetbrains.kotlin.library.KlibFormat
 import org.jetbrains.kotlin.library.KotlinAbiVersion
 import org.jetbrains.kotlin.library.KotlinLibraryVersioning
@@ -262,7 +270,7 @@ object JKlibFir2IrPipelinePhase : PipelinePhase<JKlibFrontendPipelineArtifact, J
         val fir2IrExtensions = JvmFir2IrExtensions(configuration)
         val irGenerationExtensions = configuration.getCompilerExtensions(IrGenerationExtension)
 
-        val fir2IrResult = firResult.convertToIrAndActualizeForJvm(
+        val fir2IrResult = firResult.convertToIrAndActualize(
             fir2IrExtensions,
             configuration,
             diagnosticsReporter,
@@ -277,6 +285,32 @@ object JKlibFir2IrPipelinePhase : PipelinePhase<JKlibFrontendPipelineArtifact, J
             input.rootDisposable,
         )
     }
+}
+
+private fun AllModulesFrontendOutput.convertToIrAndActualize(
+    fir2IrExtensions: Fir2IrExtensions,
+    configuration: CompilerConfiguration,
+    diagnosticsReporter: BaseDiagnosticsCollector,
+    irGeneratorExtensions: Collection<IrGenerationExtension>,
+): Fir2IrActualizedResult {
+    val fir2IrConfiguration = Fir2IrConfiguration.forJKlibCompilation(configuration, diagnosticsReporter)
+
+    return convertToIrAndActualize(
+        fir2IrExtensions,
+        fir2IrConfiguration,
+        irGeneratorExtensions,
+        // TODO(KT-86203): Check if JKlibIrMangler should not be used here.
+        JvmIrMangler,
+        FirJvmVisibilityConverter,
+        DefaultBuiltIns.Instance,
+        ::JvmIrTypeSystemContext,
+        JvmIrSpecialAnnotationSymbolProvider,
+        if (configuration.languageVersionSettings.getFlag(AnalysisFlags.stdlibCompilation)) {
+            { emptyList() }
+        } else {
+            { listOfNotNull(FirDirectJavaActualDeclarationExtractor.initializeIfNeeded(it)) }
+        },
+    )
 }
 
 object JKlibKlibSerializationPhase : PipelinePhase<JKlibFir2IrPipelineArtifact, JKlibSerializationArtifact>(

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/CommonConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/CommonConfigurationKeysContainer.kt
@@ -57,7 +57,6 @@ object CommonConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.co
     val ENABLE_IR_VISIBILITY_CHECKS by key<Boolean>("Checks pre-lowering IR for visibility violations.")
     val ENABLE_IR_VARARG_TYPES_CHECKS by key<Boolean>("Checks IR for vararg types mismatches.")
     val ENABLE_IR_NESTED_OFFSETS_CHECKS by key<Boolean>("Checks that offsets of nested IR elements conform to offsets of their containers.")
-
     val PHASE_CONFIG by key<PhaseConfig>()
 
     val DONT_CREATE_SEPARATE_SESSION_FOR_SCRIPTS by key<Boolean>("Should be used only in tests, impossible to set via compiler arguments.")

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConfiguration.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConfiguration.kt
@@ -43,6 +43,7 @@ class Fir2IrConfiguration private constructor(
     val skipBodies: Boolean,
     val irVerificationSettings: IrVerificationSettings,
     val carefulApproximationOfContravariantProjectionForSam: Boolean,
+    val propagateLazyIrPrivateMembers: Boolean,
 ) {
     val diagnosticReporter: IrDiagnosticReporter =
         KtDiagnosticReporterWithImplicitIrBasedContext(diagnosticReporter, languageVersionSettings)
@@ -75,7 +76,31 @@ class Fir2IrConfiguration private constructor(
                     enableIrNestedOffsetsChecks = compilerConfiguration.enableIrNestedOffsetsChecks,
                     validateForKlibSerialization = false,
                 ),
-                carefulApproximationOfContravariantProjectionForSam = compilerConfiguration.get(JVMConfigurationKeys.SAM_CONVERSIONS) != JvmClosureGenerationScheme.CLASS
+                carefulApproximationOfContravariantProjectionForSam = compilerConfiguration.get(JVMConfigurationKeys.SAM_CONVERSIONS) != JvmClosureGenerationScheme.CLASS,
+                propagateLazyIrPrivateMembers = false,
+            )
+
+        fun forJKlibCompilation(
+            compilerConfiguration: CompilerConfiguration,
+            diagnosticReporter: BaseDiagnosticsCollector,
+        ): Fir2IrConfiguration =
+            Fir2IrConfiguration(
+                languageVersionSettings = compilerConfiguration.languageVersionSettings,
+                diagnosticReporter = diagnosticReporter,
+                messageCollector = compilerConfiguration.messageCollector,
+                inlineConstTracker = compilerConfiguration[CommonConfigurationKeys.INLINE_CONST_TRACKER],
+                expectActualTracker = compilerConfiguration[CommonConfigurationKeys.EXPECT_ACTUAL_TRACKER],
+                allowNonCachedDeclarations = false,
+                skipBodies = compilerConfiguration.getBoolean(JVMConfigurationKeys.SKIP_BODIES),
+                irVerificationSettings = IrVerificationSettings(
+                    mode = compilerConfiguration.get(CommonConfigurationKeys.VERIFY_IR, IrVerificationMode.NONE),
+                    enableIrVisibilityChecks = compilerConfiguration.enableIrVisibilityChecks,
+                    enableIrVarargTypesChecks = compilerConfiguration.enableIrVarargTypesChecks,
+                    enableIrNestedOffsetsChecks = compilerConfiguration.enableIrNestedOffsetsChecks,
+                    validateForKlibSerialization = false,
+                ),
+                carefulApproximationOfContravariantProjectionForSam = compilerConfiguration.get(JVMConfigurationKeys.SAM_CONVERSIONS) != JvmClosureGenerationScheme.CLASS,
+                propagateLazyIrPrivateMembers = true,
             )
 
         fun forKlibCompilation(
@@ -98,6 +123,7 @@ class Fir2IrConfiguration private constructor(
                     validateForKlibSerialization = true,
                 ),
                 carefulApproximationOfContravariantProjectionForSam = false,
+                propagateLazyIrPrivateMembers = false,
             )
 
         fun forAnalysisApi(
@@ -121,6 +147,7 @@ class Fir2IrConfiguration private constructor(
                     validateForKlibSerialization = false,
                 ),
                 carefulApproximationOfContravariantProjectionForSam = compilerConfiguration.get(JVMConfigurationKeys.SAM_CONVERSIONS) != JvmClosureGenerationScheme.CLASS,
+                propagateLazyIrPrivateMembers = false,
             )
     }
 }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/lazy/Fir2IrLazyClass.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/lazy/Fir2IrLazyClass.kt
@@ -235,7 +235,7 @@ class Fir2IrLazyClass(
                 this.fir.symbol,
                 fir
             )
-            else -> !Visibilities.isPrivate(fir.visibility)
+            else -> !Visibilities.isPrivate(fir.visibility) || configuration.propagateLazyIrPrivateMembers
         }
     }
 


### PR DESCRIPTION
J2CL needs to access private members from Java classes, which are currently filtered out during lazy IR building in `Fir2IrLazyClass`. 

A new `Fir2IrConfiguration` named `propagateLazyIrPrivateMembers` has been defined and set to true only for JKlib backend.

#KT-86204 fixed