### PR TITLE
[Swift Export] Add withKotlinContinuation and swiftCoroutine functions 

### DIFF
--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/SirBridgeProviderImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/SirBridgeProviderImpl.kt
@@ -506,18 +506,9 @@ private fun BridgeFunctionDescriptor.createKotlinBridge(
         val errorParameter = errorParameter ?: error("Async function must have an error parameter")
         add(
             """
-            CoroutineScope(__${cancellation.name.kotlinIdentifier} + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-                try {
-                    val $resultName = $callSite
-                    __${continuation.name}(${resultName})
-                } catch (error: CancellationException) {
-                    __${cancellation.name.kotlinIdentifier}.cancel()
-                    __${exception.name}(null)
-                    throw error
-                } catch (error: Throwable) {
-                    __${exception.name}(error)
-                }
-            }.alsoCancel(__${cancellation.name.kotlinIdentifier})
+            swiftCoroutine(__${continuation.name}, __${exception.name}, __${cancellation.name.kotlinIdentifier}) {
+                $callSite
+            }
             """.trimIndent().prependIndent(indent)
         )
     } else {
@@ -563,28 +554,15 @@ context(session: SirSession)
 private fun BridgeFunctionDescriptor.swiftAsyncCall(typeNamer: SirTypeNamer, argumentOverrides: Map<String, String> = emptyMap()): String {
     val [continuation, exception, cancellation] = asyncParameters ?: error("Async function must have a continuation & cancellation")
     val errorParameter = errorParameter ?: error("Async function must have an error parameter")
-    val indent = "                        "
+    val indent = "            "
 
+    val continuationName = continuation.name.swiftIdentifier
+    val exceptionName = exception.name.swiftIdentifier
+    val cancellationName = cancellation.name.swiftIdentifier
     return """
-        try${"!".takeIf { !isAsync } ?: ""} await {
-            try Task.checkCancellation()
-            var ${cancellation.name.swiftIdentifier}: ${cancellation.bridge.swiftType.swiftName}! = nil
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { nativeContinuation in
-                    withUnsafeCurrentTask { currentTask in
-                        let ${continuation.name.swiftIdentifier}: ${continuation.bridge.swiftType.swiftName} = { nativeContinuation.resume(returning: $0) }
-                        let ${exception.name.swiftIdentifier}: ${exception.bridge.swiftType.swiftName} = { error in
-                            nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                        }
-                        ${cancellation.name.swiftIdentifier} = ${cancellation.bridge.swiftType.swiftName}(currentTask!)
-                        
-                        let _: Bool = ${swiftInvocationLineForCBridge(typeNamer, argumentOverrides).prependIndentToTrailingLines(indent)}
-                    }            
-                }
-            } onCancel: {
-                ${cancellation.name.swiftIdentifier}?.cancelExternally()
-            }
-        }()
+        try await withKotlinContinuation { $continuationName, $exceptionName, $cancellationName in 
+            let _: Bool = ${swiftInvocationLineForCBridge(typeNamer, argumentOverrides).prependIndentToTrailingLines(indent)}
+        }
     """.trimIndent()
 }
 
@@ -640,4 +618,3 @@ private fun String.prependIndentToTrailingLines(indent: String): String = this.l
         }
     }
 }
-

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
@@ -1079,7 +1079,7 @@ internal sealed interface Bridge {
                 val callSite = returnType.inSwiftSources.swiftToKotlin(typeNamer, "originalBlock($callArgs)")
 
                 return@with """{
-                |    let originalBlock = $valueExpression
+                |    let originalBlock: ${swiftType.swiftName} = $valueExpression
                 |    return {$defineArgs return $callSite }
                 |}()""".trimMargin()
             }

--- a/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirExtensions.kt
+++ b/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirExtensions.kt
@@ -75,7 +75,10 @@ val SirType.swiftName
         is SirErrorType -> "ERROR_TYPE"
         is SirUnsupportedType -> "Swift.Never"
         is SirFunctionalType -> {
-            val parameters = parameterTypes.joinToString { it.annotatedSwiftName }
+            val parameters = buildList {
+                contextType?.let(::add)
+                addAll(parameterTypes)
+            }.joinToString { it.annotatedSwiftName }
             val async = " async".takeIf { isAsync } ?: ""
             val throws = when (errorType) {
                 SirType.never -> ""

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
@@ -79,18 +79,9 @@ public fun kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_O
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = __self.emit(__value)
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.emit(__value)
+    }
 }
 
 @ExportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")
@@ -112,18 +103,9 @@ public fun kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swi
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = __self.emit(__value)
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.emit(__value)
+    }
 }
 
 @ExportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache")

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.swift
@@ -12,31 +12,15 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector where Sel
     public func emit(
         value: (any KotlinRuntimeSupport._KotlinBridgeable)?
     ) async throws -> Swift.Void {
-        try await {
-            try Task.checkCancellation()
-            var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { nativeContinuation in
-                    withUnsafeCurrentTask { currentTask in
-                        let continuation: (Swift.Void) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                        let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                            nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                        }
-                        cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                        let _: Bool = kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, {
-                            let originalBlock = continuation
-                            return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
-                        }(), {
-                            let originalBlock = exception
-                            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                        }(), cancellation.__externalRCRef())
-                    }
-                }
-            } onCancel: {
-                cancellation?.cancelExternally()
-            }
-        }()
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        }
     }
 }
 extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector {
@@ -50,31 +34,15 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow where
     public func emit(
         value: (any KotlinRuntimeSupport._KotlinBridgeable)?
     ) async throws -> Swift.Void {
-        try await {
-            try Task.checkCancellation()
-            var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { nativeContinuation in
-                    withUnsafeCurrentTask { currentTask in
-                        let continuation: (Swift.Void) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                        let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                            nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                        }
-                        cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                        let _: Bool = kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, {
-                            let originalBlock = continuation
-                            return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
-                        }(), {
-                            let originalBlock = exception
-                            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                        }(), cancellation.__externalRCRef())
-                    }
-                }
-            } onCancel: {
-                cancellation?.cancelExternally()
-            }
-        }()
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), value.map { it in it.__externalRCRef() } ?? nil, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        }
     }
     @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
     public func resetReplayCache() -> Swift.Void {

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.kt
@@ -29,18 +29,9 @@ public fun FunctionalInterfaceWithSuspendFunction_emit(self: kotlin.native.inter
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = __self.emit()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.emit()
+    }
 }
 
 @ExportedBridge("__root___Foo_init_allocate")
@@ -131,18 +122,9 @@ public fun __root___alwaysFails(continuation: kotlin.native.internal.NativePtr, 
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = alwaysFails()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        alwaysFails()
+    }
 }
 
 @ExportedBridge("__root___closure_returning_flow__TypesOfArguments__U28anyU20KotlinCoroutineSupport_KotlinTypedFlow_main_Foo_U29202D_U20Swift_Void__")
@@ -224,18 +206,9 @@ public fun __root___produce_function_typealias(continuation: kotlin.native.inter
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = produce_function_typealias()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        produce_function_typealias()
+    }
 }
 
 @ExportedBridge("__root___produce_suspend_function")
@@ -255,18 +228,9 @@ public fun __root___produce_suspend_function(continuation: kotlin.native.interna
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = produce_suspend_function()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        produce_suspend_function()
+    }
 }
 
 @ExportedBridge("__root___produce_suspend_function_typealias")
@@ -286,18 +250,9 @@ public fun __root___produce_suspend_function_typealias(continuation: kotlin.nati
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = produce_suspend_function_typealias()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        produce_suspend_function_typealias()
+    }
 }
 
 @ExportedBridge("__root___retunsListOfSuspend")
@@ -317,18 +272,9 @@ public fun __root___retunsListOfSuspend(continuation: kotlin.native.internal.Nat
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = retunsListOfSuspend()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        retunsListOfSuspend()
+    }
 }
 
 @ExportedBridge("__root___returnSuspendGeneric")
@@ -348,18 +294,9 @@ public fun __root___returnSuspendGeneric(continuation: kotlin.native.internal.Na
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = returnSuspendGeneric<kotlin.Any>()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        returnSuspendGeneric<kotlin.Any>()
+    }
 }
 
 @ExportedBridge("__root___returnSuspendUnit")
@@ -385,18 +322,9 @@ public fun __root___returnUnit(continuation: kotlin.native.internal.NativePtr, e
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = returnUnit()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        returnUnit()
+    }
 }
 
 @ExportedBridge("__root___returnsList")
@@ -416,18 +344,9 @@ public fun __root___returnsList(continuation: kotlin.native.internal.NativePtr, 
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = returnsList()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        returnsList()
+    }
 }
 
 @ExportedBridge("__root___returnsListOfSuspendNullables")
@@ -447,18 +366,9 @@ public fun __root___returnsListOfSuspendNullables(continuation: kotlin.native.in
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = returnsListOfSuspendNullables()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        returnsListOfSuspendNullables()
+    }
 }
 
 @ExportedBridge("main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32__")
@@ -480,18 +390,9 @@ public fun main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments_
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = (__pointerToBlock as kotlin.coroutines.SuspendFunction1<Int, Int>).invoke(___1)
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        (__pointerToBlock as kotlin.coroutines.SuspendFunction1<Int, Int>).invoke(___1)
+    }
 }
 
 @ExportedBridge("main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__")
@@ -521,18 +422,9 @@ public fun main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments_
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = (__pointerToBlock as kotlin.coroutines.SuspendFunction1<Double, Int>).invoke(___1)
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        (__pointerToBlock as kotlin.coroutines.SuspendFunction1<Double, Int>).invoke(___1)
+    }
 }
 
 @ExportedBridge("main_internal_functional_type_caller_SwiftU2EInt64__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__")
@@ -554,18 +446,9 @@ public fun main_internal_functional_type_caller_SwiftU2EInt64__TypesOfArguments_
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = (__pointerToBlock as kotlin.coroutines.SuspendFunction1<Float, Long>).invoke(___1)
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        (__pointerToBlock as kotlin.coroutines.SuspendFunction1<Float, Long>).invoke(___1)
+    }
 }
 
 @ExportedBridge("main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32__")
@@ -602,18 +485,9 @@ public fun main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = (__pointerToBlock as kotlin.coroutines.SuspendFunction0<Unit>).invoke()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        (__pointerToBlock as kotlin.coroutines.SuspendFunction0<Unit>).invoke()
+    }
 }
 
 @ExportedBridge("main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__")

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.swift
@@ -66,37 +66,21 @@ public func accept_suspend_function_type(
     }()); return () }()
 }
 public func alwaysFails() async throws -> Swift.Never {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (Swift.Never) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___alwaysFails({
-                        let originalBlock = continuation
-                        return { (arg0: Swift.Bool) in return { originalBlock({ arg0; fatalError() }()); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___alwaysFails({
+            let originalBlock: (Swift.Never) -> Swift.Void = continuation
+            return { (arg0: Swift.Bool) in return { originalBlock({ arg0; fatalError() }()); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func closure_returning_flow(
     i: @escaping (any KotlinCoroutineSupport.KotlinTypedFlow<main.Foo>) -> Swift.Void
 ) -> Swift.Void {
     return { __root___closure_returning_flow__TypesOfArguments__U28anyU20KotlinCoroutineSupport_KotlinTypedFlow_main_Foo_U29202D_U20Swift_Void__({
-        let originalBlock = i
+        let originalBlock: (any KotlinCoroutineSupport.KotlinTypedFlow<main.Foo>) -> Swift.Void = i
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(KotlinCoroutineSupport._KotlinTypedFlowImpl<main.Foo>(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.Flow)); return true }() }
     }()); return () }()
 }
@@ -158,417 +142,177 @@ public func produce_flow() -> any KotlinCoroutineSupport.KotlinTypedFlow<Swift.I
 public func produce_function() -> (Swift.Int32) async throws -> Swift.Int32 {
     return {
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: __root___produce_function(), options: .asBestFittingWrapper)!
-        return { _1 in try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (Swift.Int32) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32__(pointerToBlock.__externalRCRef()!, _1, {
-                        let originalBlock = continuation
-                        return { (arg0: Swift.Int32) in return { originalBlock(arg0); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }() }
+        return { _1 in try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32__(pointerToBlock.__externalRCRef()!, _1, {
+            let originalBlock: (Swift.Int32) -> Swift.Void = continuation
+            return { (arg0: Swift.Int32) in return { originalBlock(arg0); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    } }
     }()
 }
 public func produce_function_typealias() async throws -> main.AliasedFunctionType {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (@escaping (Swift.Float) -> Swift.Int32) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___produce_function_typealias({
-                        let originalBlock = continuation
-                        return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
-                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
-                        return { _1 in return main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__(pointerToBlock.__externalRCRef()!, _1) }
-                    }()); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___produce_function_typealias({
+            let originalBlock: (@escaping (Swift.Float) -> Swift.Int32) -> Swift.Void = continuation
+            return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
+            let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
+            return { _1 in return main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__(pointerToBlock.__externalRCRef()!, _1) }
+        }()); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func produce_suspend_function() async throws -> (Swift.Double) async throws -> Swift.Int32 {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (@escaping (Swift.Double) async throws -> Swift.Int32) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___produce_suspend_function({
-                        let originalBlock = continuation
-                        return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
-                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
-                        return { _1 in try await {
-                        try Task.checkCancellation()
-                        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-                        return try await withTaskCancellationHandler {
-                            try await withUnsafeThrowingContinuation { nativeContinuation in
-                                withUnsafeCurrentTask { currentTask in
-                                    let continuation: (Swift.Int32) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                                    }
-                                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                                    let _: Bool = main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Double__(pointerToBlock.__externalRCRef()!, _1, {
-                                        let originalBlock = continuation
-                                        return { (arg0: Swift.Int32) in return { originalBlock(arg0); return true }() }
-                                    }(), {
-                                        let originalBlock = exception
-                                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                                    }(), cancellation.__externalRCRef())
-                                }
-                            }
-                        } onCancel: {
-                            cancellation?.cancelExternally()
-                        }
-                    }() }
-                    }()); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___produce_suspend_function({
+            let originalBlock: (@escaping (Swift.Double) async throws -> Swift.Int32) -> Swift.Void = continuation
+            return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
+            let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
+            return { _1 in try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = main_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Double__(pointerToBlock.__externalRCRef()!, _1, {
+                let originalBlock: (Swift.Int32) -> Swift.Void = continuation
+                return { (arg0: Swift.Int32) in return { originalBlock(arg0); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        } }
+        }()); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func produce_suspend_function_typealias() async throws -> main.AliasedAsyncFunctionType {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (@escaping (Swift.Float) async throws -> Swift.Int64) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___produce_suspend_function_typealias({
-                        let originalBlock = continuation
-                        return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
-                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
-                        return { _1 in try await {
-                        try Task.checkCancellation()
-                        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-                        return try await withTaskCancellationHandler {
-                            try await withUnsafeThrowingContinuation { nativeContinuation in
-                                withUnsafeCurrentTask { currentTask in
-                                    let continuation: (Swift.Int64) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                                    }
-                                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                                    let _: Bool = main_internal_functional_type_caller_SwiftU2EInt64__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__(pointerToBlock.__externalRCRef()!, _1, {
-                                        let originalBlock = continuation
-                                        return { (arg0: Swift.Int64) in return { originalBlock(arg0); return true }() }
-                                    }(), {
-                                        let originalBlock = exception
-                                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                                    }(), cancellation.__externalRCRef())
-                                }
-                            }
-                        } onCancel: {
-                            cancellation?.cancelExternally()
-                        }
-                    }() }
-                    }()); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___produce_suspend_function_typealias({
+            let originalBlock: (@escaping (Swift.Float) async throws -> Swift.Int64) -> Swift.Void = continuation
+            return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
+            let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
+            return { _1 in try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = main_internal_functional_type_caller_SwiftU2EInt64__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Float__(pointerToBlock.__externalRCRef()!, _1, {
+                let originalBlock: (Swift.Int64) -> Swift.Void = continuation
+                return { (arg0: Swift.Int64) in return { originalBlock(arg0); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        } }
+        }()); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func retunsListOfSuspend() async throws -> [() async throws -> Swift.Void] {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (Swift.Array<() async throws -> Swift.Void>) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___retunsListOfSuspend({
-                        let originalBlock = continuation
-                        return { (arg0: Any) in return { originalBlock((arg0 as! [Any]).map { __element in {
-                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: Swift.UnsafeMutableRawPointer(bitPattern: __element as! Swift.Int)!, options: .asBestFittingWrapper)!
-                        return { try await {
-                        try Task.checkCancellation()
-                        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-                        return try await withTaskCancellationHandler {
-                            try await withUnsafeThrowingContinuation { nativeContinuation in
-                                withUnsafeCurrentTask { currentTask in
-                                    let continuation: (Swift.Void) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                                    }
-                                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                                    let _: Bool = main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!, {
-                                        let originalBlock = continuation
-                                        return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
-                                    }(), {
-                                        let originalBlock = exception
-                                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                                    }(), cancellation.__externalRCRef())
-                                }
-                            }
-                        } onCancel: {
-                            cancellation?.cancelExternally()
-                        }
-                    }() }
-                    }() }); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___retunsListOfSuspend({
+            let originalBlock: (Swift.Array<() async throws -> Swift.Void>) -> Swift.Void = continuation
+            return { (arg0: Any) in return { originalBlock((arg0 as! [Any]).map { __element in {
+            let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: Swift.UnsafeMutableRawPointer(bitPattern: __element as! Swift.Int)!, options: .asBestFittingWrapper)!
+            return { try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        } }
+        }() }); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func returnSuspendGeneric() async throws -> any KotlinRuntimeSupport._KotlinBridgeable {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (any KotlinRuntimeSupport._KotlinBridgeable) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___returnSuspendGeneric({
-                        let originalBlock = continuation
-                        return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: arg0)); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___returnSuspendGeneric({
+            let originalBlock: (any KotlinRuntimeSupport._KotlinBridgeable) -> Swift.Void = continuation
+            return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: arg0)); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func returnSuspendUnit() -> () async throws -> Swift.Void {
     return {
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: __root___returnSuspendUnit(), options: .asBestFittingWrapper)!
-        return { try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (Swift.Void) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!, {
-                        let originalBlock = continuation
-                        return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }() }
+        return { try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!, {
+            let originalBlock: (Swift.Void) -> Swift.Void = continuation
+            return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    } }
     }()
 }
 public func returnUnit() async throws -> Swift.Void {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (Swift.Void) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___returnUnit({
-                        let originalBlock = continuation
-                        return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___returnUnit({
+            let originalBlock: (Swift.Void) -> Swift.Void = continuation
+            return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func returnsList() async throws -> [Swift.String] {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (Swift.Array<Swift.String>) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___returnsList({
-                        let originalBlock = continuation
-                        return { (arg0: Any) in return { originalBlock(arg0 as! Swift.Array<Swift.String>); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___returnsList({
+            let originalBlock: (Swift.Array<Swift.String>) -> Swift.Void = continuation
+            return { (arg0: Any) in return { originalBlock(arg0 as! Swift.Array<Swift.String>); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 public func returnsListOfSuspendNullables() async throws -> [(() async throws -> Swift.Void)?] {
-    try await {
-        try Task.checkCancellation()
-        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-        return try await withTaskCancellationHandler {
-            try await withUnsafeThrowingContinuation { nativeContinuation in
-                withUnsafeCurrentTask { currentTask in
-                    let continuation: (Swift.Array<Swift.Optional<() async throws -> Swift.Void>>) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                    }
-                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                    let _: Bool = __root___returnsListOfSuspendNullables({
-                        let originalBlock = continuation
-                        return { (arg0: Any) in return { originalBlock((arg0 as! [Any]).map { __element in { let __v = __element as! Swift.Int; return __v == 0 ? nil : {
-                        let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: Swift.UnsafeMutableRawPointer(bitPattern: __v)!, options: .asBestFittingWrapper)!
-                        return { try await {
-                        try Task.checkCancellation()
-                        var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-                        return try await withTaskCancellationHandler {
-                            try await withUnsafeThrowingContinuation { nativeContinuation in
-                                withUnsafeCurrentTask { currentTask in
-                                    let continuation: (Swift.Void) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                                    let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                                    }
-                                    cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                                    let _: Bool = main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!, {
-                                        let originalBlock = continuation
-                                        return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
-                                    }(), {
-                                        let originalBlock = exception
-                                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                                    }(), cancellation.__externalRCRef())
-                                }
-                            }
-                        } onCancel: {
-                            cancellation?.cancelExternally()
-                        }
-                    }() }
-                    }() }() }); return true }() }
-                    }(), {
-                        let originalBlock = exception
-                        return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                    }(), cancellation.__externalRCRef())
-                }
-            }
-        } onCancel: {
-            cancellation?.cancelExternally()
-        }
-    }()
+    try await withKotlinContinuation { continuation, exception, cancellation in
+        let _: Bool = __root___returnsListOfSuspendNullables({
+            let originalBlock: (Swift.Array<Swift.Optional<() async throws -> Swift.Void>>) -> Swift.Void = continuation
+            return { (arg0: Any) in return { originalBlock((arg0 as! [Any]).map { __element in { let __v = __element as! Swift.Int; return __v == 0 ? nil : {
+            let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: Swift.UnsafeMutableRawPointer(bitPattern: __v)!, options: .asBestFittingWrapper)!
+            return { try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!, {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        } }
+        }() }() }); return true }() }
+        }(), {
+            let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+        }(), cancellation.__externalRCRef())
+    }
 }
 extension main.FunctionalInterfaceWithSuspendFunction where Self : KotlinRuntimeSupport._KotlinBridgeable {
     public func emit() async throws -> Swift.Void {
-        try await {
-            try Task.checkCancellation()
-            var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { nativeContinuation in
-                    withUnsafeCurrentTask { currentTask in
-                        let continuation: (Swift.Void) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                        let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                            nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                        }
-                        cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                        let _: Bool = FunctionalInterfaceWithSuspendFunction_emit(self.__externalRCRef(), {
-                            let originalBlock = continuation
-                            return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
-                        }(), {
-                            let originalBlock = exception
-                            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                        }(), cancellation.__externalRCRef())
-                    }
-                }
-            } onCancel: {
-                cancellation?.cancelExternally()
-            }
-        }()
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = FunctionalInterfaceWithSuspendFunction_emit(self.__externalRCRef(), {
+                let originalBlock: (Swift.Void) -> Swift.Void = continuation
+                return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        }
     }
 }
 extension main.FunctionalInterfaceWithSuspendFunction {

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutinesWithPackageFlattening/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutinesWithPackageFlattening/golden_result/main/main.kt
@@ -26,16 +26,7 @@ public fun flattened_testSuspendFunction(continuation: kotlin.native.internal.Na
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).kotlinx_coroutines_launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = flattened.testSuspendFunction()
-            __continuation(_result)
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        flattened.testSuspendFunction()
+    }
 }

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutinesWithPackageFlattening/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutinesWithPackageFlattening/golden_result/main/main.swift
@@ -9,30 +9,14 @@ public func testSuspendFunction() async throws -> Swift.Int32 {
 }
 extension ExportedKotlinPackages.flattened {
     public static func testSuspendFunction() async throws -> Swift.Int32 {
-        try await {
-            try Task.checkCancellation()
-            var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { nativeContinuation in
-                    withUnsafeCurrentTask { currentTask in
-                        let continuation: (Swift.Int32) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                        let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                            nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                        }
-                        cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                        let _: Bool = flattened_testSuspendFunction({
-                            let originalBlock = continuation
-                            return { (arg0: Swift.Int32) in return { originalBlock(arg0); return true }() }
-                        }(), {
-                            let originalBlock = exception
-                            return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
-                        }(), cancellation.__externalRCRef())
-                    }
-                }
-            } onCancel: {
-                cancellation?.cancelExternally()
-            }
-        }()
+        try await withKotlinContinuation { continuation, exception, cancellation in
+            let _: Bool = flattened_testSuspendFunction({
+                let originalBlock: (Swift.Int32) -> Swift.Void = continuation
+                return { (arg0: Swift.Int32) in return { originalBlock(arg0); return true }() }
+            }(), {
+                let originalBlock: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = exception
+                return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef: res); } }()); return true }() }
+            }(), cancellation.__externalRCRef())
+        }
     }
 }

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.swift
@@ -493,7 +493,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.`internal` {
             let __kt = kotlinx_serialization_internal_ElementMarker_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
             { kotlinx_serialization_internal_ElementMarker_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U28anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U20Swift_Int32U29202D_U20Swift_Bool__(__kt, descriptor.__externalRCRef(), {
-                let originalBlock = readIfAbsent
+                let originalBlock: (any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor, Swift.Int32) -> Swift.Bool = readIfAbsent
                 return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.Int32) in return originalBlock(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0) as! any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor, arg1) }
             }()); return () }()
         }
@@ -992,7 +992,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.modules {
         builderAction: @escaping (ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleBuilder) -> Swift.Void
     ) -> ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
         return ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule.__createClassWrapper(externalRCRef: kotlinx_serialization_modules_SerializersModule__TypesOfArguments__U28ExportedKotlinPackages_kotlinx_serialization_modules_SerializersModuleBuilderU29202D_U20Swift_Void__({
-            let originalBlock = builderAction
+            let originalBlock: (ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleBuilder) -> Swift.Void = builderAction
             return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleBuilder.__createClassWrapper(externalRCRef: arg0)); return true }() }
         }()))
     }
@@ -1516,7 +1516,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.descriptors {
         builderAction: @escaping (ExportedKotlinPackages.kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder) -> Swift.Void
     ) -> any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_serialization_descriptors_buildClassSerialDescriptor__TypesOfArguments__Swift_String_Swift_Array_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__Vararg__U28ExportedKotlinPackages_kotlinx_serialization_descriptors_ClassSerialDescriptorBuilderU29202D_U20Swift_Void__(serialName, typeParameters, {
-            let originalBlock = builderAction
+            let originalBlock: (ExportedKotlinPackages.kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder) -> Swift.Void = builderAction
             return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(ExportedKotlinPackages.kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder.__createClassWrapper(externalRCRef: arg0)); return true }() }
         }())) as! any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor
     }
@@ -1528,7 +1528,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.descriptors {
         builder: @escaping (ExportedKotlinPackages.kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder) -> Swift.Void
     ) -> any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_serialization_descriptors_buildSerialDescriptor__TypesOfArguments__Swift_String_ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialKind_Swift_Array_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor__Vararg__U28ExportedKotlinPackages_kotlinx_serialization_descriptors_ClassSerialDescriptorBuilderU29202D_U20Swift_Void__(serialName, kind.__externalRCRef(), typeParameters, {
-            let originalBlock = builder
+            let originalBlock: (ExportedKotlinPackages.kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder) -> Swift.Void = builder
             return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(ExportedKotlinPackages.kotlinx.serialization.descriptors.ClassSerialDescriptorBuilder.__createClassWrapper(externalRCRef: arg0)); return true }() }
         }())) as! any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor
     }
@@ -2297,7 +2297,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
         block: @escaping (any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
     ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
         return { switch kotlinx_serialization_encoding_decodeStructure__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoderU29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(receiver.__externalRCRef(), descriptor.__externalRCRef(), {
-            let originalBlock = block
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = block
             return { (arg0: Swift.UnsafeMutableRawPointer) in return originalBlock(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0) as! any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder).map { it in it.__externalRCRef() } ?? nil }
         }()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
     }
@@ -2308,7 +2308,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
         block: @escaping (any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder) -> Swift.Void
     ) -> Swift.Void {
         return { kotlinx_serialization_encoding_encodeCollection__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_Swift_Int32_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoderU29202D_U20Swift_Void__(receiver.__externalRCRef(), descriptor.__externalRCRef(), collectionSize, {
-            let originalBlock = block
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder) -> Swift.Void = block
             return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0) as! any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder); return true }() }
         }()); return () }()
     }
@@ -2318,7 +2318,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
         block: @escaping (any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder) -> Swift.Void
     ) -> Swift.Void {
         return { kotlinx_serialization_encoding_encodeStructure__TypesOfArgumentsE__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Encoder_anyU20ExportedKotlinPackages_kotlinx_serialization_descriptors_SerialDescriptor_U28anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeEncoderU29202D_U20Swift_Void__(receiver.__externalRCRef(), descriptor.__externalRCRef(), {
-            let originalBlock = block
+            let originalBlock: (any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder) -> Swift.Void = block
             return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0) as! any ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder); return true }() }
         }()); return () }()
     }
@@ -2494,7 +2494,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding.ChunkedDecoder w
         consumeChunk: @escaping (Swift.String) -> Swift.Void
     ) -> Swift.Void {
         return { kotlinx_serialization_encoding_ChunkedDecoder_decodeStringChunked__TypesOfArguments__U28Swift_StringU29202D_U20Swift_Void__(self.__externalRCRef(), {
-            let originalBlock = consumeChunk
+            let originalBlock: (Swift.String) -> Swift.Void = consumeChunk
             return { (arg0: Swift.String) in return { originalBlock(arg0); return true }() }
         }()); return () }()
     }

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -7145,7 +7145,7 @@ extension ExportedKotlinPackages.kotlin.time {
             action: @escaping (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
         ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
             return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
-                let originalBlock = action
+                let originalBlock: (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
                 return { (arg0: Swift.Int64, arg1: Swift.Int32, arg2: Swift.Int32, arg3: Swift.Int32, arg4: Swift.Int32) in return originalBlock(arg0, arg1, arg2, arg3, arg4).map { it in it.__externalRCRef() } ?? nil }
             }()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
         }
@@ -7153,7 +7153,7 @@ extension ExportedKotlinPackages.kotlin.time {
             action: @escaping (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
         ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
             return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
-                let originalBlock = action
+                let originalBlock: (Swift.Int64, Swift.Int32, Swift.Int32, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
                 return { (arg0: Swift.Int64, arg1: Swift.Int32, arg2: Swift.Int32, arg3: Swift.Int32) in return originalBlock(arg0, arg1, arg2, arg3).map { it in it.__externalRCRef() } ?? nil }
             }()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
         }
@@ -7161,7 +7161,7 @@ extension ExportedKotlinPackages.kotlin.time {
             action: @escaping (Swift.Int64, Swift.Int32, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
         ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
             return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
-                let originalBlock = action
+                let originalBlock: (Swift.Int64, Swift.Int32, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
                 return { (arg0: Swift.Int64, arg1: Swift.Int32, arg2: Swift.Int32) in return originalBlock(arg0, arg1, arg2).map { it in it.__externalRCRef() } ?? nil }
             }()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
         }
@@ -7169,7 +7169,7 @@ extension ExportedKotlinPackages.kotlin.time {
             action: @escaping (Swift.Int64, Swift.Int32) -> (any KotlinRuntimeSupport._KotlinBridgeable)?
         ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
             return { switch kotlin_time_Duration_toComponents__TypesOfArguments__U28Swift_Int64_U20Swift_Int32U29202D_U20Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___(self.__externalRCRef(), {
-                let originalBlock = action
+                let originalBlock: (Swift.Int64, Swift.Int32) -> Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable> = action
                 return { (arg0: Swift.Int64, arg1: Swift.Int32) in return originalBlock(arg0, arg1).map { it in it.__externalRCRef() } ?? nil }
             }()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
         }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.h
@@ -55,11 +55,11 @@ _Bool __root___complexContextProperty_get__TypesOfArgumentsEC2__Swift_String_mai
 
 _Bool __root___complexContextProperty_set__TypesOfArgumentsEC2__Swift_String_Swift_Bool_main_ContextA_main_ContextB__(NSString * receiver, _Bool value, void * contextA, void * contextB);
 
-_Bool __root___contextBlockA__TypesOfArguments__U28Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__(_Bool (^block)(void *, void *, int32_t, NSString *));
+_Bool __root___contextBlockA__TypesOfArguments__U2828main_ContextA_U20main_ContextBU29_U20Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__(_Bool (^block)(void *, void *, int32_t, NSString *));
 
 void * __root___contextBlockB();
 
-_Bool __root___contextBlockC__TypesOfArguments__U28Swift_StringU29202D_U20Swift_Void__(_Bool (^block)(void *, NSString *));
+_Bool __root___contextBlockC__TypesOfArguments__U28main_Context_U20Swift_StringU29202D_U20Swift_Void__(_Bool (^block)(void *, NSString *));
 
 void * __root___contextBlockD();
 

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.kt
@@ -222,8 +222,8 @@ public fun __root___complexContextProperty_set__TypesOfArgumentsEC2__Swift_Strin
     return run { _result; true }
 }
 
-@ExportedBridge("__root___contextBlockA__TypesOfArguments__U28Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__")
-public fun __root___contextBlockA__TypesOfArguments__U28Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): Boolean {
+@ExportedBridge("__root___contextBlockA__TypesOfArguments__U2828main_ContextA_U20main_ContextBU29_U20Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__")
+public fun __root___contextBlockA__TypesOfArguments__U2828main_ContextA_U20main_ContextBU29_U20Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): Boolean {
     val __block = run {
         val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr, Int, kotlin.native.internal.NativePtr)->Boolean>(block);
         { ctx0: ContextA, ctx1: ContextB, arg0: Int, arg1: kotlin.String ->
@@ -241,8 +241,8 @@ public fun __root___contextBlockB(): kotlin.native.internal.NativePtr {
     return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
 }
 
-@ExportedBridge("__root___contextBlockC__TypesOfArguments__U28Swift_StringU29202D_U20Swift_Void__")
-public fun __root___contextBlockC__TypesOfArguments__U28Swift_StringU29202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): Boolean {
+@ExportedBridge("__root___contextBlockC__TypesOfArguments__U28main_Context_U20Swift_StringU29202D_U20Swift_Void__")
+public fun __root___contextBlockC__TypesOfArguments__U28main_Context_U20Swift_StringU29202D_U20Swift_Void__(block: kotlin.native.internal.NativePtr): Boolean {
     val __block = run {
         val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr, kotlin.native.internal.NativePtr)->Boolean>(block);
         { ctx0: Context, arg0: kotlin.String ->

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.swift
@@ -168,7 +168,7 @@ public func complexContextFunction(
 public func contextBlockA(
     block: @escaping ((main.ContextA, main.ContextB), Swift.Int32, Swift.String) -> Swift.Void
 ) -> Swift.Void {
-    return { __root___contextBlockA__TypesOfArguments__U28Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__({
+    return { __root___contextBlockA__TypesOfArguments__U2828main_ContextA_U20main_ContextBU29_U20Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__({
         let originalBlock = block
         return { (ctx0: Swift.UnsafeMutableRawPointer, ctx1: Swift.UnsafeMutableRawPointer, arg0: Swift.Int32, arg1: Swift.String) in return { originalBlock((main.ContextA.__createClassWrapper(externalRCRef: ctx0),main.ContextB.__createClassWrapper(externalRCRef: ctx1)), arg0, arg1); return true }() }
     }()); return () }()
@@ -182,7 +182,7 @@ public func contextBlockB() -> ((main.ContextB, main.ContextA), Swift.String, Sw
 public func contextBlockC(
     block: @escaping (main.Context, Swift.String) -> Swift.Void
 ) -> Swift.Void {
-    return { __root___contextBlockC__TypesOfArguments__U28Swift_StringU29202D_U20Swift_Void__({
+    return { __root___contextBlockC__TypesOfArguments__U28main_Context_U20Swift_StringU29202D_U20Swift_Void__({
         let originalBlock = block
         return { (ctx0: Swift.UnsafeMutableRawPointer, arg0: Swift.String) in return { originalBlock((main.Context.__createClassWrapper(externalRCRef: ctx0)), arg0); return true }() }
     }()); return () }()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/contextParameters/golden_result/main/main.swift
@@ -169,7 +169,7 @@ public func contextBlockA(
     block: @escaping ((main.ContextA, main.ContextB), Swift.Int32, Swift.String) -> Swift.Void
 ) -> Swift.Void {
     return { __root___contextBlockA__TypesOfArguments__U2828main_ContextA_U20main_ContextBU29_U20Swift_Int32_U20Swift_StringU29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: ((main.ContextA, main.ContextB), Swift.Int32, Swift.String) -> Swift.Void = block
         return { (ctx0: Swift.UnsafeMutableRawPointer, ctx1: Swift.UnsafeMutableRawPointer, arg0: Swift.Int32, arg1: Swift.String) in return { originalBlock((main.ContextA.__createClassWrapper(externalRCRef: ctx0),main.ContextB.__createClassWrapper(externalRCRef: ctx1)), arg0, arg1); return true }() }
     }()); return () }()
 }
@@ -183,7 +183,7 @@ public func contextBlockC(
     block: @escaping (main.Context, Swift.String) -> Swift.Void
 ) -> Swift.Void {
     return { __root___contextBlockC__TypesOfArguments__U28main_Context_U20Swift_StringU29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: (main.Context, Swift.String) -> Swift.Void = block
         return { (ctx0: Swift.UnsafeMutableRawPointer, arg0: Swift.String) in return { originalBlock((main.Context.__createClassWrapper(externalRCRef: ctx0)), arg0); return true }() }
     }()); return () }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/collections/collections.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/collections/collections.swift
@@ -7,7 +7,7 @@ public func consume_block_with_dictRef_id(
     block: @escaping ([Swift.String: data.Foo]) -> [Swift.String: data.Foo]
 ) -> [Swift.String: data.Foo] {
     return __root___consume_block_with_dictRef_id__TypesOfArguments__U28Swift_Dictionary_Swift_String_data_Foo_U29202D_U20Swift_Dictionary_Swift_String_data_Foo___({
-        let originalBlock = block
+        let originalBlock: (Swift.Dictionary<Swift.String,data.Foo>) -> Swift.Dictionary<Swift.String,data.Foo> = block
         return { (arg0: Any) in return originalBlock(arg0 as! Swift.Dictionary<Swift.String,data.Foo>) }
     }()) as! Swift.Dictionary<Swift.String,data.Foo>
 }
@@ -15,7 +15,7 @@ public func consume_block_with_dict_id(
     block: @escaping ([Swift.Int32: Swift.Int32]) -> [Swift.Int32: Swift.Int32]
 ) -> [Swift.Int32: Swift.Int32] {
     return __root___consume_block_with_dict_id__TypesOfArguments__U28Swift_Dictionary_Swift_Int32_Swift_Int32_U29202D_U20Swift_Dictionary_Swift_Int32_Swift_Int32___({
-        let originalBlock = block
+        let originalBlock: (Swift.Dictionary<Swift.Int32,Swift.Int32>) -> Swift.Dictionary<Swift.Int32,Swift.Int32> = block
         return { (arg0: Any) in return Dictionary(uniqueKeysWithValues: originalBlock(arg0 as! Swift.Dictionary<Swift.Int32,Swift.Int32>).map { key, value in (NSNumber(value: key), NSNumber(value: value) )}) }
     }()) as! Swift.Dictionary<Swift.Int32,Swift.Int32>
 }
@@ -23,7 +23,7 @@ public func consume_block_with_listRef_id(
     block: @escaping ([data.Foo]) -> [data.Foo]
 ) -> [data.Foo] {
     return __root___consume_block_with_listRef_id__TypesOfArguments__U28Swift_Array_data_Foo_U29202D_U20Swift_Array_data_Foo___({
-        let originalBlock = block
+        let originalBlock: (Swift.Array<data.Foo>) -> Swift.Array<data.Foo> = block
         return { (arg0: Any) in return originalBlock(arg0 as! Swift.Array<data.Foo>) }
     }()) as! Swift.Array<data.Foo>
 }
@@ -31,7 +31,7 @@ public func consume_block_with_list_id(
     block: @escaping ([Swift.Int32]) -> [Swift.Int32]
 ) -> [Swift.Int32] {
     return __root___consume_block_with_list_id__TypesOfArguments__U28Swift_Array_Swift_Int32_U29202D_U20Swift_Array_Swift_Int32___({
-        let originalBlock = block
+        let originalBlock: (Swift.Array<Swift.Int32>) -> Swift.Array<Swift.Int32> = block
         return { (arg0: Any) in return originalBlock(arg0 as! Swift.Array<Swift.Int32>).map { it in NSNumber(value: it) } }
     }()) as! Swift.Array<Swift.Int32>
 }
@@ -39,7 +39,7 @@ public func consume_block_with_set_id(
     block: @escaping (Swift.Set<Swift.Int32>) -> Swift.Set<Swift.Int32>
 ) -> Swift.Set<Swift.Int32> {
     return __root___consume_block_with_set_id__TypesOfArguments__U28Swift_Set_Swift_Int32_U29202D_U20Swift_Set_Swift_Int32___({
-        let originalBlock = block
+        let originalBlock: (Swift.Set<Swift.Int32>) -> Swift.Set<Swift.Int32> = block
         return { (arg0: Any) in return Set(originalBlock(arg0 as! Swift.Set<Swift.Int32>).map { it in NSNumber(value: it) }) }
     }()) as! Swift.Set<Swift.Int32>
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/functional_types/functional_types.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/functional_types/functional_types.swift
@@ -6,7 +6,7 @@ public func consume_block_consuming_block(
     block: @escaping (@escaping () -> Swift.Void) -> Swift.Void
 ) -> Swift.Void {
     return { __root___consume_block_consuming_block__TypesOfArguments__U2840escapingU202829202D_U20Swift_VoidU29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: (@escaping () -> Swift.Void) -> Swift.Void = block
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
         return { return { functional_types_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!); return () }() }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/inline/inline.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/inline/inline.swift
@@ -7,10 +7,10 @@ public func bar(
     notInlined: @escaping () -> Swift.Void
 ) -> Swift.Void {
     return { __root___bar__TypesOfArguments__U2829202D_U20Swift_Void_U2829202D_U20Swift_Void__({
-        let originalBlock = inlined
+        let originalBlock: () -> Swift.Void = inlined
         return { return { originalBlock(); return true }() }
     }(), {
-        let originalBlock = notInlined
+        let originalBlock: () -> Swift.Void = notInlined
         return { return { originalBlock(); return true }() }
     }()); return () }()
 }
@@ -18,7 +18,7 @@ public func foo(
     inlined: @escaping () -> Swift.Void
 ) -> Swift.Void {
     return { __root___foo__TypesOfArguments__U2829202D_U20Swift_Void__({
-        let originalBlock = inlined
+        let originalBlock: () -> Swift.Void = inlined
         return { return { originalBlock(); return true }() }
     }()); return () }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.swift
@@ -6,7 +6,7 @@ public func consume_consuming_opt_closure(
     arg: (((() -> Swift.String)?) -> Swift.Void)?
 ) -> Swift.Void {
     return { __root___consume_consuming_opt_closure__TypesOfArguments__Swift_Optional_U28Swift_Optional_U2829202D_U20Swift_String_U29202D_U20Swift_Void___(arg.map { it in {
-        let originalBlock = it
+        let originalBlock: (Swift.Optional<() -> Swift.String>) -> Swift.Void = it
         return { (arg0: Swift.UnsafeMutableRawPointer?) in return { originalBlock(arg0.map { it in {
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: it, options: .asBestFittingWrapper)!
         return { return optional_closure_internal_functional_type_caller_SwiftU2EString__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!) }
@@ -17,7 +17,7 @@ public func consume_opt_closure(
     arg: (() -> Swift.Void)?
 ) -> Swift.Void {
     return { __root___consume_opt_closure__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Void___(arg.map { it in {
-        let originalBlock = it
+        let originalBlock: () -> Swift.Void = it
         return { return { originalBlock(); return true }() }
     }() } ?? nil); return () }()
 }
@@ -25,9 +25,9 @@ public func consume_producing_opt_closure(
     arg: (() -> (() -> Swift.Void)?)?
 ) -> Swift.Void {
     return { __root___consume_producing_opt_closure__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Optional_U2829202D_U20Swift_Void____(arg.map { it in {
-        let originalBlock = it
+        let originalBlock: () -> Swift.Optional<() -> Swift.Void> = it
         return { return originalBlock().map { it in {
-        let originalBlock = it
+        let originalBlock: () -> Swift.Void = it
         return { return { originalBlock(); return true }() }
     }() } ?? nil }
     }() } ?? nil); return () }()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/primitive_types/primitive_types.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/primitive_types/primitive_types.swift
@@ -6,7 +6,7 @@ public func consume_block_with_byte_id(
     block: @escaping (Swift.Int8) -> Swift.Int8
 ) -> Swift.Int8 {
     return __root___consume_block_with_byte_id__TypesOfArguments__U28Swift_Int8U29202D_U20Swift_Int8__({
-        let originalBlock = block
+        let originalBlock: (Swift.Int8) -> Swift.Int8 = block
         return { (arg0: Swift.Int8) in return originalBlock(arg0) }
     }())
 }
@@ -14,7 +14,7 @@ public func consume_block_with_uint_id(
     block: @escaping (Swift.UInt32) -> Swift.UInt32
 ) -> Swift.UInt32 {
     return __root___consume_block_with_uint_id__TypesOfArguments__U28Swift_UInt32U29202D_U20Swift_UInt32__({
-        let originalBlock = block
+        let originalBlock: (Swift.UInt32) -> Swift.UInt32 = block
         return { (arg0: Swift.UInt32) in return originalBlock(arg0) }
     }())
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/receivers/receivers.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/receivers/receivers.swift
@@ -6,7 +6,7 @@ public func foo(
     i: @escaping (Swift.Int32) -> Swift.Void
 ) -> Swift.Void {
     return { __root___foo__TypesOfArguments__U28Swift_Int32U29202D_U20Swift_Void__({
-        let originalBlock = i
+        let originalBlock: (Swift.Int32) -> Swift.Void = i
         return { (arg0: Swift.Int32) in return { originalBlock(arg0); return true }() }
     }()); return () }()
 }
@@ -14,7 +14,7 @@ public func fooAny(
     i: @escaping (any KotlinRuntimeSupport._KotlinBridgeable) -> Swift.Void
 ) -> Swift.Void {
     return { __root___fooAny__TypesOfArguments__U28anyU20KotlinRuntimeSupport__KotlinBridgeableU29202D_U20Swift_Void__({
-        let originalBlock = i
+        let originalBlock: (any KotlinRuntimeSupport._KotlinBridgeable) -> Swift.Void = i
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: arg0)); return true }() }
     }()); return () }()
 }
@@ -22,7 +22,7 @@ public func fooList(
     i: @escaping ([Swift.Int32]) -> Swift.Void
 ) -> Swift.Void {
     return { __root___fooList__TypesOfArguments__U28Swift_Array_Swift_Int32_U29202D_U20Swift_Void__({
-        let originalBlock = i
+        let originalBlock: (Swift.Array<Swift.Int32>) -> Swift.Void = i
         return { (arg0: Any) in return { originalBlock(arg0 as! Swift.Array<Swift.Int32>); return true }() }
     }()); return () }()
 }
@@ -30,7 +30,7 @@ public func fooString(
     i: @escaping (Swift.String?) -> Swift.Void
 ) -> Swift.Void {
     return { __root___fooString__TypesOfArguments__U28Swift_Optional_Swift_String_U29202D_U20Swift_Void__({
-        let originalBlock = i
+        let originalBlock: (Swift.Optional<Swift.String>) -> Swift.Void = i
         return { (arg0: Swift.String?) in return { originalBlock(arg0); return true }() }
     }()); return () }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/ref_types/ref_types.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/ref_types/ref_types.swift
@@ -7,7 +7,7 @@ public func consume_block_with_opt_reftype(
     block: @escaping (Swift.Int32?, data.Bar?, Swift.String?, Swift.Set<Swift.AnyHashable>?) -> data.Foo?
 ) -> Swift.Void {
     return { __root___consume_block_with_opt_reftype__TypesOfArguments__U28Swift_Optional_Swift_Int32__U20Swift_Optional_data_Bar__U20Swift_Optional_Swift_String__U20Swift_Optional_Swift_Set_Swift_AnyHashable__U29202D_U20Swift_Optional_data_Foo___({
-        let originalBlock = block
+        let originalBlock: (Swift.Optional<Swift.Int32>, Swift.Optional<data.Bar>, Swift.Optional<Swift.String>, Swift.Optional<Swift.Set<Swift.AnyHashable>>) -> Swift.Optional<data.Foo> = block
         return { (arg0: Foundation.NSNumber?, arg1: Swift.UnsafeMutableRawPointer?, arg2: Swift.String?, arg3: Any?) in return originalBlock(arg0.map { it in it.int32Value }, { switch arg1 { case nil: .none; case let res: data.Bar.__createClassWrapper(externalRCRef: res); } }(), arg2, arg3.map { it in it as! Swift.Set<Swift.AnyHashable> }).map { it in it.__externalRCRef() } ?? nil }
     }()); return () }()
 }
@@ -15,7 +15,7 @@ public func consume_block_with_reftype_consumer(
     block: @escaping (data.Foo) -> Swift.Void
 ) -> Swift.Void {
     return { __root___consume_block_with_reftype_consumer__TypesOfArguments__U28data_FooU29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: (data.Foo) -> Swift.Void = block
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(data.Foo.__createClassWrapper(externalRCRef: arg0)); return true }() }
     }()); return () }()
 }
@@ -23,7 +23,7 @@ public func consume_block_with_reftype_factory(
     block: @escaping () -> data.Foo
 ) -> data.Foo {
     return data.Foo.__createClassWrapper(externalRCRef: __root___consume_block_with_reftype_factory__TypesOfArguments__U2829202D_U20data_Foo__({
-        let originalBlock = block
+        let originalBlock: () -> data.Foo = block
         return { return originalBlock().__externalRCRef() }
     }()))
 }
@@ -31,7 +31,7 @@ public func consume_block_with_reftype_unzip(
     block: @escaping (data.Bar) -> data.Foo
 ) -> data.Foo {
     return data.Foo.__createClassWrapper(externalRCRef: __root___consume_block_with_reftype_unzip__TypesOfArguments__U28data_BarU29202D_U20data_Foo__({
-        let originalBlock = block
+        let originalBlock: (data.Bar) -> data.Foo = block
         return { (arg0: Swift.UnsafeMutableRawPointer) in return originalBlock(data.Bar.__createClassWrapper(externalRCRef: arg0)).__externalRCRef() }
     }()))
 }
@@ -39,7 +39,7 @@ public func consume_block_with_reftype_zip(
     block: @escaping (data.Foo, data.Foo) -> data.Bar
 ) -> data.Bar {
     return data.Bar.__createClassWrapper(externalRCRef: __root___consume_block_with_reftype_zip__TypesOfArguments__U28data_Foo_U20data_FooU29202D_U20data_Bar__({
-        let originalBlock = block
+        let originalBlock: (data.Foo, data.Foo) -> data.Bar = block
         return { (arg0: Swift.UnsafeMutableRawPointer, arg1: Swift.UnsafeMutableRawPointer) in return originalBlock(data.Foo.__createClassWrapper(externalRCRef: arg0), data.Foo.__createClassWrapper(externalRCRef: arg1)).__externalRCRef() }
     }()))
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/simple/simple.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/simple/simple.swift
@@ -11,7 +11,7 @@ public var closure_property: () -> Swift.Void {
     }
     set {
         return { __root___closure_property_set__TypesOfArguments__U2829202D_U20Swift_Void__({
-            let originalBlock = newValue
+            let originalBlock: () -> Swift.Void = newValue
             return { return { originalBlock(); return true }() }
         }()); return () }()
     }
@@ -26,7 +26,7 @@ public func foo_consume_consuming(
     block: @escaping (@escaping (Swift.UInt32, Swift.UInt32) -> Swift.ClosedRange<Swift.Int32>) -> Swift.Void
 ) -> Swift.Void {
     return { __root___foo_consume_consuming__TypesOfArguments__U2840escapingU2028Swift_UInt32_U20Swift_UInt32U29202D_U20Swift_ClosedRange_Swift_Int32_U29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: (@escaping (Swift.UInt32, Swift.UInt32) -> Swift.ClosedRange<Swift.Int32>) -> Swift.Void = block
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
         return { _1, _2 in return { let _ref = simple_internal_functional_type_caller_SwiftU2EClosedRangeU3CSwiftU2EInt32U3E__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_UInt32_Swift_UInt32__(pointerToBlock.__externalRCRef()!, _1, _2); return kotlin_ranges_intRange_getStart_int_simple(_ref) ... kotlin_ranges_intRange_getEndInclusive_int_simple(_ref) }() }
@@ -37,7 +37,7 @@ public func foo_consume_consuming_2(
     block: @escaping (@escaping (Swift.UInt32, Swift.UInt32) -> Swift.ClosedRange<Swift.Int32>) -> Swift.Void
 ) -> Swift.Void {
     return { __root___foo_consume_consuming_2__TypesOfArguments__U2840escapingU2028Swift_UInt32_U20Swift_UInt32U29202D_U20Swift_ClosedRange_Swift_Int32_U29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: (@escaping (Swift.UInt32, Swift.UInt32) -> Swift.ClosedRange<Swift.Int32>) -> Swift.Void = block
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock({
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
         return { _1, _2 in return { let _ref = simple_internal_functional_type_caller_SwiftU2EClosedRangeU3CSwiftU2EInt32U3E__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_UInt32_Swift_UInt32__(pointerToBlock.__externalRCRef()!, _1, _2); return kotlin_ranges_intRange_getStart_int_simple(_ref) ... kotlin_ranges_intRange_getEndInclusive_int_simple(_ref) }() }
@@ -48,9 +48,9 @@ public func foo_consume_producing(
     block: @escaping () -> () -> Swift.Void
 ) -> Swift.Void {
     return { __root___foo_consume_producing__TypesOfArguments__U2829202D_U202829202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: () -> () -> Swift.Void = block
         return { return {
-        let originalBlock = originalBlock()
+        let originalBlock: () -> Swift.Void = originalBlock()
         return { return { originalBlock(); return true }() }
     }() }
     }()); return () }()
@@ -59,7 +59,7 @@ public func foo_consume_simple(
     block: @escaping () -> Swift.Void
 ) -> Swift.Void {
     return { __root___foo_consume_simple__TypesOfArguments__U2829202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: () -> Swift.Void = block
         return { return { originalBlock(); return true }() }
     }()); return () }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/strings/strings.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/strings/strings.swift
@@ -6,7 +6,7 @@ public func consume_block_with_string_id(
     block: @escaping (Swift.String) -> Swift.String
 ) -> Swift.String {
     return __root___consume_block_with_string_id__TypesOfArguments__U28Swift_StringU29202D_U20Swift_String__({
-        let originalBlock = block
+        let originalBlock: (Swift.String) -> Swift.String = block
         return { (arg0: Swift.String) in return originalBlock(arg0) }
     }())
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/typealias_to_closure/typealias_to_closure.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/typealias_to_closure/typealias_to_closure.swift
@@ -9,14 +9,14 @@ public func foo_flow_with_callback(
 ) -> typealias_to_closure.CallbackWithInnerClosure {
     return {
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: __root___foo_flow_with_callback__TypesOfArguments__U2840escapingU202829202D_U20Swift_Int32U29202D_U20Swift_Int32__({
-        let originalBlock = callback
+        let originalBlock: (@escaping () -> Swift.Int32) -> Swift.Int32 = callback
         return { (arg0: Swift.UnsafeMutableRawPointer) in return originalBlock({
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: arg0, options: .asBestFittingWrapper)!
         return { return typealias_to_closure_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!) }
     }()) }
     }()), options: .asBestFittingWrapper)!
         return { _1 in return typealias_to_closure_internal_functional_type_caller_SwiftU2EInt32__TypesOfArguments__Swift_UnsafeMutableRawPointer_U2829202D_U20Swift_Int32__(pointerToBlock.__externalRCRef()!, {
-        let originalBlock = _1
+        let originalBlock: () -> Swift.Int32 = _1
         return { return originalBlock() }
     }()) }
     }()
@@ -26,7 +26,7 @@ public func typealias_demo(
 ) -> typealias_to_closure.Closure {
     return {
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: __root___typealias_demo__TypesOfArguments__U28Swift_Int32_U20Swift_Int32U29202D_U20Swift_Void__({
-        let originalBlock = input
+        let originalBlock: (Swift.Int32, Swift.Int32) -> Swift.Void = input
         return { (arg0: Swift.Int32, arg1: Swift.Int32) in return { originalBlock(arg0, arg1); return true }() }
     }()), options: .asBestFittingWrapper)!
         return { _1, _2 in return { typealias_to_closure_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Int32_Swift_Int32__(pointerToBlock.__externalRCRef()!, _1, _2); return () }() }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/unit_param/unit_param.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/unit_param/unit_param.swift
@@ -12,7 +12,7 @@ public func barIn(
     block: @escaping (Swift.String, Swift.Void) -> Swift.Void
 ) -> Swift.Void {
     return { __root___barIn__TypesOfArguments__U28Swift_String_U20Swift_VoidU29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: (Swift.String, Swift.Void) -> Swift.Void = block
         return { (arg0: Swift.String, arg1: Swift.Bool) in return { originalBlock(arg0, { arg1; return () }()); return true }() }
     }()); return () }()
 }
@@ -20,7 +20,7 @@ public func baz() -> (@escaping (Swift.String, Swift.Void) -> Swift.Void) -> Swi
     return {
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: __root___baz(), options: .asBestFittingWrapper)!
         return { _1 in return { unit_param_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_U28Swift_String_U20Swift_VoidU29202D_U20Swift_Void__(pointerToBlock.__externalRCRef()!, {
-        let originalBlock = _1
+        let originalBlock: (Swift.String, Swift.Void) -> Swift.Void = _1
         return { (arg0: Swift.String, arg1: Swift.Bool) in return { originalBlock(arg0, { arg1; return () }()); return true }() }
     }()); return () }() }
     }()
@@ -35,7 +35,7 @@ public func fooIn(
     block: @escaping (Swift.Void) -> Swift.Void
 ) -> Swift.Void {
     return { __root___fooIn__TypesOfArguments__U28Swift_VoidU29202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: (Swift.Void) -> Swift.Void = block
         return { (arg0: Swift.Bool) in return { originalBlock({ arg0; return () }()); return true }() }
     }()); return () }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.swift
@@ -302,7 +302,7 @@ public func customFilter(
     predicate: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) -> Swift.Bool
 ) -> [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
     return __root___customFilter__TypesOfArgumentsE__Swift_Array_Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___U28Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_U29202D_U20Swift_Bool__(receiver.map { it in it as! NSObject? ?? NSNull() }, {
-        let originalBlock = predicate
+        let originalBlock: (Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>) -> Swift.Bool = predicate
         return { (arg0: Swift.UnsafeMutableRawPointer?) in return originalBlock({ switch arg0 { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()) }
     }()) as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
 }
@@ -316,7 +316,7 @@ public func produceBoxUpperBound(
     box: @escaping (main.Box) -> Swift.Void
 ) -> Swift.Void {
     return { __root___produceBoxUpperBound__TypesOfArguments__U28main_BoxU29202D_U20Swift_Void__({
-        let originalBlock = box
+        let originalBlock: (main.Box) -> Swift.Void = box
         return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(main.Box.__createClassWrapper(externalRCRef: arg0)); return true }() }
     }()); return () }()
 }
@@ -357,7 +357,7 @@ public func takeBoxUpperBoundClosure(
     box: @escaping () -> main.Box
 ) -> Swift.Void {
     return { __root___takeBoxUpperBoundClosure__TypesOfArguments__U2829202D_U20main_Box__({
-        let originalBlock = box
+        let originalBlock: () -> main.Box = box
         return { return originalBlock().__externalRCRef() }
     }()); return () }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/nothing_type/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/nothing_type/golden_result/main/main.swift
@@ -65,7 +65,7 @@ public func nothingClosure(
     block: @escaping () -> Swift.Never
 ) -> Swift.Never {
     return { __root___nothingClosure__TypesOfArguments__U2829202D_U20Swift_Never__({
-        let originalBlock = block
+        let originalBlock: () -> Swift.Never = block
         return { return { originalBlock() }() }
     }()); fatalError() }()
 }
@@ -73,7 +73,7 @@ public func nothingClosureParam(
     block: @escaping (Swift.Never) -> Swift.String
 ) -> Swift.String {
     return __root___nothingClosureParam__TypesOfArguments__U28Swift_NeverU29202D_U20Swift_String__({
-        let originalBlock = block
+        let originalBlock: (Swift.Never) -> Swift.String = block
         return { (arg0: Swift.Bool) in return originalBlock({ arg0; fatalError() }()) }
     }())
 }
@@ -93,7 +93,7 @@ public func nothingOptClosure(
     block: @escaping () -> Swift.Never?
 ) -> Swift.Never {
     return { __root___nothingOptClosure__TypesOfArguments__U2829202D_U20Swift_Optional_Swift_Never___({
-        let originalBlock = block
+        let originalBlock: () -> Swift.Optional<Swift.Never> = block
         return { return { originalBlock(); return true }() }
     }()); fatalError() }()
 }
@@ -101,7 +101,7 @@ public func nothingOptClosureParam(
     block: @escaping (Swift.Never?) -> Swift.String
 ) -> Swift.String {
     return __root___nothingOptClosureParam__TypesOfArguments__U28Swift_Optional_Swift_Never_U29202D_U20Swift_String__({
-        let originalBlock = block
+        let originalBlock: (Swift.Optional<Swift.Never>) -> Swift.String = block
         return { (arg0: Swift.Bool) in return originalBlock({ arg0; return nil }()) }
     }())
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/funinterface/funinterface.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/funinterface/funinterface.swift
@@ -114,7 +114,7 @@ extension ExportedKotlinPackages.funinterface {
         function: @escaping () -> Swift.Int32
     ) -> any ExportedKotlinPackages.funinterface._123FunctionalInterfaceWithLeadingNumbers {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: funinterface__123FunctionalInterfaceWithLeadingNumbers__TypesOfArguments__U2829202D_U20Swift_Int32__({
-            let originalBlock = function
+            let originalBlock: () -> Swift.Int32 = function
             return { return originalBlock() }
         }())) as! any ExportedKotlinPackages.funinterface._123FunctionalInterfaceWithLeadingNumbers
     }
@@ -122,7 +122,7 @@ extension ExportedKotlinPackages.funinterface {
         function: @escaping () -> Swift.Int32
     ) -> any ExportedKotlinPackages.funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: funinterface__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation__TypesOfArguments__U2829202D_U20Swift_Int32__({
-            let originalBlock = function
+            let originalBlock: () -> Swift.Int32 = function
             return { return originalBlock() }
         }())) as! any ExportedKotlinPackages.funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation
     }
@@ -130,7 +130,7 @@ extension ExportedKotlinPackages.funinterface {
         function: @escaping () -> Swift.Int32
     ) -> any ExportedKotlinPackages.funinterface._FunctionalInterfaceWithLeadingUnderscore {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: funinterface__FunctionalInterfaceWithLeadingUnderscore__TypesOfArguments__U2829202D_U20Swift_Int32__({
-            let originalBlock = function
+            let originalBlock: () -> Swift.Int32 = function
             return { return originalBlock() }
         }())) as! any ExportedKotlinPackages.funinterface._FunctionalInterfaceWithLeadingUnderscore
     }
@@ -138,7 +138,7 @@ extension ExportedKotlinPackages.funinterface {
         function: @escaping () -> Swift.Int32
     ) -> any ExportedKotlinPackages.funinterface.FunctionalInterface {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: funinterface_FunctionalInterface__TypesOfArguments__U2829202D_U20Swift_Int32__({
-            let originalBlock = function
+            let originalBlock: () -> Swift.Int32 = function
             return { return originalBlock() }
         }())) as! any ExportedKotlinPackages.funinterface.FunctionalInterface
     }
@@ -146,7 +146,7 @@ extension ExportedKotlinPackages.funinterface {
         function: @escaping () -> Swift.Int32
     ) -> any ExportedKotlinPackages.funinterface.functionalInterfaceWithAlreadyLowercaseLeading {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: funinterface_functionalInterfaceWithAlreadyLowercaseLeading__TypesOfArguments__U2829202D_U20Swift_Int32__({
-            let originalBlock = function
+            let originalBlock: () -> Swift.Int32 = function
             return { return originalBlock() }
         }())) as! any ExportedKotlinPackages.funinterface.functionalInterfaceWithAlreadyLowercaseLeading
     }
@@ -154,7 +154,7 @@ extension ExportedKotlinPackages.funinterface {
         function: @escaping () -> Swift.Int32
     ) -> any ExportedKotlinPackages.funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: funinterface_XMLFunctionalInterfaceWithLeadingAbbreviation__TypesOfArguments__U2829202D_U20Swift_Int32__({
-            let originalBlock = function
+            let originalBlock: () -> Swift.Int32 = function
             return { return originalBlock() }
         }())) as! any ExportedKotlinPackages.funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation
     }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/main/main.swift
@@ -94,7 +94,7 @@ public var functionalTypePropertyA: (main.MyOptInClass) -> Swift.Void {
     @_spi(MyOptInApi)
     set {
         return { __root___functionalTypePropertyA_set__TypesOfArguments__U28main_MyOptInClassU29202D_U20Swift_Void__({
-            let originalBlock = newValue
+            let originalBlock: (main.MyOptInClass) -> Swift.Void = newValue
             return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(main.MyOptInClass.__createClassWrapper(externalRCRef: arg0)); return true }() }
         }()); return () }()
     }
@@ -111,7 +111,7 @@ public var functionalTypePropertyB: (any lib.InternalLibInterface) -> Swift.Void
     @_spi(InternalLibApi)
     set {
         return { __root___functionalTypePropertyB_set__TypesOfArguments__U28anyU20lib_InternalLibInterfaceU29202D_U20Swift_Void__({
-            let originalBlock = newValue
+            let originalBlock: (any lib.InternalLibInterface) -> Swift.Void = newValue
             return { (arg0: Swift.UnsafeMutableRawPointer) in return { originalBlock(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0) as! any lib.InternalLibInterface); return true }() }
         }()); return () }()
     }
@@ -121,7 +121,7 @@ public func callbackFunction(
     action: @escaping () -> main.MyOptInClass
 ) -> Swift.Void {
     return { __root___callbackFunction__TypesOfArguments__U2829202D_U20main_MyOptInClass__({
-        let originalBlock = action
+        let originalBlock: () -> main.MyOptInClass = action
         return { return originalBlock().__externalRCRef() }
     }()); return () }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/typealiases/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/typealiases/golden_result/main/main.swift
@@ -460,7 +460,7 @@ public var block: main.closure {
     }
     set {
         return { __root___block_set__TypesOfArguments__U2829202D_U20Swift_Void__({
-            let originalBlock = newValue
+            let originalBlock: () -> Swift.Void = newValue
             return { return { originalBlock(); return true }() }
         }()); return () }()
     }
@@ -469,7 +469,7 @@ public func consume_closure(
     block: @escaping main.closure
 ) -> Swift.Void {
     return { __root___consume_closure__TypesOfArguments__U2829202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: () -> Swift.Void = block
         return { return { originalBlock(); return true }() }
     }()); return () }()
 }
@@ -478,7 +478,7 @@ public func deeper_closure_typealiase(
 ) -> main.deeper_closure_typealias {
     return {
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: __root___deeper_closure_typealiase__TypesOfArguments__U2829202D_U20Swift_Void__({
-        let originalBlock = block
+        let originalBlock: () -> Swift.Void = block
         return { return { originalBlock(); return true }() }
     }()), options: .asBestFittingWrapper)!
         return { return { main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!); return () }() }

--- a/native/swift/swift-export-standalone/resources/swift/KotlinCoroutineSupport.kt
+++ b/native/swift/swift-export-standalone/resources/swift/KotlinCoroutineSupport.kt
@@ -63,6 +63,25 @@ class SwiftJob private constructor(
     }
 }
 
+public fun <T> swiftCoroutine(
+    continuation: (T) -> Unit,
+    exception: (Any?) -> Unit,
+    cancellation: SwiftJob,
+    block: suspend CoroutineScope.() -> T
+) {
+    CoroutineScope(cancellation + Dispatchers.Default).launch(start = CoroutineStart.UNDISPATCHED) {
+        try {
+            continuation(block())
+        } catch (error: CancellationException) {
+            cancellation.cancel()
+            exception(null)
+            throw error
+        } catch (error: Throwable) {
+            exception(error)
+        }
+    }.alsoCancel(cancellation)
+}
+
 @ExportedBridge("__root___SwiftJob_init_allocate")
 public fun __root___SwiftJob_init_allocate(): kotlin.native.internal.NativePtr {
     val instance = kotlin.native.internal.createUninitializedInstance<SwiftJob>()
@@ -238,9 +257,14 @@ public fun SwiftFlowIterator_next(self: kotlin.native.internal.NativePtr, contin
     val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as SwiftFlowIterator<kotlin.Any?>
     val __continuation = run {
         val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.Boolean, kotlin.native.internal.NativePtr)->Unit>(continuation);
-        { arg0: kotlin.Boolean, arg1: kotlin.Any? ->
-            val _arg1 = if (arg1 == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(arg1)
-            val _result = kotlinFun(arg0, _arg1)
+        { arg0: SwiftFlowIterator<kotlin.Any?>.Value? ->
+            val _result = if (arg0 == null) {
+                kotlinFun(false, kotlin.native.internal.NativePtr.NULL)
+            } else {
+                val value = arg0.value
+                val _value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
+                kotlinFun(true, _value)
+            }
             _result
         }
     }
@@ -252,22 +276,9 @@ public fun SwiftFlowIterator_next(self: kotlin.native.internal.NativePtr, contin
         }
     }
     val __cancellation = kotlin.native.internal.ref.dereferenceExternalRCRef(cancellation) as SwiftJob
-    CoroutineScope(__cancellation + Dispatchers.Default).launch(start = CoroutineStart.UNDISPATCHED) {
-        try {
-            val _result = __self.next()
-            if (_result == null) {
-                __continuation(false, null)
-            } else {
-                __continuation(true, _result.value)
-            }
-        } catch (error: CancellationException) {
-            __cancellation.cancel()
-            __exception(null)
-            throw error
-        } catch (error: Throwable) {
-            __exception(error)
-        }
-    }.alsoCancel(__cancellation)
+    swiftCoroutine(__continuation, __exception, __cancellation) {
+        __self.next()
+    }
 }
 
 @ExportedBridge("_kotlin_swift_SwiftFlowIterator_init_allocate")

--- a/native/swift/swift-export-standalone/resources/swift/KotlinCoroutineSupport.swift
+++ b/native/swift/swift-export-standalone/resources/swift/KotlinCoroutineSupport.swift
@@ -44,6 +44,29 @@ package final class KotlinTask: KotlinRuntime.KotlinBase {
     }
 }
 
+package func withKotlinContinuation<T>(
+    _ fn: (@escaping (T) -> Void, @escaping (KotlinRuntime.KotlinBase?) -> Void, KotlinTask) -> Void
+) async throws -> T {
+    try await {
+        try Task.checkCancellation()
+        var cancellation: KotlinTask! = nil
+        return try await withTaskCancellationHandler {
+            try await withUnsafeThrowingContinuation { nativeContinuation in
+                withUnsafeCurrentTask { currentTask in
+                    let continuation: (T) -> Void = { nativeContinuation.resume(returning: $0) }
+                    let exception: (KotlinRuntime.KotlinBase?) -> Void = { error in
+                        nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
+                    }
+                    cancellation = KotlinTask(currentTask!)
+                    fn(continuation, exception, cancellation)
+                }
+            }
+        } onCancel: {
+            cancellation?.cancelExternally()
+        }
+    }()
+}
+
 public protocol KotlinFlow: KotlinRuntime.KotlinBase { }
 
 public protocol KotlinTypedFlow<Element> {
@@ -229,40 +252,23 @@ internal final class KotlinFlowIterator<Element>: KotlinRuntime.KotlinBase, Asyn
     }
 
     public func next() async throws -> Element? {
-        try await {
-            try Task.checkCancellation()
-            var cancellation: KotlinCoroutineSupport.KotlinTask! = nil
-            return try await withTaskCancellationHandler {
-                try await withUnsafeThrowingContinuation { (nativeContinuation: UnsafeContinuation<Element?, any Error>) in
-                    withUnsafeCurrentTask { currentTask in
-                        let continuation: (Swift.Optional<Element>) -> Swift.Void = { nativeContinuation.resume(returning: $0) }
-                        let exception: (Swift.Optional<KotlinRuntime.KotlinBase>) -> Swift.Void = { error in
-                            nativeContinuation.resume(throwing: error.map { KotlinError(wrapped: $0) } ?? CancellationError())
-                        }
-                        cancellation = KotlinCoroutineSupport.KotlinTask(currentTask!)
-
-                        let _: () = _kotlin_swift_SwiftFlowIterator_next(self.__externalRCRef(), { arg0, arg1 in
-                                return {
-                                    if arg0 {
-                                        let element = arg1.flatMap(KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef:)) as! Element
-                                        continuation(.some(element))
-                                    } else {
-                                        continuation(.none)
-                                    }
-                                    return 0
-                                }()
-                        }, { arg0 in
-                                return {
-                                    exception(arg0.flatMap(KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef:)));
-                                    return 0
-                                }()
-                        }, cancellation.__externalRCRef())
-                    }
+        let result: Element? = try await withKotlinContinuation { continuation, exception, cancellation in
+            let _continuation: (Bool, UnsafeMutableRawPointer?) -> Int32 = { arg0, arg1 in
+                if arg0 {
+                    let element = arg1.flatMap(KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef:)) as! Element
+                    continuation(.some(element))
+                } else {
+                    continuation(.none)
                 }
-            } onCancel: {
-                cancellation?.cancelExternally()
+                return 0
             }
-        }()
+            let _exception: (UnsafeMutableRawPointer?) -> Int32 = { arg0 in
+                exception(arg0.flatMap(KotlinRuntime.KotlinBase.__createClassWrapper(externalRCRef:)));
+                return 0
+            }
+            let _: () = _kotlin_swift_SwiftFlowIterator_next(self.__externalRCRef(), _continuation, _exception, cancellation.__externalRCRef())
+        }
+        return result
     }
 }
 


### PR DESCRIPTION
These functions contain the general bridging logic for calling Kotlin suspend functions as async functions from Swift.

This removes the duplicate code in the BridgeProvider and the KotlinFlowIterator class