### PR TITLE
Missing link options in windows.def

### DIFF
--- a/kotlin-native/platformLibs/src/platform/mingw/windows.def
+++ b/kotlin-native/platformLibs/src/platform/mingw/windows.def
@@ -3,6 +3,6 @@ headers = wtypes.h minwindef.h windows.h commctrl.h dwmapi.h shlobj.h shlwapi.h 
     urlmon.h usp10.h uxtheme.h vfw.h wininet.h winsock2.h ws2tcpip.h ws2def.h
 compilerOpts = -DUNICODE -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DWINAPI_FAMILY=3 -DOEMRESOURCE \
     -Wno-incompatible-pointer-types -Wno-deprecated-declarations
-linkerOpts = -lcomctl32 -lcrypt32 -lshlwapi -lshell32 -limm32 -lusp10 -lwininet -lgdi32 -luser32 -lkernel32 -lbcrypt -luuid -ldwmapi
+linkerOpts = -lcomctl32 -lcrypt32 -lshlwapi -lshell32 -limm32 -lusp10 -lwininet -lgdi32 -luser32 -lkernel32 -lncrypt -lbcrypt -luuid -ldwmapi
 noStringConversion = LoadCursorA LoadBitmapA LoadIconA LoadImageA LoadCursorW LoadBitmapW LoadIconW LoadImageW
 depends = posix


### PR DESCRIPTION
Without this option you cannot properly utilize NCrypt API.

'ncrypt.h' in already included somewhere deep in the 'windows.h' - no problem. But to actually use it you gotta link ncrypt lib.