### PR TITLE
[K/JS] Fix dropping default params inside of exported static suspend functions

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/JsDefaultParameterInjector.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/JsDefaultParameterInjector.kt
@@ -48,7 +48,7 @@ class JsDefaultParameterInjector(context: JsIrBackendContext) :
             origin == JsLoweredDeclarationOrigin.JS_SHADOWED_EXPORT &&
                     !isTopLevel &&
                     functionAccess.origin != JsStatementOrigins.IMPLEMENTATION_DELEGATION_CALL &&
-                    (promisifiedWrapperFunction ?: this).isExported(context)
+                    (promisifiedWrapperFunction != null || isExported(context))
         }
     }
 

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/PrepareSuspendFunctionsForExportLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/PrepareSuspendFunctionsForExportLowering.kt
@@ -210,7 +210,10 @@ internal class PrepareSuspendFunctionsForExportLowering(private val context: JsI
             declaration.isTopLevel || declaration.isStatic || isExportedJsStaticWithIgnoredCompanion -> runIf(
                 isExportedJsStaticWithIgnoredCompanion || declaration.isExported(context)
             ) {
-                listOf(generatePromisifiedWrapper(declaration), declaration)
+                val promisifiedWrapperFunction = generatePromisifiedWrapper(declaration)
+                    .also { declaration.promisifiedWrapperFunction = it }
+
+                listOf(promisifiedWrapperFunction, declaration)
             }
             else -> {
                 val originallyExportedSuspendMemberFunction = declaration.originallyExportedMember ?: return null

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/handlers/JsDtsHandler.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/handlers/JsDtsHandler.kt
@@ -27,10 +27,17 @@ class JsDtsHandler(testServices: TestServices, private val expectedDtsSuffix: St
         val mainModule = JsEnvironmentConfigurator.getMainModule(testServices)
 
         val translationModes = when (globalDirectives[JsEnvironmentConfigurationDirectives.TS_COMPILATION_STRATEGY].lastOrNull()) {
-            TsCompilationStrategy.MERGED -> listOf(TranslationMode.FULL_DEV)
+            TsCompilationStrategy.MERGED -> listOf(
+                when {
+                    JsEnvironmentConfigurationDirectives.SPLIT_PER_MODULE in globalDirectives -> TranslationMode.PER_MODULE_DEV
+                    else -> TranslationMode.FULL_DEV
+                }
+            )
+
             TsCompilationStrategy.EACH_FILE -> JsEnvironmentConfigurator
                 .getTranslationModesForTest(testServices, mainModule)
                 .filter { !it.production }
+
             TsCompilationStrategy.NONE, null -> return
         }
 

--- a/js/js.translator/testData/typescript-export/js/js_static/js_static-lib_v5.aa.d.mts
+++ b/js/js.translator/testData/typescript-export/js/js_static/js_static-lib_v5.aa.d.mts
@@ -4,6 +4,7 @@ export declare class WithIgnoredCompanion {
     constructor();
     static bar(): string;
     static staticSuspend(): Promise<string>;
+    static staticSuspendWithDefault(value?: string): Promise<string>;
     static get foo(): string;
     static get baz(): string;
     static get mutable(): string;
@@ -19,6 +20,7 @@ export declare class WithoutIgnoredCompanion {
     constructor();
     static bar(): string;
     static staticSuspend(): Promise<string>;
+    static staticSuspendWithDefault(value?: string): Promise<string>;
     static get foo(): string;
     static get baz(): string;
     static get mutable(): string;
@@ -38,6 +40,7 @@ export declare namespace WithoutIgnoredCompanion {
             abstract class constructor {
                 hidden(): string;
                 companionSuspend(): Promise<string>;
+                companionSuspendWithDefault(value?: string): Promise<string>;
                 get delegated(): string;
                 private constructor();
             }
@@ -49,6 +52,7 @@ export declare abstract class ObjectWithJsStatic {
     private constructor();
     static bar(): string;
     static staticSuspend(): Promise<string>;
+    static staticSuspendWithDefault(value?: string): Promise<string>;
     static get foo(): string;
     static get baz(): string;
     static get mutable(): string;
@@ -63,6 +67,7 @@ export declare namespace ObjectWithJsStatic {
         abstract class constructor {
             hidden(): string;
             companionSuspend(): Promise<string>;
+            companionSuspendWithDefault(value?: string): Promise<string>;
             get delegated(): string;
             private constructor();
         }

--- a/js/js.translator/testData/typescript-export/js/js_static/js_static-lib_v5.d.mts
+++ b/js/js.translator/testData/typescript-export/js/js_static/js_static-lib_v5.d.mts
@@ -8,6 +8,7 @@ export declare class WithIgnoredCompanion {
     static get mutable(): string;
     static set mutable(value: string);
     static staticSuspend(): Promise<string>;
+    static staticSuspendWithDefault(value?: string): Promise<string>;
 }
 export declare namespace WithIgnoredCompanion {
     /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
@@ -23,6 +24,7 @@ export declare class WithoutIgnoredCompanion {
     static get mutable(): string;
     static set mutable(value: string);
     static staticSuspend(): Promise<string>;
+    static staticSuspendWithDefault(value?: string): Promise<string>;
 }
 export declare namespace WithoutIgnoredCompanion {
     /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
@@ -39,6 +41,7 @@ export declare namespace WithoutIgnoredCompanion {
                 hidden(): string;
                 get delegated(): string;
                 companionSuspend(): Promise<string>;
+                companionSuspendWithDefault(value?: string): Promise<string>;
                 private constructor();
             }
         }
@@ -53,6 +56,7 @@ export declare abstract class ObjectWithJsStatic {
     static get mutable(): string;
     static set mutable(value: string);
     static staticSuspend(): Promise<string>;
+    static staticSuspendWithDefault(value?: string): Promise<string>;
 }
 export declare namespace ObjectWithJsStatic {
     /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
@@ -64,6 +68,7 @@ export declare namespace ObjectWithJsStatic {
             hidden(): string;
             get delegated(): string;
             companionSuspend(): Promise<string>;
+            companionSuspendWithDefault(value?: string): Promise<string>;
             private constructor();
         }
     }

--- a/js/js.translator/testData/typescript-export/js/js_static/js_static.kt
+++ b/js/js.translator/testData/typescript-export/js/js_static/js_static.kt
@@ -35,6 +35,12 @@ class WithIgnoredCompanion {
         suspend fun staticSuspend(): String = "STATIC SUSPEND"
 
         suspend fun companionSuspend(): String = "SUSPEND"
+
+        // KT-85990
+        @JsStatic
+        suspend fun staticSuspendWithDefault(value: String = "DEFAULT STATIC SUSPEND"): String = value
+
+        suspend fun companionSuspendWithDefault(value: String = "DEFAULT COMPANION SUSPEND"): String = value
     }
 }
 
@@ -62,6 +68,12 @@ class WithoutIgnoredCompanion {
         suspend fun staticSuspend(): String = "STATIC SUSPEND"
 
         suspend fun companionSuspend(): String = "SUSPEND"
+
+        // KT-85990
+        @JsStatic
+        suspend fun staticSuspendWithDefault(value: String = "DEFAULT STATIC SUSPEND"): String = value
+
+        suspend fun companionSuspendWithDefault(value: String = "DEFAULT COMPANION SUSPEND"): String = value
     }
 }
 
@@ -88,4 +100,10 @@ object ObjectWithJsStatic {
     suspend fun staticSuspend(): String = "STATIC SUSPEND"
 
     suspend fun companionSuspend(): String = "SUSPEND"
+
+    // KT-85990
+    @JsStatic
+    suspend fun staticSuspendWithDefault(value: String = "DEFAULT STATIC SUSPEND"): String = value
+
+    suspend fun companionSuspendWithDefault(value: String = "DEFAULT COMPANION SUSPEND"): String = value
 }

--- a/js/js.translator/testData/typescript-export/js/js_static/js_static__main.mts
+++ b/js/js.translator/testData/typescript-export/js/js_static/js_static__main.mts
@@ -14,6 +14,8 @@ export async function box(): Promise<string> {
     WithIgnoredCompanion.mutable = "CHANGED"
     assert(WithIgnoredCompanion.mutable === "CHANGED")
     assert(await WithIgnoredCompanion.staticSuspend() === "STATIC SUSPEND")
+    assert(await WithIgnoredCompanion.staticSuspendWithDefault() === "DEFAULT STATIC SUSPEND")
+    assert(await WithIgnoredCompanion.staticSuspendWithDefault("PROVIDED VALUE") === "PROVIDED VALUE")
 
     assert(WithoutIgnoredCompanion.bar() === "BARRRR");
     assert(WithoutIgnoredCompanion.foo === "FOOOO");
@@ -22,10 +24,14 @@ export async function box(): Promise<string> {
     WithoutIgnoredCompanion.mutable = "CHANGED"
     assert(WithoutIgnoredCompanion.mutable === "CHANGED")
     assert(await WithoutIgnoredCompanion.staticSuspend() === "STATIC SUSPEND")
+    assert(await WithoutIgnoredCompanion.staticSuspendWithDefault() === "DEFAULT STATIC SUSPEND")
+    assert(await WithoutIgnoredCompanion.staticSuspendWithDefault("PROVIDED VALUE") === "PROVIDED VALUE")
 
     assert(WithoutIgnoredCompanion.Companion.hidden() === "BARRRR");
     assert(WithoutIgnoredCompanion.Companion.delegated === "BAZZZZ");
     assert(await WithoutIgnoredCompanion.Companion.companionSuspend() === "SUSPEND")
+    assert(await WithoutIgnoredCompanion.Companion.companionSuspendWithDefault() === "DEFAULT COMPANION SUSPEND")
+    assert(await WithoutIgnoredCompanion.Companion.companionSuspendWithDefault("PROVIDED VALUE") === "PROVIDED VALUE")
 
     assert(ObjectWithJsStatic.bar() === "BARRRR");
     assert(ObjectWithJsStatic.foo === "FOOOO");
@@ -34,10 +40,14 @@ export async function box(): Promise<string> {
     ObjectWithJsStatic.mutable = "CHANGED"
     assert(ObjectWithJsStatic.mutable === "CHANGED")
     assert(await ObjectWithJsStatic.staticSuspend() === "STATIC SUSPEND")
+    assert(await ObjectWithJsStatic.staticSuspendWithDefault() === "DEFAULT STATIC SUSPEND")
+    assert(await ObjectWithJsStatic.staticSuspendWithDefault("PROVIDED VALUE") === "PROVIDED VALUE")
 
     assert(ObjectWithJsStatic.getInstance().hidden() === "BARRRR");
     assert(ObjectWithJsStatic.getInstance().delegated === "BAZZZZ");
     assert(await ObjectWithJsStatic.getInstance().companionSuspend() === "SUSPEND")
+    assert(await ObjectWithJsStatic.getInstance().companionSuspendWithDefault() === "DEFAULT COMPANION SUSPEND")
+    assert(await ObjectWithJsStatic.getInstance().companionSuspendWithDefault("PROVIDED VALUE") === "PROVIDED VALUE")
 
     return "OK";
 }


### PR DESCRIPTION
[K/JS] Fix dropping default params inside of exported static suspend functions

Before those changes, for the following suspend functions, we haven't replaced the call sides inside the `promisified` wrapper with the default method bridge (see `JsDefaultArgumentStubGenerator`):

```kotlin
@JsExport
class Foo {
  companion object {
     @JsStatic
     suspend fun foo(x: String = "default") = ...  
  }

  // OR with the companion blocks
  companion {
     suspend fun foo(x: String = "default") = ...  
  }
}
```



As a result, when users call such functions on the TypeScript side without arguments, like this:

```typescript
await Foo.foo()
``` 

Instead of receiving a default value for the argument `x`, it will just continue function execution with `undefined` as the value for' x'.

There were 2 root causes of this problem:

1. For top-level and static functions, the `promisifiedWrapperFunction` attribute was not set (as a result, the incorrect handling on the `JsDefaultParameterInjector` lowering side)
2. Even if it's set, with the following pattern (it's used to hide the `companion` object from the JavaScript side and keep only statics):
```kotlin
@JsExport
class Foo {
  @JsExport.Ignore
  companion object {
     @JsStatic
     suspend fun foo(x: String = "default") = ...  
  }
}
```

We still mishandle it because the `promisifiedWrapperFunction` is ignored, as is its companion. So, to fix it, we should just check if it exists.

Fixes KT-85990