### PR TITLE
[IR] Visit `reflectionTargetSymbol` in `IrTreeSymbolVisitor`

### DIFF
--- a/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/util/IrTreeSymbolsVisitor.kt
+++ b/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/util/IrTreeSymbolsVisitor.kt
@@ -274,24 +274,24 @@ abstract class IrTreeSymbolsVisitor : IrTypeVisitorVoid(), SymbolVisitor {
     }
 
     override fun visitFunctionReference(expression: IrFunctionReference) {
-        expression.reflectionTarget?.let { visitReferencedFunction(expression, it) }
         visitReferencedFunction(expression, expression.symbol)
+        expression.reflectionTarget?.let { visitReferencedFunction(expression, it) }
         visitCallableReference(expression)
     }
 
     override fun visitPropertyReference(expression: IrPropertyReference) {
+        visitReferencedProperty(expression, expression.symbol)
         expression.field?.let { visitReferencedField(expression, it) }
         expression.getter?.let { visitReferencedSimpleFunction(expression, it) }
         expression.setter?.let { visitReferencedSimpleFunction(expression, it) }
-        visitReferencedProperty(expression, expression.symbol)
         visitCallableReference(expression)
     }
 
     override fun visitLocalDelegatedPropertyReference(expression: IrLocalDelegatedPropertyReference) {
+        visitReferencedLocalDelegatedProperty(expression, expression.symbol)
         visitReferencedVariable(expression, expression.delegate)
         visitReferencedSimpleFunction(expression, expression.getter)
         expression.setter?.let { visitReferencedSimpleFunction(expression, it) }
-        visitReferencedLocalDelegatedProperty(expression, expression.symbol)
         visitCallableReference(expression)
     }
 
@@ -300,11 +300,13 @@ abstract class IrTreeSymbolsVisitor : IrTypeVisitorVoid(), SymbolVisitor {
     }
 
     override fun visitRichFunctionReference(expression: IrRichFunctionReference) {
+        expression.reflectionTargetSymbol?.let { visitReferencedFunction(expression, it) }
         visitReferencedSimpleFunction(expression, expression.overriddenFunctionSymbol)
         visitRichCallableReference(expression)
     }
 
     override fun visitRichPropertyReference(expression: IrRichPropertyReference) {
+        expression.reflectionTargetSymbol?.let { visitReferencedDeclarationWithAccessors(expression, it) }
         visitRichCallableReference(expression)
     }
 
@@ -371,10 +373,14 @@ abstract class IrTreeSymbolsVisitor : IrTypeVisitorVoid(), SymbolVisitor {
     }
 
     override fun visitGetField(expression: IrGetField) {
+        visitReferencedField(expression, expression.symbol)
+        expression.superQualifierSymbol?.let { visitReferencedClass(expression, it) }
         visitFieldAccess(expression)
     }
 
     override fun visitSetField(expression: IrSetField) {
+        visitReferencedField(expression, expression.symbol)
+        expression.superQualifierSymbol?.let { visitReferencedClass(expression, it) }
         visitFieldAccess(expression)
     }
 
@@ -442,10 +448,12 @@ abstract class IrTreeSymbolsVisitor : IrTypeVisitorVoid(), SymbolVisitor {
     }
 
     override fun visitGetValue(expression: IrGetValue) {
+        visitReferencedValue(expression, expression.symbol)
         visitValueAccess(expression)
     }
 
     override fun visitSetValue(expression: IrSetValue) {
+        visitReferencedValue(expression, expression.symbol)
         visitValueAccess(expression)
     }
 

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/IrTreeSymbolsVisitorPrinter.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/IrTreeSymbolsVisitorPrinter.kt
@@ -67,7 +67,7 @@ internal class IrTreeSymbolsVisitorPrinter(
         transformTypes: Boolean,
     ): Unit = with(printer) {
         if (element.implementations.isNotEmpty()) {
-            val fieldsWithSymbol = element.fields.filter {
+            val fieldsWithSymbol = element.allFields.filter {
                 if (element == IrTree.annotation) { // TODO KT-55928 Drop this hack when `symbol` is removed from IrAnnotation
                     return@filter it.symbolClass != null && it.name != "symbol"
                 }
@@ -75,7 +75,6 @@ internal class IrTreeSymbolsVisitorPrinter(
             }
             fieldsWithSymbol.forEach { visitField(element, it) }
         }
-        visitAdditionalFields(element)
         super.printTypeRemappingsOverridable(printer, element, irTypeFields, hasDataParameter, transformTypes)
     }
 
@@ -89,14 +88,6 @@ internal class IrTreeSymbolsVisitorPrinter(
             visitSymbolValue(field, element, element.visitorParameterName, ".", field.name)
         }
         println()
-    }
-
-    private fun ImportCollectingPrinter.visitAdditionalFields(element: Element) {
-        when (element) {
-            functionReference -> println("visitReferencedFunction(expression, expression.symbol)")
-            propertyReference -> println("visitReferencedProperty(expression, expression.symbol)")
-            localDelegatedPropertyReference -> println("visitReferencedLocalDelegatedProperty(expression, expression.symbol)")
-        }
     }
 
     private fun ImportCollectingPrinter.visitSymbolValue(field: Field, element: Element, vararg valueArgs: Any?) {


### PR DESCRIPTION
Is there any reason why these symbols are not visited or are we just missing them?