### PR TITLE
Make the default stability of non-final classes `Unknown` instead of `Stable`

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ClassStabilityTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ClassStabilityTransformTests.kt
@@ -1088,20 +1088,114 @@ class ClassStabilityTransformTests : AbstractIrTransformTest() {
     )
 
     @Test
-    fun testChildOfUnstableClass() = assertStability(
-        "",
+    fun testStableClassBecomesUncertainWhenOpened() = assertStability(
+        """
+            open class C {
+                val x: Int = 0
+            }
+        """,
+        "Uncertain(C)"
+    )
+
+    @Test
+    fun testUnstableClassStaysUnstableWhenOpened() = assertStability(
+        """
+            open class C {
+                var x: Int = 0
+            }
+        """,
+        "Unstable"
+    )
+
+    @Test
+    fun testParameterStableClassWhenOpened() = assertStability(
+        """
+            open class C<T>(val x: T)
+        """,
+        "Uncertain(C),Parameter(T)"
+    )
+
+    @Test
+    fun testRuntimeStableClassWhenOpened() = assertStability(
+        """
+            class B
+        """.trimIndent(),
+        """
+            open class C(val b: B)
+        """,
+        "Uncertain(C),Runtime(B)"
+    )
+
+    @Test
+    fun testStableChildOfUncertainClass() = assertStability(
         """
             open class Parent {
-                var age: Int = 0
-                var name: String = ""
-
-                fun info() = name + "|" + age.toString()
+                val x: Int = 0
             }
 
             class Child : Parent()
         """,
-        "Child()",
+        "Stable"
+    )
+
+    @Test
+    fun testUnstableChildOfUncertainClass() = assertStability(
+        """
+            open class Parent {
+                val x: Int = 0
+            }
+
+            class Child(var y: Int) : Parent()
+        """,
         "Unstable"
+    )
+
+    @Test
+    fun testStableChildOfUnstableClass() = assertStability(
+        """
+            open class Parent {
+                var x: Int = 0
+            }
+
+            class Child : Parent()
+        """,
+        "Unstable"
+    )
+
+    @Test
+    fun testStableChildOfParameterStableClass() = assertStability(
+        "",
+        """
+            open class Parent<T>(val x: T)
+
+            class Child : Parent<Int>(50)
+        """,
+        "Uncertain(Parent),Parameter(T)"
+    )
+
+    @Test
+    fun testStableChildOfRuntimeStableClass() = assertStability(
+        """
+            class B
+        """.trimIndent(),
+        """
+            open class Parent(val b: B)
+
+            class Child : Parent(B())
+        """,
+        "Uncertain(Parent),Runtime(B)"
+    )
+
+    @Test
+    fun testStableChildOfRuntimeStableClassTransform() = assertTransform(
+        unchecked = """
+            class B
+        """.trimIndent(),
+        checked = """
+            open class Parent(val b: B)
+
+            class Child : Parent(B())
+        """,
     )
 
     @Test

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ClassStabilityTransformTests/testStableChildOfRuntimeStableClassTransform.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ClassStabilityTransformTests/testStableChildOfRuntimeStableClassTransform.txt
@@ -1,0 +1,26 @@
+//
+// Source
+// ------------------------------------------
+
+open class Parent(val b: B)
+
+class Child : Parent(B())
+
+//
+// Transformed IR
+// ------------------------------------------
+
+@StabilityInferred(parameters = 0)
+open class Parent(val b: B) {
+  val %stable: Int = B.%stable
+    get() {
+      return field
+    }
+}
+@StabilityInferred(parameters = 0)
+class Child : Parent {
+  val %stable: Int = B.%stable
+    get() {
+      return field
+    }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamTransformTests/composeValueClassDefaultParameter.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamTransformTests/composeValueClassDefaultParameter.txt
@@ -168,7 +168,7 @@ internal fun PublishedExample(data: Data?, intData: IntData, %composer: Composer
     PublishedExample(data, intData, %composer, updateChangedFlags(%changed or 0b0001), %default)
   }
 }
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 abstract class Test {
   @Composable
   private fun PrivateExample(data: Data?, %composer: Composer?, %changed: Int, %default: Int) {
@@ -281,7 +281,7 @@ abstract class Test {
       tmp0_rcvr.ProtectedExample(data, %composer, updateChangedFlags(%changed or 0b0001), %default)
     }
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamTransformTests/testAbstractComposable.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamTransformTests/testAbstractComposable.txt
@@ -29,12 +29,12 @@ class FooImpl : BaseFoo() {
 // Transformed IR
 // ------------------------------------------
 
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 abstract class BaseFoo {
   @NonRestartableComposable
   @Composable
   abstract fun bar(%composer: Composer?, %changed: Int)
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/defaultParameterOpenFunction.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/defaultParameterOpenFunction.txt
@@ -21,7 +21,7 @@ class TestImpl : Test() {
 // Transformed IR
 // ------------------------------------------
 
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class Test {
   @Composable
   open fun doSomething(value: Int, %composer: Composer?, %changed: Int) {
@@ -35,7 +35,7 @@ open class Test {
     }
     %composer.endReplaceGroup()
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }
@@ -51,7 +51,12 @@ open class Test {
         %dirty = %dirty or if (%composer.changed(value)) 0b0100 else 0b0010
       }
       if (%changed and 0b00110000 == 0) {
-        %dirty = %dirty or if (%composer.changed(%this%)) 0b00100000 else 0b00010000
+        %dirty = %dirty or if (if (%changed and 0b01000000 == 0) {
+          %composer.changed(%this%)
+        } else {
+          %composer.changedInstance(%this%)
+        }
+        ) 0b00100000 else 0b00010000
       }
       if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
         if (%default and 0b0001 != 0) {

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testDefaultArgsForFakeOverridesSuperMethods.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testDefaultArgsForFakeOverridesSuperMethods.txt
@@ -18,7 +18,7 @@ class Bar: Foo() {
 // Transformed IR
 // ------------------------------------------
 
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class Foo {
   @NonRestartableComposable
   @Composable
@@ -35,7 +35,7 @@ open class Foo {
     }
     sourceInformationMarkerEnd(%composer)
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testDefaultParamFakeOverride.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testDefaultParamFakeOverride.txt
@@ -25,7 +25,7 @@ class TestImpl : Test() {
 // Transformed IR
 // ------------------------------------------
 
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class Test {
   @Composable
   open fun foo(param: Int, %composer: Composer?, %changed: Int) {
@@ -53,7 +53,7 @@ open class Test {
     %composer.endReplaceGroup()
     return tmp0
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }
@@ -69,7 +69,12 @@ open class Test {
         %dirty = %dirty or if (%composer.changed(param)) 0b0100 else 0b0010
       }
       if (%changed and 0b00110000 == 0) {
-        %dirty = %dirty or if (%composer.changed(%this%)) 0b00100000 else 0b00010000
+        %dirty = %dirty or if (if (%changed and 0b01000000 == 0) {
+          %composer.changed(%this%)
+        } else {
+          %composer.changedInstance(%this%)
+        }
+        ) 0b00100000 else 0b00010000
       }
       if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
         if (%default and 0b0001 != 0) {
@@ -158,7 +163,12 @@ fun CallWithDefaults(test: Test, %composer: Composer?, %changed: Int) {
   sourceInformation(%composer, "C(CallWithDefaults)N(test)<foo()>,<foo(0)>,<bar()>,<bar(0)>:Test.kt")
   val %dirty = %changed
   if (%changed and 0b0110 == 0) {
-    %dirty = %dirty or if (%composer.changed(test)) 0b0100 else 0b0010
+    %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+      %composer.changed(test)
+    } else {
+      %composer.changedInstance(test)
+    }
+    ) 0b0100 else 0b0010
   }
   if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
     if (isTraceInProgress()) {

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testDefaultParamOverrideOpenFunction.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testDefaultParamOverrideOpenFunction.txt
@@ -34,7 +34,12 @@ fun CallWithDefaults(test: Test, %composer: Composer?, %changed: Int) {
   sourceInformation(%composer, "C(CallWithDefaults)N(test)<foo()>,<foo(0)>,<bar()>,<bar(0)>:Test.kt")
   val %dirty = %changed
   if (%changed and 0b0110 == 0) {
-    %dirty = %dirty or if (%composer.changed(test)) 0b0100 else 0b0010
+    %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+      %composer.changed(test)
+    } else {
+      %composer.changedInstance(test)
+    }
+    ) 0b0100 else 0b0010
   }
   if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
     if (isTraceInProgress()) {
@@ -54,7 +59,7 @@ fun CallWithDefaults(test: Test, %composer: Composer?, %changed: Int) {
     CallWithDefaults(test, %composer, updateChangedFlags(%changed or 0b0001))
   }
 }
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class Test {
   @Composable
   open fun foo(param: Int, %composer: Composer?, %changed: Int) {
@@ -82,7 +87,7 @@ open class Test {
     %composer.endReplaceGroup()
     return tmp0
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }
@@ -98,7 +103,12 @@ open class Test {
         %dirty = %dirty or if (%composer.changed(param)) 0b0100 else 0b0010
       }
       if (%changed and 0b00110000 == 0) {
-        %dirty = %dirty or if (%composer.changed(%this%)) 0b00100000 else 0b00010000
+        %dirty = %dirty or if (if (%changed and 0b01000000 == 0) {
+          %composer.changed(%this%)
+        } else {
+          %composer.changedInstance(%this%)
+        }
+        ) 0b00100000 else 0b00010000
       }
       if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
         if (%default and 0b0001 != 0) {

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testGrouplessProperty.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testGrouplessProperty.txt
@@ -27,7 +27,7 @@ fun getHashCode(): Int = currentComposer.hashCode()
 // Transformed IR
 // ------------------------------------------
 
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class Foo {
   val current: Int
     @Composable @ReadOnlyComposable @JvmName(name = "getCurrent")
@@ -51,7 +51,7 @@ open class Foo {
     sourceInformationMarkerEnd(%composer)
     return tmp0
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/openComposableFunction.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/openComposableFunction.txt
@@ -24,14 +24,14 @@ open class OpenImpl : Open() {
 // Transformed IR
 // ------------------------------------------
 
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class Open {
   @Composable
   open fun Test(%composer: Composer?, %changed: Int) {
     %composer.startReplaceGroup(<>)
     %composer.endReplaceGroup()
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }
@@ -60,7 +60,7 @@ class Impl : Open {
       return field
     }
 }
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class OpenImpl : Open {
   @Composable
   override fun Test(%composer: Composer?, %changed: Int) {
@@ -68,7 +68,7 @@ open class OpenImpl : Open {
     super<Open>.Test(%composer, 0b1110 and %changed)
     %composer.endReplaceGroup()
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/testGrouplessProperty.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/testGrouplessProperty.txt
@@ -27,7 +27,7 @@ fun getHashCode(): Int = currentComposer.hashCode()
 // Transformed IR
 // ------------------------------------------
 
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 open class Foo {
   val current: Int
     @Composable @ReadOnlyComposable @JvmName(name = "getCurrent")
@@ -41,7 +41,7 @@ open class Foo {
     val tmp0 = %composer as Any.hashCode()
     return tmp0
   }
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }

--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testInferringTargetFromAncestorMethod.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/resources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testInferringTargetFromAncestorMethod.txt
@@ -41,12 +41,12 @@ fun OpenTarget(%composer: Composer?, %changed: Int) {
     OpenTarget(%composer, updateChangedFlags(%changed or 0b0001))
   }
 }
-@StabilityInferred(parameters = 1)
+@StabilityInferred(parameters = 0)
 abstract class Base {
   @Composable
   @ComposableTarget(applier = "N")
   abstract fun Compose(%composer: Composer?, %changed: Int)
-  val %stable: Int = 0
+  val %stable: Int = 8
     get() {
       return field
     }

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
@@ -516,6 +516,25 @@ class CompositionTests {
         counter += 10
         advance()
     }
+
+    /**
+     * This is a regression test against a bug that made it possible for a value of an unstable type
+     * to get passed into code that was generated to only expect to receive values of stable types.
+     * types. For more details, see https://issuetracker.google.com/issues/511102714.
+     */
+    @Test
+    fun subtypeStabilityNeglectedRegressionTest() = compositionTest {
+        val state = mutableStateOf<LoadingState<Unstable>>(LoadingState.Loading)
+        val result = mutableStateOf(false)
+
+        compose {
+            SubtypeStabilityNeglectedRegressionTestEntrypoint(state.value, result)
+        }
+
+        state.value = LoadingState.Content(Unstable())
+        advance()
+        assertEquals(true, result.value)
+    }
 }
 
 @Composable
@@ -672,4 +691,23 @@ private fun Modifier.clickable(f: () -> Unit): Modifier = this
 @Composable
 fun AnyParameter(any: Any = Any()) {
     use(any)
+}
+
+internal class Unstable {
+    @Suppress("unused")
+    var x: Int = 0
+}
+
+internal sealed class LoadingState<T> {
+    data object Loading : LoadingState<Unstable>()
+    data class Content<T : Any>(var data: T) : LoadingState<T>()
+}
+
+@Composable
+internal fun <T> LoadingContent(state: LoadingState<T>, result: MutableState<Boolean>) {
+    LaunchedEffect(state) {
+        if (state is LoadingState.Content<*>) {
+            result.value = true
+        }
+    }
 }

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/SubtypeStabilityNeglectedRegressionTestEntrypoint.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/SubtypeStabilityNeglectedRegressionTestEntrypoint.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.compiler.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+
+// This function and [Unstable] need to be in different files so that the stability of [Unstable] is
+// `Stability.Runtime` from the perspective of this function.
+@Composable
+internal fun SubtypeStabilityNeglectedRegressionTestEntrypoint(state: LoadingState<Unstable>, result: MutableState<Boolean>) {
+    LoadingContent(state, result)
+}

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
@@ -24,6 +24,7 @@ import androidx.compose.compiler.plugins.kotlin.lower.isSyntheticComposableFunct
 import com.google.common.annotations.VisibleForTesting
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClassType
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.declarations.*
@@ -380,7 +381,11 @@ class StabilityInferencer(
             )
         }
 
-        var stability = Stability.Stable
+        var stability = if (declaration.modality == Modality.FINAL) {
+            Stability.Stable
+        } else {
+            Stability.Unknown(declaration)
+        }
 
         for (member in declaration.declarations) {
             when (member) {
@@ -398,7 +403,10 @@ class StabilityInferencer(
         }
 
         declaration.superClass?.let {
-            stability += stabilityOf(it, substitutions, analyzing, analysisEntryFile)
+            val superClassStability = stabilityOf(it, substitutions, analyzing, analysisEntryFile)
+            if (superClassStability !is Stability.Unknown) {
+                stability += superClassStability
+            }
         }
 
         return stability


### PR DESCRIPTION
This means that when the stability of a non-final class is not certainly `Unstable`, `Parameter`, or `Combined`, it will now get the default stability of `Unknown` instead of `Stable`.

This prevents situations where:
  1. An unstable class `B` extends a stable class `A`
  2. The compiler generates some code that only handles stable types, because it's only considering `A`
  3. An instance of `B` is passed into that code at runtime, causing incorrect behaviour

Relnote: "Made the default stability of non-final classes `Unknown` instead of `Stable`"

Bug: 511102714