### PR TITLE
[NI] Update reachability metadata

### DIFF
--- a/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
+++ b/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
@@ -604,6 +604,12 @@
       "type": "org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry[]"
     },
     {
+      "type": "org.jetbrains.kotlin.psi.KtDestructuringDeclaration"
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtDestructuringDeclaration[]"
+    },
+    {
       "type": "org.jetbrains.kotlin.psi.KtDotQualifiedExpression"
     },
     {


### PR DESCRIPTION
Recent changes in the compiler require expanding the reachability metadata for the compiler native image.

KT-82373