### PR TITLE
[FIR] Avoid recursive captured type substitution stack overflow

### DIFF
--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/substitution/AbstractConeSubstitutor.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/resolve/substitution/AbstractConeSubstitutor.kt
@@ -12,6 +12,10 @@ import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import org.jetbrains.kotlin.utils.exceptions.errorWithAttachment
 
 abstract class AbstractConeSubstitutor(protected val typeContext: ConeTypeContext) : ConeSubstitutor() {
+    private val activeCapturedTypeSubstitutions = ThreadLocal.withInitial {
+        java.util.IdentityHashMap<ConeCapturedType, Unit>()
+    }
+
     abstract fun substituteType(type: ConeKotlinType): ConeKotlinType?
     override fun substituteArgument(projection: ConeTypeProjection, index: Int): ConeTypeProjection? {
         val type = (projection as? ConeKotlinTypeProjection)?.type ?: return null
@@ -70,11 +74,29 @@ abstract class AbstractConeSubstitutor(protected val typeContext: ConeTypeContex
             is ConeClassLikeType -> this.substituteArguments()
             is ConeLookupTagBasedType, is ConeTypeVariableType -> null
             is ConeFlexibleType -> this.mapTypesOrNull(typeContext) { substituteOrNull(it) }
-            is ConeCapturedType -> this.substitute(::substituteOrNull)
+            is ConeCapturedType -> this.substituteCapturedType()
             is ConeDefinitelyNotNullType -> this.substituteOriginal()
             is ConeIntersectionType -> this.substituteIntersectedTypes()
             is ConeStubType -> null
             is ConeIntegerLiteralType -> null
+        }
+    }
+
+    private fun ConeCapturedType.substituteCapturedType(): ConeCapturedType? {
+        val activeTypes = activeCapturedTypeSubstitutions.get()
+        if (activeTypes.containsKey(this)) {
+            // Preserve recursive occurrences unchanged while substituting the outer captured type.
+            return null
+        }
+
+        activeTypes[this] = Unit
+        try {
+            return substitute(::substituteOrNull)
+        } finally {
+            activeTypes.remove(this)
+            if (activeTypes.isEmpty()) {
+                activeCapturedTypeSubstitutions.remove()
+            }
         }
     }
 

--- a/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/kt86319.kt
+++ b/compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/kt86319.kt
@@ -1,0 +1,54 @@
+// FIR_IDENTICAL
+// JSPECIFY_STATE: warn
+
+// FILE: com/example/package-info.java
+
+@NullMarked
+package com.example;
+
+import org.jspecify.annotations.NullMarked;
+
+// FILE: com/example/Builder.java
+
+package com.example;
+
+public interface Builder<B extends Builder<B>> {
+    B name(String name);
+    String build();
+}
+
+// FILE: com/example/ConcreteBuilder.java
+
+package com.example;
+
+import org.jspecify.annotations.NullUnmarked;
+
+@NullUnmarked
+public class ConcreteBuilder<B extends ConcreteBuilder<B>> implements Builder<B> {
+    private String name;
+
+    @Override
+    public B name(String name) {
+        this.name = name;
+        return (B) this;
+    }
+
+    @Override
+    public String build() {
+        return name;
+    }
+
+    public static ConcreteBuilder<?> newBuilder() {
+        return new ConcreteBuilder<>();
+    }
+}
+
+// FILE: main.kt
+
+package com.example
+
+fun test(): String {
+    return ConcreteBuilder.newBuilder()
+        .name("test")
+        .build()
+}


### PR DESCRIPTION
## Summary

Fixes [KT-86319](https://youtrack.jetbrains.com/issue/KT-86319).

This fixes a `StackOverflowError` in FIR type substitution for a recursive Java builder type used from Kotlin under mixed JSpecify nullness defaults. The reproducer has a package-level `@NullMarked` default, a concrete builder marked `@NullUnmarked`, and a static factory returning `ConcreteBuilder<?>`. When Kotlin resolves a chained call on that receiver, FIR captures the wildcard and then substitutes the inherited Java member receiver type.

During that substitution, the type graph can lead back to the same captured wildcard type instance:

```text
class-like type argument
  -> flexible bounds
  -> captured type
  -> captured supertypes
  -> intersection type
  -> class-like type argument
  -> same captured type
```

`AbstractConeSubstitutor` previously delegated every captured type to `ConeCapturedType.substitute(::substituteOrNull)` without tracking active captured types. For the recursive graph above, that means substitution keeps expanding the same captured type through its supertypes until the JVM stack overflows.

## Approach

The fix tracks only `ConeCapturedType` instances currently being substituted by this substitutor. If substitution re-enters the exact same captured type, it returns `null`, which is the existing `substituteOrNull` convention for preserving the current occurrence unchanged.

The guard is intentionally narrow:

- It is scoped to the `ConeCapturedType` branch rather than all `ConeKotlinType` substitution.
- It uses identity tracking because recursive type graphs should not rely on structural equality or hash code traversal.
- It is removed in `finally`, so repeated appearances of the same captured type in independent substitution branches can still be processed normally.
- It leaves existing substitution behavior unchanged for class-like types, flexible types, intersection types, definitely-not-null types, attributes, and direct type-parameter substitutions.

This follows the same general shape as earlier targeted recursion fixes around recursive captured types and substitution loops: terminate the specific recursive path while preserving the existing substitution contract for unaffected type shapes.

## Test

Added a JSpecify warn-mode diagnostics regression test mirroring the original Java builder reproducer:

`compiler/testData/diagnostics/foreignAnnotationsTests/java8Tests/jspecify/warnMode/kt86319.kt`

The test uses the existing FIR foreign-annotations diagnostics runners and verifies the reproducer compiles without overflowing.

Locally verified:

```bash
JAVA_HOME="$HOME/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.10+7/Contents/Home" ./gradlew :compiler:fir:providers:compileKotlin --no-configuration-cache --console=plain
JAVA_HOME="$HOME/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.10+7/Contents/Home" ./gradlew :compiler:fir:analysis-tests:test --tests "*ForeignAnnotations*" --no-configuration-cache --console=plain
JAVA_HOME="$HOME/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.10+7/Contents/Home" ./gradlew :kotlin-compiler:dist --stacktrace --console=plain --no-configuration-cache
JAVA_HOME="$HOME/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.10+7/Contents/Home" ./gradlew compilerTest --no-configuration-cache --console=plain
```

I also rebuilt the local compiler distribution and compiled the original standalone reproducer with `-J-Xss512k`. It succeeded, produced `MainKt.class`, and emitted an empty compiler log.
