### PR TITLE
[Tests] Fix incorrect k.t.assertNotNull usages

### DIFF
--- a/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/AbstractFileBasedKotlinDeclarationProviderTest.kt
+++ b/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/AbstractFileBasedKotlinDeclarationProviderTest.kt
@@ -39,13 +39,13 @@ abstract class AbstractFileBasedKotlinDeclarationProviderTest : AbstractAnalysis
         for (directive in moduleStructure.allDirectives[Directives.CLASS]) {
             val classId = ClassId.fromString(directive)
             assert(provider.getAllClassesByClassId(classId).isNotEmpty()) { "Class $classId not found" }
-            assertNotNull(provider.getClassLikeDeclarationByClassId(classId)) { "Class-like declaration $classId not found" }
+            assertNotNull(provider.getClassLikeDeclarationByClassId(classId), "Class-like declaration $classId not found")
         }
 
         for (directive in moduleStructure.allDirectives[Directives.TYPE_ALIAS]) {
             val classId = ClassId.fromString(directive)
             assert(provider.getAllTypeAliasesByClassId(classId).isNotEmpty()) { "Type alias $classId not found" }
-            assertNotNull(provider.getClassLikeDeclarationByClassId(classId)) { "Class-like declaration $classId not found" }
+            assertNotNull(provider.getClassLikeDeclarationByClassId(classId), "Class-like declaration $classId not found")
         }
 
         for (directive in moduleStructure.allDirectives[Directives.FUNCTION]) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/Kotlin2JsGradlePluginIT.kt
@@ -960,13 +960,13 @@ class Kotlin2JsIrGradlePluginIT : KGPBaseTest() {
 
                 val manifestLines = projectPath.resolve("build/classes/kotlin/js/main/default/manifest").readLines()
                 val serializedKlibFingerprint = manifestLines.singleOrNull { it.startsWith("serializedKlibFingerprint=") }
-                assertNotNull(serializedKlibFingerprint) { "can not find serializedKlibFingerprint" }
+                assertNotNull(serializedKlibFingerprint, "can not find serializedKlibFingerprint")
                 assertTrue("bad serializedKlibFingerprint format '$serializedKlibFingerprint'") {
                     Regex("serializedKlibFingerprint=[a-z0-9]+\\.[a-z0-9]+").matches(serializedKlibFingerprint)
                 }
 
                 val serializedIrFileFingerprints = manifestLines.singleOrNull { it.startsWith("serializedIrFileFingerprints=") }
-                assertNotNull(serializedIrFileFingerprints) { "can not find serializedIrFileFingerprints" }
+                assertNotNull(serializedIrFileFingerprints, "can not find serializedIrFileFingerprints")
                 assertTrue("bad serializedIrFileFingerprints format '$serializedIrFileFingerprints'") {
                     // kotlin2JsIrICProject has 2 files
                     Regex("serializedIrFileFingerprints=[a-z0-9]+\\.[a-z0-9]+ [a-z0-9]+\\.[a-z0-9]+").matches(serializedIrFileFingerprints)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinJsLibraryGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinJsLibraryGradlePluginIT.kt
@@ -33,8 +33,8 @@ abstract class KotlinJsIrLibraryGradlePluginITBase : KGPBaseTest() {
                     .getAsJsonObject("dependencies")
                     ?.entrySet()?.associate { [k, v] -> k to v.asString }
                     .let { dependencies ->
-                        assertNotNull(dependencies?.get("decamelize")) { "Direct npm dependency missing in package.json" }
-                        assertNotNull(dependencies?.get("@js-joda/core")) { "Transitive npm dependency missing in package.json" }
+                        assertNotNull(dependencies?.get("decamelize"), "Direct npm dependency missing in package.json")
+                        assertNotNull(dependencies?.get("@js-joda/core"), "Transitive npm dependency missing in package.json")
                     }
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT56143CinteropConfigurationAttributes.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT56143CinteropConfigurationAttributes.kt
@@ -148,9 +148,7 @@ class KT56143CinteropConfigurationAttributes {
                     "Expected no non-packed variant on $cinteropApiElements"
                 )
             } else {
-                assertNotNull(nonPackedVariant) {
-                    "Expected non-packed variant on $cinteropApiElements"
-                }
+                assertNotNull(nonPackedVariant, "Expected non-packed variant on $cinteropApiElements")
                 checkConfigurationAttributes(nonPackedVariant, true, true)
             }
 

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/klib/NativeNativeLibrarySpecialCompatibilityChecksTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/klib/NativeNativeLibrarySpecialCompatibilityChecksTest.kt
@@ -80,9 +80,10 @@ abstract class NativeLibrarySpecialCompatibilityChecksTest : LibrarySpecialCompa
 
         val version = KonanLibrarySpecialCompatibilityChecker.getCompilerVersionFromKonanProperties(stdlibLibrary)
 
-        assertNotNull(version) {
+        assertNotNull(
+            version,
             "getCompilerVersionFromKonanProperties() should return a non-null version for the real K/N stdlib at $nativeStdlibPath"
-        }
+        )
     }
 }
 


### PR DESCRIPTION
kotlin.test provides assertNotNull function accepting a lambda, but this lambda is not a lazy message-supplier,
but a callback invoked when the asserted value is not null.

This change fixes call sites where the lambda was
assumed to produce an error message.

See KT-86760 for details.