### PR TITLE
Fix missing 'package' linkage in XCSwiftPackageProductDependency

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportXcodeIntegrationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportXcodeIntegrationIT.kt
@@ -76,6 +76,11 @@ class SwiftPMImportXcodeIntegrationIT : KGPBaseTest() {
                     "productName = $SYNTHETIC_IMPORT_TARGET_MAGIC_NAME;",
                     message = "Swift package dependency should reference the synthetic product name"
                 )
+                assertContains(
+                    pbxFileContent,
+                    Regex("""\bpackage = [A-F0-9]+;"""),
+                    message = "Swift package dependency should declare a 'package = <UUID>;' linkage"
+                )
 
                 assertEquals(
                     SwiftPackageLibraryType.AUTOMATIC,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeIntegrations.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeIntegrations.kt
@@ -222,7 +222,10 @@ internal abstract class IntegrateLinkagePackageIntoXcodeProject : DefaultTask() 
 
         project.objects[buildFileDependencyReference] = PbxBuildFile(productRef = productDependencyReference)
         project.objects[localPackageReference] = XCLocalSwiftPackageReference(relativePath = GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME)
-        project.objects[productDependencyReference] = XCSwiftPackageProductDependency(productName = GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME)
+        project.objects[productDependencyReference] = XCSwiftPackageProductDependency(
+            productName = GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME,
+            packageReference = localPackageReference,
+        )
 
         saveJsonBackIntoPbxproj(
             execOps,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeProjectParsing.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeProjectParsing.kt
@@ -188,6 +188,8 @@ internal class PbxShellScriptBuildPhase(
 internal class XCSwiftPackageProductDependency(
     val isa: String = "XCSwiftPackageProductDependency",
     val productName: String?,
+    @SerialName("package")
+    val packageReference: String?,
 ) : PbxObject()
 
 @Serializable


### PR DESCRIPTION
KT-83882: `integrateLinkagePackage` emits `XCSwiftPackageProductDependency`
without the `package = <UUID>` back-reference to its
`XCLocalSwiftPackageReference`, so Xcode reports
`Missing package product 'KotlinMultiplatformLinkedPackage'`. The data class
did not model the `package` field, so the integration site could only set
`productName`.

Fix:
- Add `packageReference` (mapped to JSON key `package` via `@SerialName`) to
  `XCSwiftPackageProductDependency`.
- Pass `packageReference = localPackageReference` in
  `IntegrateLinkagePackageIntoXcodeProject.integrate()`.

Minimal repro: <https://github.com/error96num/spm-import-kt-83882-repro>.

Test: extended `integrateLinkagePackage task creates synthetic package` in
`SwiftPMImportXcodeIntegrationIT` with one assertion catching the missing
linkage (red on master, green with patch).

Note: existing projects with a buggy pbxproj won't self-heal on re-run
(see KT-83876).

^KT-83882 Fixed
