### PR TITLE
[BTA] Enhance JVM argument tests with nullable tests and invalid value cases

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-forward-compatibility-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-compatibility-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
@@ -328,8 +328,14 @@ private val jvmArgumentTestDescriptors: List<JvmArgumentTestDescriptor<*>> = lis
     JvmArgumentTestDescriptor(
         argumentName = "Xscript-resolver-environment",
         argument = X_SCRIPT_RESOLVER_ENVIRONMENT,
-        argumentValues = listOf(arrayOf("key1=value1", "key2=value2")),
-        argumentRawValues = listOf(arrayOf("key1=value1", "key2=value2").joinToString(",")),
+        argumentValues = listOf(
+            arrayOf("key1=value1", "key2=value2"),
+            arrayOf("optional="),
+        ),
+        argumentRawValues = listOf(
+            arrayOf("key1=value1", "key2=value2").joinToString(","),
+            "optional=",
+        ),
         valueString = { value -> value?.joinToString(",") },
         expectedArgumentStringsFor = { value -> listOf("-Xscript-resolver-environment=$value") },
     ),
@@ -338,6 +344,11 @@ private val jvmArgumentTestDescriptors: List<JvmArgumentTestDescriptor<*>> = lis
         argument = X_JSR305,
         argumentValues = listOf(arrayOf("strict", "under-migration:warn", "@com.example.Nullable:ignore")),
         argumentRawValues = listOf(arrayOf("strict", "under-migration:warn", "@com.example.Nullable:ignore").joinToString(",")),
+        invalidArgumentValues = listOf(
+            arrayOf("non-existent-mode"),
+            arrayOf("under-migration=warn"),
+            arrayOf("foo:bar:baz"),
+        ),
         invalidRawValues = listOf(
             "non-existent-mode",
             "under-migration=warn",
@@ -351,6 +362,16 @@ private val jvmArgumentTestDescriptors: List<JvmArgumentTestDescriptor<*>> = lis
         argument = X_NULLABILITY_ANNOTATIONS,
         argumentValues = listOf(arrayOf("@javax.annotation.Nullable:strict", "@javax.annotation.Nonnull:warn")),
         argumentRawValues = listOf(arrayOf("@javax.annotation.Nullable:strict", "@javax.annotation.Nonnull:warn").joinToString(",")),
+        invalidArgumentValues = listOf(
+            arrayOf("@javax.annotation.Nullable:bogus"),
+            arrayOf("@javax.annotation.Nullable"),
+            arrayOf("@javax.annotation.Nullable=ignore")
+        ),
+        invalidRawValues = listOf(
+            "@javax.annotation.Nullable:bogus",
+            "@javax.annotation.Nullable",
+            "@javax.annotation.Nullable=ignore"
+        ),
         valueString = { value -> value?.joinToString(",") },
         expectedArgumentStringsFor = { value -> listOf("-Xnullability-annotations=$value") },
     ),
@@ -367,6 +388,8 @@ private val jvmArgumentTestDescriptors: List<JvmArgumentTestDescriptor<*>> = lis
                     File.pathSeparator + "event=cpu,interval=1ms,threads,start" +
                     File.pathSeparator + testBaseDir.resolve("path/to/snapshots").toFile().absolutePath
         ),
+        invalidArgumentValues = listOf("path/to/libasyncProfiler.so"),
+        invalidRawValues = listOf("path/to/libasyncProfiler.so"),
         valueString = { value -> value },
         expectedArgumentStringsFor = { value -> listOf("-Xprofile=$value") },
     ),

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
@@ -239,6 +239,7 @@ private val jvmCompilerArguments: List<JvmArgumentTestDescriptor<*>> = listOf(
             ).joinToString(File.pathSeparator) { it.toFile().absolutePath }
         ),
         invalidArgumentValues = listOf(listOf(testBaseDir.resolve("path/with${File.pathSeparator}separator"))),
+        runsNullableTest = true,
         valueString = { value -> value?.joinToString(File.pathSeparator) { it.toFile().absolutePath } },
         expectedArgumentStringsFor = { value -> listOf("-Xmodule-path=$value") },
     ),
@@ -258,6 +259,7 @@ private val jvmCompilerArguments: List<JvmArgumentTestDescriptor<*>> = listOf(
         argumentValues = LambdasMode.entries.toList(),
         argumentRawValues = LambdasMode.entries.map { it.stringValue },
         invalidRawValues = listOf("non-existent-value"),
+        runsNullableTest = true,
         valueString = { value -> value?.stringValue },
         expectedArgumentStringsFor = { value -> listOf("-Xlambdas=$value") },
     ),
@@ -319,6 +321,7 @@ private val jvmCompilerArguments: List<JvmArgumentTestDescriptor<*>> = listOf(
             ).joinToString(File.pathSeparator) { it.toFile().absolutePath }
         ),
         invalidArgumentValues = listOf(listOf(testBaseDir.resolve("path/with${File.pathSeparator}separator"))),
+        runsNullableTest = true,
         valueString = { value -> value?.joinToString(File.pathSeparator) { it.toFile().absolutePath } },
         expectedArgumentStringsFor = { value -> listOf("-Xklib=$value") },
     ),
@@ -355,8 +358,14 @@ private val jvmCompilerArguments: List<JvmArgumentTestDescriptor<*>> = listOf(
     JvmArgumentTestDescriptor(
         argumentName = "Xscript-resolver-environment",
         argument = X_SCRIPT_RESOLVER_ENVIRONMENT,
-        argumentValues = listOf(listOf("key1=value1", "key2=value2")),
-        argumentRawValues = listOf(listOf("key1=value1", "key2=value2").joinToString(",")),
+        argumentValues = listOf(
+            listOf("key1=value1", "key2=value2"),
+            listOf("optional="),
+        ),
+        argumentRawValues = listOf(
+            listOf("key1=value1", "key2=value2").joinToString(","),
+            "optional=",
+        ),
         valueString = { value -> value?.joinToString(",") },
         expectedArgumentStringsFor = { value -> listOf("-Xscript-resolver-environment=$value") },
     ),
@@ -414,6 +423,11 @@ private val jvmCompilerArguments: List<JvmArgumentTestDescriptor<*>> = listOf(
                 NullabilityAnnotation("javax.annotation.Nonnull", NullabilityAnnotation.Mode.WARN),
             ).joinToString(",") { "${it.annotationFqName}:${it.mode.stringValue}" }
         ),
+        invalidRawValues = listOf(
+            "@javax.annotation.Nullable:bogus",
+            "@javax.annotation.Nullable=ignore",
+            "@javax.annotation.Nullable"
+        ),
         valueString = { value -> value?.joinToString(",") { "${it.annotationFqName}:${it.mode.stringValue}" } },
         expectedArgumentStringsFor = { value -> listOf("-Xnullability-annotations=$value") },
     ),
@@ -434,6 +448,8 @@ private val jvmCompilerArguments: List<JvmArgumentTestDescriptor<*>> = listOf(
                 outputDir = testBaseDir.resolve("/path/to/snapshots")
             ).let { it.profilerPath.toFile().absolutePath + File.pathSeparator + it.command + File.pathSeparator + it.outputDir.toFile().absolutePath }
         ),
+        invalidRawValues = listOf("path/to/libasyncProfiler.so"),
+        runsNullableTest = true,
         valueString = { value ->
             value?.let { value.profilerPath.toFile().absolutePath + File.pathSeparator + value.command + File.pathSeparator + value.outputDir.toFile().absolutePath }
         },


### PR DESCRIPTION
Extend test coverage for JVM compiler argument descriptors in the BTA test suites - test data only.                                                                                                   
                                                                                                                                                                                                                                    Backward-compat (kotlin-build-tools-api-tests):                                                                                                                                                                                   
  - Set runsNullableTest = true for nullable-typed arguments missing it: X_MODULE_PATH, X_LAMBDAS, X_KLIB, X_PROFILE.
  - Add invalidRawValues for X_NULLABILITY_ANNOTATIONS and X_PROFILE.                                                                                                                                                               
  - Add empty-value edge case "optional=" to X_SCRIPT_RESOLVER_ENVIRONMENT.

 Forward-compat (kotlin-build-tools-api-forward-compatibility-tests):
  - Add invalidArgumentValues + invalidRawValues for X_JSR305, X_NULLABILITY_ANNOTATIONS, X_PROFILE.
  - Add the same "optional=" edge case to X_SCRIPT_RESOLVER_ENVIRONMENT.