### PR TITLE
BTA: automate detection of missing versions in backward compatibility tests

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/build.gradle.kts
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/build.gradle.kts
@@ -102,6 +102,16 @@ val compatibilityTestsVersions = listOf(
     BuildToolsVersion(KotlinToolingVersion(2, 3, 20, null)),
 )
 
+val compatibilityTestsExcludedVersions = listOf(
+    BuildToolsVersion(KotlinToolingVersion(2, 3, 21, null)),
+    BuildToolsVersion(KotlinToolingVersion(2, 2, 20, null)),
+    BuildToolsVersion(KotlinToolingVersion(2, 2, 10, null)),
+    BuildToolsVersion(KotlinToolingVersion(2, 2, 0, null)),
+    BuildToolsVersion(KotlinToolingVersion(2, 1, 21, null)),
+    BuildToolsVersion(KotlinToolingVersion(2, 1, 10, null)),
+    BuildToolsVersion(KotlinToolingVersion(2, 1, 0, null)),
+)
+
 class BuildToolsVersion(val version: KotlinToolingVersion, val isCurrent: Boolean = false) {
     override fun toString() = if (isCurrent) "Snapshot" else version.toString()
 }
@@ -364,4 +374,38 @@ testing {
 
 tasks.named("check") {
     dependsOn(testing.suites.matching { it.name != "testExample" }) // do not run example tests by default
+}
+
+val checkCompatibilityCoverageTask = checkCompatibilityCoverage(
+    btaVersion = project.version.toString(),
+    compatibilityTestsVersions = compatibilityTestsVersions.map { it.version },
+    compatibilityTestsExcludedVersions = compatibilityTestsExcludedVersions.map { it.version },
+)
+
+fun Project.checkCompatibilityCoverage(
+    btaVersion: String,
+    compatibilityTestsVersions: List<KotlinToolingVersion>,
+    compatibilityTestsExcludedVersions: List<KotlinToolingVersion>,
+): TaskProvider<JavaExec> {
+    val checkerClasspath = configurations.register("checkerClasspath") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+
+    dependencies {
+        checkerClasspath(project(":compiler:build-tools:kotlin-build-tools-version-coverage-check"))
+    }
+
+    return tasks.register<JavaExec>("checkCompatibilityCoverage") {
+        group = "verification"
+        description = "Verify that tests cover all versions required by backward compatibility guarantees"
+        classpath = checkerClasspath.get()
+        mainClass.set("org.jetbrains.kotlin.buildtools.versioncoverage.MainKt")
+        args(
+            btaVersion,
+            "backward",
+            compatibilityTestsVersions.joinToString(",") { it.toString() },
+            compatibilityTestsExcludedVersions.joinToString(",") { it.toString() },
+        )
+    }
 }

--- a/compiler/build-tools/kotlin-build-tools-version-coverage-check/build.gradle.kts
+++ b/compiler/build-tools/kotlin-build-tools-version-coverage-check/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    kotlin("jvm")
+    application
+    id("project-tests-convention")
+    id("test-inputs-check")
+}
+
+dependencies {
+    implementation(kotlinStdlib())
+    implementation(project(":kotlin-tooling-core"))
+    testImplementation(kotlinTest("junit5"))
+    testImplementation(platform(libs.junit.bom))
+}
+
+application {
+    mainClass.set("org.jetbrains.kotlin.buildtools.versioncoverage.MainKt")
+}
+
+sourceSets {
+    "main" { projectDefault() }
+    "test" { projectDefault() }
+}
+
+projectTests {
+    testTask(jUnitMode = JUnitMode.JUnit5) {
+        useJUnitPlatform()
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/CompatibilityType.kt
+++ b/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/CompatibilityType.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.versioncoverage
+
+internal enum class CompatibilityType(val minorVersionSupportCount: Int) {
+    BACKWARD(3),
+    FORWARD(1);
+
+    companion object {
+        fun fromString(string: String): CompatibilityType =
+            entries.firstOrNull { it.name.lowercase() == string } ?: error("Unknown compatibility type: $string")
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/CompatibilityWindowSelector.kt
+++ b/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/CompatibilityWindowSelector.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.buildtools.versioncoverage
+
+import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+
+internal class CompatibilityWindowSelector(private val compatibilityType: CompatibilityType) {
+
+    fun select(all: List<KotlinToolingVersion>, current: KotlinToolingVersion): List<KotlinToolingVersion> {
+        val selectedVersionsWithHighestMaturity = all
+            .groupBy { KotlinToolingVersion(it.major, it.minor, it.patch, null) }
+            .filterKeys { kotlinVersion ->
+                getVersionComparator().compare(kotlinVersion, current) >= 0
+            }
+            .values.mapNotNull { it.maxOrNull() }
+
+        val compatibleVersions = selectedVersionsWithHighestMaturity
+            .groupBy { KotlinToolingVersion(it.major, it.minor, 0, null) }
+            .toSortedMap(getVersionComparator())
+            .values
+            .take(compatibilityType.minorVersionSupportCount + 1)
+            .flatten()
+
+        return compatibleVersions
+    }
+
+    private fun getVersionComparator(): Comparator<KotlinToolingVersion> =
+        when (compatibilityType) {
+            CompatibilityType.FORWARD -> compareBy { it }
+            CompatibilityType.BACKWARD -> compareByDescending { it }
+        }
+}

--- a/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/Main.kt
+++ b/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/Main.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.buildtools.versioncoverage
+
+import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import kotlin.system.exitProcess
+
+/**
+ * Arguments are as follows:
+ * 1. `<btaVersion>` - current BTA version string (can be a snapshot, e.g. `2.4.255-SNAPSHOT`)
+ * 2. `<compatibilityType>` - `backward` or `forward`
+ * 3. `<compatibilityTestsVersions>` - comma-separated list of pinned version strings already covered
+ * 4. `<compatibilityTestsExcludedVersions>` - (optional) comma-separated list of intentionally excluded versions; defaults to empty
+ */
+fun main(args: Array<String>) {
+    val btaVersion = args[0]
+    val compatibilityType = CompatibilityType.fromString(args[1])
+    val covered = parseVersionList(args[2])
+    val excluded = args.getOrNull(3)?.let { parseVersionList(it) } ?: emptyList()
+
+    try {
+        val currentVersion = KotlinToolingVersion(btaVersion)
+        val allPublishedVersions = MavenMetadataFetcher(MAVEN_METADATA_URL).fetch()
+        val compatibleVersions = CompatibilityWindowSelector(compatibilityType).select(allPublishedVersions, currentVersion)
+
+        checkCompatibilityCoverage(compatibleVersions, covered.toSet(), excluded.toSet())
+    } catch (e: Throwable) {
+        System.err.println(e.message)
+        exitProcess(1)
+    }
+}
+
+private const val MAVEN_METADATA_URL = "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-api/maven-metadata.xml"
+
+private fun parseVersionList(csv: String): List<KotlinToolingVersion> =
+    csv.split(",").filter { it.isNotBlank() }.map { KotlinToolingVersion(it.trim()) }
+
+private fun checkCompatibilityCoverage(
+    expected: List<KotlinToolingVersion>,
+    covered: Set<KotlinToolingVersion>,
+    excluded: Set<KotlinToolingVersion>,
+) {
+    val missing = expected.filterNot { it in covered || it in excluded }
+
+    if (missing.isNotEmpty()) {
+        error("BTA compatibility coverage check failed: ${missing.size} version(s) missing: [${missing.joinToString()}]")
+    }
+
+    println("All published BTA versions are covered.")
+}
+

--- a/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/MavenMetadataFetcher.kt
+++ b/compiler/build-tools/kotlin-build-tools-version-coverage-check/src/org/jetbrains/kotlin/buildtools/versioncoverage/MavenMetadataFetcher.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.buildtools.versioncoverage
+
+import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import java.net.URI
+import javax.xml.parsers.DocumentBuilderFactory
+
+internal class MavenMetadataFetcher(private val url: String) {
+
+    fun fetch(): List<KotlinToolingVersion> {
+        val xml = fetchXml()
+        return parseVersions(xml)
+    }
+
+    private fun fetchXml(): String {
+        val connection = URI(url).toURL().openConnection().apply {
+            connectTimeout = 10_000
+            readTimeout = 30_000
+        }
+        return connection.getInputStream().use { it.reader().readText() }
+    }
+
+    private fun parseVersions(xml: String): List<KotlinToolingVersion> {
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xml.byteInputStream())
+
+        val nodes = doc.getElementsByTagName("version")
+        return buildList {
+            for (i in 0 until nodes.length) {
+                val versionString = nodes.item(i).textContent
+                runCatching { KotlinToolingVersion(versionString) }
+                    .onSuccess { add(it) }
+                    .onFailure { System.err.println("WARNING: Skipping unparseable version '$versionString'") }
+            }
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-version-coverage-check/test/org/jetbrains/kotlin/buildtools/versioncoverage/CompatibilityWindowSelectorTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-version-coverage-check/test/org/jetbrains/kotlin/buildtools/versioncoverage/CompatibilityWindowSelectorTest.kt
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.buildtools.versioncoverage
+
+import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@DisplayName("Compatibility window selector")
+internal class CompatibilityWindowSelectorTest {
+
+    private lateinit var backwardSelector: CompatibilityWindowSelector
+    private lateinit var forwardSelector: CompatibilityWindowSelector
+
+    @BeforeTest
+    fun setup() {
+        backwardSelector = CompatibilityWindowSelector(CompatibilityType.BACKWARD)
+        forwardSelector = CompatibilityWindowSelector(CompatibilityType.FORWARD)
+    }
+
+    // ── BACKWARD: window size ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Backward: returns empty when input is empty")
+    fun `backward - empty input returns empty`() {
+        assertTrue(backwardSelector.select(emptyList(), KotlinToolingVersion("2.3.0")).isEmpty())
+    }
+
+    @Test
+    @DisplayName("Backward: includes current and 3 prior minor versions")
+    fun `backward - takes current minor version plus 3 previous`() {
+        val all = listOf("2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.0.0", "2.1.0", "2.2.0", "2.3.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: includes all available versions when fewer than the window count exist")
+    fun `backward - truncates when fewer minor versions available than count`() {
+        val all = listOf("2.2.0", "2.3.0", "2.4.0").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.2.0", "2.3.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: includes all patch versions within a selected minor version")
+    fun `backward - all patch versions in a minor version are included`() {
+        val all = listOf("2.3.0", "2.3.10", "2.3.20", "2.2.0").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.3.20"))
+        assertEquals(listOf("2.2.0", "2.3.0", "2.3.10", "2.3.20").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: crosses major version boundaries when counting minor versions")
+    fun `backward - cross-major boundary`() {
+        val all = listOf("1.9.0", "2.0.0", "2.1.0", "2.2.0", "2.3.0").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.2.0"))
+        assertEquals(listOf("1.9.0", "2.0.0", "2.1.0", "2.2.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: returns minor versions in descending order")
+    fun `backward - minor versions sorted descending`() {
+        val all = listOf("2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.3.0", "2.2.0", "2.1.0", "2.0.0").map { KotlinToolingVersion(it) }, result)
+    }
+
+    @Test
+    @DisplayName("Backward: SNAPSHOT is excluded since it is not published")
+    fun `backward - SNAPSHOT excluded`() {
+        val result =
+            backwardSelector.select(listOf("2.3.0-SNAPSHOT", "2.3.0").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.4.0"))
+        assertEquals(listOf("2.3.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: DEV is excluded since it is not published")
+    fun `backward - DEV excluded`() {
+        val result =
+            backwardSelector.select(listOf("2.3.0-dev-123", "2.3.0").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.4.0"))
+        assertEquals(listOf("2.3.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: STABLE, RC, and BETA versions are all included")
+    fun `backward - STABLE RC and BETA are included`() {
+        val all = listOf("2.3.0", "2.3.10-RC", "2.3.20-Beta1").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.4.0"))
+        assertEquals(listOf("2.3.0", "2.3.10-RC", "2.3.20-Beta1").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: keeps only the highest qualifier for the same major.minor.patch")
+    fun `backward - same triple keeps highest qualifier`() {
+        val result =
+            backwardSelector.select(listOf("2.3.0-Beta1", "2.3.0-RC").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.4.0"))
+        assertEquals(listOf("2.3.0-RC").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: stable release takes precedence over RC for the same major.minor.patch")
+    fun `backward - stable beats RC for same triple`() {
+        val result = backwardSelector.select(listOf("2.3.0-RC", "2.3.0").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.4.0"))
+        assertEquals(listOf("2.3.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: snapshot current includes published patches at lower patch numbers in the same minor version")
+    fun `backward - snapshot current includes published versions at lower patch in same minor version`() {
+        val all = listOf("2.3.20", "2.4.0", "2.4.20").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.4.255-SNAPSHOT"))
+        assertEquals(listOf("2.3.20", "2.4.0", "2.4.20").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: snapshot current excludes versions from future minor versions")
+    fun `backward - snapshot current excludes versions from future minor versions`() {
+        val all = listOf("2.3.0", "2.4.0", "2.5.0").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.4.255-SNAPSHOT"))
+        assertEquals(listOf("2.3.0", "2.4.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Backward: snapshot current selects prior minor versions when no versions are published in its own minor version")
+    fun `backward - snapshot current with no published versions in its minor version`() {
+        val all = listOf("2.1.0", "2.2.0", "2.3.0").map { KotlinToolingVersion(it) }
+        val result = backwardSelector.select(all, KotlinToolingVersion("2.4.0-SNAPSHOT"))
+        assertEquals(listOf("2.1.0", "2.2.0", "2.3.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    // ── FORWARD ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Forward: returns empty when input is empty")
+    fun `forward - empty input returns empty`() {
+        assertTrue(forwardSelector.select(emptyList(), KotlinToolingVersion("2.3.0")).isEmpty())
+    }
+
+    @Test
+    @DisplayName("Forward: includes current and the next minor version")
+    fun `forward - takes current version plus 1 forward minor version`() {
+        val all = listOf("2.2.0", "2.3.0", "2.4.0", "2.5.0").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.3.0", "2.4.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: includes only current version when no future minor versions exist")
+    fun `forward - takes only current when no forward versions exist`() {
+        val all = listOf("2.2.0", "2.3.0").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.3.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: crosses major version boundaries when counting minor versions")
+    fun `forward - cross-major boundary`() {
+        val all = listOf("2.9.0", "3.0.0", "3.1.0").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.9.0"))
+        assertEquals(listOf("2.9.0", "3.0.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: picks only the nearest future minor version when multiple exist")
+    fun `forward - takes only nearest forward version when multiple exist`() {
+        val all = listOf("2.3.0", "2.4.0", "2.5.0", "2.6.0").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.3.0", "2.4.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: includes all patch versions within a selected minor version")
+    fun `forward - all patch versions in forward minor version are included`() {
+        val all = listOf("2.3.0", "2.3.10", "2.4.0", "2.4.5").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.3.0", "2.3.10", "2.4.0", "2.4.5").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: returns minor versions in ascending order")
+    fun `forward - minor versions sorted ascending`() {
+        val all = listOf("2.3.0", "2.4.0").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.3.0", "2.4.0").map { KotlinToolingVersion(it) }, result)
+    }
+
+    @Test
+    @DisplayName("Forward: SNAPSHOT is excluded since it is not published")
+    fun `forward - SNAPSHOT excluded`() {
+        val result =
+            forwardSelector.select(listOf("2.4.0-SNAPSHOT", "2.4.0").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.4.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: DEV is excluded since it is not published")
+    fun `forward - DEV excluded`() {
+        val result =
+            forwardSelector.select(listOf("2.4.0-dev-123", "2.4.0").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.4.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: STABLE, RC, and BETA versions are all included")
+    fun `forward - STABLE RC and BETA are included`() {
+        val all = listOf("2.4.0", "2.4.10-RC", "2.4.20-Beta1").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.4.0", "2.4.10-RC", "2.4.20-Beta1").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: keeps only the highest qualifier for the same major.minor.patch")
+    fun `forward - same triple keeps highest qualifier`() {
+        val result =
+            forwardSelector.select(listOf("2.4.0-Beta1", "2.4.0-RC").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.4.0-RC").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: stable release takes precedence over RC for the same major.minor.patch")
+    fun `forward - stable beats RC for same triple`() {
+        val result =
+            forwardSelector.select(listOf("2.4.0-RC", "2.4.0").map { KotlinToolingVersion(it) }, KotlinToolingVersion("2.3.0"))
+        assertEquals(listOf("2.4.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: snapshot current excludes older patches in its own minor version")
+    fun `forward - snapshot current excludes older patches in same minor version`() {
+        val all = listOf("2.3.10", "2.3.20-RC", "2.4.0").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.3.20-SNAPSHOT"))
+        assertEquals(listOf("2.3.20-RC", "2.4.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+
+    @Test
+    @DisplayName("Forward: snapshot current skips to the next minor version when no versions are published in its own")
+    fun `forward - snapshot current with no published versions in its minor version`() {
+        val all = listOf("2.3.0", "2.5.0").map { KotlinToolingVersion(it) }
+        val result = forwardSelector.select(all, KotlinToolingVersion("2.4.0-SNAPSHOT"))
+        assertEquals(listOf("2.5.0").map { KotlinToolingVersion(it) }.toSet(), result.toSet())
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -608,7 +608,8 @@ include(
     ":compiler:build-tools:kotlin-build-tools-jdk-utils",
     ":compiler:build-tools:kotlin-build-tools-generator",
     ":compiler:build-tools:util-kotlinpoet",
-    ":compiler:build-tools:kotlin-build-tools-cri-impl"
+    ":compiler:build-tools:kotlin-build-tools-cri-impl",
+    ":compiler:build-tools:kotlin-build-tools-version-coverage-check"
 )
 
 include(


### PR DESCRIPTION
The implementation adds a `checkCompatibilityCoverage` task to the backward compatibility test suite. The task is executed as part of `:compiler:build-tools:kotlin-build-tools-api-tests:check` when running locally.

As a follow-up, I plan to look into automating this on TeamCity and setting up failure notifications in a channel. But I first wanted to gather feedback on the implementation itself before moving forward with the automation.