### PR TITLE
[BTA] Improve -Xjsr305 mode parse error message

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-forward-compatibility-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-compatibility-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
@@ -345,13 +345,13 @@ private val jvmArgumentTestDescriptors: List<JvmArgumentTestDescriptor<*>> = lis
         argumentValues = listOf(arrayOf("strict", "under-migration:warn", "@com.example.Nullable:ignore")),
         argumentRawValues = listOf(arrayOf("strict", "under-migration:warn", "@com.example.Nullable:ignore").joinToString(",")),
         invalidArgumentValues = listOf(
-            arrayOf("non-existent-mode"),
-            arrayOf("under-migration=warn"),
+            arrayOf("stict"),
+            arrayOf("@javax.annotation.Nullable:strct"),
             arrayOf("foo:bar:baz"),
         ),
         invalidRawValues = listOf(
-            "non-existent-mode",
-            "under-migration=warn",
+            "stict",
+            "@javax.annotation.Nullable:strct",
             "foo:bar:baz",
         ),
         valueString = { value -> value?.joinToString(",") },

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
@@ -393,8 +393,8 @@ private val jvmCompilerArguments: List<JvmArgumentTestDescriptor<*>> = listOf(
             }
         ),
         invalidRawValues = listOf(
-            "non-existent-mode",
-            "under-migration=warn",
+            "stict",
+            "@javax.annotation.Nullable:strct",
             "foo:bar:baz",
         ),
         valueString = { value ->

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/internal/wrappers/KotlinWrapperPre2_4_0.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/internal/wrappers/KotlinWrapperPre2_4_0.kt
@@ -543,11 +543,11 @@ internal class KotlinWrapperPre2_4_0(
                     if (delegate[key] == null) return emptyList<Jsr305>() as V
 
                     val arrayValue = delegate[key] as Array<String>
-                    fun jsr305mode(stringValue: String) = Jsr305.Mode.values().firstOrNull { entry -> entry.stringValue == stringValue }
-                        ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $stringValue")
+                    arrayValue.map { fullEntry ->
+                        fun jsr305mode(mode: String) = Jsr305.Mode.values().firstOrNull { entry -> entry.stringValue == mode }
+                            ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $fullEntry")
 
-                    arrayValue.map {
-                        val parts = it.split(":")
+                        val parts = fullEntry.split(":")
                         when (parts.size) {
                             1 -> Jsr305.Global(jsr305mode(parts[0]))
                             2 -> {
@@ -557,7 +557,7 @@ internal class KotlinWrapperPre2_4_0(
                                     Jsr305.SpecificAnnotation(parts[0].removePrefix("@"), jsr305mode(parts[1]))
                                 }
                             }
-                            else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $it")
+                            else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $fullEntry")
                         }
                     } as V
                 }

--- a/compiler/build-tools/kotlin-build-tools-compat/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/compat/arguments/Jsr305Related.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/compat/arguments/Jsr305Related.kt
@@ -26,20 +26,20 @@ internal fun applyJsr305(
     currentValue: List<Jsr305>,
     compilerArgs: K2JVMCompilerArguments,
 ): List<Jsr305> =
-    compilerArgs.jsr305.mapOrEmpty {
-        val parts = it.split(":")
+    compilerArgs.jsr305.mapOrEmpty { fullEntry ->
+        val parts = fullEntry.split(":")
         when (parts.size) {
-            1 -> Jsr305.Global(jsr305mode(parts[0]))
+            1 -> Jsr305.Global(jsr305mode(parts[0], fullEntry))
             2 -> {
                 if (parts[0] == "under-migration") {
-                    Jsr305.UnderMigration(jsr305mode(parts[1]))
+                    Jsr305.UnderMigration(jsr305mode(parts[1], fullEntry))
                 } else {
-                    Jsr305.SpecificAnnotation(parts[0].removePrefix("@"), jsr305mode(parts[1]))
+                    Jsr305.SpecificAnnotation(parts[0].removePrefix("@"), jsr305mode(parts[1], fullEntry))
                 }
             }
-            else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $it")
+            else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $fullEntry")
         }
     }
 
-private fun jsr305mode(stringValue: String) = Jsr305.Mode.entries.firstOrNull { entry -> entry.stringValue == stringValue }
-    ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $stringValue")
+private fun jsr305mode(mode: String, fullEntry: String) = Jsr305.Mode.entries.firstOrNull { entry -> entry.stringValue == mode }
+    ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $fullEntry")

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/arguments/CompilerArgumentValueAdapter.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/arguments/CompilerArgumentValueAdapter.kt
@@ -536,16 +536,16 @@ private object JvmCompilerArgumentPre2_4_0ValueAdapter : CommonCompilerArgumentP
                 if (value == null) return emptyList<Jsr305>() as T
 
                 val arrayValue = value as Array<String>
-                fun jsr305mode(stringValue: String) = Jsr305.Mode.entries.firstOrNull { entry -> entry.stringValue == stringValue }
-                    ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $stringValue")
+                arrayValue.map { fullEntry ->
+                    fun jsr305mode(mode: String) = Jsr305.Mode.entries.firstOrNull { entry -> entry.stringValue == mode }
+                        ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $fullEntry")
 
-                arrayValue.map {
-                    val parts = it.split(":")
+                    val parts = fullEntry.split(":")
                     when (parts.size) {
                         1 -> Jsr305.Global(jsr305mode(parts[0]))
                         2 if parts[0] == "under-migration" -> Jsr305.UnderMigration(jsr305mode(parts[1]))
                         2 -> Jsr305.SpecificAnnotation(parts[0].removePrefix("@"), jsr305mode(parts[1]))
-                        else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $it")
+                        else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $fullEntry")
                     }
                 } as T
             }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/arguments/Jsr305Related.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/arguments/Jsr305Related.kt
@@ -26,20 +26,20 @@ internal fun applyJsr305(
     currentValue: List<Jsr305>,
     compilerArgs: K2JVMCompilerArguments,
 ): List<Jsr305> =
-    compilerArgs.jsr305.mapOrEmpty {
-        val parts = it.split(":")
+    compilerArgs.jsr305.mapOrEmpty { fullEntry ->
+        val parts = fullEntry.split(":")
         when (parts.size) {
-            1 -> Jsr305.Global(jsr305mode(parts[0]))
+            1 -> Jsr305.Global(jsr305mode(parts[0], fullEntry))
             2 -> {
                 if (parts[0] == "under-migration") {
-                    Jsr305.UnderMigration(jsr305mode(parts[1]))
+                    Jsr305.UnderMigration(jsr305mode(parts[1], fullEntry))
                 } else {
-                    Jsr305.SpecificAnnotation(parts[0].removePrefix("@"), jsr305mode(parts[1]))
+                    Jsr305.SpecificAnnotation(parts[0].removePrefix("@"), jsr305mode(parts[1], fullEntry))
                 }
             }
-            else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $it")
+            else -> throw CompilerArgumentsParseException("Invalid -Xjsr305 format: $fullEntry")
         }
     }
 
-private fun jsr305mode(stringValue: String) = Jsr305.Mode.entries.firstOrNull { entry -> entry.stringValue == stringValue }
-    ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $stringValue")
+private fun jsr305mode(mode: String, fullEntry: String) = Jsr305.Mode.entries.firstOrNull { entry -> entry.stringValue == mode }
+    ?: throw CompilerArgumentsParseException("Unknown -Xjsr305 mode: $fullEntry")


### PR DESCRIPTION
Echo the full failing entry instead of just the offending token, aligning with -Xwarning-level and -Xnullability-annotations parsers. Adds missing parser-branch coverage in JvmArgumentProviders.kt in both BTA test modules.

^KT-86247 Fixed