### PR TITLE
[Swift Export] Consume cinterop klibs as re-exported ObjC modules

### DIFF
--- a/libraries/tools/analysis-api-based-klib-reader/src/org/jetbrains/kotlin/analysis/api/klib/reader/createKaModules.kt
+++ b/libraries/tools/analysis-api-based-klib-reader/src/org/jetbrains/kotlin/analysis/api/klib/reader/createKaModules.kt
@@ -19,11 +19,15 @@ import org.jetbrains.kotlin.platform.TargetPlatform
 /**
  * @property useSiteModule A target for creating Analysis API session via [analyze].
  * @property platformLibraries Platform libraries from the Kotlin Native distribution, if any.
+ * @property cinteropReexportLibraries User cinterop klibs whose types originate from an externally-defined
+ *   ObjC module; treated as platform-like (no generated Swift module), but distinguished from distribution
+ *   platform libs since they are opted in by the caller.
  */
 public class KaModules<Config> internal constructor(
     public val useSiteModule: KaModule,
     private val modulesToInputs: Map<KaLibraryModule, KlibInputModule<Config>>,
     public val platformLibraries: List<KaLibraryModule>,
+    public val cinteropReexportLibraries: List<KaLibraryModule> = emptyList(),
 ) {
     public val inputsToModules: Map<KlibInputModule<Config>, KaLibraryModule> = modulesToInputs.map { it.value to it.key }.toMap()
     public val mainModules: List<KaLibraryModule> = modulesToInputs.keys.toList()
@@ -39,15 +43,18 @@ public fun <Config> createKaModulesForStandaloneAnalysis(
     inputs: Collection<KlibInputModule<Config>>,
     targetPlatform: TargetPlatform,
     platformLibraries: Collection<KlibInputModule<Config>> = emptyList(),
+    cinteropReexportLibraries: Collection<KlibInputModule<Config>> = emptyList(),
 ): KaModules<Config> {
     lateinit var binaryModules: Map<KaLibraryModule, KlibInputModule<Config>>
     lateinit var fakeSourceModule: KaSourceModule
     var platformLibraryModules: List<KaLibraryModule> = emptyList()
+    var cinteropReexportLibraryModules: List<KaLibraryModule> = emptyList()
     buildStandaloneAnalysisAPISession {
         buildKtModuleProvider {
             platform = targetPlatform
             binaryModules = inputs.associateBy { inputModuleIntoKaLibraryModule(it, targetPlatform) }
             platformLibraryModules = platformLibraries.map { inputModuleIntoKaLibraryModule(it, targetPlatform) }
+            cinteropReexportLibraryModules = cinteropReexportLibraries.map { inputModuleIntoKaLibraryModule(it, targetPlatform) }
             // It's a pure hack: Analysis API does not properly work without root source modules.
             fakeSourceModule = addModule(
                 buildKtSourceModule {
@@ -55,11 +62,12 @@ public fun <Config> createKaModulesForStandaloneAnalysis(
                     moduleName = "fakeSourceModule"
                     binaryModules.keys.forEach(::addRegularDependency)
                     platformLibraryModules.forEach(::addRegularDependency)
+                    cinteropReexportLibraryModules.forEach(::addRegularDependency)
                 }
             )
         }
     }
-    return KaModules(fakeSourceModule, binaryModules, platformLibraryModules)
+    return KaModules(fakeSourceModule, binaryModules, platformLibraryModules, cinteropReexportLibraryModules)
 }
 
 private fun <Config> KtModuleProviderBuilder.inputModuleIntoKaLibraryModule(

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/utils/AnnotationUtils.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/utils/AnnotationUtils.kt
@@ -22,6 +22,7 @@ internal inline val <reified S : KaDeclarationSymbol> SirFromKtSymbol<S>.transla
     get() = withSessions {
         ktSymbol.allRequiredOptIns.mapNotNull {
             if (it.asFqNameString() == "kotlinx.cinterop.BetaInteropApi") return@mapNotNull null
+            if (it.asFqNameString() == "kotlinx.cinterop.ExperimentalForeignApi") return@mapNotNull null
             SirAttribute.SPI(it.asSingleFqName().pathSegments().joinToString("$"))
         }
     }

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.sir.providers.utils.KotlinRuntimeModule
 import org.jetbrains.kotlin.sir.providers.utils.KotlinRuntimeSupportModule
 import org.jetbrains.kotlin.sir.providers.utils.allRequiredOptIns
 import org.jetbrains.kotlin.sir.providers.withSessions
-import org.jetbrains.kotlin.sir.util.SirPlatformModule
+import org.jetbrains.kotlin.sir.util.SirPlatformLikeModule
 import org.jetbrains.kotlin.sir.util.SirSwiftModule
 import org.jetbrains.kotlin.sir.util.isValueType
 import org.jetbrains.kotlin.sir.util.name
@@ -132,7 +132,7 @@ private fun bridgeNominalType(type: SirNominalType, position: SirTypeVariance): 
         is SirTypealias -> bridgeType(subtype.type, position)
 
         // TODO: Right now, we just assume everything nominal that we do not recognize is a class. We should make this decision looking at kotlin type?
-        else -> if (type.typeDeclaration.parent is SirPlatformModule) {
+        else -> if (type.typeDeclaration.parent is SirPlatformLikeModule) {
             AsNSObject(type)
         } else {
             AsObject(type, KotlinType.KotlinObject, CType.Object)

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirOneToOneModuleProvider.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirOneToOneModuleProvider.kt
@@ -14,15 +14,24 @@ import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
 import org.jetbrains.kotlin.sir.SirModule
 import org.jetbrains.kotlin.sir.builder.buildModule
 import org.jetbrains.kotlin.sir.providers.SirModuleProvider
+import org.jetbrains.kotlin.sir.util.SirCinteropModule
 import org.jetbrains.kotlin.sir.util.SirPlatformModule
 
 /**
- * A module provider implementation that generates a [SirModule] for each given [KaModule]
+ * A module provider implementation that generates a [SirModule] for each given [KaModule].
+ *
+ * [platformLibs] are Kotlin/Native distribution platform libraries, represented as [SirPlatformModule].
+ * [cinteropReexportLibs] are user-provided cinterop klibs to be re-exported through an existing ObjC module,
+ * represented as [SirCinteropModule]. For both, no Swift code is generated; references become `import <name>`.
  */
-public class SirOneToOneModuleProvider(platformLibs: Collection<KaLibraryModule>) : SirModuleProvider {
+public class SirOneToOneModuleProvider(
+    platformLibs: Collection<KaLibraryModule>,
+    cinteropReexportLibs: Collection<KaLibraryModule> = emptyList(),
+) : SirModuleProvider {
 
-    private val moduleCache: MutableMap<KaModule, SirModule> = platformLibs.associate {
-        it to SirPlatformModule(it.moduleName)
+    private val moduleCache: MutableMap<KaModule, SirModule> = buildMap<KaModule, SirModule> {
+        platformLibs.forEach { put(it, SirPlatformModule(it.moduleName)) }
+        cinteropReexportLibs.forEach { put(it, SirCinteropModule(it.moduleName)) }
     }.toMutableMap()
 
     public val modules: Map<KaModule, SirModule>

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirParentProviderImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirParentProviderImpl.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.sir.providers.toSir
 import org.jetbrains.kotlin.sir.providers.utils.containingModule
 import org.jetbrains.kotlin.sir.providers.utils.updateImport
 import org.jetbrains.kotlin.sir.providers.withSessions
-import org.jetbrains.kotlin.sir.util.SirPlatformModule
+import org.jetbrains.kotlin.sir.util.SirPlatformLikeModule
 import org.jetbrains.kotlin.sir.util.addChild
 
 public class SirParentProviderImpl(
@@ -48,7 +48,7 @@ public class SirParentProviderImpl(
 
             val ktModule = symbol.containingModule
             val sirModule = with(sirSession) { ktModule.sirModule() }
-            return@withSessions if (packageFqName.isRoot || sirModule is SirPlatformModule) {
+            return@withSessions if (packageFqName.isRoot || sirModule is SirPlatformLikeModule) {
                 sirModule
             } else {
                 val enumAsPackage = with(packageEnumGenerator) { packageFqName.sirPackageEnum() }

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirVisibilityCheckerImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirVisibilityCheckerImpl.kt
@@ -75,7 +75,6 @@ public class SirVisibilityCheckerImpl(
                     visibility.value = SirVisibility.PUBLIC
             }
         }
-
         // We care only about public API.
         if (!ktSymbol.compilerVisibility.isPublicAPI || ktSymbol.compilerVisibility == Visibilities.Protected) {
             visibility.value = SirVisibility.PRIVATE

--- a/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirPlatformModule.kt
+++ b/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirPlatformModule.kt
@@ -9,7 +9,11 @@ import org.jetbrains.kotlin.sir.SirDeclaration
 import org.jetbrains.kotlin.sir.SirImport
 import org.jetbrains.kotlin.sir.SirModule
 
-class SirPlatformModule(override val name: String) : SirModule() {
+sealed class SirPlatformLikeModule(override val name: String) : SirModule() {
     override val declarations: MutableList<SirDeclaration> = mutableListOf()
     override val imports: MutableList<SirImport> = mutableListOf()
 }
+
+class SirPlatformModule(name: String) : SirPlatformLikeModule(name)
+
+class SirCinteropModule(name: String) : SirPlatformLikeModule(name)

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.kt
@@ -1,0 +1,52 @@
+// KIND: STANDALONE
+// WITH_PLATFORM_LIBS
+
+// MODULE: fooKitInterop
+// SWIFT_EXPORT_CONFIG: reexportAsObjCModule=FooKit
+
+// FILE: fooKitInterop.def
+language = Objective-C
+headers = Foo.h
+headerFilter = Foo.h
+package = foo
+
+// FILE: Foo.h
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject
+@property (nonatomic, assign) int payload;
+- (instancetype)initWithPayload:(int)payload;
+- (int)doubled;
+@end
+
+// FILE: Foo.m
+#import "Foo.h"
+
+@implementation Foo
+
+- (instancetype)initWithPayload:(int)payload {
+    if (self = [super init]) {
+        _payload = payload;
+    }
+    return self;
+}
+
+- (int)doubled {
+    return self.payload * 2;
+}
+
+@end
+
+// FILE: module.modulemap
+module FooKit {
+    header "Foo.h"
+    export *
+}
+
+// MODULE: Main(fooKitInterop)
+// FILE: main.kt
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+import foo.Foo
+
+fun payloadTriple(x: Foo): Int = x.payload * 3

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.swift
@@ -1,0 +1,10 @@
+@_spi(kotlinx$cinterop$ExperimentalForeignApi) import Main
+import FooKit
+import Testing
+
+@Test
+func testReexportedCinteropTypeRoundTrip() {
+    let foo = Foo(payload: 7)!
+    #expect(payloadTriple(x: foo) == 21)
+    #expect(foo.doubled() == 14)
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/cinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/cinteropReexport.kt
@@ -1,0 +1,37 @@
+// KIND: STANDALONE
+// WITH_PLATFORM_LIBS
+// APPLE_ONLY_VALIDATION
+
+// MODULE: fooKitInterop
+// SWIFT_EXPORT_CONFIG: reexportAsObjCModule=FooKit
+
+// FILE: fooKitInterop.def
+language = Objective-C
+headers = Foo.h
+headerFilter = Foo.h
+package = foo
+
+// FILE: Foo.h
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject
+- (int)someValue;
+@end
+
+// FILE: module.modulemap
+module FooKit {
+    header "Foo.h"
+    export *
+}
+
+// MODULE: CinteropReexport(fooKitInterop)
+// FILE: main.kt
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package main
+
+import foo.Foo
+
+fun consumesFoo(x: Foo): Int = 0
+
+fun producesFoo(): Foo? = null

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.h
@@ -1,0 +1,10 @@
+#include <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+int32_t main_consumesFoo__TypesOfArguments__FooKit_Foo__(id<NSObject> x);
+
+id<NSObject> _Nullable main_producesFoo();
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.kt
@@ -1,0 +1,20 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.*
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ExportedBridge("main_consumesFoo__TypesOfArguments__FooKit_Foo__")
+@OptIn(kotlinx.cinterop.BetaInteropApi::class, kotlinx.cinterop.ExperimentalForeignApi::class)
+public fun main_consumesFoo__TypesOfArguments__FooKit_Foo__(x: kotlin.native.internal.NativePtr): Int {
+    val __x = interpretObjCPointer<foo.Foo>(x)
+    val _result = run { main.consumesFoo(__x) }
+    return _result
+}
+
+@ExportedBridge("main_producesFoo")
+@OptIn(kotlinx.cinterop.BetaInteropApi::class, kotlinx.cinterop.ExperimentalForeignApi::class)
+public fun main_producesFoo(): kotlin.native.internal.NativePtr {
+    val _result = run { main.producesFoo() }
+    return if (_result == null) kotlin.native.internal.NativePtr.NULL else _result.objcPtr()
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.swift
@@ -1,0 +1,16 @@
+@_exported import ExportedKotlinPackages
+import FooKit
+@_implementationOnly import KotlinBridges_CinteropReexport
+import KotlinRuntime
+import KotlinRuntimeSupport
+
+extension ExportedKotlinPackages.main {
+    public static func consumesFoo(
+        x: FooKit.Foo
+    ) -> Swift.Int32 {
+        return main_consumesFoo__TypesOfArguments__FooKit_Foo__(x)
+    }
+    public static func producesFoo() -> FooKit.Foo? {
+        return main_producesFoo().map { it in it as! FooKit.Foo }
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
@@ -1,0 +1,6 @@
+public enum kotlinx {
+    public enum cinterop {
+    }
+}
+public enum main {
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.h
@@ -1,0 +1,5 @@
+#include <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -1,0 +1,4 @@
+@file:OptIn(kotlinx.cinterop.BetaInteropApi::class)
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.cinterop.ObjCObjectBase::class, "22ExportedKotlinPackages7kotlinxO8cinteropO12KotlinStdlibE14ObjCObjectBaseC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(kotlinx.cinterop.ObjCObject::class, "_ObjCObject")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -1,0 +1,26 @@
+@_exported import ExportedKotlinPackages
+@_implementationOnly import KotlinBridges_KotlinStdlib
+import KotlinRuntime
+import KotlinRuntimeSupport
+
+extension ExportedKotlinPackages.kotlinx.cinterop.ObjCObject where Self : KotlinRuntimeSupport._KotlinBridgeable {
+}
+extension ExportedKotlinPackages.kotlinx.cinterop.ObjCObject {
+}
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.cinterop.ObjCObject where Wrapped : ExportedKotlinPackages.kotlinx.cinterop._ObjCObject {
+}
+extension ExportedKotlinPackages.kotlinx.cinterop {
+    public protocol ObjCObject: KotlinRuntime.KotlinBase {
+    }
+    @objc(_ObjCObject)
+    package protocol _ObjCObject {
+    }
+    open class ObjCObjectBase: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.cinterop.ObjCObject, ExportedKotlinPackages.kotlinx.cinterop._ObjCObject {
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/external_types/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/external_types/golden_result/main/main.swift
@@ -3,13 +3,11 @@ import Foundation
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-@_spi(kotlinx$cinterop$ExperimentalForeignApi) @available(*, unavailable, message: "Declaration uses unsupported types")
+@available(*, unavailable, message: "Declaration uses unsupported types")
 public var store_cgReck: Swift.Never {
-    @_spi(kotlinx$cinterop$ExperimentalForeignApi)
     get {
         fatalError()
     }
-    @_spi(kotlinx$cinterop$ExperimentalForeignApi)
     set {
         fatalError()
     }

--- a/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportExecutionTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportExecutionTest.kt
@@ -87,7 +87,7 @@ abstract class AbstractSwiftExportExecutionTest : AbstractSwiftExportWithBinaryC
             "-framework", "Testing",
             testRunSettings.systemToolchainPath?.let { "-plugin-path" },
             testRunSettings.systemToolchainPath?.let { "${it}/usr/lib/swift/host/plugins/testing/" },
-        )
+        ) + extraSwiftCompilerOptions
 
         val success = SwiftCompilation(
             testRunSettings,

--- a/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
@@ -50,6 +50,20 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
     var givenModules: Set<TestModule.Given> = emptySet()
     var minOSVersion: String? = null
 
+    /**
+     * Maps a [TestModule.Given]'s klib-file name to the name of an externally-defined ObjC module that Swift
+     * Export should treat it as — populating [SwiftModuleConfig.reexportAsObjCModule]. This is how a cinterop
+     * klib is opted into the platform-like path at test time.
+     */
+    var cinteropReexportsByKlibFileName: Map<String, String> = emptyMap()
+
+    /**
+     * Additional options appended verbatim to every `swiftc` invocation made by the test harness. Tests that
+     * bring their own ObjC modules need to pass `-Xcc -fmodule-map-file=<path>` here so that `import <Foo>`
+     * in the generated Swift resolves through the supplied modulemap.
+     */
+    var extraSwiftCompilerOptions: List<String> = emptyList()
+
     private val binariesDir get() = testRunSettings.get<Binaries>().testBinariesDir
     protected fun buildDir(testName: String) = binariesDir.resolve(testName)
     protected val targets: KotlinNativeTargets get() = testRunSettings.get()
@@ -71,6 +85,17 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
             .getTestCaseGroup(testCaseId.testCaseGroupId, testRunSettings)
             ?.getByName(testCaseId)!!
             .copyAndAddModules(givenModules)
+
+        // Inline cinterop modules marked with the reexportAsObjCModule directive may supply a module.modulemap
+        // that swiftc needs to resolve the generated `import <ObjCModule>` references. Discover those files
+        // automatically.
+        val discoveredModuleMaps = originalTestCase.modules
+            .filter { it.swiftExportConfigMap()[REEXPORT_AS_OBJC_MODULE_DIRECTIVE] != null }
+            .flatMap { it.files }
+            .map { it.location }
+            .filter { it.name == "module.modulemap" }
+        extraSwiftCompilerOptions = extraSwiftCompilerOptions +
+            discoveredModuleMaps.flatMap { listOf("-Xcc", "-fmodule-map-file=${it.absolutePath}") }
 
         val modulesToExport = (originalTestCase.rootModules + originalTestCase.modules + givenModules).mapToSet {
             createInputModule(
@@ -102,15 +127,26 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
         val kotlinFiles = originalTestCase.rootModules.flatMapToSet { module -> module.files.map { file -> file.location } }
         val kotlinBinaryLibraryName = testPathFull.name + "Kotlin"
 
+        // Inline cinterop modules flagged for reexport cannot be passed with -Xinclude to
+        // binary compilation (the compiler rejects interop klibs via that flag). Expose their
+        // compiled klibs as Given dependencies (-library) instead, and keep their source modules
+        // (.def/.h/.modulemap) out of the Kotlin binary compilation. We identify such modules by the
+        // reexport directive rather than by InputModule.name, because the latter is overridden with the
+        // ObjC module name and would no longer match the test module name.
+        val reexportInputs = modulesToExport.filter { it.config.moduleProvidedThroughCinterop }
+        val reexportGivens = reexportInputs.map { TestModule.Given(it.path.toFile()) }.toSet()
+
         val resultingTestCase = generateSwiftExportTestCase(
             testPathFull,
             kotlinBinaryLibraryName,
             kotlinFiles.toList() + additionalKtFiles.map { it.toFile() },
-            modules = originalTestCase.rootModules
+            modules = (originalTestCase.rootModules
                 .flatMapToSet {
                     it.allRegularDependencies.filterIsInstance<TestModule.Exclusive>().toSet()
-                } - originalTestCase.rootModules,
-            dependencies = givenModules
+                } - originalTestCase.rootModules)
+                .filterNot { it.swiftExportConfigMap()[REEXPORT_AS_OBJC_MODULE_DIRECTIVE] != null }
+                .toSet(),
+            dependencies = givenModules + reexportGivens
         )
         return swiftExportOutputs to resultingTestCase
     }
@@ -121,14 +157,26 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
         shouldBeFullyExported: Boolean
     ): InputModule {
         val config = (testModule as? TestModule.Exclusive)?.swiftExportConfigMap()
-        return testModule.constructSwiftInput(
+        // For cinterop re-exports the test directive (or the test-support map) supplies the desired
+        // Swift-level ObjC module name. We translate that into the standalone API: a boolean flag on
+        // SwiftModuleConfig plus the InputModule.name set to that ObjC module name.
+        val objCModuleName = when (testModule) {
+            is TestModule.Exclusive -> config?.get(REEXPORT_AS_OBJC_MODULE_DIRECTIVE)
+            is TestModule.Given -> cinteropReexportsByKlibFileName[testModule.klibFile.name]
+            else -> null
+        }
+        val input = testModule.constructSwiftInput(
             originalTestCase.freeCompilerArgs,
             SwiftModuleConfig(
                 rootPackage = config?.get(SwiftModuleConfig.ROOT_PACKAGE),
                 unsupportedDeclarationReporterKind = getUnsupportedDeclarationsReporterKind(config),
-                shouldBeFullyExported = shouldBeFullyExported,
+                // moduleProvidedThroughCinterop implies the klib is never fully exported — it is only a container
+                // for types that may be referenced by the actually-exported modules.
+                shouldBeFullyExported = shouldBeFullyExported && objCModuleName == null,
+                moduleProvidedThroughCinterop = objCModuleName != null,
             )
         )
+        return if (objCModuleName != null) input.copy(name = objCModuleName) else input
     }
 
     private fun TestModule.constructSwiftInput(
@@ -237,7 +285,7 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
                 "-emit-module", "-parse-as-library", "-emit-library", "-static", "-enable-library-evolution",
                 "-module-name", swiftModuleName,
                 "-package-name", "SwiftExportTests",
-            ),
+            ) + extraSwiftCompilerOptions,
             outputFile = { it.binaryLibrary },
             minOSVersion = minOSVersion,
         ).result.assertSuccess().resultingArtifact
@@ -318,6 +366,14 @@ private fun modulemapFileToSwiftCompilerOptionsIfNeeded(modulemap: File?) = modu
 private fun SwiftExportModule.resolvedDependencies(allModules: Set<SwiftExportModule>): List<SwiftExportModule> = dependencies.map { dep ->
     allModules.firstOrNull { it.name == dep.name } ?: error("Module ${this.name} requested non-existing dependency ${dep.name}")
 }
+
+/**
+ * Test-fixture-only directive. Inside a `// SWIFT_EXPORT_CONFIG:` block, `reexportAsObjCModule=<Name>`
+ * marks the module as a cinterop re-export and supplies the ObjC module name. The infrastructure
+ * translates this into [SwiftModuleConfig.moduleProvidedThroughCinterop] plus an [InputModule.name]
+ * override (the standalone API itself no longer carries the ObjC name string).
+ */
+private const val REEXPORT_AS_OBJC_MODULE_DIRECTIVE: String = "reexportAsObjCModule"
 
 private fun getUnsupportedDeclarationsReporterKind(configMap: Map<String, String>?): UnsupportedDeclarationReporterKind {
     return configMap?.get(SwiftModuleConfig.UNSUPPORTED_DECLARATIONS_REPORTER_KIND)

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
@@ -154,8 +154,17 @@ private fun translateModules(
     inputModules: Set<InputModule>,
     config: SwiftExportConfig,
 ): List<TranslationResult> {
-    val allModules = inputModules + config.stdlibInputModule
-    val kaModules = createKaModulesForStandaloneAnalysis(allModules, config.targetPlatform, config.platformLibsInputModule)
+    val [cinteropReexportLibs, ordinaryInputs] = inputModules
+        .partition { it.config.moduleProvidedThroughCinterop }
+        .let { it.first.toSet() to it.second.toSet() }
+
+    val allModules = ordinaryInputs + config.stdlibInputModule
+    val kaModules = createKaModulesForStandaloneAnalysis(
+        inputs = allModules,
+        targetPlatform = config.targetPlatform,
+        platformLibraries = config.platformLibsInputModule,
+        cinteropReexportLibraries = cinteropReexportLibs,
+    )
     val explicitModulesTranslationResults = allModules
         .filter { it.config.shouldBeFullyExported }
         .map { translateModulePublicApi(it, kaModules, config) }

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/builders/buildSwiftModule.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/builders/buildSwiftModule.kt
@@ -36,7 +36,10 @@ internal fun buildSirSession(
     unsupportedTypeStrategy = config.unsupportedTypeStrategy.toInternalType(),
     moduleForPackageEnums = buildModule { name = config.moduleForPackagesName },
     unsupportedDeclarationReporter = moduleConfig.unsupportedDeclarationReporter,
-    moduleProvider = SirOneToOneModuleProvider(kaModules.platformLibraries),
+    moduleProvider = SirOneToOneModuleProvider(
+        platformLibs = kaModules.platformLibraries,
+        cinteropReexportLibs = kaModules.cinteropReexportLibraries,
+    ),
     targetPackageFqName = moduleConfig.targetPackageFqName,
     referencedTypeHandler = referenceHandler,
     enableCoroutinesSupport = config.enableCoroutinesSupport,

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftModuleConfig.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftModuleConfig.kt
@@ -20,10 +20,24 @@ public data class SwiftModuleConfig(
     val unsupportedDeclarationReporterKind: UnsupportedDeclarationReporterKind = UnsupportedDeclarationReporterKind.Silent,
     val experimentalFeatures: Map<String, String> = emptyMap(),
     val shouldBeFullyExported: Boolean,
+    /**
+     * When true, the module is a user cinterop klib whose types originate from a pre-existing ObjC module.
+     * Swift Export does not generate a separate Swift module for it; references emit `import <name>`
+     * and qualify types as `<name>.Type`, where `<name>` is the module's [InputModule.name]. The caller
+     * must set [InputModule.name] to the desired Objective-C / Swift module name.
+     * Must be combined with `shouldBeFullyExported = false`.
+     */
+    val moduleProvidedThroughCinterop: Boolean = false,
 ) {
 
     val targetPackageFqName: FqName? = rootPackage?.rootPackageToFqn()
     val unsupportedDeclarationReporter: UnsupportedDeclarationReporter = unsupportedDeclarationReporterKind.toReporter()
+
+    init {
+        require(!moduleProvidedThroughCinterop || !shouldBeFullyExported) {
+            "moduleProvidedThroughCinterop is incompatible with shouldBeFullyExported = true"
+        }
+    }
 
     public companion object {
         public const val ROOT_PACKAGE: String = "packageRoot"

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
@@ -53,7 +53,7 @@ internal fun translateModulePublicApi(module: InputModule, kaModules: KaModules,
             val sirModule = translateModule(
                 module = kaModules.mainModules.single { it.libraryName == module.name }
             )
-            createTranslationResult(sirModule, config, module.config, externalTypeDeclarationReferences)
+            createTranslationResult(sirModule, config, module.config, kaModules, externalTypeDeclarationReferences)
         }
     }
 }
@@ -141,6 +141,7 @@ internal fun translateCrossReferencingModulesTransitively(
                 sirModule,
                 config,
                 it.moduleConfig,
+                kaModules,
                 emptyMap(),
             )
         }
@@ -152,6 +153,7 @@ private fun createTranslationResult(
     sirModule: SirModule,
     config: SwiftExportConfig,
     moduleConfig: SwiftModuleConfig,
+    kaModules: KaModules,
     externalTypeDeclarationReferences: Map<KaLibraryModule, List<FqName>>,
 ): TranslationResult {
     // Assume that parts of the KotlinRuntimeSupport and KotlinRuntime module are used.
@@ -175,7 +177,9 @@ private fun createTranslationResult(
     // Serialize SirModule to sources to avoid leakage of SirSession (and KaSession, likely) outside the analyze call.
     val swiftSourceCode = printer.print(sirModule).swiftSource.joinToString("\n")
 
-    val knownModuleNames = setOf(KotlinRuntimeModule.name, bridgeModuleName) + config.platformLibsInputModule.map { it.name }
+    val knownModuleNames = setOf(KotlinRuntimeModule.name, bridgeModuleName) +
+            kaModules.platformLibraries.map { it.libraryName } +
+            kaModules.cinteropReexportLibraries.map { it.libraryName }
     val referencedSwiftModules = sirModule.imports
         .filter { it.moduleName !in knownModuleNames }
         .map { SwiftExportModule.Reference(it.moduleName) }


### PR DESCRIPTION
Introduces `SwiftModuleConfig.reexportAsObjCModule` — when a user-provided cinterop klib is tagged with this option, Swift Export treats the klib as a pre-existing ObjC/Swift module rather than generating a new Swift wrapper for its types.  References to types from such klibs are emitted as `import <ObjCModuleName>` in the Swift output, exactly mirroring how platform library types (e.g. `platform.Foundation.NSDate`) are handled.

Implementation:
- Adds `SirCinteropModule` as a sibling of `SirPlatformModule` under the new `SirPlatformLikeModule` sealed class; both branch-points in `SirParentProviderImpl` and `TypeBridging` now check for `SirPlatformLikeModule` to cover both cases uniformly.
- `SirOneToOneModuleProvider` maps cinterop-reexport klibs to `SirCinteropModule`; ordinary platform libs continue to map to `SirPlatformModule`.
- `SwiftExportRunner.translateModules` partitions inputs by `reexportAsObjCModule`, renames each reexported module to its ObjC name, and passes it to `createKaModulesForStandaloneAnalysis` as `cinteropReexportLibraries`.
- Test fixtures are added inline under `simple/testData/generation/cinteropReexport` and `simple/testData/execution/cinteropReexport`, using the existing `// MODULE:` / `// FILE:` / `// SWIFT_EXPORT_CONFIG:` infrastructure so no separate subproject or BeforeTestExecutionCallback is needed.

^KT-80632