### PR TITLE
Improve idempotency check for   integrateLinkagePackage

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportXcodeIntegrationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportXcodeIntegrationIT.kt
@@ -76,6 +76,11 @@ class SwiftPMImportXcodeIntegrationIT : KGPBaseTest() {
                     "productName = $SYNTHETIC_IMPORT_TARGET_MAGIC_NAME;",
                     message = "Swift package dependency should reference the synthetic product name"
                 )
+                assertContains(
+                    pbxFileContent,
+                    Regex("""\bpackage = [A-F0-9]+;"""),
+                    message = "Swift package dependency should declare a 'package = <UUID>;' linkage"
+                )
 
                 assertEquals(
                     SwiftPackageLibraryType.AUTOMATIC,

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportXcodeIntegrationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportXcodeIntegrationIT.kt
@@ -490,6 +490,45 @@ class SwiftPMImportXcodeIntegrationIT : KGPBaseTest() {
     }
 
     @GradleTest
+    fun `integrateLinkagePackage repairs broken linkage from prior buggy runs`(version: GradleVersion) {
+        project("emptyxcode", version, buildOptions = defaultBuildOptions.disableConfigurationCacheForGradle7(version)) {
+            initDefaultKmpWithLocalSPM()
+
+            build(
+                "integrateLinkagePackage",
+                environmentVariables = EnvironmentalVariables(
+                    "XCODEPROJ_PATH" to "iosApp/iosApp.xcodeproj",
+                )
+            )
+            val pbxFile = projectPath.resolve("iosApp/iosApp.xcodeproj/project.pbxproj")
+
+            // Simulate a pbxproj produced by a pre-fix buggy KGP: strip the
+            // `package = <UUID>;` linkage line out of the XCSwiftPackageProductDependency block.
+            val originalContent = pbxFile.readText()
+            val brokenContent = originalContent.replace(
+                Regex("""\n\s*package = [A-F0-9]{24};"""),
+                ""
+            )
+            check(brokenContent != originalContent) { "Failed to simulate broken state" }
+            pbxFile.writeText(brokenContent)
+
+            build(
+                "integrateLinkagePackage",
+                environmentVariables = EnvironmentalVariables(
+                    "XCODEPROJ_PATH" to "iosApp/iosApp.xcodeproj",
+                )
+            ) {
+                assertOutputContains("Repaired existing broken linkage")
+                assertContains(
+                    pbxFile.readText(),
+                    Regex("""\bpackage = [A-F0-9]{24};"""),
+                    message = "Swift package dependency should be repaired with the package UUID linkage"
+                )
+            }
+        }
+    }
+
+    @GradleTest
     fun `integrateLinkagePackage reruns synthetic manifest generation when new Package is added`(version: GradleVersion) {
         project("emptyxcode", version) {
             val includeSecondPackageProp = "includeSecondPackage"

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeIntegrations.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeIntegrations.kt
@@ -184,6 +184,11 @@ internal abstract class IntegrateLinkagePackageIntoXcodeProject : DefaultTask() 
 
         val pbxprojPath = projectPath.resolve("project.pbxproj")
         val project = deserializeXcodeProject(pbxprojPath, execOps)
+        if (repairBrokenLinkage(project)) {
+            saveJsonBackIntoPbxproj(execOps, xcodeprojTemporaries.getFile(), project, pbxprojPath.path)
+            logger.quiet("Repaired existing broken linkage")
+            return
+        }
         if (linkageProductsReferencedInPBXObjects(project).isNotEmpty()) {
             logger.quiet("Product already referenced, nothing to do")
             return
@@ -374,13 +379,37 @@ internal fun gradleTaskPath(
     }
 }
 
+private val XCSwiftPackageProductDependency.isForSyntheticTarget: Boolean
+    get() = productName == GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME
+
+private val XCLocalSwiftPackageReference.isForSyntheticTarget: Boolean
+    get() = relativePath == GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME
+
 internal fun linkageProductsReferencedInPBXObjects(project: XcodeProject): Set<String> {
-    // FIXME: KT-83876 Check if the product is correctly integrated into the build phase
     return project.objects.entries.mapNotNull { (id, pbxObject) ->
-        if ((pbxObject as? XCSwiftPackageProductDependency)?.productName == GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME) {
-            id
-        } else {
-            null
-        }
+        val productDep = pbxObject as? XCSwiftPackageProductDependency ?: return@mapNotNull null
+        if (productDep.isForSyntheticTarget && productDep.packageReference != null) id else null
     }.toSet()
+}
+
+/**
+ * Repair a pbxproj left in the broken state by a prior buggy run: an
+ * XCSwiftPackageProductDependency carries the synthetic productName but is
+ * missing the `package` linkage back to its XCLocalSwiftPackageReference.
+ * Adds the missing field in place so the integration recovers on re-run
+ * without manual edits. Returns true iff a repair was applied.
+ */
+internal fun repairBrokenLinkage(project: XcodeProject): Boolean {
+    val localPackageRefId = project.objects.entries.firstOrNull { (_, obj) ->
+        (obj as? XCLocalSwiftPackageReference)?.isForSyntheticTarget == true
+    }?.key ?: return false
+
+    var repaired = false
+    project.objects.values.forEach { obj ->
+        if (obj is XCSwiftPackageProductDependency && obj.isForSyntheticTarget && obj.packageReference == null) {
+            obj.packageReference = localPackageRefId
+            repaired = true
+        }
+    }
+    return repaired
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeIntegrations.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeIntegrations.kt
@@ -222,7 +222,10 @@ internal abstract class IntegrateLinkagePackageIntoXcodeProject : DefaultTask() 
 
         project.objects[buildFileDependencyReference] = PbxBuildFile(productRef = productDependencyReference)
         project.objects[localPackageReference] = XCLocalSwiftPackageReference(relativePath = GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME)
-        project.objects[productDependencyReference] = XCSwiftPackageProductDependency(productName = GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME)
+        project.objects[productDependencyReference] = XCSwiftPackageProductDependency(
+            productName = GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME,
+            packageReference = localPackageReference,
+        )
 
         saveJsonBackIntoPbxproj(
             execOps,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeProjectParsing.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeProjectParsing.kt
@@ -189,7 +189,7 @@ internal class XCSwiftPackageProductDependency(
     val isa: String = "XCSwiftPackageProductDependency",
     val productName: String?,
     @SerialName("package")
-    val packageReference: String?,
+    var packageReference: String?,
 ) : PbxObject()
 
 @Serializable

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeProjectParsing.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/xcodeProjectParsing.kt
@@ -188,6 +188,8 @@ internal class PbxShellScriptBuildPhase(
 internal class XCSwiftPackageProductDependency(
     val isa: String = "XCSwiftPackageProductDependency",
     val productName: String?,
+    @SerialName("package")
+    val packageReference: String?,
 ) : PbxObject()
 
 @Serializable


### PR DESCRIPTION
KT-83876: the idempotency check in `linkageProductsReferencedInPBXObjects`
only verified the synthetic `productName` on `XCSwiftPackageProductDependency`.
A project left in the partially-broken state fixed in #6170 (entry emitted
without the `package` linkage) would report
`Product already referenced, nothing to do` on re-run and never self-heal.

Changes:
- Tighten the check to also require a non-null `package` linkage.
- Add `repairBrokenLinkage`, called at the start of `integrate()`, which
  detects a broken `XCSwiftPackageProductDependency` (synthetic `productName`
  but missing `package`) and patches the missing field in place, pointing it
  at the existing `XCLocalSwiftPackageReference`. Users upgrading from an
  affected Kotlin version recover automatically on re-run instead of editing
  pbxproj by hand.

Test: added `integrateLinkagePackage repairs broken linkage from prior buggy
runs` to `SwiftPMImportXcodeIntegrationIT`, simulating the broken state by
stripping the `package = <UUID>;` line and asserting the repair log + the
restored linkage.

Also verified end-to-end on the minimal repro
(<https://github.com/error96num/spm-import-kt-83882-repro>): a pbxproj broken
by stock Kotlin 2.4.0 reports `nothing to do` on re-run (KT-83876), and is
repaired in place after upgrading to a locally-built KGP with this patch.

Depends on #6170 — this branch is based on it and should be merged after.

^KT-83876 Fixed
