### PR TITLE
[FIR] -XheaderMode Do not prune classes inside a private sealed interface

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/optimization/FirReachabilityAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/optimization/FirReachabilityAnalyzer.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.visitors.*
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.name.ClassIdBasedLocality
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.ClassKind
 
@@ -143,6 +144,18 @@ class FirReachabilityAnalyzer(private val session: FirSession) : FirVisitorVoid(
     }
 
     override fun visitRegularClass(regularClass: FirRegularClass) {
+        if (regularClass.status.modality == Modality.SEALED) {
+            val nestedClasses = regularClass.declarations.filterIsInstance<FirRegularClass>().associateBy { it.symbol.classId }
+            regularClass.getSealedClassInheritors(session).forEach { inheritorClassId ->
+                val localNestedClass = nestedClasses[inheritorClassId]
+                if (localNestedClass != null) {
+                    mark(localNestedClass.symbol)
+                } else {
+                    mark(session.symbolProvider.getClassLikeSymbolByClassId(inheritorClassId))
+                }
+            }
+        }
+
         regularClass.annotations.forEach { it.accept(this) }
         regularClass.superTypeRefs.forEach { it.accept(this) }
         regularClass.typeParameters.forEach { it.accept(this) }

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.ir.txt
@@ -1,0 +1,63 @@
+Module: lib
+FILE fqName:lib fileName:/first.kt
+  CLASS CLASS name:SealedClass modality:SEALED visibility:private superTypes:[kotlin.Any]
+    sealedSubclasses:
+      CLASS CLASS name:Implementation modality:FINAL visibility:public superTypes:[lib.SealedClass]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.SealedClass
+    CLASS CLASS name:Implementation modality:FINAL visibility:public superTypes:[lib.SealedClass]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.SealedClass.Implementation
+      CONSTRUCTOR visibility:public returnType:lib.SealedClass.Implementation [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in lib.SealedClass
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in lib.SealedClass
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in lib.SealedClass
+    CONSTRUCTOR visibility:protected returnType:lib.SealedClass [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:myFunc visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+Module: main
+FILE fqName:main fileName:/main.kt
+  CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
+    CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
+      BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt
@@ -1,0 +1,25 @@
+// FIR_PARSER: LightTree
+// TARGET_BACKEND: JVM_IR
+// MODULE: lib
+// HEADER_MODE
+// FILE: first.kt
+package lib
+
+private sealed class SealedClass {
+    class Implementation : SealedClass()
+}
+
+fun myFunc() {
+    val impl = SealedClass.Implementation()
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+package main
+import lib.myFunc
+
+class App {
+    fun run() {
+        myFunc()
+    }
+}

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt.txt
@@ -1,0 +1,34 @@
+// MODULE: lib
+// FILE: first.kt
+package lib
+
+private sealed class SealedClass {
+  class Implementation : SealedClass {
+    constructor() /* primary */
+
+  }
+
+  protected constructor() /* primary */
+
+}
+
+fun myFunc() {
+}
+
+// MODULE: main
+// FILE: main.kt
+package main
+
+class App {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  fun run() {
+    myFunc()
+  }
+
+}
+

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.ir.txt
@@ -1,0 +1,62 @@
+Module: lib
+FILE fqName:lib fileName:/first.kt
+  CLASS INTERFACE name:SealedInterface modality:SEALED visibility:private superTypes:[kotlin.Any]
+    sealedSubclasses:
+      CLASS CLASS name:Implementation modality:FINAL visibility:public superTypes:[lib.SealedInterface]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.SealedInterface
+    CLASS CLASS name:Implementation modality:FINAL visibility:public superTypes:[lib.SealedInterface]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.SealedInterface.Implementation
+      CONSTRUCTOR visibility:public returnType:lib.SealedInterface.Implementation [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in lib.SealedInterface
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in lib.SealedInterface
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in lib.SealedInterface
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:myFunc visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+Module: main
+FILE fqName:main fileName:/main.kt
+  CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
+    CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
+      BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt
@@ -1,0 +1,25 @@
+// FIR_PARSER: LightTree
+// TARGET_BACKEND: JVM_IR
+// MODULE: lib
+// HEADER_MODE
+// FILE: first.kt
+package lib
+
+private sealed interface SealedInterface {
+    class Implementation : SealedInterface
+}
+
+fun myFunc() {
+    val impl = SealedInterface.Implementation()
+} 
+
+// MODULE: main(lib)
+// FILE: main.kt
+package main
+import lib.myFunc
+
+class App {
+    fun run() {
+        myFunc()
+    }
+}

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt.txt
@@ -1,0 +1,32 @@
+// MODULE: lib
+// FILE: first.kt
+package lib
+
+private sealed interface SealedInterface {
+  class Implementation : SealedInterface {
+    constructor() /* primary */
+
+  }
+
+}
+
+fun myFunc() {
+}
+
+// MODULE: main
+// FILE: main.kt
+package main
+
+class App {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  fun run() {
+    myFunc()
+  }
+
+}
+

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.ir.txt
@@ -1,0 +1,62 @@
+Module: lib
+FILE fqName:lib fileName:/first.kt
+  CLASS CLASS name:TopLevelImplementation modality:FINAL visibility:public superTypes:[lib.SealedInterface]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.TopLevelImplementation
+    CONSTRUCTOR visibility:public returnType:lib.TopLevelImplementation [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in lib.SealedInterface
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in lib.SealedInterface
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in lib.SealedInterface
+  CLASS INTERFACE name:SealedInterface modality:SEALED visibility:private superTypes:[kotlin.Any]
+    sealedSubclasses:
+      CLASS CLASS name:TopLevelImplementation modality:FINAL visibility:public superTypes:[lib.SealedInterface]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.SealedInterface
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:myFunc visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+Module: main
+FILE fqName:main fileName:/main.kt
+  CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
+    CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
+      BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt
@@ -1,0 +1,25 @@
+// FIR_PARSER: LightTree
+// TARGET_BACKEND: JVM_IR
+// MODULE: lib
+// HEADER_MODE
+// FILE: first.kt
+package lib
+
+private sealed interface SealedInterface
+
+class TopLevelImplementation : SealedInterface
+
+fun myFunc() {
+    val impl = TopLevelImplementation()
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+package main
+import lib.myFunc
+
+class App {
+    fun run() {
+        myFunc()
+    }
+}

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt.txt
@@ -1,0 +1,32 @@
+// MODULE: lib
+// FILE: first.kt
+package lib
+
+class TopLevelImplementation : SealedInterface {
+  constructor() /* primary */
+
+}
+
+private sealed interface SealedInterface {
+}
+
+fun myFunc() {
+}
+
+// MODULE: main
+// FILE: main.kt
+package main
+
+class App {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  fun run() {
+    myFunc()
+  }
+
+}
+

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.ir.txt
@@ -1,0 +1,79 @@
+Module: lib
+FILE fqName:lib fileName:/first.kt
+  CLASS INTERFACE name:GrandParent modality:SEALED visibility:private superTypes:[kotlin.Any]
+    sealedSubclasses:
+      CLASS INTERFACE name:Parent modality:SEALED visibility:public superTypes:[lib.GrandParent]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.GrandParent
+    CLASS INTERFACE name:Parent modality:SEALED visibility:public superTypes:[lib.GrandParent]
+      sealedSubclasses:
+        CLASS CLASS name:Leaf modality:FINAL visibility:public superTypes:[lib.GrandParent.Parent]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.GrandParent.Parent
+      CLASS CLASS name:Leaf modality:FINAL visibility:public superTypes:[lib.GrandParent.Parent]
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:lib.GrandParent.Parent.Leaf
+        CONSTRUCTOR visibility:public returnType:lib.GrandParent.Parent.Leaf [primary]
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+          overridden:
+            public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in lib.GrandParent.Parent
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun hashCode (): kotlin.Int declared in lib.GrandParent.Parent
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun toString (): kotlin.String declared in lib.GrandParent.Parent
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in lib.GrandParent
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in lib.GrandParent
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in lib.GrandParent
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:myFunc visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+Module: main
+FILE fqName:main fileName:/main.kt
+  CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
+    CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
+      BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt
@@ -1,0 +1,27 @@
+// FIR_PARSER: LightTree
+// TARGET_BACKEND: JVM_IR
+// MODULE: lib
+// HEADER_MODE
+// FILE: first.kt
+package lib
+
+private sealed interface GrandParent {
+    sealed interface Parent : GrandParent {
+        class Leaf : Parent
+    }
+}
+
+fun myFunc() {
+    val impl = GrandParent.Parent.Leaf()
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+package main
+import lib.myFunc
+
+class App {
+    fun run() {
+        myFunc()
+    }
+}

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt.txt
@@ -1,0 +1,35 @@
+// MODULE: lib
+// FILE: first.kt
+package lib
+
+private sealed interface GrandParent {
+  sealed interface Parent : GrandParent {
+    class Leaf : Parent {
+      constructor() /* primary */
+
+    }
+
+  }
+
+}
+
+fun myFunc() {
+}
+
+// MODULE: main
+// FILE: main.kt
+package main
+
+class App {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  fun run() {
+    myFunc()
+  }
+
+}
+


### PR DESCRIPTION
This PR adds tests for jklib and jvm for private sealed interfaces using -xHeadermode
As well as a fix for it

### Problem
When compiling the kotlin-stdlib with -XheaderMode, [Instant.kt](https://github.com/JetBrains/kotlin/blob/3a64d6157d601e584a29093d9d1c2762e57b9b00/libraries/stdlib/src/kotlin/time/Instant.kt#L703)
contains

```
private sealed interface InstantParseResult {
    ...

    class Success(val epochSeconds: Long, val nanosecondsOfSecond: Int) : InstantParseResult {
      ...
     
    }
    class Failure(val error: String, val input: CharSequence) : InstantParseResult {
       ...
    }
}
```

Under `-Xheader-mode`, `FirReachabilityAnalyzer` pruned unused subclasses of a sealed class/interface, even though the top-level sealed parent was preserved. This led to a compiler crash (`IllegalStateException`) during IR generation when resolving the parent's registered sealed inheritors. (`VariousUtils.kt#getIrSymbolsForSealedSubclasses`) attempts to fetch their IR symbols, finds them missing and crashes with:
`java.lang.IllegalStateException: Source classes should be created separately before referencing`


### Solution
Updated `FirReachabilityAnalyzer.kt` to automatically mark all registered subclasses of a reachable `SEALED` parent as reachable, keeping the type hierarchy intact.

### Testing
Added and verified multi-module Header Mode tests covering:
* Sealed interfaces with nested subclasses (`sealedInterfaceNestedSubclass.kt`)
* Sealed classes with nested subclasses (`sealedClassNestedSubclass.kt`)
* Sealed interfaces with top-level package-private subclasses (`sealedInterfaceTopLevelSubclass.kt`)
* Transitive/multi-level sealed structures (`sealedTransitiveSubclass.kt`)