### PR TITLE
[repo] Fix 'kotlin-metadata-jvm' flaky wrong outgoing artifact

### DIFF
--- a/libraries/scripting/dependencies-maven-all/build.gradle.kts
+++ b/libraries/scripting/dependencies-maven-all/build.gradle.kts
@@ -56,7 +56,6 @@ sourceSets {
 
 publish()
 
-noDefaultJar()
 sourcesJar()
 javadocJar()
 

--- a/libraries/tools/klib-abi-reader/build.gradle.kts
+++ b/libraries/tools/klib-abi-reader/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
 
 publish()
 
-noDefaultJar()
-
 val relocatedJar by task<ShadowJar> {
     configurations = listOf(embedded)
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/libraries/tools/kotlin-main-kts/build.gradle.kts
+++ b/libraries/tools/kotlin-main-kts/build.gradle.kts
@@ -57,8 +57,6 @@ sourceSets {
 
 publish()
 
-noDefaultJar()
-
 val embeddedConfiguration = configurations.named("embedded")
 val relocatedJar by task<ShadowJar> {
     configurations.set(setOf(embeddedConfiguration.get()))

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/repoArtifacts.kt
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/repoArtifacts.kt
@@ -81,6 +81,7 @@ fun Project.testsJarToBeUsedAlongWithFixtures() {
 fun Project.setPublishableArtifact(
     jarTask: TaskProvider<out Jar>
 ) {
+    noDefaultJar()
     addArtifact("runtimeElements", jarTask)
     addArtifact("apiElements", jarTask)
     tasks.named("assemble").configure { dependsOn(jarTask) }


### PR DESCRIPTION
Sometimes compile of projects that depend on 'kotlin-metadata-jvm' fails
 with missing symbols error. This is caused by following:
- 'kotlin-metadata-jvm' has 'jar' task enabled, but also has
'relocatedJar' task which embeds additional compiled code
- Both of these tasks write to 'libraries/kotlinx-metadata/jvm/build/libs/kotlin-metadata-jvm-2.4.255-SNAPSHOT.jar' location
- Usually it is not a problem as 'jar' task finishes first and then
'relocatedJar' task overwrites it.
- But sometimes 'relocatedJar' task has 'UP-TO-DATE' state, Gradle
schedules 'jar' task after it and runs it as output has changed

This fix ensures that when 'setPublishableArtifact' is called to set
default publication artfiact, artifact from the default 'jar' is removed.
