### PR TITLE
[K/N] Implement downward closure for ObjC entry points

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.backend.konan.*
+import org.jetbrains.kotlin.backend.konan.descriptors.getPackageFragments
 import org.jetbrains.kotlin.backend.konan.descriptors.isInterface
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.llvm.CodeGenerator
@@ -48,12 +49,18 @@ internal fun produceObjCExportInterface(
     //   and can't do this per-module, e.g. due to global name conflict resolution.
 
     val unitSuspendFunctionExport = config.unitSuspendFunctionObjCExport
+    val moduleDescriptors = listOf(moduleDescriptor) + moduleDescriptor.getExportedDependencies(config)
     val entryPoints = config.objcEntryPoints
+    val expandEntryPoints = config.configuration.getBoolean(BinaryOptions.objcExportExpandEntryPoints)
+    val effectiveEntryPoints = if (entryPoints != ObjCEntryPoints.ALL && expandEntryPoints) {
+        ObjCEntryPoints.create(computeDownwardClosure(entryPoints, moduleDescriptors))
+    } else {
+        entryPoints
+    }
     val mapper = ObjCExportMapper(
             frontendServices.deprecationResolver,
             unitSuspendFunctionExport = unitSuspendFunctionExport,
-            entryPoints = entryPoints)
-    val moduleDescriptors = listOf(moduleDescriptor) + moduleDescriptor.getExportedDependencies(config)
+            entryPoints = effectiveEntryPoints)
     val objcGenerics = config.configuration.objcGenerics
     val disableSwiftMemberNameMangling = config.configuration.getBoolean(BinaryOptions.objcExportDisableSwiftMemberNameMangling)
     val ignoreInterfaceMethodCollisions = config.configuration.getBoolean(BinaryOptions.objcExportIgnoreInterfaceMethodCollisions)
@@ -247,3 +254,5 @@ private fun ObjCExportedInterface.generateWorkaroundForSwiftSR10177(generationSt
 
 internal val NativeBackendPhaseContext.objCExportTopLevelNamePrefix: String
     get() = abbreviate(config.fullExportedNamePrefix)
+
+

--- a/native/binary-options/src/main/kotlin/org/jetbrains/kotlin/config/nativeBinaryOptions/BinaryOptions.kt
+++ b/native/binary-options/src/main/kotlin/org/jetbrains/kotlin/config/nativeBinaryOptions/BinaryOptions.kt
@@ -40,6 +40,7 @@ object BinaryOptions : BinaryOptionRegistry() {
     val objcExportErrorOnNameCollisions by booleanOption()
 
     val objcExportEntryPointsPath by stringOption()
+    val objcExportExpandEntryPoints by booleanOption()
 
     val objcExportExplicitMethodFamily by booleanOption()
 

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCEntryPoints.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCEntryPoints.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.backend.konan.descriptors.getPackageFragments
 
 /** A predicate which checks whether the given declaration is entry point, and should be exposed in Objective-C. */
 interface ObjCEntryPoints {
@@ -16,6 +17,12 @@ interface ObjCEntryPoints {
 
     companion object {
         val ALL: ObjCEntryPoints = object : ObjCEntryPoints {}
+
+        fun create(descriptors: Set<CallableMemberDescriptor>): ObjCEntryPoints =
+            object : ObjCEntryPoints {
+                override fun shouldBeExposed(descriptor: CallableMemberDescriptor): Boolean =
+                    descriptors.contains(descriptor.original)
+            }
     }
 }
 
@@ -65,3 +72,54 @@ fun File.readObjCEntryPoints(): ObjCEntryPoints =
                     )
             }
         }
+
+fun computeDownwardClosure(
+    entryPoints: ObjCEntryPoints,
+    moduleDescriptors: List<ModuleDescriptor>
+): Set<CallableMemberDescriptor> {
+    val overriddenToOverride = mutableMapOf<CallableMemberDescriptor, MutableSet<CallableMemberDescriptor>>()
+    val matched = mutableSetOf<CallableMemberDescriptor>()
+
+    fun processCallable(descriptor: CallableMemberDescriptor) {
+        descriptor.overriddenDescriptors.forEach { overridden ->
+            overriddenToOverride.getOrPut(overridden.original, ::mutableSetOf).add(descriptor)
+        }
+        if (entryPoints.shouldBeExposed(descriptor)) {
+            matched.add(descriptor.original)
+        }
+    }
+
+    fun processClass(descriptor: ClassDescriptor) {
+        descriptor.unsubstitutedMemberScope.getContributedDescriptors().forEach { descriptor ->
+            when (descriptor) {
+                is CallableMemberDescriptor -> processCallable(descriptor)
+                is ClassDescriptor -> processClass(descriptor)
+            }
+        }
+    }
+
+    moduleDescriptors.forEach {
+        it.getPackageFragments().forEach { fragment ->
+            fragment.getMemberScope().getContributedDescriptors().forEach { descriptor ->
+                when (descriptor) {
+                    is CallableMemberDescriptor -> processCallable(descriptor)
+                    is ClassDescriptor -> processClass(descriptor)
+                }
+            }
+        }
+    }
+
+    val closure = mutableSetOf<CallableMemberDescriptor>()
+    val todo = matched.toMutableList()
+
+    while (todo.isNotEmpty()) {
+        val current = todo.removeLast()
+        if (closure.add(current)) {
+            overriddenToOverride[current]?.forEach { override ->
+                todo.add(override.original)
+            }
+        }
+    }
+
+    return closure
+}

--- a/native/objcexport-header-generator/impl/k1/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportEntryPointsClosureTest.kt
+++ b/native/objcexport-header-generator/impl/k1/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportEntryPointsClosureTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.tests
+
+import com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.backend.konan.objcexport.*
+import org.jetbrains.kotlin.backend.konan.testUtils.*
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
+import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.cli.common.disposeRootInWriteAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class ObjCExportEntryPointsClosureTest : InlineSourceTestEnvironment {
+    override val testDisposable = Disposer.newDisposable("${ObjCExportEntryPointsClosureTest::class.simpleName}.testDisposable")
+    override val kotlinCoreEnvironment: KotlinCoreEnvironment = createKotlinCoreEnvironment(testDisposable)
+
+    @TempDir
+    override lateinit var testTempDir: File
+
+    @AfterEach
+    fun dispose() {
+        disposeRootInWriteAction(testDisposable)
+    }
+
+    @Test
+    fun `test downward closure`() {
+        val source = """
+            interface MyRunnable {
+                fun run()
+            }
+            class A : MyRunnable {
+                override fun run() {}
+            }
+            class B : MyRunnable {
+                override fun run() {}
+            }
+        """.trimIndent()
+
+        val module = createModuleDescriptor(source)
+
+        val myRunnable = module.findClassAcrossModuleDependencies(ClassId.fromString("MyRunnable"))!!
+        val a = module.findClassAcrossModuleDependencies(ClassId.fromString("A"))!!
+        val b = module.findClassAcrossModuleDependencies(ClassId.fromString("B"))!!
+
+        val runnableRun = myRunnable.unsubstitutedMemberScope.getContributedDescriptors()
+            .filterIsInstance<CallableMemberDescriptor>().single { it.name.asString() == "run" }
+
+        val aRun = a.unsubstitutedMemberScope.getContributedDescriptors()
+            .filterIsInstance<CallableMemberDescriptor>().single { it.name.asString() == "run" }
+
+        val bRun = b.unsubstitutedMemberScope.getContributedDescriptors()
+            .filterIsInstance<CallableMemberDescriptor>().single { it.name.asString() == "run" }
+
+        val entryPoints = object : ObjCEntryPoints {
+            override fun shouldBeExposed(descriptor: CallableMemberDescriptor): Boolean {
+                return descriptor.original == runnableRun.original
+            }
+        }
+
+        val closure = computeDownwardClosure(entryPoints, listOf(module))
+
+        assertTrue(runnableRun in closure, "Runnable.run should be in closure")
+        assertTrue(aRun in closure, "A.run should be in closure")
+        assertTrue(bRun in closure, "B.run should be in closure")
+    }
+
+    @Test
+    fun `test downward closure with specific class`() {
+        val source = """
+            interface MyRunnable {
+                fun run()
+            }
+            class A : MyRunnable {
+                override fun run() {}
+            }
+            class B : MyRunnable {
+                override fun run() {}
+            }
+        """.trimIndent()
+
+        val module = createModuleDescriptor(source)
+
+        val myRunnable = module.findClassAcrossModuleDependencies(ClassId.fromString("MyRunnable"))!!
+        val a = module.findClassAcrossModuleDependencies(ClassId.fromString("A"))!!
+        val b = module.findClassAcrossModuleDependencies(ClassId.fromString("B"))!!
+
+        val runnableRun = myRunnable.unsubstitutedMemberScope.getContributedDescriptors()
+            .filterIsInstance<CallableMemberDescriptor>().single { it.name.asString() == "run" }
+
+        val aRun = a.unsubstitutedMemberScope.getContributedDescriptors()
+            .filterIsInstance<CallableMemberDescriptor>().single { it.name.asString() == "run" }
+
+        val bRun = b.unsubstitutedMemberScope.getContributedDescriptors()
+            .filterIsInstance<CallableMemberDescriptor>().single { it.name.asString() == "run" }
+
+        val entryPoints = object : ObjCEntryPoints {
+            override fun shouldBeExposed(descriptor: CallableMemberDescriptor): Boolean {
+                return descriptor.original == aRun.original
+            }
+        }
+
+        val closure = computeDownwardClosure(entryPoints, listOf(module))
+
+        assertFalse(runnableRun.original in closure, "Runnable.run should not be in closure")
+        assertTrue(aRun in closure, "A.run should be in closure")
+        assertFalse(bRun in closure, "B.run should not be in closure")
+    }
+}


### PR DESCRIPTION
Adds an option to compute the downward closure of ObjC entry points under overrides. This ensures that if a method is specified in the entry points list, all its implementations in subclasses are retained, preventing tree shaking from stripping them.

Enabled with -Xbinary=objcExportExpandEntryPoints=true