### PR TITLE
KT-86010: Skip checkGroup() on the regex engine hot path

### DIFF
--- a/libraries/stdlib/native-wasm/src/kotlin/text/regex/MatchResultImpl.kt
+++ b/libraries/stdlib/native-wasm/src/kotlin/text/regex/MatchResultImpl.kt
@@ -169,13 +169,14 @@ constructor (internal val input: CharSequence,
     fun isCaptured(group: Int): Boolean = getStart(group) >= 0
 
     // Setters and getters for starts and ends of groups ===============================================================
+    // These setters and getters are invoked from the regex engine with a group index already validated by construction,
+    // so they avoid the per-call checkGroup() bounds check. Public entry points (e.g. group(Int), groups[Int]) still
+    // validate the index before reaching this fast path.
     internal fun setStart(group: Int, offset: Int) {
-        checkGroup(group)
         groupBounds[group * 2] = offset
     }
 
     internal fun setEnd(group: Int, offset: Int) {
-        checkGroup(group)
         groupBounds[group * 2 + 1] = offset
     }
 
@@ -186,7 +187,6 @@ constructor (internal val input: CharSequence,
      * @return the character index.
      */
     fun getStart(group: Int = 0): Int {
-        checkGroup(group)
         return groupBounds[group * 2]
     }
 
@@ -197,7 +197,6 @@ constructor (internal val input: CharSequence,
      * @return the character index.
      */
     fun getEnd(group: Int = 0): Int {
-        checkGroup(group)
         return groupBounds[group * 2 + 1]
     }
 
@@ -210,12 +209,13 @@ constructor (internal val input: CharSequence,
      * @return the text that matched the group.
      */
     fun group(group: Int = 0): String? {
+        checkGroup(group)
         val start = getStart(group)
         val end = getEnd(group)
         if (start < 0 || end < 0) {
             return null
         }
-        return input.subSequence(getStart(group), getEnd(group)).toString()
+        return input.subSequence(start, end).toString()
     }
 
     /**
@@ -248,7 +248,6 @@ constructor (internal val input: CharSequence,
     }
 
     fun updateGroup(index: Int, srtOffset: Int, endOffset: Int) {
-        checkGroup(index)
         groupBounds[index * 2] = srtOffset
         groupBounds[index * 2 + 1] = endOffset
     }


### PR DESCRIPTION
## Summary

`MatchResultImpl::checkGroup()` is invoked from `setStart` / `setEnd` / `getStart` / `getEnd` / `updateGroup` on every group access during regex evaluation. For patterns with capturing groups, this takes a measurable share of the matching time (see the [benchmark from KT-53538](https://github.com/fzhinkin/kotlin-stdlib-native-re-benchmarks/blob/fc74ea604a3f78c80243aac0e48065bcc8eead2b/src/commonMain/kotlin/RegexBenchmarks.kt#L28) referenced in the ticket).

The regex engine only ever passes group indices it has already validated by construction — they come from the compiled pattern. So the per-call bounds check on the engine hot path is redundant.

## Change

- Drop `checkGroup()` from `setStart`, `setEnd`, `getStart`, `getEnd`, `updateGroup`.
- Validate the index exactly once in `group(Int)`, the only path that takes a user-supplied index.
- `range`, `value`, `groups[Int]`, `groupValues` either route through `group(Int)` or use group `0` (always present), so they remain safe.
- Added a short comment above the accessors explaining the invariant.

## Public API

`MatchResult` — the public interface in `kotlin.text` — does not expose `getStart`/`getEnd`. `MatchResultImpl` itself is `internal`. External callers can only reach the validated entry points, so the change is behavior-preserving for the public API surface.

## Alternative considered

A more conservative variant would keep `checkGroup()` on `getStart` / `getEnd` and drop it only from the `internal` setters (`setStart` / `setEnd` / `updateGroup`). That would preserve the exact `IndexOutOfBoundsException` message for direct calls into `MatchResultImpl.getStart(invalid)` / `getEnd(invalid)`, but since those members are not part of `MatchResult` and `MatchResultImpl` is `internal`, the trade-off didn't seem worth it. Happy to switch to that variant if reviewers would prefer the stricter boundary.

## Testing

The full `:libraries:stdlib:native-wasm` test suite was not run locally — relying on CI for verification. The existing regex assertions in `libraries/stdlib/test/text/RegexTest.kt` (group access via `match.groups[index]`, `match.value`, `match.range`) all go through `group(Int)`, so their behavior is unchanged.

^KT-86010 Fixed