### PR TITLE
runOr utilities to conditionally run a block

### DIFF
--- a/libraries/stdlib/src/kotlin/util/Standard.kt
+++ b/libraries/stdlib/src/kotlin/util/Standard.kt
@@ -60,6 +60,38 @@ public inline fun <T, R> T.run(block: T.() -> R): R {
 }
 
 /**
+ * Calls the specified function [block] and returns its result if [condition] is true, or returns `null` _without executing the given block_
+ * if [condition] is false.
+ */
+@kotlin.internal.InlineOnly
+@OptIn(ExperimentalExtendedContracts::class)
+public inline fun <R> runOrNull(condition: Boolean, block: () -> R): R? {
+    contract {
+        condition holdsIn block
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
+        returnsResultOf(block)
+    }
+    return if (condition) block() else null
+}
+
+/**
+ * Calls the specified function [block] and returns its result if [condition] is true, or returns [default] _without executing the given
+ * block_ if [condition] is false.
+ *
+ * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#run).
+ */
+@kotlin.internal.InlineOnly
+@OptIn(ExperimentalExtendedContracts::class)
+public inline fun <R> runOrDefault(condition: Boolean, default: R, block: () -> R): R {
+    contract {
+        condition holdsIn block
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
+        returnsResultOf(block)
+    }
+    return if (condition) block() else default
+}
+
+/**
  * Calls the specified function [block] with the given [receiver] as its receiver and returns its result.
  *
  * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#with).

--- a/libraries/stdlib/test/utils/RunOrTest.kt
+++ b/libraries/stdlib/test/utils/RunOrTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.utils
+
+import kotlin.test.*
+
+class RunOrTest {
+    @Test
+    fun runOrNull_true_runsBlock() {
+        val x = runOrNull(true) { "ran" }
+        assertEquals("ran", x)
+    }
+
+    @Test
+    fun runOrNull_false_blockNotRun() {
+        val x = runOrNull(false) { throw AssertionError("shouldn't run") }
+        assertNull(x)
+    }
+
+    @Test
+    fun runOrNull_conditionAssumedInBlock() {
+        fun nullableHelper(x: String?) = runOrNull(x != null) { x.reversed() } // requires contract to compile x.length
+        assertEquals("olleh", nullableHelper("hello"))
+        assertNull(nullableHelper(null))
+    }
+
+    @Test
+    fun runOrDefault_true_runsBlock() {
+        val x = runOrDefault(true, default = "didn't run") { "ran" }
+        assertEquals("ran", x)
+    }
+
+    @Test
+    fun runOrDefault_false_returnsDefault() {
+        val x = runOrDefault(false, default = 42) { throw AssertionError("shouldn't run") }
+        assertEquals(42, x)
+    }
+
+    @Test
+    fun runOrDefault_conditionAssumedInBlock() {
+        fun nullableHelper(x: String?) = runOrDefault(x != null, -1) { x.length } // requires contract to compile
+        assertEquals(5, nullableHelper("hello"))
+        assertEquals(-1, nullableHelper(null))
+    }
+}


### PR DESCRIPTION
Adds `run`-like scope functions that conditionally run a given block if a boolean condition holds.

* `runOrNull` utility to conditionally run a block or else evaluate to `null`
* `runOrDefault` to conditionally run a block or else use a given default value

Use `holdsIn` contract to assume the condition in the block, which allows smartcasts, e.g., for `!= null` conditions.

fixes https://youtrack.jetbrains.com/issue/KT-6938