### PR TITLE
[K/N] Port kotlin-tsan to C++

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
@@ -370,9 +370,17 @@ class LTOOptimizationPipeline(config: LlvmPipelineConfig, performanceManager: Pe
 class ThreadSanitizerPipeline(config: LlvmPipelineConfig, performanceManager: PerformanceManager?, logger: LoggingContext? = null) :
         LlvmOptimizationPipeline(config, performanceManager, logger) {
     override val pipelineName = "llvm-tsan"
-    override val passes = listOf("tsan-module,function(tsan)")
+    override val passes = buildList {
+        if (!config.runLLVMPassesInCompiler) {
+            add("function(kotlin-tsan)")
+        }
+        add("tsan-module")
+        add("function(tsan)")
+    }
 
     override fun executeCustomPreprocessing(config: LlvmPipelineConfig, module: LLVMModuleRef) {
+        if (!config.runLLVMPassesInCompiler)
+            return
         getFunctions(module)
                 .filter { LLVMIsDeclaration(it) == 0 }
                 .forEach { addLlvmFunctionEnumAttribute(it, LlvmFunctionAttribute.SanitizeThread) }

--- a/kotlin-native/libllvmext/README.md
+++ b/kotlin-native/libllvmext/README.md
@@ -30,3 +30,6 @@ Custom LLVM passes live in the [Passes](src/main/cpp/Passes) directory:
 - `HideSymbolsPass` (`kotlin-hide-symbols`): similar to `internalize` but makes symbols hidden instead
   of internal; the symbols remain visible during compilation, but are hidden by the linker in
   the final binary.
+- `PrepareThreadSanitizerPass` (`kotlin-tsan`): function pass, that applies `sanitize_thread` attribute
+  to all defined functions; can't simply be done in the code generator, because we want this applied to
+  the runtime as well, which is shipped as LLVM bitcode.

--- a/kotlin-native/libllvmext/src/main/cpp/KotlinPlugin.cpp
+++ b/kotlin-native/libllvmext/src/main/cpp/KotlinPlugin.cpp
@@ -5,6 +5,7 @@
 #include "KotlinPlugin.h"
 
 #include "Passes/HideSymbols.h"
+#include "Passes/PrepareThreadSanitizer.h"
 
 #include "llvm/Passes/PassBuilder.h"
 
@@ -19,6 +20,15 @@ PassPluginLibraryInfo getKotlinPluginInfo() {
                    ArrayRef<PassBuilder::PipelineElement>) {
                   if (Name == "kotlin-hide-symbols") {
                     PM.addPass(HideSymbolsPass());
+                    return true;
+                  }
+                  return false;
+                });
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, FunctionPassManager &PM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == "kotlin-tsan") {
+                    PM.addPass(PrepareThreadSanitizerPass());
                     return true;
                   }
                   return false;

--- a/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareThreadSanitizer.cpp
+++ b/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareThreadSanitizer.cpp
@@ -1,0 +1,24 @@
+// Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language
+// contributors. Use of this source code is governed by the Apache 2.0 license
+// that can be found in the license/LICENSE.txt file.
+
+#include "PrepareThreadSanitizer.h"
+
+#include "llvm/IR/Function.h"
+
+using namespace llvm;
+using namespace llvm::kotlin;
+
+PreservedAnalyses PrepareThreadSanitizerPass::run(Function &F,
+                                                  FunctionAnalysisManager &AF) {
+  if (!run(F))
+    return PreservedAnalyses::all();
+  return PreservedAnalyses::none();
+}
+
+bool PrepareThreadSanitizerPass::run(Function &F) {
+  if (F.isDeclaration())
+    return false;
+  F.addFnAttr(Attribute::AttrKind::SanitizeThread);
+  return true;
+}

--- a/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareThreadSanitizer.h
+++ b/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareThreadSanitizer.h
@@ -1,0 +1,23 @@
+// Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language
+// contributors. Use of this source code is governed by the Apache 2.0 license
+// that can be found in the license/LICENSE.txt file.
+
+#pragma once
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm::kotlin {
+
+/// Annotate all defined functions with `sanitize_thread` attribute.
+///
+/// This can't simply be done in the code generator, because we want
+/// this attribute applied to the runtime code as well, which ships as LLVM bitcode.
+class PrepareThreadSanitizerPass
+    : public PassInfoMixin<PrepareThreadSanitizerPass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AF);
+
+  bool run(Function &F);
+};
+
+} // namespace llvm::kotlin

--- a/kotlin-native/libllvmext/testData/fileCheck/tsan.ll
+++ b/kotlin-native/libllvmext/testData/fileCheck/tsan.ll
@@ -1,0 +1,11 @@
+; OPT: --passes=kotlin-tsan
+
+; CHECK: define void @f_defined() #0 {
+define void @f_defined() {
+  ret void
+}
+
+; CHECK: declare void @f_declared(){{$}}
+declare void @f_declared()
+
+; CHECK: attributes #0 = { sanitize_thread }


### PR DESCRIPTION
Add `PrepareThreadSanitizer` LLVM pass that adds `SanitizeThread` attribute to all defined functions in the module. In our case the module includes both the Kotlin code and C++ runtime. Built-in LLVM tsan passes will perform all the necessary lowerings.

^KT-84060