### PR TITLE
[NI] Fix Native image CI failures

### DIFF
--- a/prepare/compiler-embeddable/build.gradle.kts
+++ b/prepare/compiler-embeddable/build.gradle.kts
@@ -37,6 +37,7 @@ sourceSets {
 val runtimeJar = runtimeJar(embeddableCompiler()) {
     exclude("com/sun/jna/**")
     exclude("org/jetbrains/annotations/**")
+    exclude("META-INF/native-image/**")
     mergeServiceFiles()
 }
 

--- a/prepare/compiler-native-image/build.gradle.kts
+++ b/prepare/compiler-native-image/build.gradle.kts
@@ -72,9 +72,12 @@ val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
 
     val isWindows = OperatingSystem.current().isWindows
     val mainClass = "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler"
+    val outputFile = layout.buildDirectory.file("bin/kotlinc-native-image")
+    // Graal will automatically append .exe extension to the `outputFile`, but we need
+    // to explicitly specify it as an output of the task
     val executableExtension = if (isWindows) ".exe" else ""
-    val outputFile = layout.buildDirectory.file("bin/kotlinc-native-image$executableExtension")
-    outputs.file(outputFile)
+    val executableFile = layout.buildDirectory.file("bin/kotlinc-native-image$executableExtension")
+    outputs.file(executableFile)
 
     val javaLauncher = javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(JdkMajorVersion.JDK_25_0.targetName))
@@ -84,7 +87,7 @@ val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
     doFirst {
         val javaHome = javaLauncher.get().executablePath.asFile.toPath().parent.parent
 
-        val nativeImageName = if (isWindows) "native-image.cmd" else "native-image"
+        val nativeImageName = if (isWindows) "native-image.exe" else "native-image"
         val nativeImageBin = javaHome.resolve("lib/svm/bin/$nativeImageName")
         if (!nativeImageBin.exists()) {
             throw GradleException("native-image not found at ${nativeImageBin.toAbsolutePath()} (JAVA_HOME=${javaHome.toAbsolutePath()})")


### PR DESCRIPTION
While setting up nightly CI for the Kotlin Compiler Native Image I have encountered issues with the native image setup:

* Windows references native image executable by a wrong name
* compiler-embeddable.jar bundles unnecessary and incorrect `META-INF/native-image` metadata, that causes issues for the kotlin native image when its build on CI: Proguard excludes the metadata JSON files, but keeps in `META-INF/native-image/**/native-image.properties` files, that reference deleted JSONs and cause native image to fail