### PR TITLE
Cherry-pick "Use attributeOwnerId for compose metadata" to 2.4.0

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ComposeCrossModuleTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/src/jvmTest/kotlin/androidx/compose/compiler/plugins/kotlin/ComposeCrossModuleTests.kt
@@ -1539,6 +1539,47 @@ class ComposeCrossModuleTests(useFir: Boolean) : AbstractCodegenTest(useFir) {
     }
 
     @Test
+    fun openFunctionDefaultParameterCrossModule() {
+        assumeTrue(useFir)
+        compile(
+            mapOf(
+                "Base" to mapOf(
+                    "base/Base.kt" to """
+                    package base
+
+                    import androidx.compose.runtime.Composable
+
+                    open class Test {
+                        @Composable open fun Test(int: Int = 0) = int
+                    }
+                    """
+                ),
+                "Main" to mapOf(
+                    "Main.kt" to """
+                    package main
+
+                    import base.Test
+                    import androidx.compose.runtime.Composable
+                    
+                    class TestImpl : Test() {
+                        @Composable override fun Test(int: Int) = -1
+                    }
+                    """
+                )
+            ),
+            validate = { bytecode ->
+                val matcher = Regex("public Test\\(ILandroidx/compose/runtime/Composer;I\\)I")
+                val methodCount = matcher.findAll(bytecode).count()
+                assertEquals(
+                    "Expected exactly 2 methods with that signature, one for definition, one for override",
+                    2,
+                    methodCount
+                )
+            }
+        )
+    }
+
+    @Test
     fun testStablePropertyCodegen() {
         compile(
             mapOf(

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -1652,11 +1652,15 @@ abstract class AbstractComposeLowering(
     }
 
     protected var IrDeclaration.composeMetadata: ComposeMetadata?
-        get() = context.metadataDeclarationRegistrar.getCustomMetadataExtension(this, COMPOSE_PLUGIN_ID)
-            ?.let { ComposeMetadata(it) }
+        get() {
+            val attributeOwner = attributeOwnerId as? IrDeclaration ?: return null
+            return context.metadataDeclarationRegistrar.getCustomMetadataExtension(attributeOwner, COMPOSE_PLUGIN_ID)
+                ?.let { ComposeMetadata(it) }
+        }
         set(value) {
-            if (value != null && this.hasFirDeclaration()) {
-                context.metadataDeclarationRegistrar.addCustomMetadataExtension(this, COMPOSE_PLUGIN_ID, value.data)
+            val attributeOwner = attributeOwnerId as? IrDeclaration ?: return
+            if (value != null && attributeOwner.hasFirDeclaration()) {
+                context.metadataDeclarationRegistrar.addCustomMetadataExtension(attributeOwner, COMPOSE_PLUGIN_ID, value.data)
             }
         }
 


### PR DESCRIPTION
Ensures that it is preserved when declaration is copied during internal transforms. This is not a problem on current main, but it is broken in 2.3.20-2.4.0.

Test: Added a compiler test
Bug: 520177488