### PR TITLE
[Analysis API] Unify package naming logic for standalone mode

### DIFF
--- a/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/configurators/AnalysisApiBaseTestServiceRegistrar.kt
+++ b/analysis/analysis-api-impl-base/testFixtures/org/jetbrains/kotlin/analysis/api/impl/base/test/configurators/AnalysisApiBaseTestServiceRegistrar.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStan
 import org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStandaloneDeclarationProviderFactory
 import org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStandaloneDeclarationProviderMerger
 import org.jetbrains.kotlin.analysis.api.standalone.base.modification.KotlinStandaloneModificationTrackerFactory
+import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageNamesProvider
 import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageProviderFactory
 import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageProviderMerger
 import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory
@@ -125,7 +126,6 @@ object AnalysisApiBaseTestServiceRegistrar : AnalysisApiTestServiceRegistrar() {
         project.apply {
             registerService(KotlinAnnotationsResolverFactory::class.java, KotlinStandaloneAnnotationsResolverFactory(project, testKtFiles))
 
-            val ktFilesForBinaries: List<KtFile>
             val shouldBuildStubsForBinaryLibraries =
                 testServices.libraryIndexingConfiguration.binaryLibraryIndexingMode == AnalysisApiBinaryLibraryIndexingMode.INDEX_STUBS
 
@@ -141,14 +141,20 @@ object AnalysisApiBaseTestServiceRegistrar : AnalysisApiTestServiceRegistrar() {
                 postponeIndexing = true,
             )
 
-            ktFilesForBinaries = declarationProviderFactory.getAdditionalCreatedKtFiles()
             registerService(
                 KotlinDeclarationProviderFactory::class.java, declarationProviderFactory
             )
             registerService(KotlinDeclarationProviderMerger::class.java, KotlinStandaloneDeclarationProviderMerger(project))
+
+            val packageNamesProvider = KotlinStandalonePackageNamesProvider(
+                declarationProviderFactory = declarationProviderFactory,
+                libraryRoots = sharedBinaryRoots,
+            )
+            registerService(KotlinStandalonePackageNamesProvider::class.java, packageNamesProvider)
+
             registerService(
                 KotlinPackageProviderFactory::class.java,
-                KotlinStandalonePackageProviderFactory(project, testKtFiles + ktFilesForBinaries, sharedBinaryRoots),
+                KotlinStandalonePackageProviderFactory(project),
             )
             registerService(KotlinPackageProviderMerger::class.java, KotlinStandalonePackageProviderMerger(project))
         }

--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneDeclarationIndex.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneDeclarationIndex.kt
@@ -12,6 +12,12 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.*
 
 internal interface KotlinStandaloneDeclarationIndex {
+    /**
+     * All indexed files keyed by their [KtFile.getPackageFqName]. In contrast to the declaration-based maps, this map also contains files
+     * without any top-level declarations, so it can be used to find every package that is mentioned in a package directive.
+     */
+    val filesByPackage: Map<FqName, Set<KtFile>>
+
     val facadeFileMap: Map<FqName, Set<KtFile>>
     val multiFileClassPartMap: Map<FqName, Set<KtFile>>
     val scriptMap: Map<FqName, Set<KtScript>>

--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneDeclarationIndexImpl.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneDeclarationIndexImpl.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.psi.stubs.impl.*
 import org.jetbrains.kotlin.utils.addIfNotNull
 
 internal class KotlinStandaloneDeclarationIndexImpl : KotlinStandaloneDeclarationIndex {
+    override val filesByPackage: MutableMap<FqName, MutableSet<KtFile>> = mutableMapOf()
     override val facadeFileMap: MutableMap<FqName, MutableSet<KtFile>> = mutableMapOf()
     override val multiFileClassPartMap: MutableMap<FqName, MutableSet<KtFile>> = mutableMapOf()
     override val scriptMap: MutableMap<FqName, MutableSet<KtScript>> = mutableMapOf()
@@ -37,6 +38,10 @@ internal class KotlinStandaloneDeclarationIndexImpl : KotlinStandaloneDeclaratio
     override val inheritableTypeAliasesByAliasedName: MutableMap<Name, MutableSet<KtTypeAlias>> = mutableMapOf()
 
     private fun indexFile(file: KtFile) {
+        filesByPackage.computeIfAbsent(file.packageFqName) {
+            mutableSetOf()
+        }.add(file)
+
         if (!file.hasTopLevelCallables()) return
         facadeFileMap.computeIfAbsent(file.packageFqName) {
             mutableSetOf()

--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneDeclarationProvider.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneDeclarationProvider.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.analysis.api.platform.KotlinPlatformSettings
 import org.jetbrains.kotlin.analysis.api.platform.declarations.*
 import org.jetbrains.kotlin.analysis.api.platform.mergeSpecificProviders
 import org.jetbrains.kotlin.analysis.api.projectStructure.*
+import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageNamesProvider
 import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory
 import org.jetbrains.kotlin.fileClasses.javaFileFacadeFqName
 import org.jetbrains.kotlin.name.*
@@ -90,13 +91,16 @@ class KotlinStandaloneDeclarationProvider internal constructor(
     override fun computePackageNames(): Set<String>? =
         when (contextualModule) {
             is KaSourceModule, is KaScriptModule, is KaNotUnderContentRootModule ->
-                computePackageSetFromIndex()
+                computePackageSetFromIndex(contextualModule)
 
             is KaLibraryModule ->
                 if (contextualModule.canComputePackageSetFromIndex) {
-                    computePackageSetFromIndex()
+                    computePackageSetFromIndex(contextualModule)
                 } else {
-                    computeBinaryLibraryModulePackageSet(contextualModule)
+                    KotlinStandalonePackageNamesProvider.getInstance(contextualModule.project)
+                        .computeKlibPackageNames(scope)
+                        ?.mapTo(mutableSetOf()) { it.asString() }
+                        ?: computeBinaryLibraryModulePackageSet(contextualModule)
                 }
 
             else -> null
@@ -109,18 +113,10 @@ class KotlinStandaloneDeclarationProvider internal constructor(
     private val KaLibraryModule.canComputePackageSetFromIndex: Boolean
         get() = KotlinPlatformSettings.getInstance(project).deserializedDeclarationsOrigin == KotlinDeserializedDeclarationsOrigin.STUBS
 
-    private fun computePackageSetFromIndex(): Set<String> = buildSet {
-        addPackageNamesInScope(index.classLikeDeclarationsByPackage)
-        addPackageNamesInScope(index.topLevelCallablesByPackage)
-    }
-
-    private fun <T : KtDeclaration> MutableSet<String>.addPackageNamesInScope(map: Map<FqName, Set<T>>) {
-        map.forEach { [fqName, declarations] ->
-            if (declarations.any { it.inScope }) {
-                add(fqName.asString())
-            }
-        }
-    }
+    private fun computePackageSetFromIndex(module: KaModule): Set<String> =
+        KotlinStandalonePackageNamesProvider.getInstance(module.project)
+            .computePackageNamesFromIndex(scope)
+            .mapTo(mutableSetOf()) { it.asString() }
 
     /**
      * The computation only supports JARs for now and is intended for test purposes.
@@ -186,12 +182,17 @@ class KotlinStandaloneDeclarationProvider internal constructor(
  * [shouldBuildStubsForBinaryLibraries] is true. In Standalone mode, binary roots don't need to be specified because library symbols are
  * provided via class-based deserialization, not stub-based deserialization.
  *
+ * The created declaration providers compute their package names through
+ * [KotlinStandalonePackageNamesProvider][org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageNamesProvider],
+ * which must be registered as a project service with this factory instance (see its documentation).
+ *
  * @param binaryRoots Binary roots of the binary libraries that are specific to [project].
  * @param sharedBinaryRoots Binary roots that are shared between multiple different projects. This allows Kotlin tests to cache stubs for
  *  shared libraries like the Kotlin stdlib.
- * @param shouldComputeBinaryLibraryPackageSets Whether to compute package sets for binary libraries when they are NOT indexed by default.
- *  It is risky to enable this in production because in some file systems, file traversal can be slow. So we shouldn't enable this without
- *  further investigation.
+ * @param shouldComputeBinaryLibraryPackageSets Whether to compute package sets for binary libraries that are not indexed by walking JAR
+ *  contents (see `computeBinaryLibraryModulePackageSet`). This governs only the JAR-traversal fallback; index-based and KLib package
+ *  computation always runs through `KotlinStandalonePackageNamesProvider`. It is risky to enable JAR traversal in production because in
+ *  some file systems, file traversal can be slow. So we shouldn't enable this without further investigation.
  * @param postponeIndexing Whether to postpone indexing until the first access.
  *  This is useful for tests to reduce the startup time and potentially avoid redundant indexing (which might be heavy, especially if stubs are used).
  */
@@ -230,15 +231,11 @@ class KotlinStandaloneDeclarationProviderFactory(
         }
     }
 
-    private val index: KotlinStandaloneDeclarationIndex
+    internal val index: KotlinStandaloneDeclarationIndex
         get() = indexData.index
 
     override fun createDeclarationProvider(scope: GlobalSearchScope, contextualModule: KaModule?): KotlinDeclarationProvider {
         return KotlinStandaloneDeclarationProvider(index, scope, contextualModule, environment, shouldComputeBinaryLibraryPackageSets)
-    }
-
-    fun getAdditionalCreatedKtFiles(): List<KtFile> {
-        return indexData.fakeKtFiles
     }
 
     fun getAllKtClasses(): List<KtClassOrObject> = index.classesByClassId.values.flattenTo(mutableListOf())

--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneLazyDeclarationIndexImpl.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/declarations/KotlinStandaloneLazyDeclarationIndexImpl.kt
@@ -21,6 +21,7 @@ internal class KotlinStandaloneLazyDeclarationIndexImpl(
 ) : KotlinStandaloneDeclarationIndex {
     private val computedIndex: KotlinStandaloneDeclarationIndex get() = lazyIndex.value
 
+    override val filesByPackage: Map<FqName, Set<KtFile>> get() = computedIndex.filesByPackage
     override val facadeFileMap: Map<FqName, Set<KtFile>> get() = computedIndex.facadeFileMap
     override val multiFileClassPartMap: Map<FqName, Set<KtFile>> get() = computedIndex.multiFileClassPartMap
     override val scriptMap: Map<FqName, Set<KtScript>> get() = computedIndex.scriptMap

--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/packages/KotlinStandalonePackageNamesProvider.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/packages/KotlinStandalonePackageNamesProvider.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.analysis.api.standalone.base.packages
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStandaloneDeclarationProviderFactory
+import org.jetbrains.kotlin.library.KlibConstants.KLIB_FILE_EXTENSION
+import org.jetbrains.kotlin.library.components.metadata
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.metadata.parseModuleHeader
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtElement
+import java.nio.file.Path
+import kotlin.io.path.extension
+
+/**
+ * A unified source of Kotlin package names shared between [KotlinStandalonePackageProvider] and
+ * [org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStandaloneDeclarationProvider], so that both providers report
+ * consistent package sets (KT-83760).
+ *
+ * Package names are computed with two strategies:
+ *
+ * - From the declaration index of [declarationProviderFactory], which covers source files and binary libraries when they are indexed as
+ *   stubs (see [org.jetbrains.kotlin.analysis.api.platform.KotlinDeserializedDeclarationsOrigin.STUBS]).
+ * - From KLib metadata for KLib library roots.
+ *
+ * Kotlin classes in non-indexed JARs are currently not covered: in production Standalone mode, libraries are not indexed
+ * (see [org.jetbrains.kotlin.analysis.api.platform.KotlinDeserializedDeclarationsOrigin.BINARIES]), and computing precise Kotlin-only
+ * package names for a JAR requires distinguishing Kotlin class files from other JVM class files, which is expensive without an index.
+ * Java packages in JARs are still found through `KotlinPackageProviderBase.doesPlatformSpecificPackageExist`. Kotlin packages in
+ * non-indexed JARs should be supported in a follow-up to KT-83760.
+ *
+ * The provider must be registered as a project service whenever [KotlinStandaloneDeclarationProviderFactory] or
+ * [KotlinStandalonePackageProviderFactory] is registered, with [declarationProviderFactory] being the same instance that is registered as
+ * the `KotlinDeclarationProviderFactory`.
+ */
+class KotlinStandalonePackageNamesProvider(
+    private val declarationProviderFactory: KotlinStandaloneDeclarationProviderFactory,
+    libraryRoots: List<VirtualFile>,
+) {
+    companion object {
+        fun getInstance(project: Project): KotlinStandalonePackageNamesProvider = project.service()
+    }
+
+    /**
+     * A mapping from a KLib library root [VirtualFile] to the [Path] of the `.klib` file or unpacked KLib directory that contains it.
+     * JAR roots are omitted (see the class documentation).
+     */
+    private val klibFiles: Map<VirtualFile, Path> = buildMap {
+        for (libraryRoot in libraryRoots) {
+            if (libraryRoot.fileSystem.protocol == StandardFileSystems.JAR_PROTOCOL) {
+                // Root entry in the KLib archive
+                val libraryFile = runCatching { VfsUtilCore.getVirtualFileForJar(libraryRoot)?.toNioPath() }.getOrNull() ?: continue
+                if (libraryFile.extension.lowercase() == KLIB_FILE_EXTENSION) {
+                    put(libraryRoot, libraryFile)
+                }
+            } else if (libraryRoot.isDirectory) {
+                // Unpacked Kotlin library (a tree of directories with individual '.knm' files)
+                val libraryFile = runCatching { libraryRoot.toNioPath() }.getOrNull() ?: continue
+                put(libraryRoot, libraryFile)
+            }
+        }
+    }
+
+    private val klibPackages = Caffeine
+        .newBuilder()
+        .maximumSize(1000)
+        .build<Path, List<FqName>> { libraryFile ->
+            buildList {
+                val kotlinLibraries = KlibLoader { libraryPaths(libraryFile) }.load().librariesStdlibFirst
+                for (kotlinLibrary in kotlinLibraries) {
+                    val moduleHeader = parseModuleHeader(kotlinLibrary.metadata.moduleHeaderData)
+                    for (packageNameString in moduleHeader.packageFragmentNameList) {
+                        add(FqName(packageNameString))
+                    }
+                }
+            }
+        }
+
+    /**
+     * Computes the package names of all indexed files and declarations contained in [scope]. This covers source files and, when binary
+     * libraries are indexed as stubs, library declarations.
+     *
+     * The packages of indexed files are included even when a file contains no declarations, so that every package mentioned in a package
+     * directive exists (consistent with the IDE, where packages are backed by a file-based index).
+     */
+    fun computePackageNamesFromIndex(scope: GlobalSearchScope): Set<FqName> = buildSet {
+        addPackageNamesInScope(declarationProviderFactory.index.filesByPackage, scope)
+        addPackageNamesInScope(declarationProviderFactory.index.classLikeDeclarationsByPackage, scope)
+        addPackageNamesInScope(declarationProviderFactory.index.topLevelCallablesByPackage, scope)
+    }
+
+    private fun <T : KtElement> MutableSet<FqName>.addPackageNamesInScope(map: Map<FqName, Set<T>>, scope: GlobalSearchScope) {
+        map.forEach { [fqName, elements] ->
+            if (elements.any { it.containingKtFile.virtualFile in scope }) {
+                add(fqName)
+            }
+        }
+    }
+
+    /**
+     * Computes the package names of all KLib library roots contained in [scope], or `null` if no KLib root is contained in [scope].
+     *
+     * The `null` result allows callers to distinguish "no KLibs are tracked in this scope" from "the KLibs in this scope contain no
+     * packages", e.g. to fall back to another computation for JAR-based library modules.
+     */
+    fun computeKlibPackageNames(scope: GlobalSearchScope): Set<FqName>? {
+        var foundKlibRoot = false
+        val packages = mutableSetOf<FqName>()
+
+        for ([libraryRoot, libraryFile] in klibFiles) {
+            if (scope.contains(libraryRoot)) {
+                foundKlibRoot = true
+                packages.addAll(klibPackages[libraryFile] ?: emptyList())
+            }
+        }
+
+        return if (foundKlibRoot) packages else null
+    }
+
+    /**
+     * Returns all Kotlin package names known to this provider in [scope]: the packages of indexed declarations and of KLib library
+     * roots.
+     */
+    fun getPackageNamesInScope(scope: GlobalSearchScope): Set<FqName> =
+        computePackageNamesFromIndex(scope) + (computeKlibPackageNames(scope) ?: emptySet())
+}

--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/packages/KotlinStandalonePackageProvider.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/packages/KotlinStandalonePackageProvider.kt
@@ -5,28 +5,17 @@
 
 package org.jetbrains.kotlin.analysis.api.standalone.base.packages
 
-import com.github.benmanes.caffeine.cache.Caffeine
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.StandardFileSystems
-import com.intellij.openapi.vfs.VfsUtilCore
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.analysis.api.platform.mergeSpecificProviders
 import org.jetbrains.kotlin.analysis.api.platform.packages.*
-import org.jetbrains.kotlin.library.KlibConstants.KLIB_FILE_EXTENSION
-import org.jetbrains.kotlin.library.components.metadata
-import org.jetbrains.kotlin.library.loader.KlibLoader
-import org.jetbrains.kotlin.library.metadata.parseModuleHeader
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.psi.KtFile
-import java.nio.file.Path
-import kotlin.io.path.extension
 
 class KotlinStandalonePackageProvider(
     project: Project,
     internal val scope: GlobalSearchScope,
-    matchingPackageNames: Set<FqName>
+    matchingPackageNames: Set<FqName>,
 ) : KotlinPackageProviderBase(project, scope) {
     private val kotlinPackageToSubPackages: Map<FqName, Set<Name>> = run {
         val packages: MutableMap<FqName, MutableSet<Name>> = mutableMapOf() // the explicit type is here to workaround KTIJ-21172
@@ -50,60 +39,15 @@ class KotlinStandalonePackageProvider(
     }
 }
 
+/**
+ * The created package providers compute their package names through [KotlinStandalonePackageNamesProvider], which must be registered as a
+ * project service (see its documentation).
+ */
 class KotlinStandalonePackageProviderFactory(
     private val project: Project,
-    private val indexedFiles: Collection<KtFile>,
-    libraryRoots: List<VirtualFile>
 ) : KotlinCachingPackageProviderFactory(project) {
-    /** A mapping between the library root and its containing KLib file. */
-    private val klibFiles: Map<VirtualFile, Path> = buildMap {
-        for (libraryRoot in libraryRoots) {
-            if (libraryRoot.fileSystem.protocol == StandardFileSystems.JAR_PROTOCOL) {
-                // Root entry in the Klib archive
-                val libraryFile = runCatching { VfsUtilCore.getVirtualFileForJar(libraryRoot)?.toNioPath() }.getOrNull() ?: continue
-                if (libraryFile.extension.lowercase() == KLIB_FILE_EXTENSION) {
-                    put(libraryRoot, libraryFile)
-                }
-            } else if (libraryRoot.isDirectory) {
-                // Unpacked Kotlin library (a tree of directories with individual '.knm' files)
-                val libraryFile = runCatching { libraryRoot.toNioPath() }.getOrNull() ?: continue
-                put(libraryRoot, libraryFile)
-            }
-        }
-    }
-
-    /** On-demand package storage for [klibFiles]. */
-    private val klibPackages = Caffeine
-        .newBuilder()
-        .maximumSize(1000)
-        .build<Path, List<FqName>> { libraryFile ->
-            buildList {
-                val kotlinLibraries = KlibLoader { libraryPaths(libraryFile) }.load().librariesStdlibFirst
-                for (kotlinLibrary in kotlinLibraries) {
-                    val moduleHeader = parseModuleHeader(kotlinLibrary.metadata.moduleHeaderData)
-                    for (packageNameString in moduleHeader.packageFragmentNameList) {
-                        add(FqName(packageNameString))
-                    }
-                }
-            }
-        }
-
     override fun createNewPackageProvider(searchScope: GlobalSearchScope): KotlinPackageProvider {
-        val matchingPackageNames = buildSet {
-            for (sourceKtFile in indexedFiles) {
-                val sourceVirtualFile = sourceKtFile.virtualFile ?: continue
-                if (searchScope.contains(sourceVirtualFile)) {
-                    add(sourceKtFile.packageFqName)
-                }
-            }
-
-            for ([libraryRoot, libraryFile] in klibFiles) {
-                if (searchScope.contains(libraryRoot)) {
-                    addAll(klibPackages[libraryFile] ?: emptyList())
-                }
-            }
-        }
-
+        val matchingPackageNames = KotlinStandalonePackageNamesProvider.getInstance(project).getPackageNamesInScope(searchScope)
         return KotlinStandalonePackageProvider(project, searchScope, matchingPackageNames)
     }
 }

--- a/analysis/analysis-api-standalone/src/org/jetbrains/kotlin/analysis/api/standalone/StandaloneAnalysisAPISessionBuilder.kt
+++ b/analysis/analysis-api-standalone/src/org/jetbrains/kotlin/analysis/api/standalone/StandaloneAnalysisAPISessionBuilder.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStan
 import org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStandaloneDeclarationProviderMerger
 import org.jetbrains.kotlin.analysis.api.standalone.base.declarations.KotlinStandaloneFirCompilerPluginsProvider
 import org.jetbrains.kotlin.analysis.api.standalone.base.modification.KotlinStandaloneModificationTrackerFactory
+import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageNamesProvider
 import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageProviderFactory
 import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalonePackageProviderMerger
 import org.jetbrains.kotlin.analysis.api.standalone.base.permissions.KotlinStandaloneAnalysisPermissionOptions
@@ -154,6 +155,7 @@ public class StandaloneAnalysisAPISessionBuilder(
             registerService(KotlinModificationTrackerFactory::class.java, KotlinStandaloneModificationTrackerFactory::class.java)
 
             registerService(KotlinAnnotationsResolverFactory::class.java, KotlinStandaloneAnnotationsResolverFactory(this, sourceKtFiles))
+
             val declarationProviderFactory = KotlinStandaloneDeclarationProviderFactory(
                 this,
                 kotlinCoreProjectEnvironment.environment,
@@ -164,13 +166,16 @@ public class StandaloneAnalysisAPISessionBuilder(
                 declarationProviderFactory
             )
             registerService(KotlinDeclarationProviderMerger::class.java, KotlinStandaloneDeclarationProviderMerger(this))
+
+            val packageNamesProvider = KotlinStandalonePackageNamesProvider(
+                declarationProviderFactory = declarationProviderFactory,
+                libraryRoots = libraryRoots,
+            )
+            registerService(KotlinStandalonePackageNamesProvider::class.java, packageNamesProvider)
+
             registerService(
                 KotlinPackageProviderFactory::class.java,
-                KotlinStandalonePackageProviderFactory(
-                    project,
-                    sourceKtFiles + declarationProviderFactory.getAdditionalCreatedKtFiles(),
-                    libraryRoots
-                )
+                KotlinStandalonePackageProviderFactory(project)
             )
             registerService(KotlinPackageProviderMerger::class.java, KotlinStandalonePackageProviderMerger(this))
 

--- a/analysis/analysis-api-standalone/testData/behavior/declarationlessPackage/declarationless.kt
+++ b/analysis/analysis-api-standalone/testData/behavior/declarationlessPackage/declarationless.kt
@@ -1,0 +1,1 @@
+package declarationless

--- a/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandaloneBehaviorTest.kt
+++ b/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandaloneBehaviorTest.kt
@@ -6,25 +6,18 @@
 package org.jetbrains.kotlin.analysis.api.standalone.fir.test.cases.session.builder
 
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
-import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotationValue
-import org.jetbrains.kotlin.analysis.api.platform.packages.KotlinPackageProvider
-import org.jetbrains.kotlin.analysis.api.platform.packages.createPackageProvider
-import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
 import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
 import org.jetbrains.kotlin.analysis.api.standalone.fir.test.AbstractStandaloneTest
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtLibraryModule
-import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSdkModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
-import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.StandardClassIds
-import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.platform.js.JsPlatforms
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtClass
@@ -33,15 +26,8 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.test.services.StandardLibrariesPathProviderForKotlinProject
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.util.zip.ZipFile
-import kotlin.io.path.ExperimentalPathApi
-import kotlin.io.path.deleteRecursively
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 class StandaloneBehaviorTest : AbstractStandaloneTest() {
     override val suiteName: String
@@ -138,121 +124,8 @@ class StandaloneBehaviorTest : AbstractStandaloneTest() {
     }
 
     @Test
-    fun testJvmPackageProvider() {
-        val sharedPlatform = JvmPlatforms.defaultJvmPlatform
-
-        lateinit var sourceModule: KaSourceModule
-        buildStandaloneAnalysisAPISession(disposable) {
-            buildKtModuleProvider {
-                val sdkModule = addModule(
-                    buildKtSdkModule {
-                        addBinaryRootsFromJdkHome(Paths.get(System.getProperty("java.home")), isJre = true)
-                        addBinaryRootsFromJdkHome(Paths.get(System.getProperty("java.home")), isJre = false)
-                        platform = sharedPlatform
-                        libraryName = "JDK"
-                    }
-                )
-
-                val stdlibModule = addModule(
-                    buildKtLibraryModule {
-                        addBinaryRoot(ForTestCompileRuntime.runtimeJarForTests().toPath())
-                        platform = sharedPlatform
-                        libraryName = "stdlib"
-                    }
-                )
-
-                platform = sharedPlatform
-                sourceModule = addModule(
-                    buildKtSourceModule {
-                        addSourceRoot(testDataPath("packageProvider"))
-                        addRegularDependency(sdkModule)
-                        addRegularDependency(stdlibModule)
-                        platform = sharedPlatform
-                        moduleName = "source"
-                    }
-                )
-            }
-        }
-
-        testPackageProvider(sourceModule) {
-            checkPackageExistence("foo", isKotlinOnly = true, isPlatform = false)
-            checkPackageExistence("bar", isKotlinOnly = false, isPlatform = false)
-            checkPackageExistence("kotlin", isKotlinOnly = true, isPlatform = true)
-            checkPackageExistence("kotlin.collections", isKotlinOnly = true, isPlatform = true)
-            checkPackageExistence("kotlin.jvm.functions", isKotlinOnly = false, isPlatform = true)
-            checkPackageExistence("java.lang", isKotlinOnly = false, isPlatform = true)
-            checkPackageExistence("java.io", isKotlinOnly = false, isPlatform = true)
-
-            checkSubpackages("foo", emptyList())
-            checkSubpackages("bar", emptyList())
-            checkSubpackages("kotlin", listOf("collections", "jvm", "js"))
-            checkSubpackages("kotlin.collections", listOf("unsigned", "jdk8"))
-            checkSubpackages("java", listOf("lang", "io"))
-        }
-    }
-
-    @Test
-    fun testJsPackageProvider() {
-        val sharedPlatform = JsPlatforms.defaultJsPlatform
-
-        lateinit var sourceModule: KaSourceModule
-        buildStandaloneAnalysisAPISession(disposable) {
-            buildKtModuleProvider {
-                val stdlibModule = addModule(
-                    buildKtLibraryModule {
-                        addBinaryRoot(ForTestCompileRuntime.stdlibJsForTests().toPath())
-                        platform = sharedPlatform
-                        libraryName = "stdlib"
-                    }
-                )
-
-                platform = sharedPlatform
-                sourceModule = addModule(
-                    buildKtSourceModule {
-                        addSourceRoot(testDataPath("packageProvider"))
-                        addRegularDependency(stdlibModule)
-                        platform = sharedPlatform
-                        moduleName = "source"
-                    }
-                )
-            }
-        }
-
-        testPackageProvider(sourceModule) {
-            checkPackageExistence("foo", isKotlinOnly = true, isPlatform = false)
-            checkPackageExistence("bar", isKotlinOnly = false, isPlatform = false)
-            checkPackageExistence("kotlin", isKotlinOnly = true, isPlatform = false)
-            checkPackageExistence("kotlin.collections", isKotlinOnly = true, isPlatform = false)
-            checkPackageExistence("kotlin.jvm.functions", isKotlinOnly = false, isPlatform = false)
-            checkPackageExistence("java.lang", isKotlinOnly = false, isPlatform = false)
-            checkPackageExistence("java.io", isKotlinOnly = false, isPlatform = false)
-
-            checkSubpackages("foo", emptyList())
-            checkSubpackages("bar", emptyList())
-            checkSubpackages("kotlin", listOf("collections", "jvm", "js"))
-        }
-    }
-
-    @Test
     fun testUnpackedKlibDependency() {
-        val klibFile = ForTestCompileRuntime.stdlibJsForTests()
-        val tempKlibFolder = Files.createTempDirectory(klibFile.name)
-
-        try {
-            ZipFile(klibFile).use { zipFile ->
-                for (zipEntry in zipFile.entries()) {
-                    val targetPath = tempKlibFolder.resolve(zipEntry.name)
-                    if (zipEntry.isDirectory) {
-                        Files.createDirectories(targetPath)
-                    } else {
-                        Files.createDirectories(targetPath.parent)
-                        zipFile.getInputStream(zipEntry).use { input ->
-                            Files.copy(input, targetPath)
-                        }
-                    }
-                }
-            }
-
+        withUnpackedJsStdlib { tempKlibFolder ->
             val sharedPlatform = JsPlatforms.defaultJsPlatform
 
             lateinit var sourceModule: KaSourceModule
@@ -278,20 +151,6 @@ class StandaloneBehaviorTest : AbstractStandaloneTest() {
                 }
             }
 
-            testPackageProvider(sourceModule) {
-                checkPackageExistence("foo", isKotlinOnly = true, isPlatform = false)
-                checkPackageExistence("bar", isKotlinOnly = false, isPlatform = false)
-                checkPackageExistence("kotlin", isKotlinOnly = true, isPlatform = false)
-                checkPackageExistence("kotlin.collections", isKotlinOnly = true, isPlatform = false)
-                checkPackageExistence("kotlin.jvm.functions", isKotlinOnly = false, isPlatform = false)
-                checkPackageExistence("java.lang", isKotlinOnly = false, isPlatform = false)
-                checkPackageExistence("java.io", isKotlinOnly = false, isPlatform = false)
-
-                checkSubpackages("foo", emptyList())
-                checkSubpackages("bar", emptyList())
-                checkSubpackages("kotlin", listOf("collections", "jvm", "js"))
-            }
-
             val ktFile = standaloneSession.modulesWithFiles.getValue(sourceModule).single() as KtFile
             val testFunction = ktFile.declarations.filterIsInstance<KtNamedFunction>().single()
             analyze(ktFile) {
@@ -302,64 +161,6 @@ class StandaloneBehaviorTest : AbstractStandaloneTest() {
 
                 assertEquals(listOfStringsType, testFunction.returnType)
             }
-        } finally {
-            @OptIn(ExperimentalPathApi::class)
-            tempKlibFolder.deleteRecursively()
-        }
-    }
-
-    private class PackageProviderTestContext(
-        private val session: KaSession,
-        private val packageProvider: KotlinPackageProvider,
-        private val targetPlatform: TargetPlatform,
-    ) {
-        fun checkPackageExistence(name: String, isKotlinOnly: Boolean, isPlatform: Boolean) {
-            fun check(expected: Boolean, message: String, block: () -> Boolean) {
-                if (expected) {
-                    assertTrue(block(), message)
-                } else {
-                    assertFalse(block(), message.replace("must", "must not"))
-                }
-            }
-
-            val packageFqName = FqName(name)
-            check(isKotlinOnly || isPlatform, "Package '$packageFqName' must exist") {
-                packageProvider.doesPackageExist(packageFqName, targetPlatform)
-            }
-            check(isKotlinOnly || isPlatform, "Package '$packageFqName' must be visible through 'KaSession.findPackage()'") {
-                with(session) { findPackage(packageFqName) != null }
-            }
-            check(isKotlinOnly, "Kotlin-only package '$packageFqName' must exist") {
-                packageProvider.doesKotlinOnlyPackageExist(packageFqName)
-            }
-            check(isPlatform, "Platform-specific package '$packageFqName' must exist") {
-                packageProvider.doesPlatformSpecificPackageExist(packageFqName, targetPlatform)
-            }
-        }
-
-        fun checkSubpackages(name: String, expectedInside: List<String>) {
-            val packageFqName = FqName(name)
-            val actualSubpackages = packageProvider.getSubpackageNames(packageFqName, targetPlatform)
-                .mapTo(HashSet()) { it.asString() }
-
-            if (expectedInside.isEmpty()) {
-                assertEquals(emptySet(), actualSubpackages, "Subpackages of '$packageFqName' must be empty")
-            } else {
-                for (expectedSubpackage in expectedInside) {
-                    val isInside = expectedSubpackage in actualSubpackages
-                    assertTrue(isInside, "Subpackage '$name.$expectedSubpackage' must exist")
-                }
-            }
-        }
-    }
-
-    private fun testPackageProvider(module: KaModule, block: context(KaSession) PackageProviderTestContext.() -> Unit) {
-        val targetPlatform = module.targetPlatform
-
-        analyze(module) {
-            val packageProvider = module.project.createPackageProvider(analysisScope)
-            val packageProviderTestContext = PackageProviderTestContext(useSiteSession, packageProvider, targetPlatform)
-            block(packageProviderTestContext)
         }
     }
 }

--- a/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandalonePackageNamesTest.kt
+++ b/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandalonePackageNamesTest.kt
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.analysis.api.standalone.fir.test.cases.session.builder
+
+import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.platform.declarations.createDeclarationProvider
+import org.jetbrains.kotlin.analysis.api.platform.packages.KotlinPackageProvider
+import org.jetbrains.kotlin.analysis.api.platform.packages.createPackageProvider
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibraryModule
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
+import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
+import org.jetbrains.kotlin.analysis.api.standalone.fir.test.AbstractStandaloneTest
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtLibraryModule
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSdkModule
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.platform.TargetPlatform
+import org.jetbrains.kotlin.platform.js.JsPlatforms
+import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class StandalonePackageNamesTest : AbstractStandaloneTest() {
+    override val suiteName: String
+        get() = "behavior"
+
+    @Test
+    fun testJvmPackageProvider() {
+        val sharedPlatform = JvmPlatforms.defaultJvmPlatform
+
+        lateinit var sourceModule: KaSourceModule
+        buildStandaloneAnalysisAPISession(disposable) {
+            buildKtModuleProvider {
+                val sdkModule = addModule(
+                    buildKtSdkModule {
+                        addBinaryRootsFromJdkHome(Paths.get(System.getProperty("java.home")), isJre = true)
+                        addBinaryRootsFromJdkHome(Paths.get(System.getProperty("java.home")), isJre = false)
+                        platform = sharedPlatform
+                        libraryName = "JDK"
+                    }
+                )
+
+                val stdlibModule = addModule(
+                    buildKtLibraryModule {
+                        addBinaryRoot(ForTestCompileRuntime.runtimeJarForTests().toPath())
+                        platform = sharedPlatform
+                        libraryName = "stdlib"
+                    }
+                )
+
+                val kotlinTestModule = addModule(
+                    buildKtLibraryModule {
+                        addBinaryRoot(ForTestCompileRuntime.kotlinTestJarForTests().toPath())
+                        platform = sharedPlatform
+                        libraryName = "kotlin-test"
+                    }
+                )
+
+                platform = sharedPlatform
+                sourceModule = addModule(
+                    buildKtSourceModule {
+                        addSourceRoot(testDataPath("packageProvider"))
+                        addSourceRoot(testDataPath("declarationlessPackage"))
+                        addRegularDependency(sdkModule)
+                        addRegularDependency(stdlibModule)
+                        addRegularDependency(kotlinTestModule)
+                        platform = sharedPlatform
+                        moduleName = "source"
+                    }
+                )
+            }
+        }
+
+        testPackageProvider(sourceModule) {
+            checkPackageExistence("foo", isKotlinOnly = true, isPlatform = false, declarationProviderModule = sourceModule)
+            checkPackageExistence("bar", isKotlinOnly = false, isPlatform = false, declarationProviderModule = sourceModule)
+            // The package of a file without declarations must still exist (KT-83760).
+            checkPackageExistence("declarationless", isKotlinOnly = true, isPlatform = false, declarationProviderModule = sourceModule)
+            checkPackageExistence("kotlin", isKotlinOnly = true, isPlatform = true)
+            checkPackageExistence("kotlin.collections", isKotlinOnly = true, isPlatform = true)
+            checkPackageExistence("kotlin.jvm.functions", isKotlinOnly = false, isPlatform = true)
+            // `kotlin.test` comes from a non-stdlib JAR that contains only Kotlin classes. The standalone package names provider cannot
+            // yet distinguish Kotlin packages in non-indexed JARs, so the package is only visible as a platform package (to be addressed
+            // in a follow-up to KT-83760).
+            checkPackageExistence("kotlin.test", isKotlinOnly = false, isPlatform = true)
+            checkPackageExistence("java.lang", isKotlinOnly = false, isPlatform = true)
+            checkPackageExistence("java.io", isKotlinOnly = false, isPlatform = true)
+
+            checkSubpackages("foo", emptyList())
+            checkSubpackages("bar", emptyList())
+            checkSubpackages("kotlin", listOf("collections", "jvm", "js"))
+            checkSubpackages("kotlin.collections", listOf("unsigned", "jdk8"))
+            checkSubpackages("java", listOf("lang", "io"))
+        }
+    }
+
+    @Test
+    fun testJsPackageProvider() {
+        val sharedPlatform = JsPlatforms.defaultJsPlatform
+
+        lateinit var sourceModule: KaSourceModule
+        lateinit var stdlibModule: KaLibraryModule
+        buildStandaloneAnalysisAPISession(disposable) {
+            buildKtModuleProvider {
+                stdlibModule = addModule(
+                    buildKtLibraryModule {
+                        addBinaryRoot(ForTestCompileRuntime.stdlibJsForTests().toPath())
+                        platform = sharedPlatform
+                        libraryName = "stdlib"
+                    }
+                )
+
+                platform = sharedPlatform
+                sourceModule = addModule(
+                    buildKtSourceModule {
+                        addSourceRoot(testDataPath("packageProvider"))
+                        addSourceRoot(testDataPath("declarationlessPackage"))
+                        addRegularDependency(stdlibModule)
+                        platform = sharedPlatform
+                        moduleName = "source"
+                    }
+                )
+            }
+        }
+
+        testPackageProvider(sourceModule) {
+            checkPackageExistence("foo", isKotlinOnly = true, isPlatform = false, declarationProviderModule = sourceModule)
+            checkPackageExistence("bar", isKotlinOnly = false, isPlatform = false, declarationProviderModule = sourceModule)
+            // The package of a file without declarations must still exist (KT-83760).
+            checkPackageExistence("declarationless", isKotlinOnly = true, isPlatform = false, declarationProviderModule = sourceModule)
+            checkPackageExistence("kotlin", isKotlinOnly = true, isPlatform = false, declarationProviderModule = stdlibModule)
+            checkPackageExistence("kotlin.collections", isKotlinOnly = true, isPlatform = false, declarationProviderModule = stdlibModule)
+            checkPackageExistence(
+                "kotlin.jvm.functions",
+                isKotlinOnly = false,
+                isPlatform = false,
+                declarationProviderModule = stdlibModule,
+            )
+            checkPackageExistence("java.lang", isKotlinOnly = false, isPlatform = false)
+            checkPackageExistence("java.io", isKotlinOnly = false, isPlatform = false)
+
+            checkSubpackages("foo", emptyList())
+            checkSubpackages("bar", emptyList())
+            checkSubpackages("kotlin", listOf("collections", "jvm", "js"))
+        }
+    }
+
+    @Test
+    fun testUnpackedKlibPackageNames() {
+        withUnpackedJsStdlib { tempKlibFolder ->
+            val sharedPlatform = JsPlatforms.defaultJsPlatform
+
+            lateinit var sourceModule: KaSourceModule
+            lateinit var stdlibModule: KaLibraryModule
+            buildStandaloneAnalysisAPISession(disposable) {
+                buildKtModuleProvider {
+                    stdlibModule = addModule(
+                        buildKtLibraryModule {
+                            addBinaryRoot(tempKlibFolder)
+                            platform = sharedPlatform
+                            libraryName = "stdlib"
+                        }
+                    )
+
+                    platform = sharedPlatform
+                    sourceModule = addModule(
+                        buildKtSourceModule {
+                            addSourceRoot(testDataPath("packageProvider"))
+                            addRegularDependency(stdlibModule)
+                            platform = sharedPlatform
+                            moduleName = "source"
+                        }
+                    )
+                }
+            }
+
+            testPackageProvider(sourceModule) {
+                checkPackageExistence("foo", isKotlinOnly = true, isPlatform = false, declarationProviderModule = sourceModule)
+                checkPackageExistence("bar", isKotlinOnly = false, isPlatform = false, declarationProviderModule = sourceModule)
+                checkPackageExistence("kotlin", isKotlinOnly = true, isPlatform = false, declarationProviderModule = stdlibModule)
+                checkPackageExistence(
+                    "kotlin.collections",
+                    isKotlinOnly = true,
+                    isPlatform = false,
+                    declarationProviderModule = stdlibModule,
+                )
+                checkPackageExistence(
+                    "kotlin.jvm.functions",
+                    isKotlinOnly = false,
+                    isPlatform = false,
+                    declarationProviderModule = stdlibModule,
+                )
+                checkPackageExistence("java.lang", isKotlinOnly = false, isPlatform = false)
+                checkPackageExistence("java.io", isKotlinOnly = false, isPlatform = false)
+
+                checkSubpackages("foo", emptyList())
+                checkSubpackages("bar", emptyList())
+                checkSubpackages("kotlin", listOf("collections", "jvm", "js"))
+            }
+        }
+    }
+
+    /**
+     * Tests that every package name reported by `KotlinDeclarationProvider.computePackageNames` for a KLib library module is also known
+     * to `KotlinPackageProvider.doesKotlinOnlyPackageExist`, i.e. the declaration provider's package set is a subset of the package
+     * provider's, consistent with the shared package name computation (KT-83760).
+     */
+    @Test
+    fun testKlibDeclarationProviderPackageNamesAreKnownToPackageProvider() {
+        val sharedPlatform = JsPlatforms.defaultJsPlatform
+
+        lateinit var libraryModule: KaLibraryModule
+        buildStandaloneAnalysisAPISession(disposable) {
+            buildKtModuleProvider {
+                libraryModule = addModule(
+                    buildKtLibraryModule {
+                        addBinaryRoot(ForTestCompileRuntime.stdlibJsForTests().toPath())
+                        platform = sharedPlatform
+                        libraryName = "stdlib-js"
+                    }
+                )
+
+                platform = sharedPlatform
+            }
+        }
+
+        val packageProvider = libraryModule.project.createPackageProvider(libraryModule.contentScope)
+        val declarationProvider = libraryModule.project.createDeclarationProvider(libraryModule.contentScope, libraryModule)
+
+        val packageNamesFromDeclarationProvider = declarationProvider.computePackageNames()
+        assertNotNull(packageNamesFromDeclarationProvider, "computePackageNames() must return non-null for a KLib library module")
+
+        // Every package reported by computePackageNames() must also be known to the package provider
+        for (packageName in packageNamesFromDeclarationProvider) {
+            val fqName = FqName(packageName)
+            assertTrue(
+                packageProvider.doesKotlinOnlyPackageExist(fqName),
+                "Package '$packageName' is in computePackageNames() but doesKotlinOnlyPackageExist() returns false for it",
+            )
+        }
+
+        // Spot-check: a known stdlib package must be in both providers
+        val kotlinFqName = FqName("kotlin")
+        assertTrue(packageProvider.doesKotlinOnlyPackageExist(kotlinFqName), "Package 'kotlin' must exist in the package provider")
+        assertTrue("kotlin" in packageNamesFromDeclarationProvider, "Package 'kotlin' must be in computePackageNames()")
+    }
+
+    /**
+     * Tests that every package name reported by `KotlinDeclarationProvider.computePackageNames` for a source module is also known to
+     * `KotlinPackageProvider.doesKotlinOnlyPackageExist`, i.e. both providers are backed by the same centralized package name
+     * computation (KT-83760).
+     */
+    @Test
+    fun testSourceDeclarationProviderPackageNamesAreKnownToPackageProvider() {
+        val sharedPlatform = JvmPlatforms.defaultJvmPlatform
+
+        lateinit var sourceModule: KaSourceModule
+        buildStandaloneAnalysisAPISession(disposable) {
+            buildKtModuleProvider {
+                platform = sharedPlatform
+                sourceModule = addModule(
+                    buildKtSourceModule {
+                        addSourceRoot(testDataPath("packageProvider"))
+                        platform = sharedPlatform
+                        moduleName = "source"
+                    }
+                )
+            }
+        }
+
+        val packageProvider = sourceModule.project.createPackageProvider(sourceModule.contentScope)
+        val declarationProvider = sourceModule.project.createDeclarationProvider(sourceModule.contentScope, sourceModule)
+
+        val packageNames = declarationProvider.computePackageNames()
+        assertNotNull(packageNames, "computePackageNames() must return a non-null set for a source module")
+        assertTrue("foo" in packageNames, "Package 'foo' must be in computePackageNames() for the test sources")
+
+        for (packageName in packageNames) {
+            val fqName = FqName(packageName)
+            assertTrue(
+                packageProvider.doesKotlinOnlyPackageExist(fqName),
+                "Package '$packageName' is in computePackageNames() but doesKotlinOnlyPackageExist() returns false for it",
+            )
+        }
+    }
+
+    @Test
+    fun testJarLibraryModuleDeclarationProviderComputePackageNamesReturnsNull() {
+        val sharedPlatform = JvmPlatforms.defaultJvmPlatform
+
+        lateinit var libraryModule: KaLibraryModule
+        buildStandaloneAnalysisAPISession(disposable) {
+            buildKtModuleProvider {
+                libraryModule = addModule(
+                    buildKtLibraryModule {
+                        addBinaryRoot(ForTestCompileRuntime.runtimeJarForTests().toPath())
+                        platform = sharedPlatform
+                        libraryName = "stdlib"
+                    }
+                )
+
+                platform = sharedPlatform
+            }
+        }
+
+        val declarationProvider = libraryModule.project.createDeclarationProvider(libraryModule.contentScope, libraryModule)
+        val packageNames = declarationProvider.computePackageNames()
+
+        assertNull(
+            packageNames,
+            "computePackageNames() must return null for a JAR-based library module: Kotlin package names for non-indexed JARs are not yet supported by the standalone package names provider (to be addressed in a follow-up to KT-83760)",
+        )
+    }
+
+    private class PackageProviderTestContext(
+        private val session: KaSession,
+        private val packageProvider: KotlinPackageProvider,
+        private val targetPlatform: TargetPlatform,
+    ) {
+        fun checkPackageExistence(
+            name: String,
+            isKotlinOnly: Boolean,
+            isPlatform: Boolean,
+            declarationProviderModule: KaModule? = null,
+        ) {
+            fun check(expected: Boolean, message: String, block: () -> Boolean) {
+                if (expected) {
+                    assertTrue(block(), message)
+                } else {
+                    assertFalse(block(), message.replace("must", "must not"))
+                }
+            }
+
+            val packageFqName = FqName(name)
+            check(isKotlinOnly || isPlatform, "Package '$packageFqName' must exist") {
+                packageProvider.doesPackageExist(packageFqName, targetPlatform)
+            }
+            check(isKotlinOnly || isPlatform, "Package '$packageFqName' must be visible through 'KaSession.findPackage()'") {
+                with(session) { findPackage(packageFqName) != null }
+            }
+            check(isKotlinOnly, "Kotlin-only package '$packageFqName' must exist") {
+                packageProvider.doesKotlinOnlyPackageExist(packageFqName)
+            }
+            check(isPlatform, "Platform-specific package '$packageFqName' must exist") {
+                packageProvider.doesPlatformSpecificPackageExist(packageFqName, targetPlatform)
+            }
+
+            declarationProviderModule?.let { module ->
+                val declarationProvider = module.project.createDeclarationProvider(module.contentScope, module)
+                val packageNames = declarationProvider.computePackageNames()
+                assertNotNull(packageNames, "computePackageNames() must return a non-null set for module '$module'")
+                check(
+                    isKotlinOnly,
+                    "Kotlin-only package '$packageFqName' must be reported by computePackageNames() for module '$module'",
+                ) {
+                    name in packageNames
+                }
+            }
+        }
+
+        fun checkSubpackages(name: String, expectedInside: List<String>) {
+            val packageFqName = FqName(name)
+            val actualSubpackages = packageProvider.getSubpackageNames(packageFqName, targetPlatform)
+                .mapTo(HashSet()) { it.asString() }
+
+            if (expectedInside.isEmpty()) {
+                assertEquals(emptySet(), actualSubpackages, "Subpackages of '$packageFqName' must be empty")
+            } else {
+                for (expectedSubpackage in expectedInside) {
+                    val isInside = expectedSubpackage in actualSubpackages
+                    assertTrue(isInside, "Subpackage '$name.$expectedSubpackage' must exist")
+                }
+            }
+        }
+    }
+
+    private fun testPackageProvider(module: KaModule, block: context(KaSession) PackageProviderTestContext.() -> Unit) {
+        val targetPlatform = module.targetPlatform
+
+        analyze(module) {
+            val packageProvider = module.project.createPackageProvider(analysisScope)
+            val packageProviderTestContext = PackageProviderTestContext(useSiteSession, packageProvider, targetPlatform)
+            block(packageProviderTestContext)
+        }
+    }
+}

--- a/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/testUtils.kt
+++ b/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/testUtils.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.analysis.api.standalone.fir.test.cases.session.builder
+
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipFile
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
+
+/**
+ * Unpacks the JS stdlib KLib into a temporary directory and passes that directory to [action]. The directory is deleted after [action]
+ * returns.
+ */
+internal fun withUnpackedJsStdlib(action: (Path) -> Unit) {
+    val klibFile = ForTestCompileRuntime.stdlibJsForTests()
+    val tempKlibFolder = Files.createTempDirectory(klibFile.name)
+
+    try {
+        ZipFile(klibFile).use { zipFile ->
+            for (zipEntry in zipFile.entries()) {
+                val targetPath = tempKlibFolder.resolve(zipEntry.name)
+                if (zipEntry.isDirectory) {
+                    Files.createDirectories(targetPath)
+                } else {
+                    Files.createDirectories(targetPath.parent)
+                    zipFile.getInputStream(zipEntry).use { input ->
+                        Files.copy(input, targetPath)
+                    }
+                }
+            }
+        }
+
+        action(tempKlibFolder)
+    } finally {
+        @OptIn(ExperimentalPathApi::class)
+        tempKlibFolder.deleteRecursively()
+    }
+}


### PR DESCRIPTION
Create a KotlinStandalonePackageNamesProvider that serves as the single source of Kotlin package names for both KotlinStandalonePackageProvider and KotlinStandaloneDeclarationProvider, so that the two providers report consistent package sets.

Package names are computed with two strategies:

1. From the declaration index of KotlinStandaloneDeclarationProviderFactory — covers source files and binary libraries when they are indexed as stubs. The index gains a new filesByPackage map that records every indexed file by its packageFqName, so the shared computation covers packages of declaration-less files in addition to the declaration-based maps the declaration provider already used. This preserves the package provider's previous file-based behavior (it used to cache the packageFqName of every tracked KtFile), and extends the declaration provider: its computePackageNames now also reports packages that contain only declaration-less files, so every package mentioned in a package directive exists — consistent with the IDE, where packages are backed by a file-based index.
2. From KLib metadata for KLib library roots (packed or unpacked). This also lets the declaration provider compute package names for KLib library modules, for which it previously returned null (the JAR-traversal fallback cannot handle KLibs).

Kotlin packages in non-indexed JARs are not covered yet: precisely identifying them requires distinguishing Kotlin class files from other JVM class files, which is expensive without an index. This is left to a follow-up to KT-83760. Java packages in JARs are still found through KotlinPackageProviderBase.doesPlatformSpecificPackageExist, and the test-only JAR-traversal fallback in the declaration provider is kept. testJvmPackageProvider pins the limitation with a non-stdlib JAR (kotlin-test), whose kotlin.test package is only visible as a platform package.

Since the package providers now pull package names from the shared service, KotlinStandalonePackageProviderFactory only needs a Project, and KotlinStandaloneDeclarationProviderFactory.getAdditionalCreatedKtFiles — which existed only to feed binary-library KtFiles to the package provider factory — is removed.

Tests: the package name tests are extracted into a new StandalonePackageNamesTest, and checkPackageExistence can additionally verify that Kotlin-only packages are reported by KotlinDeclarationProvider.computePackageNames, so the package provider and declaration provider are checked against each other.

^KT-83760 Fixed