### PR TITLE
Update android_arm32 target settings in konan.properties

### DIFF
--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -620,10 +620,10 @@ dependencies.mingw_x64-android_arm32 = \
     target-sysroot-1-android_ndk \
     target-toolchain-2-windows-android_ndk
 
-targetTriple.android_arm32 = arm-unknown-linux-androideabi
-targetCpu.android_arm32 = arm7tdmi
-targetCpuFeatures.android_arm32 = +armv4t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp
-clangFlags.android_arm32 = -cc1 -emit-obj -disable-llvm-optzns -x ir -femulated-tls -mrelocation-model pic
+targetTriple.android_arm32 = armv7a-unknown-linux-androideabi
+targetCpu.android_arm32 = cortex-a7
+targetCpuFeatures.android_arm32 = +armv7-a,+d32,+dsp,+hwdiv,+hwdiv-arm,+neon,+vfp3,+vfp3d16,+vfp4,-thumb-mode
+clangFlags.android_arm32 = -cc1 -emit-obj -disable-llvm-optzns -x ir -femulated-tls -mrelocation-model pic -mfloat-abi=softfp
 clangOptFlags.android_arm32 = -O3 -ffunction-sections
 linkerNoDebugFlags.android_arm32 = -Wl,-S
 clangNooptFlags.android_arm32 = -O1


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-86265/androidNativeArm32-target-hardcodes-ARMv4T-arm7tdmi-incompatible-with-any-standard-Android-armeabi-v7a-native-library