### PR TITLE
[Frontend] Close several obsolete issues from backlog

### DIFF
--- a/compiler/testData/codegen/box/sam/topLevelConversions.kt
+++ b/compiler/testData/codegen/box/sam/topLevelConversions.kt
@@ -1,5 +1,6 @@
-// ISSUE: KT-67869
+// ISSUE: KT-67869, KT-74899
 // LANGUAGE: +ResolveTopLevelLambdasAsSyntheticCallArgument
+// IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_FIRST_STAGE: 2.3
 
 fun interface MyFun {
     fun foo(x: String): Int
@@ -40,17 +41,24 @@ fun box(): String {
     topLevelLateinit = { it.length }
     if (topLevelLateinit.foo("OK") != 2) return "fail"
 
-// TODO: Uncomment it once KT-74899 is fixed
-//    val whenResult: MyFun = when {
-//        "0".length == 1 -> {
-//            { it.length}
-//        }
-//        else -> {
-//            { it.length - 1 }
-//        }
-//    }
-//
-//    if (whenResult.foo("OK") != 2) return "fail"
+    val whenResult: MyFun = when {
+        "0".length == 1 -> {
+            { it.length }
+        }
+        else -> {
+            { it.length - 1 }
+        }
+    }
+
+    if (whenResult.foo("OK") != 2) return "fail"
+
+    val deeplyNested: MyFun = if (baz().foo("OK") != 2) {
+        if (whenResult.foo("OK") != 2) { { it.length } }
+        else { { it.length + 1 } }
+    } else {
+        if (whenResult.foo("OK") == 2) { { it.length } }
+        else { { it.length + 1 } }
+    }
 
     return "OK"
 }

--- a/compiler/testData/diagnostics/tests/inference/kt11218.kt
+++ b/compiler/testData/diagnostics/tests/inference/kt11218.kt
@@ -1,0 +1,15 @@
+// RUN_PIPELINE_TILL: BACKEND
+// WITH_REFLECT
+
+inline fun <reified T : kotlin.Enum<T>> safeValueOf(type: String?): T? {
+    return type?.let { java.lang.Enum.valueOf(T::class.java, type) }
+}
+enum class TestEnum
+
+fun main() {
+    val value: TestEnum? = safeValueOf("test")
+}
+
+/* GENERATED_FIR_TAGS: classReference, enumDeclaration, flexibleType, functionDeclaration, inline, javaFunction,
+lambdaLiteral, localProperty, nullableType, propertyDeclaration, reified, safeCall, smartcast, stringLiteral,
+typeConstraint, typeParameter */


### PR DESCRIPTION
I'd also consider closing related [KT-63085](https://youtrack.jetbrains.com/issue/KT-63085/Type-inference-fails-for-reified-parameter-with-null-value) as obsolete.