### PR TITLE
KT-20357: Add samples for floorDiv and mod extension functions

### DIFF
--- a/generators/builtins/floorDivMod.kt
+++ b/generators/builtins/floorDivMod.kt
@@ -40,7 +40,8 @@ class GenerateFloorDivMod(out: PrintWriter) : BuiltInsSourceGenerator(out) {
     private fun generateFloorDiv(thisKind: PrimitiveType, otherKind: PrimitiveType) {
         val returnType = getOperatorReturnType(thisKind, otherKind)
         val returnTypeName = returnType.capitalized
-        out.printDoc(BasePrimitivesGenerator.binaryOperatorDoc("floorDiv", thisKind, otherKind), "")
+        val baseDoc = BasePrimitivesGenerator.binaryOperatorDoc("floorDiv", thisKind, otherKind)
+        out.printDoc("$baseDoc\n@sample samples.misc.Builtins.floorDiv", "")
         out.println("""@SinceKotlin("1.5")""")
         out.println("@kotlin.internal.InlineOnly")
         out.println("@kotlin.internal.IntrinsicConstEvaluation")
@@ -66,7 +67,8 @@ class GenerateFloorDivMod(out: PrintWriter) : BuiltInsSourceGenerator(out) {
     private fun generateMod(thisKind: PrimitiveType, otherKind: PrimitiveType) {
         val operationType = getOperatorReturnType(thisKind, otherKind)
         val returnType = otherKind
-        out.printDoc(BasePrimitivesGenerator.binaryOperatorDoc("mod", thisKind, otherKind),"")
+        val baseDoc = BasePrimitivesGenerator.binaryOperatorDoc("mod", thisKind, otherKind)
+        out.printDoc("$baseDoc\n@sample samples.misc.Builtins.mod", "")
         out.println("""@SinceKotlin("1.5")""")
         out.println("@kotlin.internal.InlineOnly")
         out.println("@kotlin.internal.IntrinsicConstEvaluation")
@@ -92,7 +94,8 @@ class GenerateFloorDivMod(out: PrintWriter) : BuiltInsSourceGenerator(out) {
 
     private fun generateFpMod(thisKind: PrimitiveType, otherKind: PrimitiveType) {
         val operationType = getOperatorReturnType(thisKind, otherKind)
-        out.printDoc(BasePrimitivesGenerator.binaryOperatorDoc("mod", thisKind, otherKind), "")
+        val baseDoc = BasePrimitivesGenerator.binaryOperatorDoc("mod", thisKind, otherKind)
+        out.printDoc("$baseDoc\n@sample samples.misc.Builtins.modFloat", "")
         out.println("""@SinceKotlin("1.5")""")
         out.println("@kotlin.internal.InlineOnly")
         out.println("@kotlin.internal.IntrinsicConstEvaluation")

--- a/generators/builtins/unsignedTypes.kt
+++ b/generators/builtins/unsignedTypes.kt
@@ -39,6 +39,7 @@ class UnsignedTypeGenerator(val type: UnsignedType, out: PrintWriter) : BuiltIns
             Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
             
             For unsigned types, the results of flooring division and truncating division are the same.
+            @sample samples.misc.Builtins.floorDivUnsigned
             """.trimIndent()
         "rem" -> {
             """
@@ -54,6 +55,7 @@ class UnsignedTypeGenerator(val type: UnsignedType, out: PrintWriter) : BuiltIns
                 The result is always less than the divisor.
                 
                 For unsigned types, the remainders of flooring division and truncating division are the same.
+                @sample samples.misc.Builtins.modUnsigned
                 """.trimIndent()
         }
         else -> BasePrimitivesGenerator.binaryOperatorDoc(operator, operand1.asSigned, operand2.asSigned)

--- a/libraries/stdlib/samples/test/samples/misc/builtins.kt
+++ b/libraries/stdlib/samples/test/samples/misc/builtins.kt
@@ -42,5 +42,36 @@ class Builtins {
         assertPrints(x, "1")
         assertPrints(z, "1")
     }
+
+    @Sample
+    fun floorDiv() {
+        // Regular integer division (/) truncates toward zero
+        assertPrints((-7) / 3, "-2")
+        // floorDiv rounds toward negative infinity
+        assertPrints((-7).floorDiv(3), "-3")
+        assertPrints(7.floorDiv(3), "2")
+        assertPrints(7.floorDiv(-3), "-3")
+    }
+
+    @Sample
+    fun mod() {
+        // Regular remainder (%) takes the sign of the dividend
+        assertPrints((-7) % 3, "-1")
+        // mod takes the sign of the divisor
+        assertPrints((-7).mod(3), "2")
+        assertPrints(7.mod(3), "1")
+        assertPrints(7.mod(-3), "-2")
+    }
+
+    @Sample
+    fun floorDivLong() {
+        assertPrints((-7L).floorDiv(3L), "-3")
+    }
+
+    @Sample
+    fun modFloat() {
+        // Floating-point mod also takes the sign of the divisor
+        assertPrints((-1.5).mod(1.0), "0.5")
+    }
 }
 

--- a/libraries/stdlib/samples/test/samples/misc/builtins.kt
+++ b/libraries/stdlib/samples/test/samples/misc/builtins.kt
@@ -6,6 +6,7 @@
 package samples.misc
 
 import samples.*
+import kotlin.test.assertFailsWith
 
 class Builtins {
 
@@ -51,6 +52,9 @@ class Builtins {
         assertPrints((-7).floorDiv(3), "-3")
         assertPrints(7.floorDiv(3), "2")
         assertPrints(7.floorDiv(-3), "-3")
+
+        // Dividing by zero throws, just like the / operator
+        assertFailsWith<ArithmeticException> { 1.floorDiv(0) }
     }
 
     @Sample
@@ -61,17 +65,56 @@ class Builtins {
         assertPrints((-7).mod(3), "2")
         assertPrints(7.mod(3), "1")
         assertPrints(7.mod(-3), "-2")
-    }
 
-    @Sample
-    fun floorDivLong() {
-        assertPrints((-7L).floorDiv(3L), "-3")
+        // A zero divisor throws, just like the % operator
+        assertFailsWith<ArithmeticException> { 1.mod(0) }
     }
 
     @Sample
     fun modFloat() {
-        // Floating-point mod also takes the sign of the divisor
-        assertPrints((-1.5).mod(1.0), "0.5")
+        // For finite arguments, the result has the same sign as the divisor
+        assertPrints((-7.5).mod(3.0), "1.5")
+        assertPrints(7.5.mod(-3.0), "-1.5")
+
+        // The divisor is not required to be an integer
+        assertPrints(5.0.mod(1.1), "0.5999999999999996")
+
+        // A negative-zero dividend keeps its sign
+        assertPrints((-0.0).mod(3.0), "-0.0")
+
+        // Unlike integer mod, a zero divisor produces NaN instead of throwing
+        assertPrints(5.0.mod(0.0), "NaN")
+
+        // If either argument is NaN, or the dividend is infinite, the result is NaN
+        assertPrints(Double.NaN.mod(3.0), "NaN")
+        assertPrints(Double.POSITIVE_INFINITY.mod(3.0), "NaN")
+
+        // If only the divisor is infinite, the result is the dividend when the
+        // signs agree, and the infinite divisor otherwise
+        assertPrints(3.0.mod(Double.POSITIVE_INFINITY), "3.0")
+        assertPrints((-3.0).mod(Double.POSITIVE_INFINITY), "Infinity")
+    }
+
+    @Sample
+    fun floorDivUnsigned() {
+        // Unsigned types have no negative values, so floorDiv produces the
+        // same result as the / operator
+        assertPrints(7u.floorDiv(3u), "2")
+        assertPrints(7u / 3u, "2")
+
+        // Dividing by zero throws
+        assertFailsWith<ArithmeticException> { 1u.floorDiv(0u) }
+    }
+
+    @Sample
+    fun modUnsigned() {
+        // Unsigned types have no negative values, so mod produces the
+        // same result as the % operator
+        assertPrints(7u.mod(3u), "1")
+        assertPrints(7u % 3u, "1")
+
+        // A zero divisor throws
+        assertFailsWith<ArithmeticException> { 1u.mod(0u) }
     }
 }
 

--- a/libraries/stdlib/src/kotlin/util/FloorDivMod.kt
+++ b/libraries/stdlib/src/kotlin/util/FloorDivMod.kt
@@ -12,7 +12,10 @@ package kotlin
 
 import kotlin.math.sign
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -23,6 +26,7 @@ public inline fun Byte.floorDiv(other: Byte): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -30,7 +34,10 @@ public inline fun Byte.floorDiv(other: Byte): Int =
 public inline fun Byte.mod(other: Byte): Byte = 
     this.toInt().mod(other.toInt()).toByte()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -41,6 +48,7 @@ public inline fun Byte.floorDiv(other: Short): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -48,7 +56,10 @@ public inline fun Byte.floorDiv(other: Short): Int =
 public inline fun Byte.mod(other: Short): Short = 
     this.toInt().mod(other.toInt()).toShort()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -59,6 +70,7 @@ public inline fun Byte.floorDiv(other: Int): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -66,7 +78,10 @@ public inline fun Byte.floorDiv(other: Int): Int =
 public inline fun Byte.mod(other: Int): Int = 
     this.toInt().mod(other)
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -77,6 +92,7 @@ public inline fun Byte.floorDiv(other: Long): Long =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -84,7 +100,10 @@ public inline fun Byte.floorDiv(other: Long): Long =
 public inline fun Byte.mod(other: Long): Long = 
     this.toLong().mod(other)
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -95,6 +114,7 @@ public inline fun Short.floorDiv(other: Byte): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -102,7 +122,10 @@ public inline fun Short.floorDiv(other: Byte): Int =
 public inline fun Short.mod(other: Byte): Byte = 
     this.toInt().mod(other.toInt()).toByte()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -113,6 +136,7 @@ public inline fun Short.floorDiv(other: Short): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -120,7 +144,10 @@ public inline fun Short.floorDiv(other: Short): Int =
 public inline fun Short.mod(other: Short): Short = 
     this.toInt().mod(other.toInt()).toShort()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -131,6 +158,7 @@ public inline fun Short.floorDiv(other: Int): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -138,7 +166,10 @@ public inline fun Short.floorDiv(other: Int): Int =
 public inline fun Short.mod(other: Int): Int = 
     this.toInt().mod(other)
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -149,6 +180,7 @@ public inline fun Short.floorDiv(other: Long): Long =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -156,7 +188,10 @@ public inline fun Short.floorDiv(other: Long): Long =
 public inline fun Short.mod(other: Long): Long = 
     this.toLong().mod(other)
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -167,6 +202,7 @@ public inline fun Int.floorDiv(other: Byte): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -174,7 +210,10 @@ public inline fun Int.floorDiv(other: Byte): Int =
 public inline fun Int.mod(other: Byte): Byte = 
     this.mod(other.toInt()).toByte()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -185,6 +224,7 @@ public inline fun Int.floorDiv(other: Short): Int =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -192,7 +232,10 @@ public inline fun Int.floorDiv(other: Short): Int =
 public inline fun Int.mod(other: Short): Short = 
     this.mod(other.toInt()).toShort()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -206,6 +249,7 @@ public inline fun Int.floorDiv(other: Int): Int {
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -215,7 +259,10 @@ public inline fun Int.mod(other: Int): Int {
     return r + (other and (((r xor other) and (r or -r)) shr 31))
 }
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -226,6 +273,7 @@ public inline fun Int.floorDiv(other: Long): Long =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -233,7 +281,10 @@ public inline fun Int.floorDiv(other: Long): Long =
 public inline fun Int.mod(other: Long): Long = 
     this.toLong().mod(other)
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -244,6 +295,7 @@ public inline fun Long.floorDiv(other: Byte): Long =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -251,7 +303,10 @@ public inline fun Long.floorDiv(other: Byte): Long =
 public inline fun Long.mod(other: Byte): Byte = 
     this.mod(other.toLong()).toByte()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -262,6 +317,7 @@ public inline fun Long.floorDiv(other: Short): Long =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -269,7 +325,10 @@ public inline fun Long.floorDiv(other: Short): Long =
 public inline fun Long.mod(other: Short): Short = 
     this.mod(other.toLong()).toShort()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -280,6 +339,7 @@ public inline fun Long.floorDiv(other: Int): Long =
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -287,7 +347,10 @@ public inline fun Long.floorDiv(other: Int): Long =
 public inline fun Long.mod(other: Int): Int = 
     this.mod(other.toLong()).toInt()
 
-/** Divides this value by the other value, flooring the result to an integer that is closer to negative infinity. */
+/**
+ * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
+ * @sample samples.misc.Builtins.floorDiv
+ */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
 @kotlin.internal.IntrinsicConstEvaluation
@@ -301,6 +364,7 @@ public inline fun Long.floorDiv(other: Long): Long {
  * Calculates the remainder of flooring division of this value (dividend) by the other value (divisor).
  *
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
+ * @sample samples.misc.Builtins.mod
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -316,6 +380,7 @@ public inline fun Long.mod(other: Long): Long {
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  *
  * If the result cannot be represented exactly, it is rounded to the nearest representable number. In this case the absolute value of the result can be less than or _equal to_ the absolute value of the divisor.
+ * @sample samples.misc.Builtins.modFloat
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -331,6 +396,7 @@ public inline fun Float.mod(other: Float): Float {
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  *
  * If the result cannot be represented exactly, it is rounded to the nearest representable number. In this case the absolute value of the result can be less than or _equal to_ the absolute value of the divisor.
+ * @sample samples.misc.Builtins.modFloat
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -344,6 +410,7 @@ public inline fun Float.mod(other: Double): Double =
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  *
  * If the result cannot be represented exactly, it is rounded to the nearest representable number. In this case the absolute value of the result can be less than or _equal to_ the absolute value of the divisor.
+ * @sample samples.misc.Builtins.modFloat
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly
@@ -357,6 +424,7 @@ public inline fun Double.mod(other: Float): Double =
  * The result is either zero or has the same sign as the _divisor_ and has the absolute value less than the absolute value of the divisor.
  *
  * If the result cannot be represented exactly, it is rounded to the nearest representable number. In this case the absolute value of the result can be less than or _equal to_ the absolute value of the divisor.
+ * @sample samples.misc.Builtins.modFloat
  */
 @SinceKotlin("1.5")
 @kotlin.internal.InlineOnly

--- a/libraries/stdlib/unsigned/src/kotlin/UByte.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/UByte.kt
@@ -179,6 +179,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -187,6 +188,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -195,6 +197,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -203,6 +206,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -214,6 +218,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -224,6 +229,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -234,6 +240,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -244,6 +251,7 @@ public value class UByte @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation

--- a/libraries/stdlib/unsigned/src/kotlin/UInt.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/UInt.kt
@@ -179,6 +179,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -187,6 +188,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -195,6 +197,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -203,6 +206,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -214,6 +218,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -224,6 +229,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -234,6 +240,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -244,6 +251,7 @@ public value class UInt @kotlin.internal.IntrinsicConstEvaluation @PublishedApi 
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation

--- a/libraries/stdlib/unsigned/src/kotlin/ULong.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/ULong.kt
@@ -179,6 +179,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -187,6 +188,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -195,6 +197,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -203,6 +206,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -214,6 +218,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -224,6 +229,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -234,6 +240,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -244,6 +251,7 @@ public value class ULong @kotlin.internal.IntrinsicConstEvaluation @PublishedApi
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation

--- a/libraries/stdlib/unsigned/src/kotlin/UShort.kt
+++ b/libraries/stdlib/unsigned/src/kotlin/UShort.kt
@@ -179,6 +179,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -187,6 +188,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -195,6 +197,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -203,6 +206,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * Divides this value by the other value, flooring the result to an integer that is closer to negative infinity.
      *
      * For unsigned types, the results of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.floorDivUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -214,6 +218,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -224,6 +229,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -234,6 +240,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation
@@ -244,6 +251,7 @@ public value class UShort @kotlin.internal.IntrinsicConstEvaluation @PublishedAp
      * The result is always less than the divisor.
      *
      * For unsigned types, the remainders of flooring division and truncating division are the same.
+     * @sample samples.misc.Builtins.modUnsigned
      */
     @kotlin.internal.InlineOnly
     @kotlin.internal.IntrinsicConstEvaluation


### PR DESCRIPTION
Added samples for floorDiv and mod extension functions.

These functions have non-trivial semantics that differ from the conventional `/` and `%` operators, particularly for negative operands. Adding @sample tags makes the difference visible in the generated KDoc.

Related issue: [KT-20357](https://youtrack.jetbrains.com/issue/KT-20357)