### PR TITLE
KT-86268: Keep abiValidation working with compilerVersion < 2.4.0 after migrating to BTA

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationKmpIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationKmpIT.kt
@@ -12,6 +12,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.abi.utils.*
@@ -20,6 +21,7 @@ import org.jetbrains.kotlin.gradle.abi.utils.AbiValidationTestDumps.SIMPLE_CLASS
 import org.jetbrains.kotlin.gradle.abi.utils.AbiValidationTestDumps.assertDumpsEqual
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.gradle.util.useCompilerVersion
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.junit.jupiter.api.Assumptions
@@ -47,6 +49,26 @@ class AbiValidationKmpIT : KGPBaseTest() {
     private fun TestProject.defaultKmpProject() {
         defaultNativeTargets()
         abiValidation()
+    }
+
+    @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
+    @GradleTest
+    @DisplayName("Test abiValidation compatibility with compilerVersion prior 2.4.0")
+    fun testCompilerVersionCompatibility(gradleVersion: GradleVersion) {
+        kmpProject(gradleVersion) {
+            buildScriptInjection {
+                kotlinMultiplatform.jvm()
+                kotlinMultiplatform.compilerVersion.set("2.2.0")
+            }
+
+            abiValidation()
+
+            build("updateKotlinAbi")
+
+            build("check") {
+                assertTasksExecuted(":checkKotlinAbi")
+            }
+        }
     }
 
     @GradleTest

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
@@ -177,19 +177,19 @@ abstract class KotlinProjectExtension @Inject constructor(
     @ExperimentalAbiValidation
     override val abiValidation: AbiValidationExtension
         get() {
-            abiValidationInternal.activate()
+            abiValidationInternal.activate(compilerVersion)
             return abiValidationInternal
         }
 
     @ExperimentalAbiValidation
     override fun abiValidation(action: Action<AbiValidationExtension>) {
-        abiValidationInternal.activate()
+        abiValidationInternal.activate(compilerVersion)
         action.execute(abiValidationInternal)
     }
 
     @ExperimentalAbiValidation
     override fun abiValidation() {
-        abiValidationInternal.activate()
+        abiValidationInternal.activate(compilerVersion)
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/AbstractKotlinPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/AbstractKotlinPlugin.kt
@@ -35,6 +35,7 @@ internal const val BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME = "kotlinBuildTo
 internal const val KLIB_COMMONIZER_CLASSPATH_CONFIGURATION_NAME = "kotlinKlibCommonizerClasspath"
 internal const val KOTLIN_NATIVE_BUNDLE_CONFIGURATION_NAME = "kotlinNativeBundleConfiguration"
 internal const val KOTLIN_BOUNCY_CASTLE_CONFIGURATION_NAME = "kotlinBouncyCastleConfiguration"
+internal const val ABI_VALIDATION_COMPAT_CLASSPATH_CONFIGURATION_NAME = "kotlinAbiValidationCompatClasspath"
 
 internal abstract class AbstractKotlinPlugin(
     val tasksProvider: KotlinTasksProvider,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper.kt
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.internal.operations.BuildOperationListenerManager
+import org.gradle.kotlin.dsl.add
 import org.jetbrains.kotlin.compilerRunner.btapi.BuildSessionService
 import org.jetbrains.kotlin.compilerRunner.maybeCreateCommonizerClasspathConfiguration
 import org.jetbrains.kotlin.gradle.dsl.*
@@ -160,6 +161,25 @@ abstract class DefaultKotlinBasePlugin : KotlinBasePlugin {
                         }
                 }
             }
+
+        project
+            .configurations
+            .maybeCreateResolvable(ABI_VALIDATION_COMPAT_CLASSPATH_CONFIGURATION_NAME) {
+                project.dependencies.add(name, "$KOTLIN_MODULE_GROUP:$KOTLIN_BUILD_TOOLS_API_COMPAT:$pluginVersion")
+                // ABI validation BTA toolchain was added only in 2.4.0-Beta2.
+                // Before that, abi-tools corresponding to project's KGP version was used.
+                // To support using abiValidation with compilerVersion < 2.4.0-Beta2,
+                // this configuration should be used instead of the BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME.
+                // It will effectively ignore configure compilerVersion
+                // and will fix toolchain's version to the latest 2.4 toolchain (it applies to abiValidation toolchain only).
+                project.dependencies.add(name, "$KOTLIN_MODULE_GROUP:$KOTLIN_BUILD_TOOLS_API_IMPL") {
+                    version { versionConstraint ->
+                        versionConstraint.strictly("[2.4.0-Beta2, 2.5.0)")
+                    }
+                }
+            }
+
+
         project
             .tasks
             .withType(AbstractKotlinCompileTool::class.java)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/abi/internal/AbiValidationExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/abi/internal/AbiValidationExtension.kt
@@ -37,10 +37,10 @@ internal abstract class AbiValidationExtensionImpl @Inject constructor(
 ) : AbiValidationExtension {
     private var activated = false
 
-    internal fun activate() {
+    internal fun activate(compilerVersion: Provider<String>) {
         if (!activated) {
             activated = true
-            registerTasks(projectName, tasks, layout, buildSessionService, configurations)
+            registerTasks(projectName, tasks, layout, buildSessionService, configurations, compilerVersion)
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/abi/internal/Configs.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/abi/internal/Configs.kt
@@ -16,12 +16,15 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.compilerRunner.btapi.BuildSessionService
 import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+import org.jetbrains.kotlin.gradle.plugin.ABI_VALIDATION_COMPAT_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.plugin.BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.abi.internal.AbiValidationPaths.LEGACY_JVM_DUMP_EXTENSION
 import org.jetbrains.kotlin.gradle.plugin.abi.internal.AbiValidationPaths.LEGACY_KLIB_DUMP_EXTENSION
-import org.jetbrains.kotlin.gradle.plugin.BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.tasks.abi.AbiToolsTask
 import org.jetbrains.kotlin.gradle.tasks.abi.KotlinAbiCheckTaskImpl
 import org.jetbrains.kotlin.gradle.tasks.abi.KotlinAbiDumpTaskImpl
 import org.jetbrains.kotlin.gradle.tasks.abi.KotlinAbiUpdateTask
+import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 
 /**
  * Configures the extension for Kotlin/JVM or Kotlin Android Gradle plugins.
@@ -30,6 +33,32 @@ import org.jetbrains.kotlin.gradle.tasks.abi.KotlinAbiUpdateTask
 internal fun AbiValidationExtensionImpl.configure(project: Project) {
     referenceDumpDir.convention(project.layout.projectDirectory.dir(AbiValidationPaths.LEGACY_DEFAULT_REFERENCE_DUMP_DIR))
     keepLocallyUnsupportedTargets.convention(true)
+}
+
+// Kotlin version where ABI validation was migrated to build tools API (BTA).
+private val KOTLIN_2_4_0_BETA2 = KotlinToolingVersion("2.4.0-Beta2")
+
+/**
+ * Configure [AbiToolsTask.buildToolsClasspath] to use either [BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME]
+ * or [ABI_VALIDATION_COMPAT_CLASSPATH_CONFIGURATION_NAME] classpath depending on a [compilerVersion].
+ *
+ * For [compilerVersion] prior [KOTLIN_2_4_0_BETA2] there is no ABI validation toolchain,
+ * so the latest 2.4.x toolchain will be used instead (it corresponds to [ABI_VALIDATION_COMPAT_CLASSPATH_CONFIGURATION_NAME]).
+ * For all other versions, the toolchain corresponding to [compilerVersion] will be used ([BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME]).
+ */
+private fun AbiToolsTask.configureClasspath(compilerVersion: Provider<String>, configurations: ConfigurationContainer) {
+    val actualBuildToolsClasspath = configurations.named(BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME)
+    val compatBuildToolsClasspath = configurations.named(ABI_VALIDATION_COMPAT_CLASSPATH_CONFIGURATION_NAME)
+    val configurationSelector =
+        compilerVersion.zip(compatBuildToolsClasspath) { providedCompilerVersion, providedCompatBuildToolsClasspath ->
+            val version = KotlinToolingVersion(providedCompilerVersion)
+            if (version < KOTLIN_2_4_0_BETA2) {
+                providedCompatBuildToolsClasspath
+            } else {
+                null
+            }
+        }.orElse(actualBuildToolsClasspath)
+    buildToolsClasspath.setFrom(configurationSelector)
 }
 
 /**
@@ -41,7 +70,8 @@ internal fun AbiValidationExtension.registerTasks(
     tasks: TaskContainer,
     layout: ProjectLayout,
     buildSessionService: Provider<BuildSessionService>,
-    configurations: ConfigurationContainer
+    configurations: ConfigurationContainer,
+    compilerVersion: Provider<String>,
 ) {
     val klibFileName = "$projectName$LEGACY_KLIB_DUMP_EXTENSION"
 
@@ -50,12 +80,10 @@ internal fun AbiValidationExtension.registerTasks(
     val dumpDir =
         layout.buildDirectory.dir(AbiValidationPaths.ACTUAL_DUMP_DIR)
 
-    val buildToolsClasspath = configurations.named(BUILD_TOOLS_API_CLASSPATH_CONFIGURATION_NAME)
-
     val dumpTaskProvider =
         tasks.register(KotlinAbiDumpTaskImpl.NAME, KotlinAbiDumpTaskImpl::class.java) {
             it.buildSessionService.convention(buildSessionService)
-            it.buildToolsClasspath.from(buildToolsClasspath)
+            it.configureClasspath(compilerVersion, configurations)
 
             it.dumpDir.convention(dumpDir)
             it.referenceKlibDump.convention(referenceDir.map { dir -> dir.file(klibFileName) })
@@ -75,7 +103,7 @@ internal fun AbiValidationExtension.registerTasks(
 
     val checkTaskProvider = tasks.register(KotlinAbiCheckTaskImpl.NAME, KotlinAbiCheckTaskImpl::class.java) {
         it.buildSessionService.convention(buildSessionService)
-        it.buildToolsClasspath.from(buildToolsClasspath)
+        it.configureClasspath(compilerVersion, configurations)
 
         it.actualDir.convention(dumpTaskProvider.map { t -> t.dumpDir.get() })
         it.referenceDir.convention(referenceDir)


### PR DESCRIPTION
After migrating to build-tools API (BTA), ABI validation no longer works if the project uses `compilerVersion` < 2.4.0.

For versions starting from 2.4.0 all should work fine, as there will be a ABI validation toolchain. But for previous versions there is no such a toolchain. Instead, ABI validation was using an implementation corresponding to a KGP version applied to a project.

To keep ABI validation working for projects that uses `compilerVersion`, this PR falls back to using the 2.4.x ABI validation toolchain if the `compilerVersion` < 2.4.0.

^KT-86268