### PR TITLE
[Wasm] Fix cross-module signature mismatch for parent companion getIn…

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ObjectLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ObjectLowering.kt
@@ -80,7 +80,12 @@ class ObjectDeclarationLowering(
             var superClass = declaration.parent.safeAs<IrClass>()?.superClass
             var result: IrSimpleFunction? = null
             while (superClass != null && result == null) {
-                result = superClass.companionObject()?.let { getOrCreateGetInstanceFunction(it) }
+                val companion = superClass.companionObject()
+                if (companion != null) {
+                    result = declaration.factory.stageController.restrictTo(companion) {
+                        getOrCreateGetInstanceFunction(companion)
+                    }
+                }
                 superClass = superClass.superClass
             }
             result


### PR DESCRIPTION
Since now we call getOrCreateInstanceFunction in contexts where the
parent's getInstance function hasn't been created yet, it's possible
for the scoping of the current declaration to be incorrect. Therefore
we need to restrict to the correct scope to get the correct signature,
so that the scope always comes from the object and not the dynamic
context of the function call.

This issue was exposed by single module box tests which probably
caused the traversal order of the companions to be in such a way that
we could get a mismatch in scopes. Specifically, we were getting a
link time failure: the precompiled stdlib exports
`Enum.Companion_getInstance` under one hash, but the test module
imports it under a different hash, producing "function import requires
a callable" errors across all Wasm VMs.

^[KT-86640](https://youtrack.jetbrains.com/issue/KT-86640) Fixed