### PR TITLE
KT-86199 Fix scalability problems with packageFragmentProviderImpl

### DIFF
--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/PackageFragmentProviderImpl.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/PackageFragmentProviderImpl.kt
@@ -22,20 +22,23 @@ import org.jetbrains.kotlin.name.Name
 class PackageFragmentProviderImpl(
     private val packageFragments: Collection<PackageFragmentDescriptor>
 ) : PackageFragmentProviderOptimized {
+    private val packageFragmentsByFqName = packageFragments.groupBy { it.fqName }
+
+    private val subPackagesByParent = packageFragments.asSequence()
+        .map {it.fqName}
+        .filter { !it.isRoot }
+        .groupBy { it.parent() }
+
     override fun collectPackageFragments(fqName: FqName, packageFragments: MutableCollection<PackageFragmentDescriptor>) {
-        this.packageFragments.filterTo(packageFragments) { it.fqName == fqName }
+        packageFragmentsByFqName[fqName]?.let { packageFragments.addAll(it) }
     }
 
     override fun isEmpty(fqName: FqName): Boolean =
-        this.packageFragments.none { it.fqName == fqName }
+        !packageFragmentsByFqName.containsKey(fqName)
 
     @Deprecated("for usages use #packageFragments(FqName) at final point, for impl use #collectPackageFragments(FqName, MutableCollection<PackageFragmentDescriptor>)")
-    override fun getPackageFragments(fqName: FqName): List<PackageFragmentDescriptor> =
-        packageFragments.filter { it.fqName == fqName }
+    override fun getPackageFragments(fqName: FqName): List<PackageFragmentDescriptor> = packageFragmentsByFqName[fqName] ?: emptyList()
 
     override fun getSubPackagesOf(fqName: FqName, nameFilter: (Name) -> Boolean): Collection<FqName> =
-        packageFragments.asSequence()
-            .map { it.fqName }
-            .filter { !it.isRoot && it.parent() == fqName }
-            .toList()
+        subPackagesByParent[fqName] ?: emptyList()
 }

--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/PackageFragmentProviderImpl.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/PackageFragmentProviderImpl.kt
@@ -20,22 +20,25 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 class PackageFragmentProviderImpl(
-    private val packageFragments: Collection<PackageFragmentDescriptor>
+    private val packageFragments: Collection<PackageFragmentDescriptor>,
 ) : PackageFragmentProviderOptimized {
+    private val packageFragmentsByFqName = packageFragments.groupBy { it.fqName }
+
+    private val subPackagesByParent = packageFragments.asSequence()
+        .map { it.fqName }
+        .filter { !it.isRoot }
+        .groupBy { it.parent() }
+
     override fun collectPackageFragments(fqName: FqName, packageFragments: MutableCollection<PackageFragmentDescriptor>) {
-        this.packageFragments.filterTo(packageFragments) { it.fqName == fqName }
+        packageFragmentsByFqName[fqName]?.let { packageFragments.addAll(it) }
     }
 
     override fun isEmpty(fqName: FqName): Boolean =
-        this.packageFragments.none { it.fqName == fqName }
+        !packageFragmentsByFqName.containsKey(fqName)
 
     @Deprecated("for usages use #packageFragments(FqName) at final point, for impl use #collectPackageFragments(FqName, MutableCollection<PackageFragmentDescriptor>)")
-    override fun getPackageFragments(fqName: FqName): List<PackageFragmentDescriptor> =
-        packageFragments.filter { it.fqName == fqName }
+    override fun getPackageFragments(fqName: FqName): List<PackageFragmentDescriptor> = packageFragmentsByFqName[fqName] ?: emptyList()
 
     override fun getSubPackagesOf(fqName: FqName, nameFilter: (Name) -> Boolean): Collection<FqName> =
-        packageFragments.asSequence()
-            .map { it.fqName }
-            .filter { !it.isRoot && it.parent() == fqName }
-            .toList()
+        subPackagesByParent[fqName] ?: emptyList()
 }


### PR DESCRIPTION
Fixing a scaling issue with packageFragments when dependencies are over 10k by 

* reducing allocations
* remove linear look ups by grouping the fragments

When profiling an app with over 40k dependencies it when from 32s~ or 9%~ to 8s~ or 2%~

[details in issue](https://youtrack.jetbrains.com/issue/KT-86199/PackageFragmentProviderImpl-bottleneck)