### PR TITLE
Fail build if dynamic versions are present in dependency tree

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -625,44 +625,47 @@ allprojects {
         if (name != "compileClasspath") {
             return@all
         }
-        resolutionStrategy.eachDependency {
-            if (requested.group != "org.jetbrains.kotlin") {
-                return@eachDependency
-            }
+        resolutionStrategy {
+            failOnNonReproducibleResolution()
+            eachDependency {
+                if (requested.group != "org.jetbrains.kotlin") {
+                    return@eachDependency
+                }
 
-            val isReflect = requested.name == "kotlin-reflect"
-            // More strict check for "compilerModules". We can't apply this check for all modules because it would force to
-            // exclude kotlin-reflect from transitive dependencies of kotlin-poet, ktor, com.android.tools.build:gradle, etc
-            if (project.path in @Suppress("UNCHECKED_CAST") (rootProject.extra["compilerModules"] as Array<String>)) {
-                val expectedReflectVersion = commonDependencyVersion("org.jetbrains.kotlin", "kotlin-reflect")
-                if (isReflect) {
-                    check(requested.version == expectedReflectVersion) {
-                        """
+                val isReflect = requested.name == "kotlin-reflect"
+                // More strict check for "compilerModules". We can't apply this check for all modules because it would force to
+                // exclude kotlin-reflect from transitive dependencies of kotlin-poet, ktor, com.android.tools.build:gradle, etc
+                if (project.path in @Suppress("UNCHECKED_CAST") (rootProject.extra["compilerModules"] as Array<String>)) {
+                    val expectedReflectVersion = commonDependencyVersion("org.jetbrains.kotlin", "kotlin-reflect")
+                    if (isReflect) {
+                        check(requested.version == expectedReflectVersion) {
+                            """
                             $configuration: 'kotlin-reflect' should have '$expectedReflectVersion' version. But it was '${requested.version}'
                             Suggestions:
                                 1. Use 'commonDependency("org.jetbrains.kotlin:kotlin-reflect") { isTransitive = false }'
                                 2. Avoid 'kotlin-reflect' leakage from transitive dependencies with 'exclude("org.jetbrains.kotlin")'
                         """.trimIndent()
+                        }
                     }
-                }
-                if (requested.name.startsWith("kotlin-stdlib")) {
-                    check(requested.version != expectedReflectVersion) {
-                        """
+                    if (requested.name.startsWith("kotlin-stdlib")) {
+                        check(requested.version != expectedReflectVersion) {
+                            """
                             $configuration: '${requested.name}' has a wrong version. It's not allowed to be '$expectedReflectVersion'
                             Suggestions:
                                 1. Most likely, it leaked from 'kotlin-reflect' transitive dependencies. Use 'isTransitive = false' for
                                    'kotlin-reflect' dependencies
                                 2. Avoid '${requested.name}' leakage from other transitive dependencies with 'exclude("org.jetbrains.kotlin")'
                         """.trimIndent()
+                        }
                     }
                 }
-            }
-            if (isReflect && project.path !in dependencyOnSnapshotReflectWhitelist) {
-                check(requested.version != kotlinVersion) {
-                    """
+                if (isReflect && project.path !in dependencyOnSnapshotReflectWhitelist) {
+                    check(requested.version != kotlinVersion) {
+                        """
                         $configuration: 'kotlin-reflect' is not allowed to have '$kotlinVersion' version.
                         Suggestion: Use 'commonDependency("org.jetbrains.kotlin:kotlin-reflect") { isTransitive = false }'
                     """.trimIndent()
+                    }
                 }
             }
         }


### PR DESCRIPTION
without this build may start to fail unexpectedly
new undeclared version being used leads verification metadata failures