### PR TITLE
[Swift Export] Forward unlabeled arguments positionally in package-fl…

### DIFF
--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtPropertySymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtPropertySymbol.kt
@@ -142,7 +142,7 @@ internal class SirFunctionFromKtPropertySymbol(
 
         val contextParameters = contextParameters?.second ?: emptyList()
         val extensionReceiverParameter = extensionReceiverParameter?.let {
-            SirParameter("", "receiver", it.type)
+            SirParameter(null, "receiver", it.type)
         }
 
         generateFunctionBridge(
@@ -152,12 +152,12 @@ internal class SirFunctionFromKtPropertySymbol(
             kotlinFqName = fqName,
             kotlinOptIns = ktSymbol.allRequiredOptIns,
             selfParameter = (parent !is SirModule && isInstance).ifTrue {
-                SirParameter("", "self", selfType ?: error("Only a member can have a self parameter"))
+                SirParameter(null, "self", selfType ?: error("Only a member can have a self parameter"))
             },
             contextParameters = contextParameters,
             extensionReceiverParameter = extensionReceiverParameter,
             errorParameter = errorType.takeIf { it != SirType.never }?.let {
-                SirParameter("", "_out_error", it)
+                SirParameter(null, "_out_error", it)
             },
             isAsync = false,
         )

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirFunctionFromKtSymbol.kt
@@ -117,7 +117,7 @@ internal open class SirFunctionFromKtSymbol(
 
         val contextParameters = contextParameters?.second ?: emptyList()
         val extensionReceiverParameter = extensionReceiverParameter?.let {
-            SirParameter("", "receiver", it.type)
+            SirParameter(null, "receiver", it.type)
         }
 
         // For F-bounded methods, use the interface type as self type to generate direct cast
@@ -130,12 +130,12 @@ internal open class SirFunctionFromKtSymbol(
             kotlinFqName = fqName,
             kotlinOptIns = ktSymbol.allRequiredOptIns,
             selfParameter = (parent !is SirModule && isInstance).ifTrue {
-                SirParameter("", "self", effectiveSelfType ?: error("Only a member can have a self parameter"))
+                SirParameter(null, "self", effectiveSelfType ?: error("Only a member can have a self parameter"))
             },
             contextParameters = contextParameters,
             extensionReceiverParameter = extensionReceiverParameter,
             errorParameter = errorType.takeIf { it != SirType.never }?.let {
-                SirParameter("", "_out_error", it)
+                SirParameter(null, "_out_error", it)
             },
             isAsync = isAsync,
         )

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirInitFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirInitFromKtSymbol.kt
@@ -46,7 +46,7 @@ import org.jetbrains.sir.lightclasses.utils.translatedAttributes
 import kotlin.lazy
 
 private val obj = SirParameter(
-    "", "__kt", SirNominalType(SirSwiftModule.unsafeMutableRawPointer)
+    null, "__kt", SirNominalType(SirSwiftModule.unsafeMutableRawPointer)
 )
 
 internal sealed class SirInitFromKtSymbol(
@@ -262,7 +262,7 @@ internal class SirRegularInitFromKtSymbol(
             contextParameters = emptyList(),
             extensionReceiverParameter = null,
             errorParameter = errorType.takeIf { it != SirType.never }?.let {
-                SirParameter("", "__error", it)
+                SirParameter(null, "__error", it)
             },
             isAsync = false,
         )

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirVariableFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirVariableFromKtSymbol.kt
@@ -156,12 +156,12 @@ internal abstract class SirAbstractGetter(
             kotlinFqName = fqName,
             kotlinOptIns = getterSymbol?.allRequiredOptIns ?: emptyList(),
             selfParameter = (variable.parent !is SirModule && variable.isInstance).ifTrue {
-                SirParameter("", "self", selfType ?: error("Only a member can have a self parameter"))
+                SirParameter(null, "self", selfType ?: error("Only a member can have a self parameter"))
             },
             contextParameters = emptyList(),
             extensionReceiverParameter = null,
             errorParameter = errorType.takeIf { it != SirType.never }?.let {
-                SirParameter("", "_out_error", it)
+                SirParameter(null, "_out_error", it)
             },
             isAsync = false,
         )
@@ -226,12 +226,12 @@ internal abstract class SirAbstractSetter(
             kotlinFqName = fqName,
             kotlinOptIns = setterSymbol?.allRequiredOptIns ?: emptyList(),
             selfParameter = (parent !is SirModule && variable.isInstance).ifTrue {
-                SirParameter("", "self", selfType ?: error("Only a member can have a self parameter"))
+                SirParameter(null, "self", selfType ?: error("Only a member can have a self parameter"))
             },
             contextParameters = emptyList(),
             extensionReceiverParameter = null,
             errorParameter = errorType.takeIf { it != SirType.never }?.let {
-                SirParameter("", "_out_error", it)
+                SirParameter(null, "_out_error", it)
             },
             isAsync = false,
         )

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/utils/TypeTranslationUtils.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/utils/TypeTranslationUtils.kt
@@ -54,7 +54,11 @@ internal inline fun <reified T : KaFunctionSymbol> SirFromKtSymbol<T>.translateP
         this@translateParameters.ktSymbol.valueParameters.map { parameter ->
             val sirType = createParameterType(ktSymbol, parameter).escaping
             val objCNameAnnotation = parameter.objCNameAnnotation
-            val argumentName = objCNameAnnotation?.argumentName ?: parameter.name.asString()
+            val argumentName: String? = when (val raw = objCNameAnnotation?.argumentName) {
+                null -> parameter.name.asString()
+                "" -> null
+                else -> raw
+            }
             val parameterName = objCNameAnnotation?.name ?: parameter.name.asString()
             SirParameter(
                 argumentName = argumentName,

--- a/native/swift/sir/src/org/jetbrains/kotlin/sir/SirParameter.kt
+++ b/native/swift/sir/src/org/jetbrains/kotlin/sir/SirParameter.kt
@@ -12,6 +12,10 @@ class SirParameter(
     val origin: Origin? = null,
     val isVariadic: Boolean = false,
 ) {
+    init {
+        require(argumentName?.isEmpty() != true) { "argumentName must not be empty; use null to suppress the argument label" }
+    }
+
     interface Origin
 
     override fun equals(other: Any?): Boolean {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/golden_result/main/main.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/golden_result/main/main.h
@@ -11,6 +11,8 @@ int32_t org_kotlin_foo_constant_get();
 
 int32_t org_kotlin_foo_function__TypesOfArguments__Swift_Int32__(int32_t arg);
 
+_Bool org_kotlin_foo_renamedParameter__TypesOfArguments__Swift_String__(NSString * input);
+
 int32_t org_kotlin_foo_variable_get();
 
 _Bool org_kotlin_foo_variable_set__TypesOfArguments__Swift_Int32__(int32_t newValue);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/golden_result/main/main.kt
@@ -33,6 +33,13 @@ public fun org_kotlin_foo_function__TypesOfArguments__Swift_Int32__(arg: Int): I
     return _result
 }
 
+@ExportedBridge("org_kotlin_foo_renamedParameter__TypesOfArguments__Swift_String__")
+public fun org_kotlin_foo_renamedParameter__TypesOfArguments__Swift_String__(input: kotlin.native.internal.NativePtr): Boolean {
+    val __input = interpretObjCPointer<kotlin.String>(input)
+    val _result = run { org.kotlin.foo.renamedParameter(__input) }
+    return run { _result; true }
+}
+
 @ExportedBridge("org_kotlin_foo_variable_get")
 public fun org_kotlin_foo_variable_get(): Int {
     val _result = run { org.kotlin.foo.variable }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/golden_result/main/main.swift
@@ -29,6 +29,11 @@ public func getX(
 ) -> Swift.String {
     ExportedKotlinPackages.org.kotlin.foo.getX(receiver)
 }
+public func renamedParameter(
+    _ input: Swift.String
+) -> Swift.Void {
+    ExportedKotlinPackages.org.kotlin.foo.renamedParameter(input)
+}
 public func y(
     _ receiver: Swift.String
 ) -> Swift.Int32 {
@@ -77,6 +82,11 @@ extension ExportedKotlinPackages.org.kotlin.foo {
         _ receiver: Swift.Int32
     ) -> Swift.String {
         return org_kotlin_foo_x_get__TypesOfArgumentsE__Swift_Int32__(receiver)
+    }
+    public static func renamedParameter(
+        _ input: Swift.String
+    ) -> Swift.Void {
+        return { org_kotlin_foo_renamedParameter__TypesOfArguments__Swift_String__(input); return () }()
     }
     public static func y(
         _ receiver: Swift.String

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/package_flattening.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/package_flattening/package_flattening.kt
@@ -26,3 +26,6 @@ fun String.y(): Int = 5
 var variable: Int = 0
 
 val constant: Int = 0
+
+@OptIn(kotlin.experimental.ExperimentalObjCName::class)
+fun renamedParameter(@ObjCName(swiftName="_") input: String): Unit = TODO()


### PR DESCRIPTION
…attening trampolines

A parameter renamed with @ObjCName(swiftName="_") has no external Swift argument label, which Swift Export models as an empty argument name. When such a function is reached through a package-flattening trampoline, the trampoline built its delegating call as "<argumentName>: <name>". With an empty argument name this produced an invalid call expression such as `renamedParameter(: input)`, so the generated Swift did not compile.

Forward the argument positionally whenever the argument name is empty, matching how the printer renders an empty label as `_` in the declaration. Non-empty labels are unaffected.

^KT-86650 Fixed