### PR TITLE
[K/N] Mangle names that clash with C and Objective-C macros

### DIFF
--- a/native/base/src/main/kotlin/org/jetbrains/kotlin/backend/konan/objCReservedNames.kt
+++ b/native/base/src/main/kotlin/org/jetbrains/kotlin/backend/konan/objCReservedNames.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan
+
+val objCMacroDefinitions = setOf("NULL", "DEBUG", "YES", "NO")
+
+fun String.mangleIfStdMacro(): String = if (objCMacroDefinitions.contains(this)) this + "_" else this

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyGetter.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyGetter.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.backend.konan.objCMacroDefinitions
 import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
 
 /**
@@ -18,7 +19,7 @@ import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
  */
 internal fun ObjCExportContext.getObjCPropertyGetter(symbol: KaPropertySymbol, objCName: String): String? {
 
-    if (!symbol.hasReservedName) return null
+    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions) return null
 
     val symbolGetter = symbol.getter
     val getterBridge = if (symbolGetter == null) error("KtPropertySymbol.getter is undefined") else getFunctionMethodBridge(symbolGetter)

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyName.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyName.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.analysis.api.symbols.KaVariableSymbol
+import org.jetbrains.kotlin.backend.konan.mangleIfStdMacro
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportPropertyName
 
 
@@ -15,7 +16,7 @@ fun ObjCExportContext.getObjCPropertyName(symbol: KaVariableSymbol): ObjCExportP
     val propertyName = stringName.mangleIfReservedObjCName()
 
     return ObjCExportPropertyName(
-        objCName = resolveObjCNameAnnotation?.objCName ?: propertyName,
+        objCName = (resolveObjCNameAnnotation?.objCName ?: propertyName).mangleIfStdMacro(),
         swiftName = resolveObjCNameAnnotation?.swiftName ?: resolveObjCNameAnnotation?.objCName ?: propertyName
     )
 }

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertySetter.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertySetter.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.backend.konan.objCMacroDefinitions
 import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
 
 /**
@@ -18,7 +19,7 @@ import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
  */
 internal fun ObjCExportContext.getObjCPropertySetter(symbol: KaPropertySymbol, objCName: String): String? {
 
-    if (!symbol.hasReservedName) return null
+    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions) return null
 
     val setterName = symbol.setter?.let {
         val setterSelector = getSelector(it, getFunctionMethodBridge(it))

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/mangling/mangleUtils.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/mangling/mangleUtils.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlin.objcexport.mangling
 
 import org.jetbrains.kotlin.backend.konan.cKeywords
+import org.jetbrains.kotlin.backend.konan.objCMacroDefinitions
 import org.jetbrains.kotlin.objcexport.toValidObjCSwiftIdentifier
 
 internal fun String.mangleSelector(postfix: String): String {
@@ -10,7 +11,7 @@ internal fun String.mangleSelector(postfix: String): String {
 
 internal fun unifyName(initialName: String, usedNames: Set<String>): String {
     var unique = initialName.toValidObjCSwiftIdentifier()
-    while (unique in usedNames || unique in cKeywords) {
+    while (unique in usedNames || unique in cKeywords || unique in objCMacroDefinitions) {
         unique += "_"
     }
     return unique

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCMethod.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCMethod.kt
@@ -10,6 +10,7 @@ package org.jetbrains.kotlin.objcexport
 import org.jetbrains.kotlin.analysis.api.export.utilities.isFakeOverride
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.backend.konan.KonanFqNames
+import org.jetbrains.kotlin.backend.konan.mangleIfStdMacro
 import org.jetbrains.kotlin.backend.konan.objcexport.*
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
@@ -244,7 +245,7 @@ fun ObjCExportContext.getSelector(symbol: KaFunctionSymbol, methodBridge: Method
         return anyMethodSelector
     }
 
-    sb.append(getMangledName(symbol, forSwift = false))
+    val methodName = getMangledName(symbol, forSwift = false)
 
     parameters.forEachIndexed { index, [bridge, parameter] ->
         val name = when (bridge) {
@@ -268,21 +269,29 @@ fun ObjCExportContext.getSelector(symbol: KaFunctionSymbol, methodBridge: Method
         }
 
         if (index == 0) {
-            sb.append(
+            val firstParam = (
                 when {
                     bridge is MethodBridgeValueParameter.ErrorOutParameter -> "AndReturn"
                     bridge is MethodBridgeValueParameter.SuspendCompletion -> "With"
                     method.isConstructor -> "With"
                     else -> ""
                 }
-            )
-            sb.append(name.replaceFirstChar(Char::uppercaseChar))
+                ) + name.replaceFirstChar(Char::uppercaseChar)
+
+            // First parameter, when combined with the method name may require mangling. E.g.: fun N(ULL: Int)
+            sb.append((methodName + firstParam).mangleIfStdMacro())
         } else {
-            sb.append(name)
+            sb.append(name.mangleIfStdMacro())
         }
 
         if (!isPropertyGetter) sb.append(':')
     }
+
+    // No parameters to add to the method name. Mangle and append the method name.
+    if (parameters.isEmpty()) {
+        sb.append(methodName.mangleIfStdMacro())
+    }
+
     return sb.toString()
 }
 
@@ -298,7 +307,7 @@ fun ObjCExportContext.getMangledName(symbol: KaFunctionSymbol, forSwift: Boolean
 }
 
 internal fun String.startsWithWords(words: String) = this.startsWith(words) &&
-        (this.length == words.length || !this[words.length].isLowerCase())
+    (this.length == words.length || !this[words.length].isLowerCase())
 
 /**
  * [org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportTranslatorImpl.mapReturnType]

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -565,7 +565,7 @@ class ObjCExportNamerImpl(
         val parameters = mapper.bridgeMethod(method).valueParametersAssociated(method)
 
         StringBuilder().apply {
-            append(method.getMangledName(forSwift = false))
+            val methodName = method.getMangledName(forSwift = false)
 
             parameters.forEachIndexed { index, [bridge, it] ->
                 val name = when (bridge) {
@@ -582,20 +582,27 @@ class ObjCExportNamerImpl(
                 }
 
                 if (index == 0) {
-                    append(
+                    val firstParam = (
                         when {
                             bridge is MethodBridgeValueParameter.ErrorOutParameter -> "AndReturn"
                             bridge is MethodBridgeValueParameter.SuspendCompletion -> "With"
                             method is ConstructorDescriptor -> "With"
                             else -> ""
                         }
-                    )
-                    append(name.replaceFirstChar(Char::uppercaseChar))
+                        ) + name.replaceFirstChar(Char::uppercaseChar)
+
+                    // First parameter, when combined with the method name may require mangling. E.g.: fun N(ULL: Int)
+                    append((methodName + firstParam).mangleIfStdMacro())
                 } else {
-                    append(name)
+                    append(name.mangleIfStdMacro())
                 }
 
                 append(':')
+            }
+
+            // No parameters to add to the method name. Mangle and append the method name.
+            if (parameters.isEmpty()) {
+                append(methodName.mangleIfStdMacro())
             }
         }.mangledSequence {
             if (parameters.isNotEmpty()) {
@@ -659,7 +666,12 @@ class ObjCExportNamerImpl(
         val objCName = property.getObjCName()
         fun PropertyNameMapping.getOrPut(forSwift: Boolean) = getOrPut(property) {
             StringBuilder().apply {
-                append(objCName.asIdentifier(forSwift))
+                val identifier = objCName.asIdentifier(forSwift)
+                if (!forSwift) {
+                    append(identifier.mangleIfStdMacro())
+                } else {
+                    append(identifier)
+                }
             }.mangledSequence {
                 append('_')
             }

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportTranslator.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportTranslator.kt
@@ -623,7 +623,7 @@ class ObjCExportTranslatorImpl(
 
     private fun unifyName(initialName: String, usedNames: Set<String>): String {
         var unique = initialName.toValidObjCSwiftIdentifier()
-        while (unique in usedNames || unique in cKeywords) {
+        while (unique in usedNames || unique in cKeywords || unique in objCMacroDefinitions) {
             unique += "_"
         }
         return unique

--- a/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
+++ b/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
@@ -430,7 +430,7 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
 
     @Test
     fun `test - functionWithReservedMethodName`() {
-        doTest(headersTestDataDir.resolve("functionWithReservedMethodName"))
+        doTest(headersTestDataDir.resolve("functionWithReservedMethodName"), Configuration(frameworkName = "Shared"))
     }
 
     @Test
@@ -698,6 +698,22 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
     @Test
     fun `test - extensions mangling`() {
         doTest(headersTestDataDir.resolve("extensionsMangling"))
+    }
+
+    @Test
+    fun `test - function parameters mangling`() {
+        doTest(headersTestDataDir.resolve("functionParametersMangling"))
+    }
+
+    @Test
+    fun `test - properties with reserved names`() {
+        doTest(headersTestDataDir.resolve("propertiesWithReservedNames"))
+    }
+
+    @Test
+    @TodoAnalysisApi
+    fun `test - conflict upon mangling a property or a method should be handled by the manglers`() {
+        doTest(headersTestDataDir.resolve("conflictUponManglingPropertyOrMethod"))
     }
 
     private fun doTest(root: File, configuration: Configuration = Configuration()) {

--- a/native/objcexport-header-generator/testData/headers/conflictUponManglingPropertyOrMethod/!conflictUponManglingPropertyOrMethod.h
+++ b/native/objcexport-header-generator/testData/headers/conflictUponManglingPropertyOrMethod/!conflictUponManglingPropertyOrMethod.h
@@ -1,0 +1,42 @@
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSSet.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+
+NS_ASSUME_NONNULL_BEGIN
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wincompatible-property-type"
+#pragma clang diagnostic ignored "-Wnullability"
+
+#pragma push_macro("_Nullable_result")
+#if !__has_feature(nullability_nullable_result)
+#undef _Nullable_result
+#define _Nullable_result _Nullable
+#endif
+
+__attribute__((objc_subclassing_restricted))
+@interface Foo : Base
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (void)NO_ __attribute__((swift_name("NO()")));
+- (void)NOX:(int32_t)x y:(int64_t)y z:(double)z __attribute__((swift_name("NO(x:y:z:)")));
+- (void)NOX __attribute__((swift_name("NOX()")));
+- (void)YES_ __attribute__((swift_name("YES()")));
+- (void)YES__ __attribute__((swift_name("YES_()")));
+@property (setter=setNULL:) int32_t NULL_ __attribute__((swift_name("NULL")));
+@property (readonly) int32_t NULL__ __attribute__((swift_name("NULL_")));
+@end
+
+__attribute__((objc_subclassing_restricted))
+@interface FooKt : Base
++ (void)DEBUG_:(int32_t)BUG __attribute__((swift_name("DE(BUG:)")));
++ (void)DEBUG_ __attribute__((swift_name("DEBUG()")));
+@end
+
+#pragma pop_macro("_Nullable_result")
+#pragma clang diagnostic pop
+NS_ASSUME_NONNULL_END

--- a/native/objcexport-header-generator/testData/headers/conflictUponManglingPropertyOrMethod/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/conflictUponManglingPropertyOrMethod/Foo.kt
@@ -1,0 +1,14 @@
+class Foo {
+    var NULL = 0  // When mangled, it clashes with the next property; should be handled by the mangler.
+    val NULL_ = 1 // Should be mangled as NULL__ to avoid conflict with the previous property.
+
+    fun YES() {}  // When mangled, it clashes with the next method; should be handled by the mangler.
+    fun YES_() {} // Should be mangled as YES__ to avoid conflict with the previous method.
+
+    fun NO() {}
+    fun NO(x: Int, y: Long, z: Double) {}
+    fun NOX() {}
+}
+
+fun DEBUG() {}
+fun DE(BUG: Int) {}

--- a/native/objcexport-header-generator/testData/headers/enumCKeywordsAndSpecialNamesTranslation/!enumCKeywordsAndSpecialNamesTranslation.h
+++ b/native/objcexport-header-generator/testData/headers/enumCKeywordsAndSpecialNamesTranslation/!enumCKeywordsAndSpecialNamesTranslation.h
@@ -6,7 +6,7 @@
 #import <Foundation/NSString.h>
 #import <Foundation/NSValue.h>
 
-@class Foo, KotlinArray<T>, KotlinEnum<E>, KotlinEnumCompanion;
+@class Bar, Foo, KotlinArray<T>, KotlinEnum<E>, KotlinEnumCompanion;
 
 @protocol KotlinComparable, KotlinIterator;
 
@@ -36,6 +36,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)description __attribute__((swift_name("description()")));
 @property (readonly) NSString *name __attribute__((swift_name("name")));
 @property (readonly) int32_t ordinal __attribute__((swift_name("ordinal")));
+@end
+
+__attribute__((objc_subclassing_restricted))
+@interface Bar : KotlinEnum<Bar *>
++ (instancetype)alloc __attribute__((unavailable));
++ (instancetype)allocWithZone:(struct _NSZone *)zone __attribute__((unavailable));
+- (instancetype)initWithName:(NSString *)name ordinal:(int32_t)ordinal __attribute__((swift_name("init(name:ordinal:)"))) __attribute__((objc_designated_initializer)) __attribute__((unavailable));
+@property (class, readonly) Bar *null __attribute__((swift_name("null")));
+@property (class, readonly) Bar *debug __attribute__((swift_name("debug")));
+@property (class, readonly) Bar *yes __attribute__((swift_name("yes")));
+@property (class, readonly) Bar *no __attribute__((swift_name("no")));
+@property (class, readonly) Bar *something __attribute__((swift_name("something")));
++ (KotlinArray<Bar *> *)values __attribute__((swift_name("values()")));
+@property (class, readonly) NSArray<Bar *> *entries __attribute__((swift_name("entries")));
 @end
 
 __attribute__((objc_subclassing_restricted))

--- a/native/objcexport-header-generator/testData/headers/enumCKeywordsAndSpecialNamesTranslation/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/enumCKeywordsAndSpecialNamesTranslation/Foo.kt
@@ -1,3 +1,6 @@
 enum class Foo {
     DEFAULT, ALLOC, NEW, AUTO, CASE
 }
+enum class Bar {
+    NULL, DEBUG, YES, NO, SOMETHING
+}

--- a/native/objcexport-header-generator/testData/headers/functionParametersMangling/!functionParametersMangling.h
+++ b/native/objcexport-header-generator/testData/headers/functionParametersMangling/!functionParametersMangling.h
@@ -1,0 +1,30 @@
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSSet.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+
+NS_ASSUME_NONNULL_BEGIN
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wincompatible-property-type"
+#pragma clang diagnostic ignored "-Wnullability"
+
+#pragma push_macro("_Nullable_result")
+#if !__has_feature(nullability_nullable_result)
+#undef _Nullable_result
+#define _Nullable_result _Nullable
+#endif
+
+__attribute__((objc_subclassing_restricted))
+@interface FooKt : Base
++ (void)barYES:(id _Nullable)YES_ a:(id _Nullable)a b:(int64_t)b __attribute__((swift_name("bar(YES:a:b:)")));
++ (void)barNO:(id _Nullable)NO_ a:(int32_t)a b:(id _Nullable)b __attribute__((swift_name("bar(NO:a:b:)")));
++ (void)fooNULL:(unichar)NULL_ a:(int32_t)a DEBUG_:(int64_t)DEBUG_ __attribute__((swift_name("foo(NULL:a:DEBUG:)")));
+@end
+
+#pragma pop_macro("_Nullable_result")
+#pragma clang diagnostic pop
+NS_ASSUME_NONNULL_END

--- a/native/objcexport-header-generator/testData/headers/functionParametersMangling/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/functionParametersMangling/Foo.kt
@@ -1,0 +1,8 @@
+fun foo(NULL: Char, a: Int, DEBUG: Long) {
+}
+
+fun <T, DEBUG> bar(YES: T, a: DEBUG, b: Long) {
+}
+
+fun <T, DEBUG> bar(NO: T, a: Int, b: DEBUG) {
+}

--- a/native/objcexport-header-generator/testData/headers/functionWithReservedMethodName/!functionWithReservedMethodName.h
+++ b/native/objcexport-header-generator/testData/headers/functionWithReservedMethodName/!functionWithReservedMethodName.h
@@ -6,6 +6,10 @@
 #import <Foundation/NSString.h>
 #import <Foundation/NSValue.h>
 
+@class SharedNULL<T>;
+
+@protocol SharedNO;
+
 NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-warning-option"
@@ -19,9 +23,52 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 __attribute__((objc_subclassing_restricted))
-@interface Foo : Base
+__attribute__((swift_name("Bar")))
+@interface SharedBar : SharedBase
 - (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
 + (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+
+/**
+ * Documented [YES] method.
+ */
+- (void)YES_:(SharedNULL<id<SharedNO>> *)receiver __attribute__((swift_name("YES(_:)")));
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("Foo")))
+@interface SharedFoo : SharedBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+
+/**
+ * Documented [DEBUG] method.
+ */
+- (void)DEBUG_ __attribute__((swift_name("DEBUG()")));
+
+/**
+ * Documented [N] method.
+ */
+- (void)NULL_:(int32_t)ULL DEBUG_:(int64_t)DEBUG_ __attribute__((swift_name("N(ULL:DEBUG:)")));
+
+/**
+ * Documented [NO] method.
+ */
+- (void)NO_ __attribute__((swift_name("NO()")));
+
+/**
+ * Documented [NO] method.
+ */
+- (void)NOParam1:(int32_t)param1 __attribute__((swift_name("NO(param1:)")));
+
+/**
+ * Documented [NULL] method.
+ */
+- (void)NULL_ __attribute__((swift_name("NULL()")));
+
+/**
+ * Documented [YES] method.
+ */
+- (void)YES_ __attribute__((swift_name("YES()")));
 
 /**
  * Documented [autorelease] method.
@@ -47,6 +94,18 @@ __attribute__((objc_subclassing_restricted))
  * Documented [superclass] method.
  */
 - (void)superclass_ __attribute__((swift_name("superclass()")));
+@end
+
+__attribute__((swift_name("NO")))
+@protocol SharedNO
+@required
+@end
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("NULL")))
+@interface SharedNULL<T> : SharedBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
 @end
 
 #pragma pop_macro("_Nullable_result")

--- a/native/objcexport-header-generator/testData/headers/functionWithReservedMethodName/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/functionWithReservedMethodName/Foo.kt
@@ -28,4 +28,52 @@ class Foo {
      */
     fun retain() {
     }
+
+    /**
+     * Documented [NULL] method.
+     */
+    fun NULL() {
+    }
+
+    /**
+     * Documented [DEBUG] method.
+     */
+    fun DEBUG() {
+    }
+
+    /**
+     * Documented [YES] method.
+     */
+    fun YES() {
+    }
+
+    /**
+     * Documented [NO] method.
+      */
+    fun NO() {
+    }
+
+    /**
+     * Documented [NO] method.
+     */
+    fun NO(param1: Int) {
+    }
+
+    /**
+     * Documented [N] method.
+     */
+    fun N(ULL: Int, DEBUG: Long) {
+    }
 }
+
+class Bar {
+
+    /**
+     * Documented [YES] method.
+     */
+    fun NULL<NO>.YES() {}
+}
+
+class NULL<T>
+
+interface NO

--- a/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/!propertiesWithReservedNames.h
+++ b/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/!propertiesWithReservedNames.h
@@ -1,0 +1,41 @@
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSSet.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+
+@class Foo;
+
+NS_ASSUME_NONNULL_BEGIN
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wincompatible-property-type"
+#pragma clang diagnostic ignored "-Wnullability"
+
+#pragma push_macro("_Nullable_result")
+#if !__has_feature(nullability_nullable_result)
+#undef _Nullable_result
+#define _Nullable_result _Nullable
+#endif
+
+__attribute__((objc_subclassing_restricted))
+@interface Foo : Base
++ (instancetype)alloc __attribute__((unavailable));
++ (instancetype)allocWithZone:(struct _NSZone *)zone __attribute__((unavailable));
++ (instancetype)foo __attribute__((swift_name("init()")));
+@property (class, readonly, getter=shared) Foo *shared __attribute__((swift_name("shared")));
+@property (readonly) NSString *NO_ __attribute__((swift_name("NO")));
+@property (setter=setDEBUG:) BOOL DEBUG_ __attribute__((swift_name("DEBUG")));
+@property (readonly) NSString *NULL_ __attribute__((swift_name("NULL")));
+@end
+
+__attribute__((objc_subclassing_restricted))
+@interface FooKt : Base
+@property (class, readonly) NSString *YES_ __attribute__((swift_name("YES")));
+@end
+
+#pragma pop_macro("_Nullable_result")
+#pragma clang diagnostic pop
+NS_ASSUME_NONNULL_END

--- a/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/Foo.kt
@@ -1,0 +1,9 @@
+object Foo {
+    const val NULL = "null_as_string"
+    var DEBUG = false
+
+    @ObjCName("NO")
+    val Bar = "no_as_string"
+}
+
+val YES = Foo.NULL


### PR DESCRIPTION
We already use various `Set<>`-s across the codebase to track C, C++,
and Objective-C specific keywords and handle them accordingly. This
was after users reported compilation errors due to using such
clash-prone keywords in their Kotlin code. However, a similar issue
persists due to macro definitions. Should you use `NULL`, `DEBUG`,
etc., as identifiers, the resultant generated header file could still
cause build failures.

Consider this simple valid top-level declaration:
```kotlin
public const val DEBUG: String = "Debug"
```

The resultant header file can cause the following compilation error:
```
<command line>:19:15: note: expanded from macro 'DEBUG'
```

as the `DEBUG` macro is injected by Clang during the build. Similar is
the case with `NULL` that's defined in `__stddef_null.h`:

```
error: expected member name or ';' after declaration
       specifiers
  146 | @property (class, readonly) NSString *NULL __attribute__((swift_name("NULL")));
      |                             ~~~~~~~~  ^
usr/lib/clang/21/include/__stddef_null.h:26:16: note: 
      expanded from macro 'NULL'
   26 | #define NULL ((void*)0)

```

Tracking the generated identifier for potential clashes and mangling it
could help prevent this issue.