### PR TITLE
Cherry pick "[JKlib] Fixes for 2.4.0-RC" to 2.4.0

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -109,7 +109,7 @@ class JKlibIrCompilationPhase :
         )
 
         val descriptors = dependencyDescriptorsByKlib.values + jarDepsModuleDescriptor
-        descriptors.forEach { if (it != jarDepsModuleDescriptor) it.setDependencies(descriptors) }
+        descriptors.forEach { it.setDependencies(descriptors) }
 
         val mainModule = dependencyDescriptorsByKlib.getValue(sortedDependencies.single { it.libraryFile == klib })
 
@@ -150,13 +150,6 @@ class JKlibIrCompilationPhase :
         // Deserialize modules
         // We explicitly use the DeserializationStrategy.ALL to deserialize the whole world,
         // so that we don't rely on linker side effects for proper deserialization.
-        linker.deserializeIrModuleHeader(
-            jarDepsModuleDescriptor,
-            null,
-            { DeserializationStrategy.ALL },
-            jarDepsModuleDescriptor.name.asString(),
-        )
-
         lateinit var mainModuleFragment: IrModuleFragment
         for ((dep, descriptor) in dependencyDescriptorsByKlib) {
             when {
@@ -166,6 +159,13 @@ class JKlibIrCompilationPhase :
                 else -> linker.deserializeIrModuleHeader(descriptor, dep, { DeserializationStrategy.ALL })
             }
         }
+
+        linker.deserializeIrModuleHeader(
+            jarDepsModuleDescriptor,
+            null,
+            { DeserializationStrategy.ALL },
+            jarDepsModuleDescriptor.name.asString(),
+        )
 
         irBuiltIns.functionFactory = IrDescriptorBasedFunctionFactory(
             irBuiltIns,

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.common.serialization.DescriptorByIdSignature
 import org.jetbrains.kotlin.backend.common.serialization.DeserializationStrategy
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureDescriptor
 import org.jetbrains.kotlin.backend.jvm.JvmGeneratorExtensionsImpl
+import org.jetbrains.kotlin.builtins.jvm.JvmBuiltInClassDescriptorFactory
 import org.jetbrains.kotlin.builtins.jvm.JvmBuiltIns
 import org.jetbrains.kotlin.builtins.jvm.JvmBuiltInsPackageFragmentProvider
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
@@ -34,6 +35,7 @@ import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
 import org.jetbrains.kotlin.descriptors.deserialization.AdditionalClassPartsProvider
+import org.jetbrains.kotlin.descriptors.deserialization.ClassDescriptorFactory
 import org.jetbrains.kotlin.descriptors.impl.CompositePackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.frontend.java.di.createContainerForLazyResolveWithJava
@@ -61,6 +63,8 @@ import org.jetbrains.kotlin.load.java.lazy.ModuleClassResolver
 import org.jetbrains.kotlin.load.java.structure.JavaClass
 import org.jetbrains.kotlin.load.java.structure.impl.VirtualFileBoundJavaClass
 import org.jetbrains.kotlin.load.kotlin.JavaFlexibleTypeDeserializer
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi2ir.descriptors.IrBuiltInsOverDescriptors
@@ -284,7 +288,26 @@ class JKlibIrCompilationPhase :
 
                 override fun getFunctionsNames(classDescriptor: ClassDescriptor): Collection<Name> =
                     delegate.getFunctionsNames(classDescriptor)
-            }
+            },
+            // ClassDescriptorFactories for intrinsic builtin classes.
+            fictitiousClassDescriptorFactories = listOf(
+                // TODO(KT-86369): Investigate if we need to wire up BuiltInFictitiousFunctionClassFactory in the list. J2CL is currently
+                //  passing definitions for these classes and we could remove those and use BuiltInFictitiousFunctionClassFactory instead.
+                object : ClassDescriptorFactory {
+                    private val delegate by lazy {
+                        JvmBuiltInClassDescriptorFactory(storageManager, builtIns.builtInsModule)
+                    }
+
+                    override fun shouldCreateClass(packageFqName: FqName, name: Name): Boolean =
+                        delegate.shouldCreateClass(packageFqName, name)
+
+                    override fun createClass(classId: ClassId): ClassDescriptor? =
+                        delegate.createClass(classId)
+
+                    override fun getAllContributedClassesIfPossible(packageFqName: FqName): Collection<ClassDescriptor> =
+                        delegate.getAllContributedClassesIfPossible(packageFqName)
+                }
+            )
         )
 
         val dependencyDescriptorsByKlib = sortedDependencies.associateWith { klib ->

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.common.serialization.DescriptorByIdSignature
 import org.jetbrains.kotlin.backend.common.serialization.DeserializationStrategy
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureDescriptor
 import org.jetbrains.kotlin.backend.jvm.JvmGeneratorExtensionsImpl
+import org.jetbrains.kotlin.builtins.jvm.JvmBuiltInClassDescriptorFactory
 import org.jetbrains.kotlin.builtins.jvm.JvmBuiltIns
 import org.jetbrains.kotlin.builtins.jvm.JvmBuiltInsPackageFragmentProvider
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
@@ -34,6 +35,7 @@ import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
 import org.jetbrains.kotlin.descriptors.deserialization.AdditionalClassPartsProvider
+import org.jetbrains.kotlin.descriptors.deserialization.ClassDescriptorFactory
 import org.jetbrains.kotlin.descriptors.impl.CompositePackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.frontend.java.di.createContainerForLazyResolveWithJava
@@ -61,6 +63,8 @@ import org.jetbrains.kotlin.load.java.lazy.ModuleClassResolver
 import org.jetbrains.kotlin.load.java.structure.JavaClass
 import org.jetbrains.kotlin.load.java.structure.impl.VirtualFileBoundJavaClass
 import org.jetbrains.kotlin.load.kotlin.JavaFlexibleTypeDeserializer
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi2ir.descriptors.IrBuiltInsOverDescriptors
@@ -105,7 +109,7 @@ class JKlibIrCompilationPhase :
         )
 
         val descriptors = dependencyDescriptorsByKlib.values + jarDepsModuleDescriptor
-        descriptors.forEach { if (it != jarDepsModuleDescriptor) it.setDependencies(descriptors) }
+        descriptors.forEach { it.setDependencies(descriptors) }
 
         val mainModule = dependencyDescriptorsByKlib.getValue(sortedDependencies.single { it.libraryFile == klib })
 
@@ -146,13 +150,6 @@ class JKlibIrCompilationPhase :
         // Deserialize modules
         // We explicitly use the DeserializationStrategy.ALL to deserialize the whole world,
         // so that we don't rely on linker side effects for proper deserialization.
-        linker.deserializeIrModuleHeader(
-            jarDepsModuleDescriptor,
-            null,
-            { DeserializationStrategy.ALL },
-            jarDepsModuleDescriptor.name.asString(),
-        )
-
         lateinit var mainModuleFragment: IrModuleFragment
         for ((dep, descriptor) in dependencyDescriptorsByKlib) {
             when {
@@ -162,6 +159,13 @@ class JKlibIrCompilationPhase :
                 else -> linker.deserializeIrModuleHeader(descriptor, dep, { DeserializationStrategy.ALL })
             }
         }
+
+        linker.deserializeIrModuleHeader(
+            jarDepsModuleDescriptor,
+            null,
+            { DeserializationStrategy.ALL },
+            jarDepsModuleDescriptor.name.asString(),
+        )
 
         irBuiltIns.functionFactory = IrDescriptorBasedFunctionFactory(
             irBuiltIns,
@@ -284,7 +288,26 @@ class JKlibIrCompilationPhase :
 
                 override fun getFunctionsNames(classDescriptor: ClassDescriptor): Collection<Name> =
                     delegate.getFunctionsNames(classDescriptor)
-            }
+            },
+            // ClassDescriptorFactories for intrinsic builtin classes.
+            fictitiousClassDescriptorFactories = listOf(
+                // TODO(KT-86369): Investigate if we need to wire up BuiltInFictitiousFunctionClassFactory in the list. J2CL is currently
+                //  passing definitions for these classes and we could remove those and use BuiltInFictitiousFunctionClassFactory instead.
+                object : ClassDescriptorFactory {
+                    private val delegate by lazy {
+                        JvmBuiltInClassDescriptorFactory(storageManager, builtIns.builtInsModule)
+                    }
+
+                    override fun shouldCreateClass(packageFqName: FqName, name: Name): Boolean =
+                        delegate.shouldCreateClass(packageFqName, name)
+
+                    override fun createClass(classId: ClassId): ClassDescriptor? =
+                        delegate.createClass(classId)
+
+                    override fun getAllContributedClassesIfPossible(packageFqName: FqName): Collection<ClassDescriptor> =
+                        delegate.getAllContributedClassesIfPossible(packageFqName)
+                }
+            )
         )
 
         val dependencyDescriptorsByKlib = sortedDependencies.associateWith { klib ->

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -113,7 +113,7 @@ class JKlibIrLinker(
     ) : IrModuleDeserializer(moduleDescriptor, KotlinAbiVersion.CURRENT) {
         override val klib: KotlinLibrary get() = error("'klib' is not available for ${this::class.java}")
 
-        override fun contains(idSig: IdSignature): Boolean = true
+        override fun contains(idSig: IdSignature): Boolean = resolveDescriptor(idSig) != null
 
         private val descriptorFinder = DescriptorByIdSignatureFinderImpl(
             moduleDescriptor,

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -181,6 +181,9 @@ class JKlibIrLinker(
 
         private val deserializedSymbols = mutableMapOf<IdSignature, IrSymbol>()
 
+        override fun contains(idSig: IdSignature): Boolean =
+            super.contains(idSig) || descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null
+
         override fun tryDeserializeIrSymbol(
             idSig: IdSignature,
             symbolKind: BinarySymbolData.SymbolKind,

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -113,7 +113,7 @@ class JKlibIrLinker(
     ) : IrModuleDeserializer(moduleDescriptor, KotlinAbiVersion.CURRENT) {
         override val klib: KotlinLibrary get() = error("'klib' is not available for ${this::class.java}")
 
-        override fun contains(idSig: IdSignature): Boolean = true
+        override fun contains(idSig: IdSignature): Boolean = resolveDescriptor(idSig) != null
 
         private val descriptorFinder = DescriptorByIdSignatureFinderImpl(
             moduleDescriptor,
@@ -180,6 +180,9 @@ class JKlibIrLinker(
         )
 
         private val deserializedSymbols = mutableMapOf<IdSignature, IrSymbol>()
+
+        override fun contains(idSig: IdSignature): Boolean =
+            super.contains(idSig) || descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null
 
         override fun tryDeserializeIrSymbol(
             idSig: IdSignature,

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataFactories.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataFactories.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.library.metadata
 
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.deserialization.AdditionalClassPartsProvider
+import org.jetbrains.kotlin.descriptors.deserialization.ClassDescriptorFactory
 import org.jetbrains.kotlin.library.metadata.impl.KlibMetadataDeserializedPackageFragmentsFactoryImpl
 import org.jetbrains.kotlin.library.metadata.impl.KlibMetadataModuleDescriptorFactoryImpl
 import org.jetbrains.kotlin.library.metadata.impl.KlibModuleDescriptorFactoryImpl
@@ -21,11 +22,12 @@ class KlibMetadataFactories(
     createBuiltIns: (StorageManager) -> KotlinBuiltIns,
     val flexibleTypeDeserializer: FlexibleTypeDeserializer,
     val additionalClassPartsProvider: AdditionalClassPartsProvider,
+    val fictitiousClassDescriptorFactories: List<ClassDescriptorFactory>,
 ) {
     constructor(
         createBuiltIns: (StorageManager) -> KotlinBuiltIns,
         flexibleTypeDeserializer: FlexibleTypeDeserializer,
-    ) : this(createBuiltIns, flexibleTypeDeserializer, AdditionalClassPartsProvider.None)
+    ) : this(createBuiltIns, flexibleTypeDeserializer, AdditionalClassPartsProvider.None, emptyList())
 
     /**
      * The default [KlibModuleDescriptorFactory] factory instance.
@@ -61,6 +63,7 @@ class KlibMetadataFactories(
             packageFragmentsFactory,
             flexibleTypeDeserializer,
             additionalClassPartsProvider,
+            fictitiousClassDescriptorFactories,
         )
 
     fun createDefaultKonanResolvedModuleDescriptorsFactory(

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.contracts.ContractDeserializerImpl
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.deserialization.AdditionalClassPartsProvider
+import org.jetbrains.kotlin.descriptors.deserialization.ClassDescriptorFactory
 import org.jetbrains.kotlin.descriptors.impl.CompositePackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.EmptyPackageFragmentDescriptor
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
@@ -34,6 +35,7 @@ class KlibMetadataModuleDescriptorFactoryImpl(
     override val packageFragmentsFactory: KlibMetadataDeserializedPackageFragmentsFactory,
     override val flexibleTypeDeserializer: FlexibleTypeDeserializer,
     val additionalClassPartsProvider: AdditionalClassPartsProvider = AdditionalClassPartsProvider.None,
+    val fictitiousClassDescriptorFactories: List<ClassDescriptorFactory> = emptyList(),
 ) : KlibMetadataModuleDescriptorFactory {
 
     override fun createDescriptorOptionalBuiltIns(
@@ -158,7 +160,7 @@ class KlibMetadataModuleDescriptorFactoryImpl(
             ErrorReporter.DO_NOTHING,
             lookupTracker,
             flexibleTypeDeserializer,
-            emptyList(),
+            fictitiousClassDescriptorFactories,
             notFoundClasses,
             ContractDeserializerImpl(configuration, storageManager),
             additionalClassPartsProvider = additionalClassPartsProvider,


### PR DESCRIPTION
- Wire up JvmBuiltInClassDescriptorFactory to correctly create kotlin.Cloneable Class Descriptor.

- Fix MetadataJVMModuleDeserializer to only claim symbols they responsible for and add klibs modules descriptor to the Jar module descriptor dependencies to correctly deserialize any symbols that could come from a klibs dependencies.

#KT-86368 fixed
#KT-86367 fixed