### PR TITLE
[Wasm] Ignore failing Invalidation single module tests (issue to investigate: KT-86906)

### DIFF
--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/incremental/FirWasmAbstractInvalidationTest.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/incremental/FirWasmAbstractInvalidationTest.kt
@@ -46,6 +46,17 @@ abstract class AbstractFirWasmInvalidationSingleModuleTest :
 
     private val ignoredTests = setOf(
         "mainFunctionSelect", //KT-85577 Single module mode execute all main functions in dependencies
+        "mainFunctionSelectPlainAndArgs", //Investigate KT-86906
+        "mainFunctionSelectSameFileDualShape", //Investigate KT-86906
+        "mainFunctionSelectSamePackage", //Investigate KT-86906
+        "mainFunctionSelectSingleAddWrapperLater", //Investigate KT-86906
+        "mainFunctionSelectCrossedFilePackagePlainAndArgsFail", //Investigate KT-86906
+        "mainFunctionSelectCrossedFilePackageTwoPlainFail", //Investigate KT-86906
+        "mainFunctionSelectDoubleWrapper", //Investigate KT-86906
+        "mainFunctionSelectSamePackageMixedShape", //Investigate KT-86906
+        "mainFunctionSelectSingleAddPlainEarlier", //Investigate KT-86906
+        "mainFunctionSelectSingleAddPlainLater", //Investigate KT-86906
+        "mainFunctionSelectSingleAddWrapperEarlier", //Investigate KT-86906
     )
 
     override fun isIgnoredTest(projectInfo: ProjectInfo): Boolean =


### PR DESCRIPTION
mute by now failing invalidation single module tests