### PR TITLE
KT-86197 Adding topLevelSignature cache to avoid linear search

### DIFF
--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/KotlinIrLinker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/KotlinIrLinker.kt
@@ -85,6 +85,8 @@ abstract class KotlinIrLinker(
 
     private val triedToDeserializeDeclarationForSymbol = hashSetOf<IrSymbol>()
 
+    private val topLevelSignatureToDeserializer = HashMap<IdSignature, IrModuleDeserializer?>()
+
     open val partialLinkageSupport: PartialLinkageSupportForLinker get() = PartialLinkageSupportForLinker.DISABLED
 
     open val returnUnboundSymbolsIfSignatureNotFound: Boolean
@@ -104,10 +106,14 @@ abstract class KotlinIrLinker(
         // handle such situation appropriately. See KT-41378.
         //
         // TODO (KT-84837): The lookup for a IrModuleDeserializer should work through an index.
-        val actualModuleDeserializer: IrModuleDeserializer? = if (topLevelSignature in moduleDeserializer) {
-            moduleDeserializer
-        } else {
-            deserializersForModules.values.firstOrNull { topLevelSignature in it }
+        val actualModuleDeserializer: IrModuleDeserializer? = when {
+            topLevelSignature in moduleDeserializer -> moduleDeserializer
+            topLevelSignatureToDeserializer.containsKey(topLevelSignature) -> topLevelSignatureToDeserializer[topLevelSignature]
+            else -> {
+                val deserializer = deserializersForModules.values.firstOrNull { topLevelSignature in it }
+                topLevelSignatureToDeserializer[topLevelSignature] = deserializer
+                deserializer
+            }
         }
 
         // Note: It might happen that the top-level symbol still exists in KLIB, but nested symbol has been removed.
@@ -138,7 +144,14 @@ abstract class KotlinIrLinker(
     }
 
     private fun resolveModuleDeserializer(idSignature: IdSignature): IrModuleDeserializer? {
-        return deserializersForModules.values.firstOrNull() { idSignature in it }
+        val topLevelSignature = idSignature.topLevelSignature()
+        return if (topLevelSignatureToDeserializer.containsKey(topLevelSignature)) {
+            topLevelSignatureToDeserializer[topLevelSignature]
+        } else {
+            val deserializer = deserializersForModules.values.firstOrNull() { topLevelSignature in it }
+            topLevelSignatureToDeserializer[topLevelSignature] = deserializer
+            deserializer
+        }
     }
 
     protected abstract fun createModuleDeserializer(
@@ -224,12 +237,14 @@ abstract class KotlinIrLinker(
             val currentModuleDeserializer = createCurrentModuleDeserializer(moduleFragment)
             deserializersForModules[moduleFragment.name.asString()] =
                 maybeWrapWithBuiltInAndInit(moduleFragment.descriptor, currentModuleDeserializer)
+            topLevelSignatureToDeserializer.clear()
         }
         deserializersForModules.values.forEach { it.init() }
     }
 
     fun clear() {
         irInterner.reset()
+        topLevelSignatureToDeserializer.clear()
     }
 
     override fun postProcess(inOrAfterLinkageStep: Boolean) {
@@ -286,6 +301,7 @@ abstract class KotlinIrLinker(
         }
 
         val moduleFragment = deserializersForModules.getOrPut(moduleName) {
+            topLevelSignatureToDeserializer.clear()
             maybeWrapWithBuiltInAndInit(
                 moduleDescriptor = moduleDescriptor,
                 moduleDeserializer = createModuleDeserializer(


### PR DESCRIPTION
This fixes a performance issue when generation a framework with over 10k dependencies by adding topLevelSignature cache to avoid linear search. It went from 41s~ or 11% total time to 27s~ or 6%~

[details in issue](https://youtrack.jetbrains.com/issue/KT-86197/Linear-search-bottleneck-KotlinIrLinker)