### PR TITLE
[BTA] Check versioned options declare availableSinceVersion

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/AvailableSinceTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/AvailableSinceTest.kt
@@ -493,6 +493,8 @@ class AvailableSinceTest : BaseCompilationTest() {
         "org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration",
         "org.jetbrains.kotlin.buildtools.api.js.operations.JsKlibCompilationOperation",
         "org.jetbrains.kotlin.buildtools.api.js.JsHistoryBasedIncrementalCompilationConfiguration",
+        "org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmKlibCompilationOperation",
+        "org.jetbrains.kotlin.buildtools.api.wasm.WasmHistoryBasedIncrementalCompilationConfiguration",
     )
 
     /**
@@ -507,8 +509,6 @@ class AvailableSinceTest : BaseCompilationTest() {
         "org.jetbrains.kotlin.buildtools.api.abi.AbiFilters",
         "org.jetbrains.kotlin.buildtools.api.abi.operations.DumpJvmAbiToStringOperation",
         "org.jetbrains.kotlin.buildtools.api.abi.operations.DumpKlibAbiToStringOperation",
-        "org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmKlibCompilationOperation",
-        "org.jetbrains.kotlin.buildtools.api.wasm.WasmHistoryBasedIncrementalCompilationConfiguration",
     )
 
     private fun Class<*>.declaredOptionFields(): List<Field> =

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/AvailableSinceTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/AvailableSinceTest.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation.Companion.CO
 import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation.Companion.GENERATE_COMPILER_REF_INDEX
 import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation.Companion.LOOKUP_TRACKER
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.internal.BaseOption
 import org.jetbrains.kotlin.buildtools.api.js.JsHistoryBasedIncrementalCompilationConfiguration
 import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain.Companion.js
 import org.jetbrains.kotlin.buildtools.api.js.jsKlibCompilationOperation
@@ -34,7 +35,12 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.lang.reflect.Field
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.jar.JarFile
 import kotlin.io.path.Path
 
 class AvailableSinceTest : BaseCompilationTest() {
@@ -86,7 +92,7 @@ class AvailableSinceTest : BaseCompilationTest() {
                                 message: String,
                                 location: CompilerMessageRenderer.SourceLocation?,
                             ): String {
-                                TODO("Not yet implemented")
+                                return message
                             }
                         }
                     }
@@ -249,7 +255,7 @@ class AvailableSinceTest : BaseCompilationTest() {
                                 message: String,
                                 location: CompilerMessageRenderer.SourceLocation?,
                             ): String {
-                                TODO("Not yet implemented")
+                                return message
                             }
                         }
                     }
@@ -329,6 +335,193 @@ class AvailableSinceTest : BaseCompilationTest() {
             }
         }
     }
+
+    /**
+     * Sanity check: reflection-based discovery must find at least one option holder.
+     */
+    @Test
+    fun testOptionHoldersAreDiscovered() {
+        val holders = discoverOptionHoldersOrSkip()
+        assertTrue(holders.isNotEmpty()) {
+            "Expected to discover at least one option holder in the `org.jetbrains.kotlin.buildtools.api` package"
+        }
+    }
+
+    /**
+     * Checks that the manually maintained registry of option holders stays in sync with reflection-based discovery:
+     * every expected holder is discovered, and every discovered holder is registered. Problems are aggregated so that
+     * one mismatch does not hide the others.
+     */
+    @Test
+    fun testOptionHoldersMatchKnownSets() {
+        val holders = discoverOptionHoldersOrSkip()
+        val discoveredOptionsHolders = holders.map { it.name }.toSet()
+        val expectedOptionsHolders = knownVersionedOptionHolders + knownUnversionedOptionHolders
+
+        val problems = buildList {
+            val notDiscovered = expectedOptionsHolders - discoveredOptionsHolders
+            if (notDiscovered.isNotEmpty()) {
+                add(
+                    "Reflection-based discovery did not find expected option holder(s): $notDiscovered.\n" +
+                            "Either the holder was removed/renamed, or the discovery criteria in `discoverOptionHolders()` broke."
+                )
+            }
+
+            val unregistered = discoveredOptionsHolders - expectedOptionsHolders
+            if (unregistered.isNotEmpty()) {
+                add(
+                    "New option holder(s) discovered but not registered: $unregistered.\n" +
+                            "Add each to `knownVersionedOptionHolders` (and `trySet(...)` coverage in a dedicated test above), " +
+                            "or to `knownUnversionedOptionHolders` if `availableSinceVersion` adoption is postponed."
+                )
+            }
+        }
+
+        assertTrue(problems.isEmpty()) {
+            "The set of registered option holders is out of sync with reflection-based discovery:\n" + problems.joinToString("\n")
+        }
+    }
+
+    /**
+     * A holder must appear in exactly one of the registry sets. Temporary: this check goes away together with
+     * `knownUnversionedOptionHolders`.
+     */
+    @Test
+    fun testKnownOptionHolderSetsDoNotOverlap() {
+        val overlap = knownVersionedOptionHolders intersect knownUnversionedOptionHolders
+        assertTrue(overlap.isEmpty()) {
+            "Option holder(s) listed both as versioned and unversioned: $overlap.\n" +
+                    "Each holder must appear in exactly one of `knownVersionedOptionHolders` / `knownUnversionedOptionHolders`."
+        }
+    }
+
+    /**
+     * Every option of a holder registered in [knownVersionedOptionHolders] must declare an `availableSinceVersion`.
+     */
+    @Test
+    fun testKnownVersionedOptionHoldersHaveAvailableSinceVersion() {
+        val versionedHolders = discoverOptionHoldersOrSkip().filter { it.name in knownVersionedOptionHolders }
+        val problems = versionedHolders.mapNotNull { holder ->
+            val options = holder.declaredOptions()
+            val optionsMissingVersion = options.filterNot { it.hasAvailableSinceVersion() }
+            when {
+                optionsMissingVersion.isEmpty() -> null
+                optionsMissingVersion.size < options.size -> {
+                    "${holder.name} is only partially versioned, options without an `availableSinceVersion`: ${optionsMissingVersion.map { it.id }}. " +
+                            "Declare it for all options and add `trySet(...)` coverage in a dedicated test above"
+                }
+                else -> {
+                    "${holder.name} declares options without an `availableSinceVersion`: ${optionsMissingVersion.map { it.id }}. " +
+                            "Declare it and add `trySet(...)` coverage in a dedicated test above"
+                }
+            }
+        }
+
+        assertTrue(problems.isEmpty()) {
+            "The Build Tools API option version checking is inconsistent:\n" + problems.joinToString("\n")
+        }
+    }
+
+    /**
+     * Holders registered in [knownUnversionedOptionHolders] postponed `availableSinceVersion` adoption and must not
+     * declare it yet. Temporary: this check goes away once the adoption is complete. Once a holder adopts
+     * `availableSinceVersion`, it must be moved to [knownVersionedOptionHolders].
+     */
+    @Test
+    fun testKnownUnversionedOptionHoldersDoNotHaveAvailableSinceVersion() {
+        val unversionedHolders = discoverOptionHoldersOrSkip().filter { it.name in knownUnversionedOptionHolders }
+        val problems = unversionedHolders.mapNotNull { holder ->
+            val options = holder.declaredOptions()
+            val stillUnversionedOptions = options.filterNot { it.hasAvailableSinceVersion() }
+            when {
+                stillUnversionedOptions.isEmpty() -> {
+                    "${holder.name} is versioned now: remove it from `knownUnversionedOptionHolders` " +
+                            "and add `trySet(...)` coverage for its options in a dedicated test above"
+                }
+                stillUnversionedOptions.size < options.size -> {
+                    "${holder.name} is only partially versioned, options without an `availableSinceVersion`: ${stillUnversionedOptions.map { it.id }}. " +
+                            "Declare it for all options and add `trySet(...)` coverage in a dedicated test above"
+                }
+                else -> null
+            }
+        }
+
+        assertTrue(problems.isEmpty()) {
+            "The Build Tools API option version checking is inconsistent:\n" + problems.joinToString("\n")
+        }
+    }
+
+    private fun discoverOptionHolders(): List<Class<*>> {
+        val apiLoader = BaseOption::class.java.classLoader
+        val location = Paths.get(BaseOption::class.java.protectionDomain.codeSource.location.toURI())
+        val classFilePaths = if (Files.isDirectory(location)) {
+            location.toFile().walkTopDown().map { location.relativize(it.toPath()).joinToString("/") }.toList()
+        } else {
+            JarFile(location.toFile()).use { jar -> jar.entries().asSequence().map { it.name }.toList() }
+        }
+        // Derived from a real class in the target package instead of a hardcoded path, so a typo or
+        // a future package rename cannot silently make discovery return nothing
+        val packagePrefix = BuildOperation::class.java.name.substringBeforeLast('.').replace('.', '/') + "/"
+        return classFilePaths
+            .filter { it.startsWith(packagePrefix) && it.endsWith(".class") }
+            .mapNotNull { runCatching { apiLoader.loadClass(it.removeSuffix(".class").replace('/', '.')) }.getOrNull() }
+            .filter { it.declaredOptionFields().isNotEmpty() }
+    }
+
+    /**
+     * Loads the implementation, skips the test if the loaded compiler version has no option version checking, and
+     * returns the discovered option holders.
+     */
+    private fun discoverOptionHoldersOrSkip(): List<Class<*>> {
+        val toolchains = KotlinToolchains.loadImplementation(btaClassloader)
+        assumeTrue(toolchains.hasOptionVersionChecking())
+        return discoverOptionHolders()
+    }
+
+    /**
+     * Option holders that adopt `availableSinceVersion`.
+     * Manually maintained registry, cross-checked against reflection-based discovery.
+     */
+    private val knownVersionedOptionHolders: Set<String> = setOf(
+        "org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation",
+        "org.jetbrains.kotlin.buildtools.api.BuildOperation",
+        "org.jetbrains.kotlin.buildtools.api.BaseIncrementalCompilationConfiguration",
+        $$"org.jetbrains.kotlin.buildtools.api.ExecutionPolicy$WithDaemon",
+        "org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation",
+        "org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshottingOperation",
+        "org.jetbrains.kotlin.buildtools.api.jvm.operations.DiscoverScriptExtensionsOperation",
+        "org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration",
+        "org.jetbrains.kotlin.buildtools.api.js.operations.JsKlibCompilationOperation",
+        "org.jetbrains.kotlin.buildtools.api.js.JsHistoryBasedIncrementalCompilationConfiguration",
+    )
+
+    /**
+     * Option holders that intentionally do not adopt `availableSinceVersion`: either the adoption is postponed
+     * (tracked by a ticket), or the holder is deprecated to error for removal.
+     * Manually maintained registry, cross-checked against reflection-based discovery.
+     */
+    private val knownUnversionedOptionHolders: Set<String> = setOf(
+        // deprecated with `DeprecationLevel.ERROR`, awaiting removal
+        "org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationOptions",
+        // `availableSinceVersion` adoption is postponed
+        "org.jetbrains.kotlin.buildtools.api.abi.AbiFilters",
+        "org.jetbrains.kotlin.buildtools.api.abi.operations.DumpJvmAbiToStringOperation",
+        "org.jetbrains.kotlin.buildtools.api.abi.operations.DumpKlibAbiToStringOperation",
+        "org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmKlibCompilationOperation",
+        "org.jetbrains.kotlin.buildtools.api.wasm.WasmHistoryBasedIncrementalCompilationConfiguration",
+    )
+
+    private fun Class<*>.declaredOptionFields(): List<Field> =
+        declaredFields.filter { Modifier.isStatic(it.modifiers) && BaseOption::class.java.isAssignableFrom(it.type) }
+
+    private fun Class<*>.declaredOptions(): List<BaseOption<*>> =
+        declaredOptionFields().map { field ->
+            field.isAccessible = true
+            field.get(null) as BaseOption<*>
+        }
+
+    private fun BaseOption<*>.hasAvailableSinceVersion(): Boolean =
+        this::class.java.methods.find { it.name == "getAvailableSinceVersion" }?.invoke(this) != null
 
     private fun KotlinToolchains.hasOptionVersionChecking(): Boolean =
         KotlinToolingVersion(getCompilerVersion()) >= KotlinToolingVersion(2, 4, 20, "snapshot")

--- a/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
+++ b/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
@@ -1972,6 +1972,7 @@ public final class org/jetbrains/kotlin/buildtools/api/wasm/WasmHistoryBasedIncr
 }
 
 public final class org/jetbrains/kotlin/buildtools/api/wasm/WasmHistoryBasedIncrementalCompilationConfiguration$Option : org/jetbrains/kotlin/buildtools/api/internal/BaseOption {
+	public final fun getAvailableSinceVersion ()Lorg/jetbrains/kotlin/buildtools/api/KotlinReleaseVersion;
 }
 
 public abstract interface class org/jetbrains/kotlin/buildtools/api/wasm/WasmIncrementalCompilationConfiguration {
@@ -2019,6 +2020,7 @@ public final class org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmKlibC
 }
 
 public final class org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmKlibCompilationOperation$Option : org/jetbrains/kotlin/buildtools/api/internal/BaseOption {
+	public final fun getAvailableSinceVersion ()Lorg/jetbrains/kotlin/buildtools/api/KotlinReleaseVersion;
 }
 
 public final class org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmKlibCompilationOperationKt {
@@ -2044,5 +2046,6 @@ public abstract interface class org/jetbrains/kotlin/buildtools/api/wasm/operati
 }
 
 public final class org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmLinkingOperation$Option : org/jetbrains/kotlin/buildtools/api/internal/BaseOption {
+	public final fun getAvailableSinceVersion ()Lorg/jetbrains/kotlin/buildtools/api/KotlinReleaseVersion;
 }
 

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/wasm/WasmHistoryBasedIncrementalCompilationConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/wasm/WasmHistoryBasedIncrementalCompilationConfiguration.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.buildtools.api.wasm
 
 import org.jetbrains.kotlin.buildtools.api.BaseIncrementalCompilationConfiguration
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.buildtools.api.internal.BaseOption
 import java.nio.file.Path
@@ -105,7 +106,10 @@ public interface WasmHistoryBasedIncrementalCompilationConfiguration : WasmIncre
      * @see get
      * @see set
      */
-    public class Option<V> internal constructor(id: String) : BaseOption<V>(id)
+    public class Option<V> internal constructor(
+        id: String,
+        public val availableSinceVersion: KotlinReleaseVersion,
+    ) : BaseOption<V>(id)
 
     /**
      * Get the value for option specified by [key] if it was previously [set] or if it has a default value.
@@ -122,7 +126,8 @@ public interface WasmHistoryBasedIncrementalCompilationConfiguration : WasmIncre
          * @see BaseIncrementalCompilationConfiguration.ROOT_PROJECT_DIR
          */
         @JvmField
-        public val ROOT_PROJECT_BUILD_DIR: Option<Path?> = Option("ROOT_PROJECT_BUILD_DIR")
+        public val ROOT_PROJECT_BUILD_DIR: Option<Path?> =
+            Option("ROOT_PROJECT_BUILD_DIR", availableSinceVersion = KotlinReleaseVersion(2, 4, 20))
 
         /**
          * The directory where the build history files will be stored.
@@ -132,6 +137,6 @@ public interface WasmHistoryBasedIncrementalCompilationConfiguration : WasmIncre
          * The contents of this directory should not be cached, as they are only valid for subsequent local executions.
          */
         @JvmField
-        public val HISTORY_FILE_DIR: Option<Path?> = Option("HISTORY_FILE_DIR")
+        public val HISTORY_FILE_DIR: Option<Path?> = Option("HISTORY_FILE_DIR", availableSinceVersion = KotlinReleaseVersion(2, 4, 20))
     }
 }

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmKlibCompilationOperation.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmKlibCompilationOperation.kt
@@ -104,7 +104,10 @@ public interface WasmKlibCompilationOperation : BaseCompilationOperation, Cancel
     /**
      * An option for configuring a [WasmKlibCompilationOperation].
      */
-    public class Option<V> internal constructor(id: String) : BaseOption<V>(id)
+    public class Option<V> internal constructor(
+        id: String,
+        public val availableSinceVersion: KotlinReleaseVersion,
+    ) : BaseOption<V>(id)
 
     /**
      * Get the value for option specified by [key] if it was previously [set] or if it has a default value.
@@ -116,7 +119,8 @@ public interface WasmKlibCompilationOperation : BaseCompilationOperation, Cancel
 
     public companion object {
         @JvmField
-        public val INCREMENTAL_COMPILATION: Option<WasmIncrementalCompilationConfiguration?> = Option("INCREMENTAL_COMPILATION")
+        public val INCREMENTAL_COMPILATION: Option<WasmIncrementalCompilationConfiguration?> =
+            Option("INCREMENTAL_COMPILATION", availableSinceVersion = KotlinReleaseVersion(2, 4, 20))
     }
 }
 

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmLinkingOperation.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/wasm/operations/WasmLinkingOperation.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.CancellableBuildOperation
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerLinkingArguments
 import org.jetbrains.kotlin.buildtools.api.internal.BaseOption
@@ -94,5 +95,8 @@ public interface WasmLinkingOperation : BaseCompilationOperation, CancellableBui
     /**
      * An option for configuring a [WasmLinkingOperation].
      */
-    public class Option<V> internal constructor(id: String) : BaseOption<V>(id)
+    public class Option<V> internal constructor(
+        id: String,
+        public val availableSinceVersion: KotlinReleaseVersion,
+    ) : BaseOption<V>(id)
 }


### PR DESCRIPTION
Add a test asserting every option carries `availableSinceVersion`. ABI/WASM holders use an inverted check that fails once they adopt it. Drop two render() TODO stubs.

^KT-82986
^KT-86914
^KT-86916