### PR TITLE
JVM: Wait for android emulator before adb logcat

### DIFF
--- a/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidRunner.kt
+++ b/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/CodegenTestsOnAndroidRunner.kt
@@ -49,17 +49,24 @@ class CodegenTestsOnAndroidRunner private constructor(private val pathManager: P
             emulator.startAdbServer()
 
             val emulatorJob = launch { emulator.runEmulator() }
-            val logcatJob = launch { emulator.printLog() }
 
             try {
                 emulator.waitEmulatorStart()
                 emulator.waitForInstallStabilization()
 
-                for (flavor in flavorsToRun) {
-                    installAndroidDebugTestWithRetry(gradleRunner, emulator, flavor)
-                    val className = flavor.capitalizeAsciiOnly()
-                    runTestsOnEmulator(emulator, className, TestSuite(className)).apply {
-                        rootSuite.addTest(this)
+                val logcatJob = launch { emulator.printLog() }
+
+                try {
+                    for (flavor in flavorsToRun) {
+                        installAndroidDebugTestWithRetry(gradleRunner, emulator, flavor)
+                        val className = flavor.capitalizeAsciiOnly()
+                        runTestsOnEmulator(emulator, className, TestSuite(className)).apply {
+                            rootSuite.addTest(this)
+                        }
+                    }
+                } finally {
+                    withContext(NonCancellable) {
+                        logcatJob.cancelAndJoin()
                     }
                 }
             } catch (e: RuntimeException) {
@@ -67,7 +74,6 @@ class CodegenTestsOnAndroidRunner private constructor(private val pathManager: P
                 throw e
             } finally {
                 withContext(NonCancellable) {
-                    logcatJob.cancelAndJoin()
                     emulatorJob.cancelAndJoin()
                     emulator.stopAdbServer()
                 }

--- a/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/emulator/Emulator.kt
+++ b/compiler/android-tests/tests/org/jetbrains/kotlin/android/tests/emulator/Emulator.kt
@@ -151,7 +151,17 @@ class Emulator(private val pathManager: PathManager, private val platform: Strin
         val commandLine = createAdbCommand()
         commandLine.addParameter("start-server")
         println("Start adb server...")
-        runProcessCancellable(commandLine)
+        runProcessCancellable(commandLine, timeout = 120.seconds)
+        // Wait until daemon is actually ready
+        val checkCommand = createAdbCommand().also { it.addParameter("devices") }
+        repeat(10) { attempt ->
+            val result = runProcessCancellable(checkCommand, checkExitCode = false, timeout = 5.seconds)
+            if (result.exitCode == 0) return
+            println("Waiting for adb daemon to be ready (attempt ${attempt + 1})...")
+            delay(10.seconds)
+        }
+
+        error("Failed to start adb server")
     }
 
     suspend fun runEmulator() {


### PR DESCRIPTION
Otherwise, if adb server restarts, adb logcat will disconnect from it, cancelling the whole coroutine tree, eventually leading to android tests failing.
 #KTI-3106