### PR TITLE
KT-86527 Remove unreachable code from UpgradeCallableReferences

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrRichFunctionReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrRichPropertyReferenceImpl
@@ -70,11 +71,11 @@ open class UpgradeCallableReferences(
             }
         }
 
-        private fun IrFunction.flattenParameters(hasBoundExtensionReceiver: Boolean) {
+        private fun IrFunction.flattenParameters(isLambda: Boolean) {
             for (parameter in parameters) {
                 require(parameter.kind != IrParameterKind.DispatchReceiver) { "No dispatch receiver allowed in wrappers" }
-                if (parameter.kind == IrParameterKind.ExtensionReceiver) {
-                    parameter.origin = if (hasBoundExtensionReceiver) BOUND_RECEIVER_PARAMETER else LAMBDA_EXTENSION_RECEIVER
+                if (parameter.kind == IrParameterKind.ExtensionReceiver && isLambda) {
+                    parameter.origin = IrDeclarationOrigin.LAMBDA_EXTENSION_RECEIVER
                 }
                 parameter.kind = IrParameterKind.Regular
             }
@@ -83,7 +84,7 @@ open class UpgradeCallableReferences(
         override fun visitFunctionExpression(expression: IrFunctionExpression, data: IrDeclarationParent): IrElement {
             expression.transformChildren(this, data)
             val isRestrictedSuspension = expression.function.isRestrictedSuspensionFunction()
-            expression.function.flattenParameters(hasBoundExtensionReceiver = false)
+            expression.function.flattenParameters(isLambda = true)
             return IrRichFunctionReferenceImpl(
                 startOffset = expression.startOffset,
                 endOffset = expression.endOffset,
@@ -171,11 +172,7 @@ open class UpgradeCallableReferences(
             function.isInline = false
             reference.transformChildren(this, data)
             val isRestrictedSuspension = function.isRestrictedSuspensionFunction()
-            function.flattenParameters(
-                function.parameters.any {
-                    it.kind == IrParameterKind.ExtensionReceiver && reference.arguments[it] != null
-                }
-            )
+            function.flattenParameters(isLambda = false)
             val [boundParameters, unboundParameters] = function.parameters.partition { reference.arguments[it.indexInParameters] != null }
             function.parameters = boundParameters + unboundParameters
             val reflectionTarget = reference.reflectionTarget.takeUnless { expression.origin.isLambda }
@@ -547,5 +544,3 @@ open class UpgradeCallableReferences(
         }
     }
 }
-
-val LAMBDA_EXTENSION_RECEIVER by IrDeclarationOriginImpl.Regular

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
@@ -30,9 +30,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
 open class UpgradeCallableReferences(
     val context: LoweringContext,
-    val upgradeFunctionReferencesAndLambdas: Boolean = true,
-    val upgradePropertyReferences: Boolean = true,
-    val upgradeLocalDelegatedPropertyReferences: Boolean = true,
     val upgradeSamConversions: Boolean = true,
     val upgradeExtractedAdaptedBlocks: Boolean = false,
     val castDispatchReceiver: Boolean = true,
@@ -86,7 +83,6 @@ open class UpgradeCallableReferences(
 
         override fun visitFunctionExpression(expression: IrFunctionExpression, data: IrDeclarationParent): IrElement {
             expression.transformChildren(this, data)
-            if (!upgradeFunctionReferencesAndLambdas) return expression
             val isRestrictedSuspension = expression.function.isRestrictedSuspensionFunction()
             expression.function.flattenParameters(hasBoundExtensionReceiver = false)
             return IrRichFunctionReferenceImpl(
@@ -179,7 +175,6 @@ open class UpgradeCallableReferences(
         }
 
         override fun visitBlock(expression: IrBlock, data: IrDeclarationParent): IrExpression {
-            if (!upgradeFunctionReferencesAndLambdas) return super.visitBlock(expression, data)
             (val function, val reference, val samType = samConversionType, val referenceType) = expression.parseAdaptedBlock()
                 ?: return super.visitBlock(expression, data)
             fixCallableReferenceComingFromKlib(reference)
@@ -250,7 +245,6 @@ open class UpgradeCallableReferences(
         override fun visitFunctionReference(expression: IrFunctionReference, data: IrDeclarationParent): IrExpression {
             expression.transformChildren(this, data)
             fixCallableReferenceComingFromKlib(expression)
-            if (!upgradeFunctionReferencesAndLambdas) return expression
             val arguments = expression.getCapturedValues()
             return IrRichFunctionReferenceImpl(
                 startOffset = expression.startOffset,
@@ -269,7 +263,6 @@ open class UpgradeCallableReferences(
         override fun visitPropertyReference(expression: IrPropertyReference, data: IrDeclarationParent): IrExpression {
             expression.transformChildren(this, data)
             fixCallableReferenceComingFromKlib(expression)
-            if (!upgradePropertyReferences) return expression
             val getter = expression.getter?.owner
             val setter = expression.setter?.owner
             val getterFun: IrSimpleFunction
@@ -368,7 +361,6 @@ open class UpgradeCallableReferences(
             data: IrDeclarationParent
         ): IrExpression {
             expression.transformChildren(this, data)
-            if (!upgradeLocalDelegatedPropertyReferences) return expression
             return IrRichPropertyReferenceImpl(
                 startOffset = expression.startOffset,
                 endOffset = expression.endOffset,

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/UpgradeCallableReferences.kt
@@ -31,7 +31,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.runIf
 open class UpgradeCallableReferences(
     val context: LoweringContext,
     val upgradeSamConversions: Boolean = true,
-    val upgradeExtractedAdaptedBlocks: Boolean = false,
     val castDispatchReceiver: Boolean = true,
     val generateFakeAccessorsForReflectionProperty: Boolean = false,
 ) : FileLoweringPass {
@@ -136,28 +135,16 @@ open class UpgradeCallableReferences(
             IrStatementOrigin.LAMBDA, IrStatementOrigin.INLINE_LAMBDA, IrStatementOrigin.FUN_INTERFACE_CONSTRUCTOR_REFERENCE, IrStatementOrigin.ANONYMOUS_FUNCTION,
         )
 
-        // TODO delete once the lowering is moved
-        private val usedLambdas = mutableSetOf<IrFunction>()
-
-        // TODO delete once the lowering is moved
-        override fun visitClass(declaration: IrClass, data: IrDeclarationParent): IrStatement {
-            return super.visitClass(declaration, data).also { declaration.declarations.removeIf { it in usedLambdas } }
-        }
-
         private fun IrBlock.parseAdaptedBlock() : AdaptedBlock? {
             if (origin !in blockReferenceOrigins) return null
             if (statements.size != 2) return null
             val [function, reference] = statements
             return when (reference) {
                 is IrFunctionReference -> {
-                    when (function) {
-                        is IrSimpleFunction -> AdaptedBlock(function, reference, null, reference.type)
-                        is IrContainerExpression if upgradeExtractedAdaptedBlocks && function.statements.isEmpty() -> {
-                            val lambda = reference.symbol.owner as IrSimpleFunction
-                            val lambdaToAdd = if (usedLambdas.add(lambda)) lambda else lambda.deepCopyWithSymbols()
-                            AdaptedBlock(lambdaToAdd, reference, null, reference.type)
-                        }
-                        else -> null
+                    if (function is IrSimpleFunction) {
+                        AdaptedBlock(function, reference, null, reference.type)
+                    } else {
+                        null
                     }
                 }
                 is IrTypeOperatorCall -> {

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsLoweringPhases.kt
@@ -90,9 +90,6 @@ private fun createSyntheticAccessorGenerationPhase(context: LoweringContext): Sy
 private fun createUpgradeCallableReferences(context: LoweringContext): UpgradeCallableReferences {
     return UpgradeCallableReferences(
         context,
-        upgradeFunctionReferencesAndLambdas = true,
-        upgradePropertyReferences = true,
-        upgradeLocalDelegatedPropertyReferences = true,
         upgradeSamConversions = false,
     )
 }

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.backend.jvm.codegen
 
 import org.jetbrains.kotlin.backend.common.lower.BOUND_RECEIVER_PARAMETER
-import org.jetbrains.kotlin.backend.common.lower.LAMBDA_EXTENSION_RECEIVER
 import org.jetbrains.kotlin.backend.jvm.*
 import org.jetbrains.kotlin.backend.jvm.intrinsics.IntrinsicMethod
 import org.jetbrains.kotlin.backend.jvm.intrinsics.JavaClassProperty
@@ -32,6 +31,7 @@ import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.descriptors.toIrBasedKotlinType
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
@@ -386,7 +386,7 @@ class ExpressionCodegen(
 
         // If the parameter is an extension receiver parameter or a captured extension receiver from enclosing,
         // then generate name accordingly.
-        val name = if (param.origin == BOUND_RECEIVER_PARAMETER || param.origin == LAMBDA_EXTENSION_RECEIVER || isReceiver) {
+        val name = if (param.origin == BOUND_RECEIVER_PARAMETER || param.origin == IrDeclarationOrigin.LAMBDA_EXTENSION_RECEIVER || isReceiver) {
             getNameForReceiverParameter(irFunction, context.config.languageVersionSettings)
         } else {
             param.name.asString()

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.*
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.irAttribute
@@ -91,7 +92,7 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
         for (parameter in expression.invokeFunction.parameters) {
             // this origin affects how name in bytecode would be generated. We need this change only for inline lambdas,
             // so let's drop it for everything else.
-            if (parameter.origin == LAMBDA_EXTENSION_RECEIVER) {
+            if (parameter.origin == IrDeclarationOrigin.LAMBDA_EXTENSION_RECEIVER) {
                 parameter.origin = IrDeclarationOrigin.DEFINED
             }
         }

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
@@ -11,9 +11,6 @@ import org.jetbrains.kotlin.ir.expressions.*
 
 internal class JvmUpgradeCallableReferences(context: JvmBackendContext) : UpgradeCallableReferences(
     context = context,
-    upgradeFunctionReferencesAndLambdas = true,
-    upgradePropertyReferences = true,
-    upgradeLocalDelegatedPropertyReferences = true,
     upgradeSamConversions = true,
     upgradeExtractedAdaptedBlocks = true,
     castDispatchReceiver = false,

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmUpgradeCallableReferences.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.ir.expressions.*
 internal class JvmUpgradeCallableReferences(context: JvmBackendContext) : UpgradeCallableReferences(
     context = context,
     upgradeSamConversions = true,
-    upgradeExtractedAdaptedBlocks = true,
     castDispatchReceiver = false,
     generateFakeAccessorsForReflectionProperty = true,
 )

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/SuspendLambdaLowering.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.ir.moveBodyTo
 import org.jetbrains.kotlin.backend.common.lower.BOUND_RECEIVER_PARAMETER
 import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationsLowering
-import org.jetbrains.kotlin.backend.common.lower.LAMBDA_EXTENSION_RECEIVER
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.jvm.*
 import org.jetbrains.kotlin.backend.jvm.ir.hasChild
@@ -28,6 +27,7 @@ import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.*
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.expressions.IrContainerExpression
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
@@ -189,7 +189,7 @@ internal class SuspendLambdaLowering(context: JvmBackendContext) : SuspendLoweri
                     origin = LocalDeclarationsLowering.DECLARATION_ORIGIN_FIELD_FOR_CAPTURED_VALUE
                     isFinal = false
                     visibility =
-                        if (it.origin == BOUND_RECEIVER_PARAMETER || it.origin == LAMBDA_EXTENSION_RECEIVER) DescriptorVisibilities.PRIVATE
+                        if (it.origin == BOUND_RECEIVER_PARAMETER || it.origin == IrDeclarationOrigin.LAMBDA_EXTENSION_RECEIVER) DescriptorVisibilities.PRIVATE
                         else JavaDescriptorVisibilities.PACKAGE_VISIBILITY
                 } else null
                 ParameterInfo(field, unboxedType, it.type, it.name, it.origin)

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
@@ -70,9 +70,6 @@ private fun createSyntheticAccessorGenerationPhase(context: LoweringContext): Sy
 private fun createUpgradeCallableReferences(context: LoweringContext): UpgradeCallableReferences {
     return UpgradeCallableReferences(
         context,
-        upgradeFunctionReferencesAndLambdas = true,
-        upgradePropertyReferences = true,
-        upgradeLocalDelegatedPropertyReferences = true,
         upgradeSamConversions = false,
     )
 }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrDeclarationOrigin.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrDeclarationOrigin.kt
@@ -123,6 +123,8 @@ interface IrDeclarationOrigin {
         val STUB_FOR_TYPE_SWITCH by IrDeclarationOriginImpl.Synthetic
 
         val VERSION_OVERLOAD_WRAPPER by IrDeclarationOriginImpl.Regular
+
+        val LAMBDA_EXTENSION_RECEIVER by IrDeclarationOriginImpl.Regular
     }
 
     /**


### PR DESCRIPTION
This MR is cleanup of the lowering after it was moved in the top of jvm pipeline.