### PR TITLE
[K/N] Port kotlin-ssp to C++

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
@@ -387,6 +387,22 @@ class ThreadSanitizerPipeline(config: LlvmPipelineConfig, performanceManager: Pe
     }
 }
 
+class StackProtectorPipeline(config: LlvmPipelineConfig, performanceManager: PerformanceManager?, logger: LoggingContext? = null) :
+        LlvmOptimizationPipeline(config, performanceManager, logger) {
+    override val pipelineName = "llvm-ssp"
+    override val passes = buildList {
+        val arg = when (config.sspMode) {
+            StackProtectorMode.NO -> null
+            StackProtectorMode.YES -> ""
+            StackProtectorMode.STRONG -> "<strong>"
+            StackProtectorMode.ALL -> "<req>"
+        }
+        arg?.let {
+            add("function(kotlin-ssp$it)")
+        }
+    }
+}
+
 internal fun RelocationModeFlags.currentRelocationMode(context: NativeBackendPhaseContext): RelocationModeFlags.Mode =
         when (determineLinkerOutput(context)) {
             LinkerOutputKind.DYNAMIC_LIBRARY -> dynamicLibraryRelocationMode

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
@@ -103,7 +103,7 @@ internal val ThreadSanitizerPhase = optimizationPipelinePass(
         pipeline = ::ThreadSanitizerPipeline
 )
 
-internal val StackProtectorPhase = createSimpleNamedCompilerPhase<OptimizationState, LLVMModuleRef>(
+internal val StackProtectorPhaseInCompiler = createSimpleNamedCompilerPhase<OptimizationState, LLVMModuleRef>(
         name = "StackProtectorPhase",
         postactions = getDefaultLlvmModuleActions(),
         op = { context: OptimizationState, module: LLVMModuleRef ->
@@ -119,6 +119,11 @@ internal val StackProtectorPhase = createSimpleNamedCompilerPhase<OptimizationSt
                         .forEach { addLlvmFunctionEnumAttribute(it, sspAttribute) }
             }
         }
+)
+
+internal val StackProtectorPhaseInLLVM = optimizationPipelinePass(
+        name = "StackProtectorPhase",
+        pipeline = ::StackProtectorPipeline
 )
 
 internal val RemoveRedundantSafepointsPhase = createSimpleNamedCompilerPhase<BitcodePostProcessingContext, Unit>(
@@ -163,7 +168,11 @@ internal fun <T : BitcodePostProcessingContext> PhaseEngine<T>.runBitcodePostPro
     )
     useContext(OptimizationState(context.config, optimizationConfig, context.performanceManager)) {
         val module = this@runBitcodePostProcessing.context.llvmModule
-        it.runAndMeasurePhase(StackProtectorPhase, module)
+        if (context.config.runLLVMPassesInCompiler) {
+            it.runAndMeasurePhase(StackProtectorPhaseInCompiler, module)
+        } else {
+            it.runAndMeasurePhase(StackProtectorPhaseInLLVM, module)
+        }
         it.runAndMeasurePhase(MandatoryBitcodeLLVMPostprocessingPhase, module)
         it.runAndMeasurePhase(ModuleBitcodeOptimizationPhase, module)
         it.runAndMeasurePhase(LTOBitcodeOptimizationPhase, module)

--- a/kotlin-native/libllvmext/README.md
+++ b/kotlin-native/libllvmext/README.md
@@ -33,3 +33,7 @@ Custom LLVM passes live in the [Passes](src/main/cpp/Passes) directory:
 - `PrepareThreadSanitizerPass` (`kotlin-tsan`): function pass, that applies `sanitize_thread` attribute
   to all defined functions; can't simply be done in the code generator, because we want this applied to
   the runtime as well, which is shipped as LLVM bitcode.
+- `PrepareStackProtectorPass` (`kotlin-ssp`): function pass, that applies `ssp` attribute to all defined
+  functions; can be configured as `kotlin-ssp<strong>` or `kotlin-ssp<req>` to apply `sspstrong` or `sspreq`
+  respectively; can't simply be done in the code generator, because we want this applied to the runtime
+  as well, which is shipped as LLVM bitcode.

--- a/kotlin-native/libllvmext/src/main/cpp/KotlinPlugin.cpp
+++ b/kotlin-native/libllvmext/src/main/cpp/KotlinPlugin.cpp
@@ -5,12 +5,51 @@
 #include "KotlinPlugin.h"
 
 #include "Passes/HideSymbols.h"
+#include "Passes/PrepareStackProtector.h"
 #include "Passes/PrepareThreadSanitizer.h"
 
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#include <optional>
 
 using namespace llvm;
 using namespace llvm::kotlin;
+
+static Expected<SspMode> ParseSspModePassOptions(StringRef Params) {
+  if (Params.empty()) {
+    return SspMode::Default;
+  }
+  if (Params == "strong") {
+    return SspMode::Strong;
+  }
+  if (Params == "req") {
+    return SspMode::Req;
+  }
+  return make_error<StringError>(
+      formatv("invalid kotlin-ssp pass parameter '{0}'", Params).str(),
+      inconvertibleErrorCode());
+}
+
+static bool parsePass(StringRef Name, StringRef PassName) {
+  return Name == PassName;
+}
+
+template <typename F>
+static auto parsePass(StringRef Name, StringRef PassName, F &&Parser)
+    -> std::optional<typename decltype(Parser(StringRef{}))::value_type> {
+  if (!PassBuilder::checkParametrizedPassName(Name, PassName)) {
+    return std::nullopt;
+  }
+  auto Param =
+      PassBuilder::parsePassParameters(std::forward<F>(Parser), Name, PassName);
+  if (auto E = Param.takeError()) {
+    reportFatalUsageError(std::move(E));
+  }
+  return std::make_optional(std::move(*Param));
+}
 
 PassPluginLibraryInfo getKotlinPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "Kotlin", LLVM_VERSION_STRING,
@@ -18,7 +57,7 @@ PassPluginLibraryInfo getKotlinPluginInfo() {
             PB.registerPipelineParsingCallback(
                 [](StringRef Name, ModulePassManager &PM,
                    ArrayRef<PassBuilder::PipelineElement>) {
-                  if (Name == "kotlin-hide-symbols") {
+                  if (parsePass(Name, "kotlin-hide-symbols")) {
                     PM.addPass(HideSymbolsPass());
                     return true;
                   }
@@ -27,8 +66,13 @@ PassPluginLibraryInfo getKotlinPluginInfo() {
             PB.registerPipelineParsingCallback(
                 [](StringRef Name, FunctionPassManager &PM,
                    ArrayRef<PassBuilder::PipelineElement>) {
-                  if (Name == "kotlin-tsan") {
+                  if (parsePass(Name, "kotlin-tsan")) {
                     PM.addPass(PrepareThreadSanitizerPass());
+                    return true;
+                  }
+                  if (auto Param = parsePass(Name, "kotlin-ssp",
+                                             ParseSspModePassOptions)) {
+                    PM.addPass(PrepareStackProtectorPass(*Param));
                     return true;
                   }
                   return false;

--- a/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareStackProtector.cpp
+++ b/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareStackProtector.cpp
@@ -1,0 +1,40 @@
+// Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language
+// contributors. Use of this source code is governed by the Apache 2.0 license
+// that can be found in the license/LICENSE.txt file.
+
+#include "PrepareStackProtector.h"
+
+#include "llvm/IR/Function.h"
+
+using namespace llvm;
+using namespace llvm::kotlin;
+
+static Attribute::AttrKind SSPAttributeForMode(SspMode Mode) {
+  switch (Mode) {
+  case SspMode::Default:
+    return Attribute::AttrKind::StackProtect;
+  case SspMode::Strong:
+    return Attribute::AttrKind::StackProtectStrong;
+  case SspMode::Req:
+    return Attribute::AttrKind::StackProtectReq;
+  }
+}
+
+PrepareStackProtectorPass::PrepareStackProtectorPass(SspMode Mode)
+    : Attr(SSPAttributeForMode(Mode)) {}
+
+PreservedAnalyses PrepareStackProtectorPass::run(Function &F,
+                                                 FunctionAnalysisManager &AF) {
+  if (!run(F))
+    return PreservedAnalyses::all();
+  return PreservedAnalyses::none();
+}
+
+bool PrepareStackProtectorPass::run(Function &F) {
+  if (F.isDeclaration())
+    return false;
+  if (F.getName() == "__clang_call_terminate")
+    return false;
+  F.addFnAttr(Attr);
+  return true;
+}

--- a/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareStackProtector.h
+++ b/kotlin-native/libllvmext/src/main/cpp/Passes/PrepareStackProtector.h
@@ -1,0 +1,39 @@
+// Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language
+// contributors. Use of this source code is governed by the Apache 2.0 license
+// that can be found in the license/LICENSE.txt file.
+
+#pragma once
+
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/PassManager.h"
+
+namespace llvm::kotlin {
+
+enum class SspMode {
+  Default,
+  Strong,
+  Req,
+};
+
+/// Annotate all defined functions with one of the `ssp` attributes:
+/// * `SspMode::Default`: `ssp`
+/// * `SspMode::Strong`: `sspstrong`
+/// * `SspMode::Req`: `sspreq`
+///
+/// This can't simply be done in the code generator, because we want
+/// this attribute applied to the runtime code as well, which ships as LLVM
+/// bitcode.
+class PrepareStackProtectorPass
+    : public PassInfoMixin<PrepareStackProtectorPass> {
+public:
+  explicit PrepareStackProtectorPass(SspMode Mode);
+
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AF);
+
+  bool run(Function &F);
+
+private:
+  Attribute::AttrKind Attr;
+};
+
+} // namespace llvm::kotlin

--- a/kotlin-native/libllvmext/testData/fileCheck/stackProtector.ll
+++ b/kotlin-native/libllvmext/testData/fileCheck/stackProtector.ll
@@ -1,0 +1,16 @@
+; OPT: --passes=kotlin-ssp
+
+; CHECK: define void @f_defined() #0 {
+define void @f_defined() {
+  ret void
+}
+
+; CHECK: define void @__clang_call_terminate() {
+define void @__clang_call_terminate() {
+  ret void
+}
+
+; CHECK: declare void @f_declared(){{$}}
+declare void @f_declared()
+
+; CHECK: attributes #0 = { ssp }

--- a/kotlin-native/libllvmext/testData/fileCheck/stackProtectorReq.ll
+++ b/kotlin-native/libllvmext/testData/fileCheck/stackProtectorReq.ll
@@ -1,0 +1,16 @@
+; OPT: --passes=kotlin-ssp<req>
+
+; CHECK: define void @f_defined() #0 {
+define void @f_defined() {
+  ret void
+}
+
+; CHECK: define void @__clang_call_terminate() {
+define void @__clang_call_terminate() {
+  ret void
+}
+
+; CHECK: declare void @f_declared(){{$}}
+declare void @f_declared()
+
+; CHECK: attributes #0 = { sspreq }

--- a/kotlin-native/libllvmext/testData/fileCheck/stackProtectorStrong.ll
+++ b/kotlin-native/libllvmext/testData/fileCheck/stackProtectorStrong.ll
@@ -1,0 +1,16 @@
+; OPT: --passes=kotlin-ssp<strong>
+
+; CHECK: define void @f_defined() #0 {
+define void @f_defined() {
+  ret void
+}
+
+; CHECK: define void @__clang_call_terminate() {
+define void @__clang_call_terminate() {
+  ret void
+}
+
+; CHECK: declare void @f_declared(){{$}}
+declare void @f_declared()
+
+; CHECK: attributes #0 = { sspstrong }


### PR DESCRIPTION
Add `PrepareStackProtector` LLVM pass that adds `StackProtect` attribute to all defined functions in the module.
In our case the module includes both Kotlin code and C++ runtime. Built-in LLVM ssp passes will perform any necessary lowerings.

The pass can be optionally parameterisised with `strong` or `req`, which will (respectively) add `StackProtectStrong` or `StackProtectReq` instead of `StackProtect`.

Before this commit, the transformation was performed manually in the compiler.

^KT-84060