### PR TITLE
[ObjCExport] Correctly pickup `@ObjCName` values for `enum` members in K2 impl

### DIFF
--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyName.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyName.kt
@@ -10,10 +10,13 @@ import org.jetbrains.kotlin.backend.konan.mangleIfStdMacro
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportPropertyName
 
 
-fun ObjCExportContext.getObjCPropertyName(symbol: KaVariableSymbol): ObjCExportPropertyName {
+
+fun ObjCExportContext.getObjCPropertyName(symbol: KaVariableSymbol): ObjCExportPropertyName = getObjCPropertyName(symbol) { it }
+
+fun ObjCExportContext.getObjCPropertyName(symbol: KaVariableSymbol, transform: (String) -> String): ObjCExportPropertyName {
     val resolveObjCNameAnnotation = symbol.resolveObjCNameAnnotation()
     val stringName = exportSession.overrideObjCNameOrSymbolName(symbol)
-    val propertyName = stringName.mangleIfReservedObjCName()
+    val propertyName = transform(stringName.mangleIfReservedObjCName())
 
     return ObjCExportPropertyName(
         objCName = (resolveObjCNameAnnotation?.objCName ?: propertyName).mangleIfStdMacro(),

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateEnumMembers.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateEnumMembers.kt
@@ -85,17 +85,23 @@ internal fun ObjCExportContext.getNSEnumEntryName(symbol: KaEnumEntrySymbol, for
  * See K1 implementation as [org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportNamerImpl.getEnumEntryName]
  */
 internal fun ObjCExportContext.getEnumEntryName(symbol: KaEnumEntrySymbol, forSwift: Boolean): String {
-
-    val name = getObjCPropertyName(symbol).run {
+    val name = getObjCPropertyName(symbol) {
+        it.split('_').mapIndexed { index, s ->
+            // This is the transformation block that'd run if the @ObjCName annotation was not present.
+            // If present, we'd use the user provided name as-is.
+            //
+            // FOO_BAR_BAZ -> fooBarBaz:
+            val lower = s.lowercase()
+            if (index == 0) lower else lower.replaceFirstChar(Char::uppercaseChar)
+        }.joinToString("").toIdentifier()
+    }.run {
         when {
+            // In case no @ObjCName annotation was present, both swiftName and objCName point to the resultant
+            // string from the transformation run above.
             forSwift -> this.swiftName
             else -> this.objCName
         }
-    }.split('_').mapIndexed { index, s ->
-        // FOO_BAR_BAZ -> fooBarBaz:
-        val lower = s.lowercase()
-        if (index == 0) lower else lower.replaceFirstChar(Char::uppercaseChar)
-    }.joinToString("").toIdentifier()
+    }
 
     return if (name in objCSpecialNames) name.handleSpecialNames("the")
     else if (name.isReservedPropertyName) name + "_"

--- a/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
+++ b/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
@@ -59,7 +59,6 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
     }
 
     @Test
-    @TodoAnalysisApi
     fun `test - enumClassWithObjCEnumAndRenamedLiterals`() {
         doTest(headersTestDataDir.resolve("enumClassWithObjCEnumAndRenamedLiterals"))
     }


### PR DESCRIPTION
In the K1 implementation in `ObjCExportNamerImpl.getEnumEntryName()`, the entry name is obtained as-is via `getObjCName().asIdentifier()` whose implementation is:

```kotlin
fun asIdentifier(forSwift: Boolean, default: (String) -> String = { it.toIdentifier() }): String =
        swiftName.takeIf { forSwift } ?: objCName ?: default(kotlinName)
```

The transformation op is defined by the 2nd argument to this function, which is not run on the `swiftName` and `objCName` extracted from `@ObjCName`. In the k2 implementation, however, we ended up doing that which unnecessarily transformed the annotation's value. For example, here:

```kotlin
@ObjCName("objCName1Renamed") OBJC_NAME_1_ORIGINAL,
```
`objCName1Renamed` is transformed into `objcname1renamed`. This change fixes it. I've also removed `@TodoAnalysisApi` from the corresponding tests.