### PR TITLE
[K/N][perf] Remove cinterop workaround for kotlinx-benchmark

### DIFF
--- a/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/KotlinxBenchmarkingPlugin.kt
+++ b/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/KotlinxBenchmarkingPlugin.kt
@@ -131,26 +131,6 @@ open class KotlinxBenchmarkingPlugin : BenchmarkingPlugin() {
             compilerFlags.addAll(linkTaskProvider.map { it.toolOptions.freeCompilerArgs.get() })
         }
         afterEvaluate {
-            // For some reason, the generated `*Benchmark` compilations do not inherit a dependency on cinterops from
-            // the main compilations (even though they `associateWith` them). Just create a new cinterop in the new
-            // compilation and copy the important configuration bits over.
-            // See https://github.com/Kotlin/kotlinx-benchmark/issues/190
-            kotlin.apply {
-                targets.filterIsInstance<KotlinNativeTarget>().forEach {
-                    val main by it.compilations.getting
-
-                    it.compilations.findByName("${it.name}Benchmark")?.apply {
-                        cinterops {
-                            main.cinterops.forEach {
-                                create(it.name) {
-                                    this.headers = it.headers
-                                    this.extraOpts = it.extraOpts
-                                }
-                            }
-                        }
-                    }
-                }
-            }
             benchmark.runBenchmark.configure {
                 // We do not want to cache benchmarking runs; we want the task to run whenever requested.
                 outputs.upToDateWhen { false }

--- a/kotlin-native/performance/settings.gradle.kts
+++ b/kotlin-native/performance/settings.gradle.kts
@@ -22,13 +22,13 @@ plugins {
 
 val knownGroups = buildList {
     add("ring")
-//    add("cinterop")
+    add("cinterop")
     add("helloworld")
-//    add("numerical")
+    add("numerical")
     add("startup")
     add("logging")
     if (System.getProperty("os.name") == "Mac OS X") {
-//        add("objcinterop")
+        add("objcinterop")
         add("swiftinterop")
     }
 }


### PR DESCRIPTION
Bootstrap version of KGP makes the workaround for kotlinx-benchmark unnecessary. Remove it and restore the disabled benchmarks

^KT-86889