### PR TITLE
[NI] Add reachability metadata generation tests for native image

### DIFF
--- a/.idea/runConfigurations/Compiler_Native_Image__Smoke_Test.xml
+++ b/.idea/runConfigurations/Compiler_Native_Image__Smoke_Test.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Compiler Native Image: Smoke Test" type="GradleRunConfiguration" factoryName="Gradle" folderName="Compiler Native Image">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":kotlin-compiler-native-image:nativeImageSmokeTest" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Generate_Reachability_Metadata__Full_.xml
+++ b/.idea/runConfigurations/Generate_Reachability_Metadata__Full_.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Generate Reachability Metadata (Full)" type="GradleRunConfiguration" factoryName="Gradle" folderName="Compiler Native Image">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":kotlin-compiler-native-image:generateReachabilityMetadataBox" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Generate_Reachability_Metadata__Smoke_.xml
+++ b/.idea/runConfigurations/Generate_Reachability_Metadata__Smoke_.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Generate Reachability Metadata (Smoke)" type="GradleRunConfiguration" factoryName="Gradle" folderName="Compiler Native Image">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":kotlin-compiler-native-image:generateReachabilityMetadataSmoke" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -493,6 +493,7 @@ tasks {
 
     testLifecycleTask("nativeImageCompilerTest") {
         dependsOn(":kotlin-compiler-native-image:nativeImageBoxTest")
+        dependsOn(":kotlin-compiler-native-image:nativeImageSmokeTest")
     }
 
     testLifecycleTask("jsCompilerTest") {

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
@@ -234,6 +234,16 @@ public class ForTestCompileRuntime {
     }
 
     @NotNull
+    public static File kotlinNativeImageResourcesPathForTests() {
+        return getFileFromProperty(KOTLIN_NATIVE_IMAGE_RESOURCES_PATH);
+    }
+
+    @NotNull
+    public static List<File> kotlinCompilerEmbeddableClasspathForTests() {
+        return getFilesFromProperty(KOTLIN_COMPILER_EMBEDDABLE_CLASSPATH);
+    }
+
+    @NotNull
     public static synchronized ClassLoader runtimeAndReflectJarClassLoader() {
         ClassLoader loader = reflectJarClassLoader.get();
         if (loader == null) {

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
@@ -25,6 +25,8 @@ object TestCompilePaths {
     const val KOTLIN_TEST_SCRIPT_DEFINITION_CLASSPATH = "kotlin.script.test.script.definition.classpath"
     const val KOTLIN_DIST_PATH = "kotlin.dist.path"
     const val KOTLIN_NATIVE_IMAGE_DIST_PATH = "kotlin.native-image.dist.path"
+    const val KOTLIN_NATIVE_IMAGE_RESOURCES_PATH = "kotlin.native-image.resources.path"
+    const val KOTLIN_COMPILER_EMBEDDABLE_CLASSPATH = "kotlin.compiler-embeddable.classpath"
     const val KOTLIN_MOCKJDK_RUNTIME_PATH = "kotlin.mockJDK.runtime.path"
     const val KOTLIN_MOCKJDKMODIFIED_RUNTIME_PATH = "kotlin.mockJDKModified.runtime.path"
     const val KOTLIN_MOCKJDK_ANNOTATIONS_PATH = "kotlin.mockJDK.annotations.path"

--- a/prepare/compiler-native-image/README.md
+++ b/prepare/compiler-native-image/README.md
@@ -47,7 +47,13 @@ dist/kotlinc-native-image/bin/kotlinc-native-image.sh path/to/Foo.kt -d out/
 
 ## Tests
 
-Run the test suite with:
+For a quick sanity check, use:
+```
+./gradlew :kotlin-compiler-native-image:nativeImageSmokeTest
+```
+It compiles a "Hello World" with the native image compiler and verifies that the compilation succeeds.
+
+For the full suite, run:
 ```
 ./gradlew :kotlin-compiler-native-image:nativeImageBoxTest
 ```
@@ -76,39 +82,18 @@ GraalVM reachability metadata is stored in [prepare/compiler-native-image/resour
 Initial metadata was collected by running the Kotlin Compiler Embeddable JAR with the [GraalVM Tracing Agent](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/)
 on the same set of compiler box tests [compiler/testData/codegen/box](../../compiler/testData/codegen/box).
 
-Metadata can be updated manually when necessary. You can use this script template:
-
-```bash
-#!/bin/bash
-
-GRAAL_HOME=$JAVA_HOME
-UPDATE_REACHABILITY_METADATA=false
-NATIVE_IMAGE_BIN=$GRAAL_HOME/bin/native-image
-
-echo '--- Building kotlin compiler dist ---'
-./gradlew -q :dist
-
-echo '--- Building kotlin compiler embeddable ---'
-./gradlew -q :kotlin-compiler-embeddable:embeddable
-
-EMBEDDABLE_JAR=$(find prepare/compiler-embeddable -name 'kotlin-compiler-embeddable-*.jar')
-STDLIB_JAR='dist/kotlinc/lib/kotlin-stdlib.jar'
-REFLECT_JAR='dist/kotlinc/lib/kotlin-reflect.jar'
-COROUTINES_JAR='dist/kotlinc/lib/kotlin-coroutines-core-jvm.jar'
-ANNOTATIONS_JAR=$(find dist/kotlinc/lib/ -name 'annotations-*.jar')
-
-CLASSPATH=$EMBEDDABLE_JAR:$STDLIB_JAR:$REFLECT_JAR:$COROUTINES_JAR:$ANNOTATIONS_JAR
-
-$GRAAL_HOME/bin/java \
-  --add-opens java.base/java.lang=ALL-UNNAMED \
-  --add-opens java.base/java.io=ALL-UNNAMED \
-  --add-opens java.base/java.nio=ALL-UNNAMED \
-  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
-  --add-opens java.desktop/javax.swing=ALL-UNNAMED \
-  -cp $CLASSPATH \
-  -Dkotlin.home=dist/kotlinc \
-  -Djava.home=$GRAAL_HOME \
-  -agentlib:native-image-agent=config-merge-dir=prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable \
-  org.jetbrains.kotlin.cli.jvm.K2JVMCompiler \
-  $@
+Metadata can be regenerated when necessary. For a quick update, use:
 ```
+./gradlew :kotlin-compiler-native-image:generateReachabilityMetadataSmoke
+```
+It will run the reachability metadata collection on the sample "Hello World" program.
+
+For a full regeneration over all the box test data, use (takes ~3&ndash;4 hours):
+```
+./gradlew :kotlin-compiler-native-image:generateReachabilityMetadataBox
+```
+
+## IDE
+
+IDE run configurations are available both for running native image tests and 
+collecting reachability metadata. You can find them in the "Compiler Native Image" run configuration folder.

--- a/prepare/compiler-native-image/build.gradle.kts
+++ b/prepare/compiler-native-image/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.kotlin.dsl.javaToolchains
 import org.gradle.kotlin.dsl.register
 import java.util.regex.Pattern.quote
 import kotlin.io.path.exists
@@ -10,7 +11,7 @@ plugins {
     kotlin("jvm")
     id("java-test-fixtures")
     id("project-tests-convention")
-    id("test-inputs-check")
+    id("test-inputs-check-v2")
 }
 
 val nativeImageClasspath by configurations.creating {
@@ -35,6 +36,11 @@ sourceSets {
     "testFixtures" { projectDefault() }
 }
 
+val graalLauncher = javaToolchains.launcherFor {
+    languageVersion.set(JavaLanguageVersion.of(JdkMajorVersion.JDK_25_0.targetName))
+    vendor.set(JvmVendorSpec.GRAAL_VM)
+}
+
 projectTests {
     testData(project(":compiler").isolated, "testData/codegen")
 
@@ -43,17 +49,39 @@ projectTests {
         generateTestsInBuildDirectory = true,
     )
 
-    testTask(
-        taskName = "nativeImageBoxTest",
-        jUnitMode = JUnitMode.JUnit5,
-        skipInLocalBuild = false,
-    ) {
+    nativeImageTestTask("nativeImageBoxTest") {
         description = "Compares native-image kotlinc against default kotlinc on " +
                 "compiler/testData/codegen/box."
-        addClasspathProperty(
-            kotlincNativeImageDist.map { layout.files(it.destinationDir) },
-            "kotlin.native-image.dist.path"
+        exclude("**/*ReachabilityMetadataTest*.class")
+        exclude("**/*SmokeTest*.class")
+        useNativeImageDist()
+    }
+
+    nativeImageTestTask("nativeImageSmokeTest") {
+        description = "Smoke test: compiles a hello-world with the native-image kotlinc " +
+                "and verifies it succeeds."
+        include("**/NativeImageSmokeTest.class")
+        useNativeImageDist()
+    }
+
+    nativeImageTestTask("generateReachabilityMetadataSmoke") {
+        description = "Quick reachability metadata regen: runs JVM kotlinc with the " +
+                "native-image-agent on the smoke test."
+        include("**/ReachabilityMetadataSmokeTest.class")
+        useReachabilityMetadataResources()
+    }
+
+    nativeImageTestTask("generateReachabilityMetadataBox") {
+        description = "Runs JVM kotlinc with reachability metadata collector agent on " +
+                "compiler/testData/codegen/box."
+        exclude("**/*BoxTest*.class")
+        exclude("**/*SmokeTest*.class")
+        // We can't run in parallel because of the tracing agent
+        systemProperty(
+            "junit.jupiter.execution.parallel.enabled",
+            "false",
         )
+        useReachabilityMetadataResources()
     }
 
     withJvmStdlibAndReflect()
@@ -79,13 +107,9 @@ val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
     val executableFile = layout.buildDirectory.file("bin/kotlinc-native-image$executableExtension")
     outputs.file(executableFile)
 
-    val javaLauncher = javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(JdkMajorVersion.JDK_25_0.targetName))
-        vendor.set(JvmVendorSpec.GRAAL_VM)
-    }
-
+    val launcher = graalLauncher
     doFirst {
-        val javaHome = javaLauncher.get().executablePath.asFile.toPath().parent.parent
+        val javaHome = launcher.get().executablePath.asFile.toPath().parent.parent
 
         val nativeImageName = if (isWindows) "native-image.exe" else "native-image"
         val nativeImageBin = javaHome.resolve("lib/svm/bin/$nativeImageName")
@@ -140,4 +164,30 @@ val kotlincNativeImageDist = tasks.register<Copy>("kotlincNativeImageDist") {
             unix("rw-r--r--")
         }
     }
+}
+
+fun ProjectTestsExtension.nativeImageTestTask(name: String, body: Test.() -> Unit): TaskProvider<out Task> =
+    testTask(taskName = name, jUnitMode = JUnitMode.JUnit5, skipInLocalBuild = false) {
+        javaLauncher.set(graalLauncher)
+        body()
+    }
+
+fun Test.useNativeImageDist() {
+    addClasspathProperty(
+        kotlincNativeImageDist.map { layout.files(it.destinationDir) },
+        "kotlin.native-image.dist.path",
+    )
+}
+
+@OptIn(KotlinCompilerDistUsage::class)
+fun Test.useReachabilityMetadataResources() {
+    withDist()
+    addClasspathProperty(
+        nativeImageClasspath,
+        "kotlin.compiler-embeddable.classpath",
+    )
+    addDirectoryProperty(
+        layout.projectDirectory.dir("resources").asFile,
+        "kotlin.native-image.resources.path",
+    )
 }

--- a/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
+++ b/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
@@ -7,7 +7,16 @@
       "type": "java.io.Serializable"
     },
     {
-      "type": "java.lang.Boolean"
+      "type": "java.lang.Boolean",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getBoolean",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
     },
     {
       "type": "java.lang.Byte"
@@ -897,6 +906,290 @@
       "type": "org.jetbrains.kotlin.psi.stubs.elements.KtFileElementType"
     },
     {
+      "type": "org.jetbrains.kotlin.resolve.BindingContext",
+      "fields": [
+        {
+          "name": "ABBREVIATED_TYPE"
+        },
+        {
+          "name": "AMBIGUOUS_LABEL_TARGET"
+        },
+        {
+          "name": "AMBIGUOUS_REFERENCE_TARGET"
+        },
+        {
+          "name": "ANNOTATION"
+        },
+        {
+          "name": "AUTO_CREATED_IT"
+        },
+        {
+          "name": "BACKING_FIELD_REQUIRED"
+        },
+        {
+          "name": "BLOCK"
+        },
+        {
+          "name": "BOUND_INITIALIZER_VALUE"
+        },
+        {
+          "name": "CALL"
+        },
+        {
+          "name": "CAPTURED_IN_CLOSURE"
+        },
+        {
+          "name": "CAST_TYPE_USED_AS_EXPECTED_TYPE"
+        },
+        {
+          "name": "CLASS"
+        },
+        {
+          "name": "COLLECTION_LITERAL_CALL"
+        },
+        {
+          "name": "COMPILER_CONFIGURATION"
+        },
+        {
+          "name": "COMPILE_TIME_VALUE"
+        },
+        {
+          "name": "COMPONENT_RESOLVED_CALL"
+        },
+        {
+          "name": "CONSTRAINT_SYSTEM_COMPLETER"
+        },
+        {
+          "name": "CONSTRUCTOR"
+        },
+        {
+          "name": "CONSTRUCTOR_RESOLVED_DELEGATION_CALL"
+        },
+        {
+          "name": "CONTRACT_NOT_ALLOWED"
+        },
+        {
+          "name": "DATAFLOW_INFO_AFTER_CONDITION"
+        },
+        {
+          "name": "DATA_CLASS_COMPONENT_FUNCTION"
+        },
+        {
+          "name": "DATA_CLASS_COPY_FUNCTION"
+        },
+        {
+          "name": "DATA_FLOW_INFO_BEFORE"
+        },
+        {
+          "name": "DECLARATIONS_TO_DESCRIPTORS"
+        },
+        {
+          "name": "DECLARATION_TO_DESCRIPTOR"
+        },
+        {
+          "name": "DEFERRED_TYPE"
+        },
+        {
+          "name": "DELEGATED_PROPERTY_CALL"
+        },
+        {
+          "name": "DELEGATED_PROPERTY_RESOLVED_CALL"
+        },
+        {
+          "name": "DELEGATE_EXPRESSION_TO_PROVIDE_DELEGATE_CALL"
+        },
+        {
+          "name": "DEPRECATED_SHORT_NAME_ACCESS"
+        },
+        {
+          "name": "DESCRIPTOR_TO_CONTEXT_RECEIVER_MAP"
+        },
+        {
+          "name": "DOUBLE_COLON_LHS"
+        },
+        {
+          "name": "EMPTY"
+        },
+        {
+          "name": "EXHAUSTIVE_WHEN"
+        },
+        {
+          "name": "EXPECTED_EXPRESSION_TYPE"
+        },
+        {
+          "name": "EXPECTED_RETURN_TYPE"
+        },
+        {
+          "name": "EXPRESSION_EFFECTS"
+        },
+        {
+          "name": "EXPRESSION_TYPE_INFO"
+        },
+        {
+          "name": "FQNAME_TO_CLASS_DESCRIPTOR"
+        },
+        {
+          "name": "FUNCTION"
+        },
+        {
+          "name": "IMPLICIT_EXHAUSTIVE_WHEN"
+        },
+        {
+          "name": "IMPLICIT_RECEIVER_SMARTCAST"
+        },
+        {
+          "name": "INDEXED_LVALUE_GET"
+        },
+        {
+          "name": "INDEXED_LVALUE_SET"
+        },
+        {
+          "name": "IS_CONTRACT_DECLARATION_BLOCK"
+        },
+        {
+          "name": "IS_DEFINITELY_NOT_ASSIGNED_IN_CONSTRUCTOR"
+        },
+        {
+          "name": "IS_UNINITIALIZED"
+        },
+        {
+          "name": "LABEL_TARGET"
+        },
+        {
+          "name": "LAMBDA_INVOCATIONS"
+        },
+        {
+          "name": "LEAKING_THIS"
+        },
+        {
+          "name": "LEXICAL_SCOPE"
+        },
+        {
+          "name": "LOOP_RANGE_HAS_NEXT_RESOLVED_CALL"
+        },
+        {
+          "name": "LOOP_RANGE_ITERATOR_RESOLVED_CALL"
+        },
+        {
+          "name": "LOOP_RANGE_NEXT_RESOLVED_CALL"
+        },
+        {
+          "name": "MARKED_EQUALIY_CALL_PROPER_IN_BUILDER_INFERENCE"
+        },
+        {
+          "name": "MUST_BE_LATEINIT"
+        },
+        {
+          "name": "NEW_INFERENCE_CATCH_EXCEPTION_PARAMETER"
+        },
+        {
+          "name": "NEW_INFERENCE_IS_LAMBDA_FOR_OVERLOAD_RESOLUTION_INLINE"
+        },
+        {
+          "name": "NEW_INFERENCE_LAMBDA_INFO"
+        },
+        {
+          "name": "ONLY_RESOLVED_CALL"
+        },
+        {
+          "name": "PACKAGE_TO_FILES"
+        },
+        {
+          "name": "PARTIAL_CALL_RESOLUTION_CONTEXT"
+        },
+        {
+          "name": "PRELIMINARY_VISITOR"
+        },
+        {
+          "name": "PRIMARY_CONSTRUCTOR_PARAMETER"
+        },
+        {
+          "name": "PRIMITIVE_NUMERIC_COMPARISON_INFO"
+        },
+        {
+          "name": "PROCESSED"
+        },
+        {
+          "name": "PROPERTY_ACCESSOR"
+        },
+        {
+          "name": "PROVIDE_DELEGATE_CALL"
+        },
+        {
+          "name": "PROVIDE_DELEGATE_RESOLVED_CALL"
+        },
+        {
+          "name": "QUALIFIER"
+        },
+        {
+          "name": "REFERENCE_TARGET"
+        },
+        {
+          "name": "RESOLVED_CALL"
+        },
+        {
+          "name": "SCRIPT"
+        },
+        {
+          "name": "SCRIPT_SCOPE"
+        },
+        {
+          "name": "SHORT_REFERENCE_TO_COMPANION_OBJECT"
+        },
+        {
+          "name": "SMARTCAST"
+        },
+        {
+          "name": "SMARTCAST_NULL"
+        },
+        {
+          "name": "SUPER_EXPRESSION_FROM_ANY_MIGRATION"
+        },
+        {
+          "name": "THIS_REFERENCE_TARGET"
+        },
+        {
+          "name": "THIS_TYPE_FOR_SUPER_EXPRESSION"
+        },
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "TYPE_ALIAS"
+        },
+        {
+          "name": "TYPE_PARAMETER"
+        },
+        {
+          "name": "UNSTABLE_SMARTCAST"
+        },
+        {
+          "name": "UNUSED_MAIN_PARAMETER"
+        },
+        {
+          "name": "USED_AS_EXPRESSION"
+        },
+        {
+          "name": "USED_AS_RESULT_OF_LAMBDA"
+        },
+        {
+          "name": "VALUE_PARAMETER"
+        },
+        {
+          "name": "VALUE_PARAMETER_AS_PROPERTY"
+        },
+        {
+          "name": "VARIABLE"
+        },
+        {
+          "name": "VARIABLE_REASSIGNMENT"
+        },
+        {
+          "name": "_static_initializer"
+        }
+      ]
+    },
+    {
       "type": "org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingCommandLineProcessor",
       "methods": [
         {
@@ -969,6 +1262,15 @@
           "parameterTypes": [
             "java.nio.ByteBuffer"
           ]
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.MD5",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },

--- a/prepare/compiler-native-image/testData/projects/smoke/Smoke.kt
+++ b/prepare/compiler-native-image/testData/projects/smoke/Smoke.kt
@@ -1,0 +1,5 @@
+package smoke
+
+fun main(args: Array<String>) {
+    System.out.print(args)
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageBoxTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageBoxTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import java.io.File
+
+abstract class AbstractNativeImageBoxTest : AbstractNativeImageCodegenTest() {
+    private val runner: NativeImageCompilerRunner by lazy { NativeImageCompilerRunner(javaHome) }
+
+    override fun runCompiler(
+        arguments: List<String>,
+        classpath: List<File>,
+    ): Pair<Int, String> = runner.run(
+        workingDir = workingDir,
+        arguments = arguments,
+        classpath = classpath,
+        jvmArgs = listOf("-Dkotlinc.test.allow.testonly.language.features=true"),
+    )
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageCodegenTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageCodegenTest.kt
@@ -36,32 +36,23 @@ import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
 
-abstract class AbstractNativeImageBlackBoxCodegenTest {
+
+abstract class AbstractNativeImageCodegenTest {
     @TempDir
     lateinit var workingDir: File
 
-    private val nativeImageDist: File by lazy { ForTestCompileRuntime.kotlinNativeImageDistForTests() }
+    protected val javaHome: String = System.getProperty("java.home")
 
-    private val nativeImageExecutable: File by lazy {
-        val launcher = when {
-            System.getProperty("os.name").startsWith("windows", ignoreCase = true) -> "kotlinc-native-image.bat"
-            else -> "kotlinc-native-image.sh"
-        }
-        nativeImageDist.resolve("bin").resolve(launcher)
-    }
-
-    private val javaHome: String = System.getProperty("java.home")
-
-    private val compilationClasspath: List<File> by lazy {
+    protected val compilationClasspath: List<File> by lazy {
         listOf(
             ForTestCompileRuntime.runtimeJarForTests(),
             ForTestCompileRuntime.kotlinTestJarForTests(),
         )
     }
 
-    private val reflectClasspath: File by lazy { ForTestCompileRuntime.reflectJarForTests() }
+    protected val reflectClasspath: File by lazy { ForTestCompileRuntime.reflectJarForTests() }
 
-    private val mockJdkRtJar: File by lazy { KtTestUtil.findMockJdkRtJar() }
+    protected val mockJdkRtJar: File by lazy { KtTestUtil.findMockJdkRtJar() }
 
     open fun runTest(filePath: String) {
         val testFile = ForTestCompileRuntime.transformTestDataPath(filePath)
@@ -77,31 +68,20 @@ abstract class AbstractNativeImageBlackBoxCodegenTest {
         val boxFile = File(workingDir, "box.kt").apply { writeText(prepareSource(source)) }
         val outDir = File(workingDir, "ni-out").apply { mkdirs() }
 
-        val [exitCode, compilerStdout] = runNativeImageCompiler(
+        val [exitCode, compilerStdout] = runCompiler(
             arguments = buildCompilerArgs(boxFile, outDir, directives, withFullJdk),
             classpath = buildClasspath(withReflect, withFullJdk),
         )
-        assertEquals(0, exitCode, "native-image compilation failed:\n$compilerStdout")
+        assertEquals(0, exitCode, "compilation failed:\n$compilerStdout")
 
         val result = invokeBox(outDir, boxClassName(source), withReflect)
         assertEquals("OK", result, "box() != 'OK'")
     }
 
-    private fun runNativeImageCompiler(
+    abstract fun runCompiler(
         arguments: List<String>,
         classpath: List<File>,
-    ): Pair<Int, String> {
-        val cmd = listOf(
-            nativeImageExecutable.absolutePath,
-            "-Dkotlinc.test.allow.testonly.language.features=true",
-            "-cp", classpath.joinToString(File.pathSeparator),
-        ) + arguments
-        val builder = ProcessBuilder(cmd).directory(workingDir).redirectErrorStream(true)
-        builder.environment().putIfAbsent("JAVA_HOME", javaHome)
-        val proc = builder.start()
-        val out = proc.inputStream.reader().use { it.readText() }
-        return proc.waitFor() to out
-    }
+    ): Pair<Int, String>
 
     private fun buildCompilerArgs(
         boxFile: File,

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageReachabilityMetadataTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageReachabilityMetadataTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import java.io.File
+
+abstract class AbstractNativeImageReachabilityMetadataTest : AbstractNativeImageCodegenTest() {
+    private val runner: ReachabilityMetadataGeneratingCompilerRunner by lazy { ReachabilityMetadataGeneratingCompilerRunner(javaHome) }
+
+    override fun runCompiler(
+        arguments: List<String>,
+        classpath: List<File>,
+    ): Pair<Int, String> = runner.run(
+        workingDir = workingDir,
+        arguments = arguments,
+        classpath = classpath,
+        jvmArgs = listOf("-Dkotlinc.test.allow.testonly.language.features=true"),
+    )
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/GenerateNativeImageTests.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/GenerateNativeImageTests.kt
@@ -12,7 +12,10 @@ fun main(args: Array<String>) {
 
     generateTestGroupSuiteWithJUnit5(args) {
         testGroup(testsRoot = args[0], testDataRoot = "compiler/testData/codegen") {
-            testClass<AbstractNativeImageBlackBoxCodegenTest> {
+            testClass<AbstractNativeImageBoxTest> {
+                model("box")
+            }
+            testClass<AbstractNativeImageReachabilityMetadataTest> {
                 model("box")
             }
         }

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImageCompilerRunner.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImageCompilerRunner.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import java.io.File
+
+class NativeImageCompilerRunner(private val javaHome: String) {
+    private val nativeImageDist: File by lazy { ForTestCompileRuntime.kotlinNativeImageDistForTests() }
+
+    private val executable: File by lazy {
+        val launcher = when {
+            System.getProperty("os.name").startsWith("windows", ignoreCase = true) -> "kotlinc-native-image.bat"
+            else -> "kotlinc-native-image.sh"
+        }
+        nativeImageDist.resolve("bin").resolve(launcher)
+    }
+
+    fun run(
+        workingDir: File,
+        arguments: List<String>,
+        classpath: List<File>,
+        jvmArgs: List<String> = emptyList(),
+    ): Pair<Int, String> {
+        val cmd = buildList {
+            add(executable.absolutePath)
+            addAll(jvmArgs)
+            if (classpath.isNotEmpty()) {
+                add("-cp")
+                add(classpath.joinToString(File.pathSeparator))
+            }
+            addAll(arguments)
+        }
+        val process = ProcessBuilder(cmd)
+            .directory(workingDir)
+            .redirectErrorStream(true)
+            .also { it.environment().putIfAbsent("JAVA_HOME", javaHome) }
+            .start()
+        val out = process.inputStream.reader().use { it.readText() }
+        return process.waitFor() to out
+    }
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/ReachabilityMetadataGeneratingCompilerRunner.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/ReachabilityMetadataGeneratingCompilerRunner.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import java.io.File
+
+class ReachabilityMetadataGeneratingCompilerRunner(private val javaHome: String) {
+    private val javaExecutable: String by lazy {
+        val binName = if (System.getProperty("os.name").startsWith("windows", ignoreCase = true)) "java.exe" else "java"
+        File(javaHome, "bin").resolve(binName).absolutePath
+    }
+
+    private val embeddableClasspath: List<File> = ForTestCompileRuntime.kotlinCompilerEmbeddableClasspathForTests()
+
+    private val kotlinHome: File = ForTestCompileRuntime.distKotlincForTests()
+
+    private val reachabilityMetadataPath: String = ForTestCompileRuntime.kotlinNativeImageResourcesPathForTests()
+        .resolve("META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable")
+        .absolutePath
+
+    fun run(
+        workingDir: File,
+        arguments: List<String>,
+        classpath: List<File>,
+        jvmArgs: List<String> = emptyList(),
+    ): Pair<Int, String> {
+        val cmd = buildList {
+            add(javaExecutable)
+            add("--add-opens"); add("java.base/java.lang=ALL-UNNAMED")
+            add("--add-opens"); add("java.base/java.io=ALL-UNNAMED")
+            add("--add-opens"); add("java.base/java.nio=ALL-UNNAMED")
+            add("--add-opens"); add("java.base/sun.nio.ch=ALL-UNNAMED")
+            add("--add-opens"); add("java.desktop/javax.swing=ALL-UNNAMED")
+            add("-agentlib:native-image-agent=config-merge-dir=$reachabilityMetadataPath")
+            add("-Djava.home=$javaHome")
+            add("-Dkotlin.home=${kotlinHome.absolutePath}")
+            // We simulate how the native image compiler runs, so we set this flag
+            // Otherwise reachability metadata will contain plugins info which is not necessary
+            add("-Dorg.graalvm.nativeimage.runtime=true")
+            addAll(jvmArgs)
+            add("-cp"); add(embeddableClasspath.joinToString(File.pathSeparator) { it.absolutePath })
+            add("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+            if (classpath.isNotEmpty()) {
+                add("-cp")
+                add(classpath.joinToString(File.pathSeparator))
+            }
+            addAll(arguments)
+        }
+        val process = ProcessBuilder(cmd)
+            .directory(workingDir)
+            .redirectErrorStream(true)
+            .start()
+        val out = process.inputStream.reader().use { it.readText() }
+        return process.waitFor() to out
+    }
+}

--- a/prepare/compiler-native-image/tests/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImageSmokeTest.kt
+++ b/prepare/compiler-native-image/tests/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImageSmokeTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class NativeImageSmokeTest {
+    @TempDir
+    lateinit var workingDir: File
+
+    private val runner = NativeImageCompilerRunner(System.getProperty("java.home"))
+
+    @Test
+    fun testSmoke() {
+        val source = File("testData/projects/smoke/Smoke.kt").absoluteFile
+        val outDir = File(workingDir, "out").apply { mkdirs() }
+
+        val [exitCode, output] = runner.run(
+            workingDir = workingDir,
+            arguments = listOf(source.absolutePath, "-d", outDir.absolutePath),
+            classpath = emptyList(),
+        )
+
+        assertEquals(0, exitCode, "compilation failed:\n$output")
+    }
+}

--- a/prepare/compiler-native-image/tests/kotlin/org/jetbrains/kotlin/compiler/nativeimage/ReachabilityMetadataSmokeTest.kt
+++ b/prepare/compiler-native-image/tests/kotlin/org/jetbrains/kotlin/compiler/nativeimage/ReachabilityMetadataSmokeTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ReachabilityMetadataSmokeTest {
+    @TempDir
+    lateinit var workingDir: File
+
+    private val runner = ReachabilityMetadataGeneratingCompilerRunner(System.getProperty("java.home"))
+
+    @Test
+    fun testRegenerateReachabilityMetadata() {
+        val source = File("testData/projects/smoke/Smoke.kt").absoluteFile
+        val outDir = File(workingDir, "out").apply { mkdirs() }
+
+        val [exitCode, output] = runner.run(
+            workingDir = workingDir,
+            arguments = listOf(source.absolutePath, "-d", outDir.absolutePath),
+            classpath = emptyList(),
+        )
+
+        assertEquals(0, exitCode, "compilation failed:\n$output")
+    }
+}


### PR DESCRIPTION
* Add tests for generating reachability metadata (smoke + full)
* Add smoke tests for the native image
* Update Readme
* Add IDE run configurations

^KT-86670 Fixed