### PR TITLE
[Tests] Mute tests that are not supposed to be run with LV<=2.4

### DIFF
--- a/compiler/testData/codegen/box/basics/unchecked_cast10.kt
+++ b/compiler/testData/codegen/box/basics/unchecked_cast10.kt
@@ -1,4 +1,6 @@
 // IGNORE_BACKEND: JS_IR, JS_IR_ES6
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.3,2.4
+// KT-86822 is fixed no earlier than in 2.4.20-Beta1
 
 val any = Any()
 fun <T> foo(): T = any as T

--- a/compiler/testData/codegen/box/inference/earlierReifiedFix.kt
+++ b/compiler/testData/codegen/box/inference/earlierReifiedFix.kt
@@ -1,6 +1,8 @@
 // WITH_REFLECT
 // WITH_STDLIB
 // ISSUE: KT-86728
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_FIRST_STAGE: 2.4
+// KT-86728 is fixed in 2.4.20-Beta1
 import kotlin.reflect.KClass
 
 // Records which type argument the compiler reified at the call site.


### PR DESCRIPTION
Green CI: https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KlibBackwardAndForwardCompatibilityTestsNightly/970428876