### PR TITLE
[PowerAssert] Prefer overloads which take a lambda message parameter

### DIFF
--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/PowerAssertCallTransformer.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/PowerAssertCallTransformer.kt
@@ -27,7 +27,10 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.jvm.ir.parentClassId
-import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
@@ -58,6 +61,20 @@ class PowerAssertCallTransformer(
     private val factory: PowerAssertFunctionFactory?,
     private val explanationFactory: ExplanationFactory?
 ) : IrElementTransformerVoidWithContext() {
+    companion object {
+        private val CALL_BUILDER_COMPARATOR = compareBy<CallBuilder> { builder ->
+            // First, prefer builders with a lambda-like message parameter.
+            when (builder) {
+                is LambdaCallBuilder -> 1
+                is SamConversionLambdaCallBuilder -> 2
+                is SimpleCallBuilder -> 3
+            }
+        }.thenByDescending { builder ->
+            // Second, prefer builders with more regular parameters.
+            builder.targetFunction.parameters.count { it.kind == IrParameterKind.Regular }
+        }
+    }
+
     private val irTypeSystemContext = IrTypeSystemContextImpl(context.irBuiltIns)
 
     override fun visitCall(expression: IrCall): IrExpression {
@@ -109,11 +126,8 @@ class PowerAssertCallTransformer(
 
     private fun buildForOverride(originalCall: IrCall, function: IrSimpleFunction): IrExpression {
         // Find a valid delegate function or do not translate
-        // TODO better way to determine which delegate to actually use
         val callBuilders = findCallBuilders(function, originalCall)
-        val callBuilder = callBuilders.maxByOrNull { builder ->
-            builder.targetFunction.parameters.count { it.kind == IrParameterKind.Regular }
-        }
+        val callBuilder = callBuilders.firstOrNull()
 
         if (callBuilder == null) {
             val regularParameters = function.parameters.filter { it.kind == IrParameterKind.Regular }
@@ -211,6 +225,10 @@ class PowerAssertCallTransformer(
         return recursive(0, persistentListOf(), persistentMapOf())
     }
 
+    /**
+     * Available [CallBuilder]s which can consume a diagram argument from the call site.
+     * CallBuilders are sorted from most preferred to least.
+     */
     private fun findCallBuilders(function: IrFunction, original: IrCall): List<CallBuilder> {
         val values = function.parameters
         if (values.isEmpty()) return emptyList()
@@ -227,7 +245,7 @@ class PowerAssertCallTransformer(
         val possible = (finder.findFunctions(function.callableId) + parentClassFunctions)
             .distinct()
 
-        return possible.mapNotNull { overload ->
+        val builders = possible.mapNotNull { overload ->
             // Type parameters must be compatible.
             if (function.typeParameters.size != overload.owner.typeParameters.size) {
                 return@mapNotNull null
@@ -273,6 +291,8 @@ class PowerAssertCallTransformer(
                 else -> null
             }
         }
+
+        return builders.sortedWith(CALL_BUILDER_COMPARATOR)
     }
 
     private fun isStringFunction(type: IrType): Boolean =

--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/builder/call/CallBuilder.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/builder/call/CallBuilder.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.utils.addToStdlib.assignFrom
 
-interface CallBuilder {
+sealed interface CallBuilder {
     val targetFunction: IrFunction
 
     fun buildCall(

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/junit5/JunitAssertTrue.kt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/junit5/JunitAssertTrue.kt
@@ -1,5 +1,6 @@
 // FUNCTION: org.junit.jupiter.api.Assertions.assertTrue
 // WITH_JUNIT5
+// DUMP_KT_IR
 
 import org.junit.jupiter.api.Assertions.assertTrue
 

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/junit5/JunitAssertTrue.kt.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/junit5/JunitAssertTrue.kt.txt
@@ -1,0 +1,15 @@
+fun box(): String {
+  return expectThrowableMessage(block = local fun <anonymous>() {
+    { // BLOCK
+      val tmp0_Explain: Int = 1
+      val tmp1_Explain: Int = 1
+      val tmp2_Explain: Boolean = EQEQ(arg0 = tmp0_Explain, arg1 = tmp1_Explain).not()
+      assertTrue(condition = tmp2_Explain, messageSupplier = local fun <anonymous>(): String {
+        return "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 176, source = "    assertTrue(1 != 1)", arguments = listOf<Argument>(elements = [Argument(startOffset = 15, endOffset = 21, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 15, endOffset = 16, displayOffset = 15, value = tmp0_Explain), LiteralExpression(startOffset = 20, endOffset = 21, displayOffset = 20, value = tmp1_Explain), ValueExpression(startOffset = 15, endOffset = 21, displayOffset = 17, value = tmp2_Explain)]))])) */)
+      }
+ /*-> @FlexibleNullability Supplier<@FlexibleNullability String?>? */)
+    }
+  }
+)
+}
+


### PR DESCRIPTION
When there are multiple overloads for power-assert to choose from, there should be a preference towards lambda-like message parameters. Since diagram construction could be expensive, this offers the smallest performance impact at runtime if the message is not needed.

^KT-86773 Fixed