### PR TITLE
FE: rename FirSimpleFunctionChecker -> FirNamedFunctionChecker

### DIFF
--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/Main.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/Main.kt
@@ -198,7 +198,7 @@ fun main(args: Array<String>) {
                 visitAlso<FirErrorProperty>(it)
             }
             alias<FirFunction>("FunctionChecker", false)
-            alias<FirNamedFunction>("SimpleFunctionChecker")
+            alias<FirNamedFunction>("NamedFunctionChecker")
             alias<FirProperty>("PropertyChecker")
             alias<FirClassLikeDeclaration>("ClassLikeChecker", false)
             alias<FirClass>("ClassChecker")

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsDeclarationCheckers.kt
@@ -49,7 +49,7 @@ object JsDeclarationCheckers : DeclarationCheckers() {
             FirJsNameClashClassMembersChecker.ForExpectClass,
         )
 
-    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
+    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
         get() = setOf(
             FirJsNativeInvokeChecker,
             FirJsNativeGetterChecker,

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/JsDeclarationCheckers.kt
@@ -49,7 +49,7 @@ object JsDeclarationCheckers : DeclarationCheckers() {
             FirJsNameClashClassMembersChecker.ForExpectClass,
         )
 
-    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
+    override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
         get() = setOf(
             FirJsNativeInvokeChecker,
             FirJsNativeGetterChecker,

--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/JvmDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/JvmDeclarationCheckers.kt
@@ -72,7 +72,7 @@ object JvmDeclarationCheckers : DeclarationCheckers() {
             FirUpperBoundsChecker,
         )
 
-    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
+    override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
         get() = setOf(
             FirAccidentalOverrideClashChecker,
         )

--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/JvmDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/JvmDeclarationCheckers.kt
@@ -72,7 +72,7 @@ object JvmDeclarationCheckers : DeclarationCheckers() {
             FirUpperBoundsChecker,
         )
 
-    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
+    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
         get() = setOf(
             FirAccidentalOverrideClashChecker,
         )

--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirAccidentalOverrideClashChecker.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirAccidentalOverrideClashChecker.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.unsubstitutedScope
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.ACCIDENTAL_OVERRIDE_CLASH_BY_JVM_SIGNATURE
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.JVM_SHORT_NAME_TO_BUILTIN_SHORT_NAMES_MAP
 import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.sameAsBuiltinMethodWithErasedValueParameters
 
-object FirAccidentalOverrideClashChecker : FirSimpleFunctionChecker(MppCheckerKind.Platform) {
+object FirAccidentalOverrideClashChecker : FirNamedFunctionChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         if (!declaration.isOverride) return

--- a/compiler/fir/checkers/checkers.wasm/src/org/jetbrains/kotlin/fir/analysis/wasm/checkers/WasmDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.wasm/src/org/jetbrains/kotlin/fir/analysis/wasm/checkers/WasmDeclarationCheckers.kt
@@ -41,7 +41,7 @@ object WasmJsDeclarationCheckers : DeclarationCheckers() {
             FirWasmJsAssociatedObjectChecker,
         )
 
-    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
+    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
         get() = setOf(
             FirWasmJsNativeInvokeChecker,
         )

--- a/compiler/fir/checkers/checkers.wasm/src/org/jetbrains/kotlin/fir/analysis/wasm/checkers/WasmDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.wasm/src/org/jetbrains/kotlin/fir/analysis/wasm/checkers/WasmDeclarationCheckers.kt
@@ -41,7 +41,7 @@ object WasmJsDeclarationCheckers : DeclarationCheckers() {
             FirWasmJsAssociatedObjectChecker,
         )
 
-    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
+    override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
         get() = setOf(
             FirWasmJsNativeInvokeChecker,
         )

--- a/compiler/fir/checkers/checkers.web.common/src/org/jetbrains/kotlin/fir/analysis/web/common/checkers/declaration/FirWebCommonNativeAnnotationCheckers.kt
+++ b/compiler/fir/checkers/checkers.web.common/src/org/jetbrains/kotlin/fir/analysis/web/common/checkers/declaration/FirWebCommonNativeAnnotationCheckers.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactory1
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.fir.declarations.utils.isExtension
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.WebCommonStandardClassIds
 import org.jetbrains.kotlin.fir.analysis.checkers.isTopLevel
 import org.jetbrains.kotlin.fir.declarations.utils.isNativeObject
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
@@ -29,7 +28,7 @@ import org.jetbrains.kotlin.fir.types.ConeKotlinType
 abstract class FirWebCommonAbstractNativeAnnotationChecker(
     private val requiredAnnotation: ClassId,
     private val error: KtDiagnosticFactory1<ConeKotlinType>,
-) : FirSimpleFunctionChecker(MppCheckerKind.Platform) {
+) : FirNamedFunctionChecker(MppCheckerKind.Platform) {
 
     context(context: CheckerContext)
     protected fun hasRequiredAnnotation(declaration: FirFunction): Boolean =

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/ComposedDeclarationCheckers.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/ComposedDeclarationCheckers.kt
@@ -25,8 +25,8 @@ class ComposedDeclarationCheckers(val predicate: (FirCheckerWithMppKind) -> Bool
         get() = _callableDeclarationCheckers
     override val functionCheckers: Set<FirFunctionChecker>
         get() = _functionCheckers
-    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
-        get() = _simpleFunctionCheckers
+    override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
+        get() = _namedFunctionCheckers
     override val propertyCheckers: Set<FirPropertyChecker>
         get() = _propertyCheckers
     override val classLikeCheckers: Set<FirClassLikeChecker>
@@ -71,7 +71,7 @@ class ComposedDeclarationCheckers(val predicate: (FirCheckerWithMppKind) -> Bool
     private val _basicDeclarationCheckers: MutableSet<FirBasicDeclarationChecker> = mutableSetOf()
     private val _callableDeclarationCheckers: MutableSet<FirCallableDeclarationChecker> = mutableSetOf()
     private val _functionCheckers: MutableSet<FirFunctionChecker> = mutableSetOf()
-    private val _simpleFunctionCheckers: MutableSet<FirSimpleFunctionChecker> = mutableSetOf()
+    private val _namedFunctionCheckers: MutableSet<FirNamedFunctionChecker> = mutableSetOf()
     private val _propertyCheckers: MutableSet<FirPropertyChecker> = mutableSetOf()
     private val _classLikeCheckers: MutableSet<FirClassLikeChecker> = mutableSetOf()
     private val _classCheckers: MutableSet<FirClassChecker> = mutableSetOf()
@@ -98,7 +98,7 @@ class ComposedDeclarationCheckers(val predicate: (FirCheckerWithMppKind) -> Bool
         checkers.basicDeclarationCheckers.filterTo(_basicDeclarationCheckers, predicate)
         checkers.callableDeclarationCheckers.filterTo(_callableDeclarationCheckers, predicate)
         checkers.functionCheckers.filterTo(_functionCheckers, predicate)
-        checkers.simpleFunctionCheckers.filterTo(_simpleFunctionCheckers, predicate)
+        checkers.namedFunctionCheckers.filterTo(_namedFunctionCheckers, predicate)
         checkers.propertyCheckers.filterTo(_propertyCheckers, predicate)
         checkers.classLikeCheckers.filterTo(_classLikeCheckers, predicate)
         checkers.classCheckers.filterTo(_classCheckers, predicate)

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/DeclarationCheckers.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/DeclarationCheckers.kt
@@ -23,7 +23,7 @@ abstract class DeclarationCheckers {
     open val basicDeclarationCheckers: Set<FirBasicDeclarationChecker> = emptySet()
     open val callableDeclarationCheckers: Set<FirCallableDeclarationChecker> = emptySet()
     open val functionCheckers: Set<FirFunctionChecker> = emptySet()
-    open val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = emptySet()
+    open val namedFunctionCheckers: Set<FirNamedFunctionChecker> = emptySet()
     open val propertyCheckers: Set<FirPropertyChecker> = emptySet()
     open val classLikeCheckers: Set<FirClassLikeChecker> = emptySet()
     open val classCheckers: Set<FirClassChecker> = emptySet()
@@ -49,7 +49,7 @@ abstract class DeclarationCheckers {
     @CheckersComponentInternal internal val allBasicDeclarationCheckers: Array<FirBasicDeclarationChecker> by lazy { basicDeclarationCheckers.toTypedArray() }
     @CheckersComponentInternal internal val allCallableDeclarationCheckers: Array<FirCallableDeclarationChecker> by lazy { (callableDeclarationCheckers + basicDeclarationCheckers).toTypedArray() as Array<FirCallableDeclarationChecker> }
     @CheckersComponentInternal internal val allFunctionCheckers: Array<FirFunctionChecker> by lazy { (functionCheckers + callableDeclarationCheckers + basicDeclarationCheckers).toTypedArray() as Array<FirFunctionChecker> }
-    @CheckersComponentInternal internal val allSimpleFunctionCheckers: Array<FirSimpleFunctionChecker> by lazy { (simpleFunctionCheckers + functionCheckers + callableDeclarationCheckers + basicDeclarationCheckers).toTypedArray() as Array<FirSimpleFunctionChecker> }
+    @CheckersComponentInternal internal val allNamedFunctionCheckers: Array<FirNamedFunctionChecker> by lazy { (namedFunctionCheckers + functionCheckers + callableDeclarationCheckers + basicDeclarationCheckers).toTypedArray() as Array<FirNamedFunctionChecker> }
     @CheckersComponentInternal internal val allPropertyCheckers: Array<FirPropertyChecker> by lazy { (propertyCheckers + callableDeclarationCheckers + basicDeclarationCheckers).toTypedArray() as Array<FirPropertyChecker> }
     @CheckersComponentInternal internal val allClassLikeCheckers: Array<FirClassLikeChecker> by lazy { (classLikeCheckers + basicDeclarationCheckers).toTypedArray() as Array<FirClassLikeChecker> }
     @CheckersComponentInternal internal val allClassCheckers: Array<FirClassChecker> by lazy { (classCheckers + classLikeCheckers + basicDeclarationCheckers).toTypedArray() as Array<FirClassChecker> }

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/DeclarationCheckersDiagnosticComponent.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/DeclarationCheckersDiagnosticComponent.kt
@@ -48,7 +48,7 @@ class DeclarationCheckersDiagnosticComponent(
     }
 
     override fun visitNamedFunction(namedFunction: FirNamedFunction, data: CheckerContext) {
-        checkers.allSimpleFunctionCheckers.check(namedFunction, data)
+        checkers.allNamedFunctionCheckers.check(namedFunction, data)
     }
 
     override fun visitProperty(property: FirProperty, data: CheckerContext) {

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FilteredDeclarationCheckers.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FilteredDeclarationCheckers.kt
@@ -23,7 +23,7 @@ class FilteredDeclarationCheckers(
     override val basicDeclarationCheckers: Set<FirBasicDeclarationChecker> = delegate.basicDeclarationCheckers.filterTo(mutableSetOf(), predicate)
     override val callableDeclarationCheckers: Set<FirCallableDeclarationChecker> = delegate.callableDeclarationCheckers.filterTo(mutableSetOf(), predicate)
     override val functionCheckers: Set<FirFunctionChecker> = delegate.functionCheckers.filterTo(mutableSetOf(), predicate)
-    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = delegate.simpleFunctionCheckers.filterTo(mutableSetOf(), predicate)
+    override val namedFunctionCheckers: Set<FirNamedFunctionChecker> = delegate.namedFunctionCheckers.filterTo(mutableSetOf(), predicate)
     override val propertyCheckers: Set<FirPropertyChecker> = delegate.propertyCheckers.filterTo(mutableSetOf(), predicate)
     override val classLikeCheckers: Set<FirClassLikeChecker> = delegate.classLikeCheckers.filterTo(mutableSetOf(), predicate)
     override val classCheckers: Set<FirClassChecker> = delegate.classCheckers.filterTo(mutableSetOf(), predicate)

--- a/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerAliases.kt
+++ b/compiler/fir/checkers/gen/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDeclarationCheckerAliases.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 typealias FirBasicDeclarationChecker = FirDeclarationChecker<FirDeclaration>
 typealias FirCallableDeclarationChecker = FirDeclarationChecker<FirCallableDeclaration>
 typealias FirFunctionChecker = FirDeclarationChecker<FirFunction>
-typealias FirSimpleFunctionChecker = FirDeclarationChecker<FirNamedFunction>
+typealias FirNamedFunctionChecker = FirDeclarationChecker<FirNamedFunction>
 typealias FirPropertyChecker = FirDeclarationChecker<FirProperty>
 typealias FirClassLikeChecker = FirDeclarationChecker<FirClassLikeDeclaration>
 typealias FirClassChecker = FirDeclarationChecker<FirClass>

--- a/compiler/fir/checkers/module.md
+++ b/compiler/fir/checkers/module.md
@@ -30,7 +30,7 @@ All checkers are expected to satisfy the following contracts:
 These contracts imply the following:
 1. Usually, a checker is an `object` without any state.
 2. Each checker should work correctly even if all other checkers are disabled.
-3. If a checker is meant to check only simple functions, there is no need to parameterize it with `FirDeclaration` and check if the declaration is a `FirSimpleFunction`. Instead, parameterize the checker itself with `FirSimpleFunction`.
+3. If a checker is meant to check only simple functions, there is no need to parameterize it with `FirDeclaration` and check if the declaration is a `FirNamedFunction`. Instead, parameterize the checker itself with `FirNamedFunction`.
     - This is necessary not only to simplify the code but also to improve performance. Typed checkers are run only on elements with a suitable type. For example, if you declare a `FirRegularClassChecker`, it will never be run for a `FirAnonymousObject`.
 4. If a checker is supposed to check anonymous initializers, it's better to create a `FirAnonymousInitializerChecker` that is separately run for each `init` block in the class, rather than creating a `FirClassChecker` that manually iterates over each `init` block in the class. There are several reasons for this:
     - The diagnostic suppression mechanism is implemented in the checkers dispatcher, so reporting something on a sub-element can cause false-positive diagnostics if there is a `@Suppress` annotation between the root element (passed to the checker) and the sub-element. While there is a mechanism to fix this, it is not recommended to use it.

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/CommonDeclarationCheckers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/CommonDeclarationCheckers.kt
@@ -74,11 +74,11 @@ object CommonDeclarationCheckers : DeclarationCheckers() {
         FirVersionOverloadsChecker,
     )
 
-    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(
+    override val namedFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(
         FirFunctionNameChecker,
         FirFunctionTypeParametersSyntaxChecker,
         FirMemberFunctionsChecker,
-        FirInlineBodySimpleFunctionChecker,
+        FirInlineBodyNamedFunctionChecker,
         FirDataObjectContentChecker,
         ContractSyntaxV2FunctionChecker,
         FirAnyDeprecationChecker,

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/CommonDeclarationCheckers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/CommonDeclarationCheckers.kt
@@ -74,7 +74,7 @@ object CommonDeclarationCheckers : DeclarationCheckers() {
         FirVersionOverloadsChecker,
     )
 
-    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = setOf(
+    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(
         FirFunctionNameChecker,
         FirFunctionTypeParametersSyntaxChecker,
         FirMemberFunctionsChecker,

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/ExtraDeclarationCheckers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/ExtraDeclarationCheckers.kt
@@ -33,7 +33,7 @@ object ExtraDeclarationCheckers : DeclarationCheckers() {
         UnreachableCodeChecker,
     )
 
-    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(
+    override val namedFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(
         RedundantReturnUnitType,
     )
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/ExtraDeclarationCheckers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/ExtraDeclarationCheckers.kt
@@ -33,7 +33,7 @@ object ExtraDeclarationCheckers : DeclarationCheckers() {
         UnreachableCodeChecker,
     )
 
-    override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = setOf(
+    override val simpleFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(
         RedundantReturnUnitType,
     )
 }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/FirConflictsHelpers.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/FirConflictsHelpers.kt
@@ -99,7 +99,7 @@ private fun isAtLeastOneExpect(first: FirBasedSymbol<*>, second: FirBasedSymbol<
     first.resolvedStatus?.isExpect == true || second.resolvedStatus?.isExpect == true
 
 private class DeclarationBuckets {
-    val simpleFunctions = mutableListOf<Pair<FirNamedFunctionSymbol, String>>()
+    val namedFunctions = mutableListOf<Pair<FirNamedFunctionSymbol, String>>()
     val constructors = mutableListOf<Pair<FirConstructorSymbol, String>>()
     val classLikes = mutableListOf<Pair<FirClassLikeSymbol<*>, String>>()
     val properties = mutableListOf<Pair<FirPropertySymbol, String>>()
@@ -114,7 +114,7 @@ private fun groupTopLevelByName(declarations: List<FirDeclaration>): Map<Name, D
 
         when (declaration) {
             is FirNamedFunction ->
-                groups.getOrPut(declaration.name, ::DeclarationBuckets).simpleFunctions +=
+                groups.getOrPut(declaration.name, ::DeclarationBuckets).namedFunctions +=
                     declaration.symbol to FirRedeclarationPresenter.represent(declaration.symbol)
             is FirProperty -> {
                 val group = groups.getOrPut(declaration.name, ::DeclarationBuckets)
@@ -333,7 +333,7 @@ private fun <D : FirBasedSymbol<*>, S : D> FirDeclarationCollector<D>.collect(
  *
  * #### Matrix of possible conflicts between "sources" and "buckets"
  *
- * |                         | simpleFunctions | constructors | classLikes | Properties | extensionProperties |
+ * |                         |  namedFunctions | constructors | classLikes | Properties | extensionProperties |
  * |-------------------------|-----------------|--------------|------------|------------|---------------------|
  * | functions               | X               | X            |            |            |                     |
  * | classifiers             |                 |              | X          | X          |                     |
@@ -347,7 +347,7 @@ fun FirDeclarationCollector<FirBasedSymbol<*>>.collectTopLevel(
     @OptIn(DirectDeclarationsAccess::class)
     for ((declarationName, group) in groupTopLevelByName(file.declarations)) {
         val groupHasClassLikesOrProperties = group.classLikes.isNotEmpty() || group.properties.isNotEmpty()
-        val groupHasSimpleFunctions = group.simpleFunctions.isNotEmpty()
+        val groupHasNamedFunctions = group.namedFunctions.isNotEmpty()
 
         fun collect(
             declarations: List<Pair<FirBasedSymbol<*>, String>>,
@@ -377,7 +377,7 @@ fun FirDeclarationCollector<FirBasedSymbol<*>>.collectTopLevel(
             collect(group.classLikes, conflictingSymbol, conflictingPresentation, conflictingFile)
             collect(group.properties, conflictingSymbol, conflictingPresentation, conflictingFile)
 
-            if (groupHasSimpleFunctions) {
+            if (groupHasNamedFunctions) {
                 if (conflictingSymbol !is FirClassLikeSymbol<*>) {
                     return
                 }
@@ -389,7 +389,7 @@ fun FirDeclarationCollector<FirBasedSymbol<*>>.collectTopLevel(
 
                     scopeWithConstructors.processDeclaredConstructors { constructor ->
                         val ctorRepresentation = FirRedeclarationPresenter.represent(constructor, conflictingSymbol)
-                        collect(group.simpleFunctions, conflictingSymbol = constructor, conflictingPresentation = ctorRepresentation)
+                        collect(group.namedFunctions, conflictingSymbol = constructor, conflictingPresentation = ctorRepresentation)
                     }
                 }
             }
@@ -398,15 +398,15 @@ fun FirDeclarationCollector<FirBasedSymbol<*>>.collectTopLevel(
         // Check sources in the order from the table above. Skip the check if all relevant buckets are empty.
 
         // Function source
-        if (groupHasSimpleFunctions || group.constructors.isNotEmpty()) {
+        if (groupHasNamedFunctions || group.constructors.isNotEmpty()) {
             packageMemberScope.processFunctionsByName(declarationName) {
-                collect(group.simpleFunctions, it)
+                collect(group.namedFunctions, it)
                 collect(group.constructors, it)
             }
         }
 
         // Classifier sources, collectForClassifierSource will also check constructors.
-        if (groupHasClassLikesOrProperties || groupHasSimpleFunctions) {
+        if (groupHasClassLikesOrProperties || groupHasNamedFunctions) {
             // Scope will only return one classifier per name
             packageMemberScope.processClassifiersByNameWithSubstitution(declarationName) { symbol, _ ->
                 collectFromClassifierSource(conflictingSymbol = symbol)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirAnyDeprecationChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirAnyDeprecationChecker.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.fir.declarations.utils.isMethodOfAny
 import org.jetbrains.kotlin.fir.declarations.utils.isOverride
 
-object FirAnyDeprecationChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object FirAnyDeprecationChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         if (!declaration.isOverride || !declaration.symbol.isMethodOfAny) return

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDataObjectContentChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirDataObjectContentChecker.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
-object FirDataObjectContentChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object FirDataObjectContentChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         if (!declaration.hasModifier(KtTokens.OVERRIDE_KEYWORD)) return

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirFunctionNameChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirFunctionNameChecker.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFileSymbol
 import org.jetbrains.kotlin.name.SpecialNames
 
-object FirFunctionNameChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object FirFunctionNameChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         val source = declaration.source

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirInlineBodyNamedFunctionChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirInlineBodyNamedFunctionChecker.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 
-object FirInlineBodySimpleFunctionChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
+object FirInlineBodyNamedFunctionChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         if (isInsideInlineContext(declaration)) {

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirInlineBodyRegularClassChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirInlineBodyRegularClassChecker.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 object FirInlineBodyRegularClassChecker : FirRegularClassChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirRegularClass) {
-        if (FirInlineBodySimpleFunctionChecker.isInsideInlineContext(declaration) && !declaration.classKind.isSingleton) {
+        if (FirInlineBodyNamedFunctionChecker.isInsideInlineContext(declaration) && !declaration.classKind.isSingleton) {
             reporter.reportOn(declaration.source, FirErrors.NOT_YET_SUPPORTED_IN_INLINE, "Local classes")
         }
     }

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirInlineBodySimpleFunctionChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirInlineBodySimpleFunctionChecker.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirAnonymousObjectSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 
-object FirInlineBodySimpleFunctionChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object FirInlineBodySimpleFunctionChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         if (isInsideInlineContext(declaration)) {

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirMemberFunctionsChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirMemberFunctionsChecker.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.utils.addToStdlib.lastIsInstanceOrNull
 
 // See old FE's [DeclarationsChecker]
-object FirMemberFunctionsChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object FirMemberFunctionsChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         val containingDeclaration = context.containingDeclarations.lastIsInstanceOrNull<FirClassSymbol<*>>() ?: return

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/NiceContractSyntaxChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/NiceContractSyntaxChecker.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.fir.declarations.FirContractDescriptionOwner
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 
-object ContractSyntaxV2FunctionChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object ContractSyntaxV2FunctionChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         checkFeatureIsEnabled(declaration)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extra/RedundantReturnUnitType.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extra/RedundantReturnUnitType.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.fir.analysis.checkers.extra
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors
 import org.jetbrains.kotlin.diagnostics.reportOn
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.fir.resolve.fullyExpandedType
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.isUnit
 
-object RedundantReturnUnitType : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object RedundantReturnUnitType : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         if (declaration.body is FirSingleExpressionBlock) return

--- a/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/FirAssignmentPluginCheckersExtension.kt
+++ b/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/FirAssignmentPluginCheckersExtension.kt
@@ -19,7 +19,7 @@ class FirAssignmentPluginCheckersExtension(
 ) : FirAdditionalCheckersExtension(session) {
 
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
-        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
+        override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
             get() = setOf(FirAssignmentPluginFunctionChecker)
     }
 

--- a/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/FirAssignmentPluginCheckersExtension.kt
+++ b/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/FirAssignmentPluginCheckersExtension.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.assignment.plugin.k2.diagnostics.FirAssignmentPlugin
 import org.jetbrains.kotlin.assignment.plugin.k2.diagnostics.FirAssignmentPluginFunctionChecker
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
@@ -19,7 +19,7 @@ class FirAssignmentPluginCheckersExtension(
 ) : FirAdditionalCheckersExtension(session) {
 
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
-        override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
+        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
             get() = setOf(FirAssignmentPluginFunctionChecker)
     }
 

--- a/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/diagnostics/FirAssignmentPluginFunctionChecker.kt
+++ b/plugins/assign-plugin/assign-plugin.k2/src/org/jetbrains/kotlin/assignment/plugin/k2/diagnostics/FirAssignmentPluginFunctionChecker.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.utils.isExtension
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
 import org.jetbrains.kotlin.types.expressions.OperatorConventions.ASSIGN_METHOD
 
-object FirAssignmentPluginFunctionChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object FirAssignmentPluginFunctionChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {

--- a/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/DataSchemaInfoCheckers.kt
+++ b/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/DataSchemaInfoCheckers.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirPropertyChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirRegularClassChecker
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirPropertyAccessExpressionChecker
@@ -63,7 +63,7 @@ class DataSchemaInfoCheckers(
         override val propertyCheckers: Set<FirPropertyChecker> = setOf(
             PropertySchemaReporter,
         )
-        override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> =
+        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker> =
             setOf(
                 FunctionDeclarationSchemaReporter,
             )
@@ -127,7 +127,7 @@ private data object PropertySchemaReporter : FirPropertyChecker(mppKind = MppChe
     }
 }
 
-private data object FunctionDeclarationSchemaReporter : FirSimpleFunctionChecker(mppKind = MppCheckerKind.Common) {
+private data object FunctionDeclarationSchemaReporter : FirNamedFunctionChecker(mppKind = MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         val type = declaration.returnTypeRef.coneType

--- a/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/DataSchemaInfoCheckers.kt
+++ b/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/extensions/DataSchemaInfoCheckers.kt
@@ -63,7 +63,7 @@ class DataSchemaInfoCheckers(
         override val propertyCheckers: Set<FirPropertyChecker> = setOf(
             PropertySchemaReporter,
         )
-        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker> =
+        override val namedFunctionCheckers: Set<FirNamedFunctionChecker> =
             setOf(
                 FunctionDeclarationSchemaReporter,
             )

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeCheckersExtension.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeCheckersExtension.kt
@@ -30,7 +30,7 @@ class FirParcelizeCheckersExtension(
         override val propertyCheckers: Set<FirPropertyChecker>
             get() = setOf(FirParcelizePropertyChecker(parcelizeAnnotations))
 
-        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
+        override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
             get() = setOf(FirParcelizeFunctionChecker(parcelizeAnnotations))
 
         override val constructorCheckers: Set<FirConstructorChecker>

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeCheckersExtension.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/FirParcelizeCheckersExtension.kt
@@ -30,7 +30,7 @@ class FirParcelizeCheckersExtension(
         override val propertyCheckers: Set<FirPropertyChecker>
             get() = setOf(FirParcelizePropertyChecker(parcelizeAnnotations))
 
-        override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
+        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
             get() = setOf(FirParcelizeFunctionChecker(parcelizeAnnotations))
 
         override val constructorCheckers: Set<FirConstructorChecker>

--- a/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeFunctionChecker.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.k2/src/org/jetbrains/kotlin/parcelize/fir/diagnostics/FirParcelizeFunctionChecker.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.utils.isOverride
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.fir.types.isUnit
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.name.ClassId
 
-class FirParcelizeFunctionChecker(private val parcelizeAnnotations: List<ClassId>) : FirSimpleFunctionChecker(MppCheckerKind.Platform) {
+class FirParcelizeFunctionChecker(private val parcelizeAnnotations: List<ClassId>) : FirNamedFunctionChecker(MppCheckerKind.Platform) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         val containingClassSymbol = declaration.dispatchReceiverType?.toRegularClassSymbol()

--- a/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/PluginAdditionalCheckers.kt
+++ b/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/PluginAdditionalCheckers.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.plugin.sandbox.fir.checkers.SignedNumberCallChecker
 
 class PluginAdditionalCheckers(session: FirSession) : FirAdditionalCheckersExtension(session) {
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
-        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
+        override val namedFunctionCheckers: Set<FirNamedFunctionChecker>
             get() = setOf(DummyNameChecker)
     }
 

--- a/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/PluginAdditionalCheckers.kt
+++ b/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/PluginAdditionalCheckers.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.plugin.sandbox.fir
 
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.plugin.sandbox.fir.checkers.SignedNumberCallChecker
 
 class PluginAdditionalCheckers(session: FirSession) : FirAdditionalCheckersExtension(session) {
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
-        override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
+        override val simpleFunctionCheckers: Set<FirNamedFunctionChecker>
             get() = setOf(DummyNameChecker)
     }
 

--- a/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/checkers/DummyNameChecker.kt
+++ b/plugins/plugin-sandbox/src/org/jetbrains/kotlin/plugin/sandbox/fir/checkers/DummyNameChecker.kt
@@ -9,10 +9,10 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 
-object DummyNameChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object DummyNameChecker : FirNamedFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirNamedFunction) {
         val name = declaration.name.asString()


### PR DESCRIPTION
The purpose is mostly about having consistent names along the whole FIR