### PR TITLE
[NI] Bundle core compiler plugins into the native image

### DIFF
--- a/.idea/runConfigurations/Compiler_Native_Image__Full_Tests.xml
+++ b/.idea/runConfigurations/Compiler_Native_Image__Full_Tests.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Compiler Native Image: Full Tests" type="GradleRunConfiguration" factoryName="Gradle" folderName="Compiler Native Image">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":kotlin-compiler-native-image:nativeImageBoxTest" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt
@@ -83,7 +83,6 @@ import org.jetbrains.kotlin.resolve.jvm.modules.JavaModuleResolver
 import org.jetbrains.kotlin.resolve.lazy.declarations.CliDeclarationProviderFactoryService
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactoryService
 import org.jetbrains.kotlin.serialization.DescriptorSerializerPlugin
-import org.jetbrains.kotlin.utils.isGraalNativeImageRuntime
 import java.io.File
 
 class KotlinCoreEnvironment private constructor(
@@ -168,11 +167,8 @@ class KotlinCoreEnvironment private constructor(
 
         fun registerExtensionsFromPlugins(configuration: CompilerConfiguration) {
             if (!extensionRegistered) {
-                if (!isGraalNativeImageRuntime) {
-                    // native image currently does not support dynamic class loading
-                    registerPluginExtensionPoints(project)
-                    registerExtensionsFromPlugins(project, configuration)
-                }
+                registerPluginExtensionPoints(project)
+                registerExtensionsFromPlugins(project, configuration)
                 extensionRegistered = true
             }
         }

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginCliParser.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginCliParser.kt
@@ -23,9 +23,12 @@ import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.plugins.*
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.cli.reportException
+import org.jetbrains.kotlin.cli.reportInfo
 import org.jetbrains.kotlin.compiler.plugin.*
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.util.ServiceLoaderLite
+import org.jetbrains.kotlin.utils.graalvm.BundledCompilerPlugins
+import org.jetbrains.kotlin.utils.graalvm.BundledPluginInfo
 import org.jetbrains.kotlin.utils.topologicalSort
 import java.io.File
 import java.lang.ref.WeakReference
@@ -96,16 +99,69 @@ object PluginCliParser {
         pluginOrderConstraints: Collection<String>,
         configuration: CompilerConfiguration,
         parentDisposable: Disposable,
-    ): ExitCode {
-        try {
-            // Parse order constraints before creating class loaders and loading services.
-            val orderConstraints = pluginOrderConstraints.map { rawConstraint ->
-                extractPluginOrderConstraint(rawConstraint)
-                    ?: throw PluginProcessingException("Could not parse plugin order constraint: $rawConstraint")
-            }
+    ): ExitCode = loadPluginsSafe(configuration) {
+        // Parse order constraints before creating class loaders and loading services.
+        val orderConstraints = pluginOrderConstraints.map { rawConstraint ->
+            extractPluginOrderConstraint(rawConstraint)
+                ?: throw PluginProcessingException("Could not parse plugin order constraint: $rawConstraint")
+        }
 
-            loadPluginsLegacyStyle(pluginClasspaths, orderConstraints, pluginOptions, configuration, parentDisposable)
-            loadPluginsModernStyle(pluginConfigurations, orderConstraints, configuration, parentDisposable)
+        loadPluginsLegacyStyle(pluginClasspaths, orderConstraints, pluginOptions, configuration, parentDisposable)
+        loadPluginsModernStyle(pluginConfigurations, orderConstraints, configuration, parentDisposable)
+    }
+
+    /**
+     * Loads native image-bundled compiler plugins from the given configurations/classpaths
+     */
+    internal fun loadBundledCompilerPlugins(
+        pluginConfigurations: List<String>,
+        pluginOptions: List<String>,
+        pluginClasspaths: List<String>,
+        pluginOrderConstraints: List<String>,
+        configuration: CompilerConfiguration,
+    ): ExitCode = loadPluginsSafe(configuration) {
+        val [requestedBundledPlugins, nonBundledPlugins] = findRequestedBundledPlugins(
+            pluginConfigurations,
+            pluginClasspaths,
+            pluginOptions
+        )
+
+        if (nonBundledPlugins.isNotEmpty()) {
+            configuration.report(
+                COMPILER_ARGUMENTS_ERROR,
+                "Compiler plugin(s) cannot be loaded by the native-image compiler: ${nonBundledPlugins.joinToString("\n")}. " +
+                        "Only bundled plugins are supported. " +
+                        "Bundled plugins: ${BundledCompilerPlugins.pluginInfos.joinToString { it.pluginId }}."
+            )
+        }
+
+        val pluginsById = requestedBundledPlugins.associateBy { it.id }
+        val orderConstraints = pluginOrderConstraints.map { rawConstraint ->
+            extractPluginOrderConstraint(rawConstraint)
+                ?: throw PluginProcessingException("Could not parse plugin order constraint: $rawConstraint")
+        }
+        val dependenciesById = orderConstraints
+            .filter { it.before in pluginsById && it.after in pluginsById }
+            .groupBy(keySelector = { it.after }, valueTransform = { it.before })
+
+        val orderedPluginIds = topologicalSort(
+            nodes = pluginsById.keys,
+            reportCycle = {
+                throw PluginProcessingException(
+                    "Compiler plugin '${it}' is part of an constraint cycle: ${orderConstraints.joinToString(", ")}"
+                )
+            },
+            dependencies = { dependenciesById[this].orEmpty() }
+        ).asReversed()
+
+        for (plugin in orderedPluginIds) {
+            loadBundledPlugin(pluginsById[plugin]!!.info, pluginsById[plugin]!!.options, configuration)
+        }
+    }
+
+    private fun loadPluginsSafe(configuration: CompilerConfiguration, action: () -> Unit): ExitCode {
+        try {
+            action()
             return ExitCode.OK
         } catch (e: PluginProcessingException) {
             configuration.report(COMPILER_ARGUMENTS_ERROR, e.message!!)
@@ -211,6 +267,75 @@ object PluginCliParser {
             val commandLineProcessor = pluginInfo.commandLineProcessor ?: throw RuntimeException() // TODO: proper exception
             processCompilerPluginOptions(commandLineProcessor, pluginInfo.pluginOptions, configuration)
         }
+    }
+
+    private class RequestedBundledPluginInfo(
+        val id: String,
+        val info: BundledPluginInfo,
+        val options: List<CliOptionValue>,
+    )
+
+    /**
+     * Parses the [pluginConfigurations] and [pluginClasspaths] and returns a list of
+     * bundled plugins that are requested in them correspondingly. As a second parameter
+     * returns a list of non-bundled plugins that were requested to register.
+     */
+    private fun findRequestedBundledPlugins(
+        pluginConfigurations: List<String>,
+        pluginClasspaths: List<String>,
+        pluginOptions: List<String>,
+    ): Pair<List<RequestedBundledPluginInfo>, List<String>> {
+        val bundledPlugins = mutableListOf<RequestedBundledPluginInfo>()
+        val nonBundledPlugins = mutableListOf<String>()
+
+        fun register(info: BundledPluginInfo?, configuration: String, options: List<CliOptionValue>) {
+            if (info == null) {
+                nonBundledPlugins += configuration
+                return
+            }
+            bundledPlugins += RequestedBundledPluginInfo(info.pluginId, info, options)
+        }
+
+        for (pluginConfiguration in pluginConfigurations) {
+            val [_, classpath, options] = extractPluginClasspathAndOptions(pluginConfiguration)
+            val info = classpath.firstNotNullOfOrNull { BundledCompilerPlugins.lookupByClasspathEntry(it) }
+            register(info, pluginConfiguration, options)
+        }
+
+        for (classpath in pluginClasspaths) {
+            val info = BundledCompilerPlugins.lookupByClasspathEntry(classpath)
+            val options = pluginOptions.mapNotNull { parseLegacyPluginOption(it) }.filter { it.pluginId == info?.pluginId }
+            register(info, classpath, options)
+        }
+
+        return bundledPlugins to nonBundledPlugins
+    }
+
+    /**
+     * Loads the bundled plugin's registrar from the current classloader and
+     * provides the user-provided options if there are any
+     */
+    private fun loadBundledPlugin(
+        info: BundledPluginInfo,
+        options: List<CliOptionValue>,
+        configuration: CompilerConfiguration,
+    ) {
+        val classLoader = PluginCliParser::class.java.classLoader
+        val registrar = try {
+            classLoader.loadClass(info.pluginRegistrarFqName).getDeclaredConstructor().newInstance() as CompilerPluginRegistrar
+        } catch (e: Throwable) {
+            throw PluginProcessingException("Could not create '${info.pluginRegistrarFqName}' plugin registrar.", e)
+        }
+
+        configuration.reportInfo("Loading bundled compiler plugin '${info.pluginId}'.")
+        configuration.add(CompilerPluginRegistrar.COMPILER_PLUGIN_REGISTRARS, registrar)
+
+        if (options.isEmpty()) return
+        val commandLineProcessor = info.commandLineProcessorFqName?.let {
+            classLoader.loadClass(it).getDeclaredConstructor().newInstance() as? CommandLineProcessor
+                ?: throw IllegalStateException("Could not instantiate $it")
+        } ?: return
+        processCompilerPluginOptions(commandLineProcessor, options, configuration)
     }
 
     @JvmStatic

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/pipeline/AbstractConfigurationPhase.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/pipeline/AbstractConfigurationPhase.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.ir.validation.IrValidationDiagnostics
 import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.utils.KotlinPaths
 import org.jetbrains.kotlin.utils.PathUtil
+import org.jetbrains.kotlin.utils.graalvm.isGraalNativeImageRuntime
 import java.io.File
 
 /**
@@ -95,6 +96,17 @@ abstract class AbstractConfigurationPhase<A : CommonCompilerArguments>(
         val pluginConfigurations = arguments.pluginConfigurations.asList()
         val pluginOrderConstraints = arguments.pluginOrderConstraints.asList()
 
+        if (isGraalNativeImageRuntime) {
+            PluginCliParser.loadBundledCompilerPlugins(
+                pluginConfigurations = pluginConfigurations,
+                pluginOptions = pluginOptions,
+                pluginClasspaths = pluginClasspaths,
+                pluginOrderConstraints = pluginOrderConstraints,
+                configuration = configuration,
+            )
+            return
+        }
+
         if (!checkPluginsArguments(configuration, useK2 = true, pluginClasspaths, pluginOptions, pluginConfigurations)) {
             return
         }
@@ -139,6 +151,7 @@ abstract class AbstractConfigurationPhase<A : CommonCompilerArguments>(
             input.rootDisposable
         )
     }
+
 
     private fun tryLoadScriptingPluginFromCurrentClassLoader(
         configuration: CompilerConfiguration,

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
@@ -239,6 +239,11 @@ public class ForTestCompileRuntime {
     }
 
     @NotNull
+    public static List<File> kotlinNativeImagePluginsRuntimeForTests() {
+        return getFilesFromProperty(KOTLIN_NATIVE_IMAGE_PLUGINS_RUNTIME);
+    }
+
+    @NotNull
     public static List<File> kotlinCompilerEmbeddableClasspathForTests() {
         return getFilesFromProperty(KOTLIN_COMPILER_EMBEDDABLE_CLASSPATH);
     }

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
@@ -26,6 +26,7 @@ object TestCompilePaths {
     const val KOTLIN_DIST_PATH = "kotlin.dist.path"
     const val KOTLIN_NATIVE_IMAGE_DIST_PATH = "kotlin.native-image.dist.path"
     const val KOTLIN_NATIVE_IMAGE_RESOURCES_PATH = "kotlin.native-image.resources.path"
+    const val KOTLIN_NATIVE_IMAGE_PLUGINS_RUNTIME = "kotlin.native-image.plugins-runtime.classpath"
     const val KOTLIN_COMPILER_EMBEDDABLE_CLASSPATH = "kotlin.compiler-embeddable.classpath"
     const val KOTLIN_MOCKJDK_RUNTIME_PATH = "kotlin.mockJDK.runtime.path"
     const val KOTLIN_MOCKJDKMODIFIED_RUNTIME_PATH = "kotlin.mockJDKModified.runtime.path"

--- a/compiler/util/src/org/jetbrains/kotlin/utils/graalvm/BundledCompilerPlugins.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/graalvm/BundledCompilerPlugins.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.utils.graalvm
+
+import java.io.File
+
+/**
+ * Information about a compiler plugin that is bundled into the compiler. Used in the context of the GraalVM native
+ * image: these plugins are included in the native image and are loaded reflectively when the user requests them via
+ * either `-Xplugin/-Xcompiler-plugin`.
+ */
+data class BundledPluginInfo(
+    val pluginId: String,
+    val pluginRegistrarFqName: String,
+    val commandLineProcessorFqName: String?,
+    val jarPrefixes: List<String>,
+)
+
+object BundledCompilerPlugins {
+    val pluginInfos = listOf(
+        BundledPluginInfo(
+            pluginId = "org.jetbrains.kotlinx.serialization",
+            pluginRegistrarFqName = "org.jetbrains.kotlinx.serialization.compiler.extensions.SerializationComponentRegistrar",
+            commandLineProcessorFqName = "org.jetbrains.kotlinx.serialization.compiler.extensions.SerializationPluginOptions",
+            jarPrefixes = listOf(
+                "kotlin-serialization-compiler-plugin",
+            ),
+        ),
+        BundledPluginInfo(
+            pluginId = "org.jetbrains.kotlin.allopen",
+            pluginRegistrarFqName = "org.jetbrains.kotlin.allopen.AllOpenComponentRegistrar",
+            commandLineProcessorFqName = "org.jetbrains.kotlin.allopen.AllOpenCommandLineProcessor",
+            jarPrefixes = listOf(
+                "allopen-compiler-plugin",
+                "kotlin-allopen-compiler-plugin",
+            ),
+        ),
+        BundledPluginInfo(
+            pluginId = "org.jetbrains.kotlin.noarg",
+            pluginRegistrarFqName = "org.jetbrains.kotlin.noarg.NoArgComponentRegistrar",
+            commandLineProcessorFqName = "org.jetbrains.kotlin.noarg.NoArgCommandLineProcessor",
+            jarPrefixes = listOf(
+                "noarg-compiler-plugin",
+                "kotlin-noarg-compiler-plugin",
+            ),
+        ),
+        BundledPluginInfo(
+            pluginId = "org.jetbrains.kotlin.samWithReceiver",
+            pluginRegistrarFqName = "org.jetbrains.kotlin.samWithReceiver.SamWithReceiverComponentRegistrar",
+            commandLineProcessorFqName = "org.jetbrains.kotlin.samWithReceiver.SamWithReceiverCommandLineProcessor",
+            jarPrefixes = listOf(
+                "sam-with-receiver-compiler-plugin",
+                "kotlin-sam-with-receiver-compiler-plugin",
+            ),
+        ),
+        BundledPluginInfo(
+            pluginId = "org.jetbrains.kotlin.assignment",
+            pluginRegistrarFqName = "org.jetbrains.kotlin.assignment.plugin.AssignmentComponentRegistrar",
+            commandLineProcessorFqName = "org.jetbrains.kotlin.assignment.plugin.AssignmentCommandLineProcessor",
+            jarPrefixes = listOf(
+                "assignment-compiler-plugin",
+                "kotlin-assignment-compiler-plugin",
+            ),
+        ),
+        BundledPluginInfo(
+            pluginId = "org.jetbrains.kotlin.lombok",
+            pluginRegistrarFqName = "org.jetbrains.kotlin.lombok.LombokComponentRegistrar",
+            commandLineProcessorFqName = "org.jetbrains.kotlin.lombok.LombokCommandLineProcessor",
+            jarPrefixes = listOf(
+                "lombok-compiler-plugin",
+                "kotlin-lombok-compiler-plugin",
+            ),
+        ),
+        BundledPluginInfo(
+            pluginId = "org.jetbrains.kotlin.powerassert",
+            pluginRegistrarFqName = "org.jetbrains.kotlin.powerassert.PowerAssertCompilerPluginRegistrar",
+            commandLineProcessorFqName = "org.jetbrains.kotlin.powerassert.PowerAssertCommandLineProcessor",
+            jarPrefixes = listOf(
+                "power-assert-compiler-plugin",
+                "kotlin-power-assert-compiler-plugin",
+            ),
+        ),
+        BundledPluginInfo(
+            pluginId = "androidx.compose.compiler.plugins.kotlin",
+            pluginRegistrarFqName = "androidx.compose.compiler.plugins.kotlin.ComposePluginRegistrar",
+            commandLineProcessorFqName = "androidx.compose.compiler.plugins.kotlin.ComposeCommandLineProcessor",
+            jarPrefixes = listOf(
+                "compose-compiler-plugin",
+                "kotlin-compose-compiler-plugin",
+            ),
+        ),
+    )
+
+    /**
+     * Resolves a single classpath entry to a bundled plugin by matching an [entry] file
+     * name against [BundledPluginInfo.jarPrefixes]
+     */
+    fun lookupByClasspathEntry(entry: String): BundledPluginInfo? {
+        val fileName = File(entry).nameWithoutExtension
+        return pluginInfos.firstOrNull { info -> info.jarPrefixes.any { fileName.startsWith(it) } }
+    }
+}

--- a/compiler/util/src/org/jetbrains/kotlin/utils/graalvm/graalvm.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/utils/graalvm/graalvm.kt
@@ -3,8 +3,8 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.utils
+package org.jetbrains.kotlin.utils.graalvm
 
 val isGraalNativeImageRuntime: Boolean by lazy {
-    System.getProperty("org.graalvm.nativeimage.runtime")?.toBooleanStrictOrNull() == true
+    System.getProperty("org.graalvm.nativeimage.imagecode") == "runtime"
 }

--- a/prepare/compiler-native-image/build.gradle.kts
+++ b/prepare/compiler-native-image/build.gradle.kts
@@ -19,10 +19,36 @@ val nativeImageClasspath by configurations.creating {
     isCanBeResolved = true
 }
 
+val pluginsRuntime by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+val bundledCompilerPluginProjects = listOf(
+    ":kotlin-allopen-compiler-plugin.embeddable",
+    ":kotlin-noarg-compiler-plugin.embeddable",
+    ":kotlin-sam-with-receiver-compiler-plugin.embeddable",
+    ":kotlin-assignment-compiler-plugin.embeddable",
+    ":kotlin-lombok-compiler-plugin.embeddable",
+    ":kotlin-power-assert-compiler-plugin.embeddable",
+    ":kotlinx-serialization-compiler-plugin.embeddable",
+    ":plugins:compose-compiler-plugin:compiler",
+)
+
 dependencies {
     nativeImageClasspath(project(":kotlin-compiler-embeddable", configuration = "runtimeElements"))
 
+    bundledCompilerPluginProjects.forEach {
+        nativeImageClasspath(project(it))
+    }
+
+    pluginsRuntime(libs.kotlinx.serialization.core)
+    pluginsRuntime(composeRuntime())
+    pluginsRuntime(composeRuntimeAnnotations())
+    pluginsRuntime(libs.androidx.collections)
+
     testFixturesApi(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
     testFixturesApi(testFixtures(project(":compiler:test-infrastructure")))
     testFixturesApi(testFixtures(project(":compiler:tests-common-new")))
     testFixturesApi(testFixtures(project(":generators:test-generator")))
@@ -43,19 +69,12 @@ val graalLauncher = javaToolchains.launcherFor {
 
 projectTests {
     testData(project(":compiler").isolated, "testData/codegen")
+    testData(project.isolated, "testData/projects/box")
 
     testGenerator(
         "org.jetbrains.kotlin.compiler.nativeimage.GenerateNativeImageTestsKt",
         generateTestsInBuildDirectory = true,
     )
-
-    nativeImageTestTask("nativeImageBoxTest") {
-        description = "Compares native-image kotlinc against default kotlinc on " +
-                "compiler/testData/codegen/box."
-        exclude("**/*ReachabilityMetadataTest*.class")
-        exclude("**/*SmokeTest*.class")
-        useNativeImageDist()
-    }
 
     nativeImageTestTask("nativeImageSmokeTest") {
         description = "Smoke test: compiles a hello-world with the native-image kotlinc " +
@@ -66,22 +85,34 @@ projectTests {
 
     nativeImageTestTask("generateReachabilityMetadataSmoke") {
         description = "Quick reachability metadata regen: runs JVM kotlinc with the " +
-                "native-image-agent on the smoke test."
+                "reachability metadata collector agent on the smoke test."
         include("**/ReachabilityMetadataSmokeTest.class")
         useReachabilityMetadataResources()
+        @OptIn(KotlinCompilerDistUsage::class)
+        withDist()
+    }
+
+    nativeImageTestTask("nativeImageBoxTest") {
+        description = "Runs native-image kotlinc against default kotlinc on box tests"
+        include("**/NativeImageBoxTestGenerated.class")
+        include("**/NativeImagePluginBoxTestGenerated.class")
+        include("**/NativeImageLegacyPluginBoxTestGenerated.class")
+        useNativeImageDist()
+        usePluginsRuntime()
     }
 
     nativeImageTestTask("generateReachabilityMetadataBox") {
-        description = "Runs JVM kotlinc with reachability metadata collector agent on " +
-                "compiler/testData/codegen/box."
-        exclude("**/*BoxTest*.class")
-        exclude("**/*SmokeTest*.class")
+        description = "Runs JVM kotlinc with reachability metadata collector agent on box tests"
+        include("**/NativeImageReachabilityMetadataTestGenerated.class")
+        include("**/NativeImagePluginReachabilityMetadataTestGenerated.class")
+        include("**/NativeImageLegacyPluginReachabilityMetadataTestGenerated.class")
         // We can't run in parallel because of the tracing agent
         systemProperty(
             "junit.jupiter.execution.parallel.enabled",
             "false",
         )
         useReachabilityMetadataResources()
+        usePluginsRuntime()
     }
 
     withJvmStdlibAndReflect()
@@ -92,9 +123,10 @@ projectTests {
 val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
     description = "Build a native image of the kotlin-compiler-embeddable"
 
+    val launcher = graalLauncher
     val resources = layout.projectDirectory.dir("resources")
     val classpathFiles = files(nativeImageClasspath, resources)
-    inputs.files(nativeImageClasspath, resources)
+    inputs.files(nativeImageClasspath, resources, launcher.map { it.metadata.installationPath.asFile })
         .withNormalizer(ClasspathNormalizer::class)
         .withPropertyName("nativeImageClasspath")
 
@@ -107,7 +139,6 @@ val kotlincNativeImageTask = tasks.register<Exec>("kotlincNativeImage") {
     val executableFile = layout.buildDirectory.file("bin/kotlinc-native-image$executableExtension")
     outputs.file(executableFile)
 
-    val launcher = graalLauncher
     doFirst {
         val javaHome = launcher.get().executablePath.asFile.toPath().parent.parent
 
@@ -180,8 +211,15 @@ fun Test.useNativeImageDist() {
 }
 
 @OptIn(KotlinCompilerDistUsage::class)
-fun Test.useReachabilityMetadataResources() {
+fun Test.usePluginsRuntime() {
     withDist()
+    addClasspathProperty(
+        pluginsRuntime,
+        "kotlin.native-image.plugins-runtime.classpath",
+    )
+}
+
+fun Test.useReachabilityMetadataResources() {
     addClasspathProperty(
         nativeImageClasspath,
         "kotlin.compiler-embeddable.classpath",

--- a/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
+++ b/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
@@ -1,6 +1,24 @@
 {
   "reflection": [
     {
+      "type": "androidx.compose.compiler.plugins.kotlin.ComposeCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "androidx.compose.compiler.plugins.kotlin.ComposePluginRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "gnu.trove.TObjectHashingStrategy"
     },
     {
@@ -157,6 +175,17 @@
     },
     {
       "type": "java.util.Set"
+    },
+    {
+      "type": "java.util.zip.Inflater",
+      "methods": [
+        {
+          "name": "setInput",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
     },
     {
       "type": "jdk.internal.jrtfs.JrtFileSystemProvider"
@@ -354,6 +383,42 @@
       "type": "kotlinx.coroutines.scheduling.CoroutineScheduler"
     },
     {
+      "type": "org.jetbrains.kotlin.allopen.AllOpenCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.allopen.AllOpenComponentRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.assignment.plugin.AssignmentCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.assignment.plugin.AssignmentComponentRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "org.jetbrains.kotlin.backend.jvm.extensions.ClassBuilderExtensionAdapter",
       "methods": [
         {
@@ -469,10 +534,28 @@
       "type": "org.jetbrains.kotlin.extensions.CompilerConfigurationExtension[]"
     },
     {
+      "type": "org.jetbrains.kotlin.extensions.DeclarationAttributeAltererExtension"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.DeclarationAttributeAltererExtension[]"
+    },
+    {
       "type": "org.jetbrains.kotlin.extensions.PreprocessedVirtualFileFactoryExtension"
     },
     {
       "type": "org.jetbrains.kotlin.extensions.PreprocessedVirtualFileFactoryExtension[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.StorageComponentContainerContributor"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.StorageComponentContainerContributor[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.internal.TypeResolutionInterceptorExtension"
+    },
+    {
+      "type": "org.jetbrains.kotlin.extensions.internal.TypeResolutionInterceptorExtension[]"
     },
     {
       "type": "org.jetbrains.kotlin.load.java.ErasedOverridabilityCondition"
@@ -485,6 +568,60 @@
     },
     {
       "type": "org.jetbrains.kotlin.load.java.structure.impl.source.JavaFixedElementSourceFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.lombok.LombokCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.lombok.LombokComponentRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.noarg.NoArgCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.noarg.NoArgComponentRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.powerassert.PowerAssertCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.powerassert.PowerAssertCompilerPluginRegistrar",
       "methods": [
         {
           "name": "<init>",
@@ -1190,6 +1327,48 @@
       ]
     },
     {
+      "type": "org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor"
+    },
+    {
+      "type": "org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.resolve.extensions.AssignResolutionAltererExtension"
+    },
+    {
+      "type": "org.jetbrains.kotlin.resolve.extensions.AssignResolutionAltererExtension[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.resolve.extensions.SyntheticResolveExtension"
+    },
+    {
+      "type": "org.jetbrains.kotlin.resolve.extensions.SyntheticResolveExtension[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.resolve.jvm.extensions.SyntheticJavaResolveExtension"
+    },
+    {
+      "type": "org.jetbrains.kotlin.resolve.jvm.extensions.SyntheticJavaResolveExtension[]"
+    },
+    {
+      "type": "org.jetbrains.kotlin.samWithReceiver.SamWithReceiverCommandLineProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.samWithReceiver.SamWithReceiverComponentRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingCommandLineProcessor",
       "methods": [
         {
@@ -1217,7 +1396,31 @@
       ]
     },
     {
+      "type": "org.jetbrains.kotlin.serialization.DescriptorSerializerPlugin"
+    },
+    {
+      "type": "org.jetbrains.kotlin.serialization.DescriptorSerializerPlugin[]"
+    },
+    {
       "type": "org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInsLoaderImpl"
+    },
+    {
+      "type": "org.jetbrains.kotlinx.serialization.compiler.extensions.SerializationComponentRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlinx.serialization.compiler.extensions.SerializationPluginOptions",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "type": "sun.management.VMManagementImpl",

--- a/prepare/compiler-native-image/testData/projects/box/plugins/allopen/AllOpen.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/allopen/AllOpen.kt
@@ -1,0 +1,14 @@
+// COMPILER_PLUGIN: allopen-compiler-plugin.jar annotation=AllOpen
+
+annotation class AllOpen
+
+@AllOpen
+class Base {
+    fun foo() {}
+}
+
+class Derived : Base()
+
+fun box(): String {
+    return "OK"
+}

--- a/prepare/compiler-native-image/testData/projects/box/plugins/assignment/Assignment.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/assignment/Assignment.kt
@@ -1,0 +1,20 @@
+// COMPILER_PLUGIN: assignment-compiler-plugin.jar annotation=ValueContainer
+
+annotation class ValueContainer
+
+@ValueContainer
+class StringProperty(var value: String) {
+    fun assign(newValue: String) {
+        value = newValue
+    }
+}
+
+class Container {
+    val input = StringProperty("")
+}
+
+fun box(): String {
+    val container = Container()
+    container.input = "OK"
+    return container.input.value
+}

--- a/prepare/compiler-native-image/testData/projects/box/plugins/compose/box.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/compose/box.kt
@@ -1,0 +1,14 @@
+// COMPILER_PLUGIN: compose-compiler-plugin.jar generateFunctionKeyMetaAnnotations=true
+// FULL_JDK
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun Greeting() {
+}
+
+fun box(): String {
+    val method = Class.forName("BoxKt").declaredMethods.single { it.name == "Greeting" }
+    return if (method.parameterCount == 2) "OK"
+    else "fail: Compose plugin did not rewrite Greeting (parameterCount=${method.parameterCount})"
+}

--- a/prepare/compiler-native-image/testData/projects/box/plugins/lombok/box.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/lombok/box.kt
@@ -1,0 +1,3 @@
+// COMPILER_PLUGIN: lombok-compiler-plugin.jar config=lombok.config
+
+fun box(): String = "OK"

--- a/prepare/compiler-native-image/testData/projects/box/plugins/noarg/NoArg.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/noarg/NoArg.kt
@@ -1,0 +1,18 @@
+// COMPILER_PLUGIN: noarg-compiler-plugin.jar annotation=NoArg
+// FULL_JDK
+
+annotation class NoArg
+
+@NoArg
+class Entity(val id: Int, val name: String)
+
+class Foo {
+    fun load() {
+        val entity = this::class.java.classLoader.loadClass("Entity").getDeclaredConstructor().newInstance()
+    }
+}
+
+fun box(): String {
+    Foo().load()
+    return "OK"
+}

--- a/prepare/compiler-native-image/testData/projects/box/plugins/powerassert/PowerAssert.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/powerassert/PowerAssert.kt
@@ -1,0 +1,31 @@
+// COMPILER_PLUGIN: power-assert-compiler-plugin.jar function=kotlin.assert
+// ASSERTIONS_MODE: always-enable
+
+fun a(): Int = 1
+fun b(): Int = 2
+
+fun fail() {
+    assert(a() == b())
+}
+
+fun box(): String {
+    val message = try {
+        fail()
+        "Function did not fail"
+    } catch (e: Throwable) {
+        e.message.orEmpty()
+    }
+
+    val expectedMessage = """
+
+assert(a() == b())
+       |   |  |
+       |   |  2
+       |   false
+       1
+
+    """.trimIndent()
+
+    return if (message == expectedMessage) "OK"
+    else message
+}

--- a/prepare/compiler-native-image/testData/projects/box/plugins/sam/SamWithReceiver.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/sam/SamWithReceiver.kt
@@ -1,0 +1,13 @@
+// COMPILER_PLUGIN: sam-with-receiver-compiler-plugin.jar annotation=java.lang.FunctionalInterface
+// FULL_JDK
+
+import java.util.function.Consumer
+
+fun box(): String {
+    val sb = StringBuilder()
+    val consumer = Consumer<StringBuilder> {
+        append("OK")
+    }
+    consumer.accept(sb)
+    return sb.toString()
+}

--- a/prepare/compiler-native-image/testData/projects/box/plugins/serialization/Serialization.kt
+++ b/prepare/compiler-native-image/testData/projects/box/plugins/serialization/Serialization.kt
@@ -1,0 +1,12 @@
+// COMPILER_PLUGIN: kotlin-serialization-compiler-plugin.jar disableIntrinsic=false
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Message(val id: Int, val text: String)
+
+fun box(): String {
+    val serializer: KSerializer<Message> = Message.serializer()
+    return "OK"
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageCodegenTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageCodegenTest.kt
@@ -72,7 +72,7 @@ abstract class AbstractNativeImageCodegenTest {
             arguments = buildCompilerArgs(boxFile, outDir, directives, withFullJdk),
             classpath = buildClasspath(withReflect, withFullJdk),
         )
-        assertEquals(0, exitCode, "compilation failed:\n$compilerStdout")
+        assertCompilerOutput(exitCode, compilerStdout, directives)
 
         val result = invokeBox(outDir, boxClassName(source), withReflect)
         assertEquals("OK", result, "box() != 'OK'")
@@ -83,7 +83,22 @@ abstract class AbstractNativeImageCodegenTest {
         classpath: List<File>,
     ): Pair<Int, String>
 
-    private fun buildCompilerArgs(
+    protected open fun assertCompilerOutput(exitCode: Int, compilerStdout: String, directives: RegisteredDirectives) {
+        assertEquals(0, exitCode, "compilation failed:\n$compilerStdout")
+    }
+
+    protected open fun shouldSkip(source: String, directives: RegisteredDirectives): String? = when {
+        MULTI_FILE_MARKER.containsMatchIn(source) -> "multi-file (// FILE:) tests are not supported"
+        HELPERS_IMPORT.containsMatchIn(source) -> "tests importing helpers.* are not supported"
+        "+MultiPlatformProjects" in directives[LanguageSettingsDirectives.LANGUAGE] -> "multiplatform projects are not supported"
+        isBackendIgnored(directives) -> "ignored on $BACKEND via directive"
+        else -> null
+    }
+
+    protected open fun runtimeClasspath(withReflect: Boolean): List<File> =
+        if (withReflect) listOf(reflectClasspath) else emptyList()
+
+    protected open fun buildCompilerArgs(
         boxFile: File,
         outDir: File,
         directives: RegisteredDirectives,
@@ -103,7 +118,7 @@ abstract class AbstractNativeImageCodegenTest {
         add(outDir.absolutePath)
     }
 
-    private fun buildClasspath(withReflect: Boolean, withFullJdk: Boolean): List<File> = buildList {
+    protected open fun buildClasspath(withReflect: Boolean, withFullJdk: Boolean): List<File> = buildList {
         addAll(compilationClasspath)
         if (withReflect) add(reflectClasspath)
         if (!withFullJdk) add(mockJdkRtJar)
@@ -123,7 +138,10 @@ abstract class AbstractNativeImageCodegenTest {
     ): String? = this[directive].singleOrNull()?.let { "$flagPrefix=${render(it)}" }
 
     private fun invokeBox(classDir: File, boxClass: String, withReflect: Boolean): String? {
-        URLClassLoader(arrayOf(classDir.toURI().toURL()), sharedRuntimeLoader(withReflect)).use { loader ->
+        URLClassLoader(
+            arrayOf(classDir.toURI().toURL()),
+            sharedRuntimeLoader(runtimeClasspath(withReflect))
+        ).use { loader ->
             val method = loader.loadClass(boxClass).getMethod("box")
             val thread = Thread.currentThread()
             val previous = thread.contextClassLoader
@@ -147,19 +165,21 @@ abstract class AbstractNativeImageCodegenTest {
         }
     }
 
-    private fun sharedRuntimeLoader(withReflect: Boolean): URLClassLoader =
-        sharedRuntimeLoaders.computeIfAbsent(withReflect) {
-            val cp = compilationClasspath + if (withReflect) listOf(reflectClasspath) else emptyList()
+    private fun sharedRuntimeLoader(runtimeClasspath: List<File>): URLClassLoader {
+        val cp = compilationClasspath + runtimeClasspath
+        val key = cp.map { it.absolutePath }
+        return sharedRuntimeLoaders.computeIfAbsent(key) {
             URLClassLoader(
                 cp.map { it.toURI().toURL() }.toTypedArray(),
                 ClassLoader.getSystemClassLoader().parent,
             )
         }
+    }
 
     companion object {
         private val BACKEND = TargetBackend.JVM_IR
 
-        private val sharedRuntimeLoaders = ConcurrentHashMap<Boolean, URLClassLoader>()
+        private val sharedRuntimeLoaders = ConcurrentHashMap<List<String>, URLClassLoader>()
 
         private const val HELPERS_PATH = "diagnostics/helpers"
 
@@ -178,10 +198,12 @@ abstract class AbstractNativeImageCodegenTest {
             CodegenTestDirectives,
             JvmEnvironmentConfigurationDirectives,
             AdditionalFilesDirectives,
+            NativeImagePluginDirectives,
         )
 
         private val MULTI_FILE_MARKER = Regex("""(?m)^// FILE:""")
         private val HELPERS_IMPORT = Regex("""(?m)^import helpers\.""")
+        private val LOADED_PLUGINS = Regex("""(?i)loading bundled compiler plugin '([^']+)'""")
 
         private fun prepareSource(source: String): String =
             clearTextFromDiagnosticMarkup(JvmInlineSourceTransformer.computeModifier(BACKEND).invoke(source))
@@ -192,14 +214,6 @@ abstract class AbstractNativeImageCodegenTest {
                 if (line.startsWith("//")) parser.parse(line)
             }
             return parser.build()
-        }
-
-        private fun shouldSkip(source: String, directives: RegisteredDirectives): String? = when {
-            MULTI_FILE_MARKER.containsMatchIn(source) -> "multi-file (// FILE:) tests are not supported"
-            HELPERS_IMPORT.containsMatchIn(source) -> "tests importing helpers.* are not supported"
-            "+MultiPlatformProjects" in directives[LanguageSettingsDirectives.LANGUAGE] -> "multiplatform projects are not supported"
-            isBackendIgnored(directives) -> "ignored on $BACKEND via directive"
-            else -> null
         }
 
         private fun isBackendIgnored(directives: RegisteredDirectives): Boolean {

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageLegacyPluginBoxTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageLegacyPluginBoxTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import java.io.File
+
+abstract class AbstractNativeImageLegacyPluginBoxTest : AbstractNativeImageLegacyPluginTest() {
+    private val runner: NativeImageCompilerRunner by lazy { NativeImageCompilerRunner(javaHome) }
+
+    override fun runCompiler(
+        arguments: List<String>,
+        classpath: List<File>,
+    ): Pair<Int, String> = runner.run(
+        workingDir = workingDir,
+        arguments = arguments,
+        classpath = classpath,
+        jvmArgs = listOf("-Dkotlinc.test.allow.testonly.language.features=true"),
+    )
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageLegacyPluginReachabilityMetadataTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageLegacyPluginReachabilityMetadataTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import java.io.File
+
+abstract class AbstractNativeImageLegacyPluginReachabilityMetadataTest : AbstractNativeImageLegacyPluginTest() {
+    private val runner: ReachabilityMetadataGeneratingCompilerRunner by lazy { ReachabilityMetadataGeneratingCompilerRunner(javaHome) }
+
+    override fun runCompiler(
+        arguments: List<String>,
+        classpath: List<File>,
+    ): Pair<Int, String> = runner.run(
+        workingDir = workingDir,
+        arguments = arguments,
+        classpath = classpath,
+        jvmArgs = listOf("-Dkotlinc.test.allow.testonly.language.features=true"),
+    )
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageLegacyPluginTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImageLegacyPluginTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
+import java.io.File
+
+/**
+ * Test plugins with `-Xplugin` + `-P plugin:<id>:<option>` flags
+ */
+abstract class AbstractNativeImageLegacyPluginTest : AbstractNativeImageCodegenTest() {
+    protected val pluginsRuntimeClasspath: List<File> by lazy { ForTestCompileRuntime.kotlinNativeImagePluginsRuntimeForTests() }
+
+    private val kotlinHome: File by lazy { ForTestCompileRuntime.distKotlincForTests() }
+
+    override fun buildCompilerArgs(
+        boxFile: File,
+        outDir: File,
+        directives: RegisteredDirectives,
+        withFullJdk: Boolean,
+    ): List<String> = buildList {
+        addAll(super.buildCompilerArgs(boxFile, outDir, directives, withFullJdk))
+        for ([pluginId, jarName, options] in directives.pluginSpecs()) {
+            val jar = kotlinHome.resolve("lib").resolve(jarName).absolutePath
+            add("-Xplugin=$jar")
+            for (option in options) {
+                add("-P")
+                add("plugin:${pluginId}:$option")
+            }
+        }
+        for (constraint in directives.pluginOrderConstraints()) {
+            add("-Xcompiler-plugin-order=$constraint")
+        }
+    }
+
+    override fun buildClasspath(withReflect: Boolean, withFullJdk: Boolean): List<File> =
+        super.buildClasspath(withReflect, withFullJdk) + pluginsRuntimeClasspath
+
+    override fun runtimeClasspath(withReflect: Boolean): List<File> = super.runtimeClasspath(withReflect) + pluginsRuntimeClasspath
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImagePluginBoxTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImagePluginBoxTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import java.io.File
+
+abstract class AbstractNativeImagePluginBoxTest : AbstractNativeImagePluginTest() {
+    private val runner: NativeImageCompilerRunner by lazy { NativeImageCompilerRunner(javaHome) }
+
+    override fun runCompiler(
+        arguments: List<String>,
+        classpath: List<File>,
+    ): Pair<Int, String> = runner.run(
+        workingDir = workingDir,
+        arguments = arguments,
+        classpath = classpath,
+        jvmArgs = listOf("-Dkotlinc.test.allow.testonly.language.features=true"),
+    )
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImagePluginReachabilityMetadataTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImagePluginReachabilityMetadataTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import java.io.File
+
+abstract class AbstractNativeImagePluginReachabilityMetadataTest : AbstractNativeImagePluginTest() {
+    private val runner: ReachabilityMetadataGeneratingCompilerRunner by lazy { ReachabilityMetadataGeneratingCompilerRunner(javaHome) }
+
+    override fun runCompiler(
+        arguments: List<String>,
+        classpath: List<File>,
+    ): Pair<Int, String> = runner.run(
+        workingDir = workingDir,
+        arguments = arguments,
+        classpath = classpath,
+        jvmArgs = listOf("-Dkotlinc.test.allow.testonly.language.features=true"),
+    )
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImagePluginTest.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/AbstractNativeImagePluginTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
+import java.io.File
+
+/**
+ * Test plugins with `-Xcompiler-plugin` flag
+ */
+abstract class AbstractNativeImagePluginTest : AbstractNativeImageCodegenTest() {
+    protected val pluginsRuntimeClasspath: List<File> by lazy { ForTestCompileRuntime.kotlinNativeImagePluginsRuntimeForTests() }
+
+    private val kotlinHome: File by lazy { ForTestCompileRuntime.distKotlincForTests() }
+
+    override fun buildCompilerArgs(
+        boxFile: File,
+        outDir: File,
+        directives: RegisteredDirectives,
+        withFullJdk: Boolean,
+    ): List<String> = buildList {
+        addAll(super.buildCompilerArgs(boxFile, outDir, directives, withFullJdk))
+        if (directives.expectedPluginOrder().isNotEmpty()) add("-verbose")
+        for ([_, jarName, options] in directives.pluginSpecs()) {
+            val jar = kotlinHome.resolve("lib").resolve(jarName).absolutePath
+            add(
+                when {
+                    options.isEmpty() -> "-Xcompiler-plugin=$jar"
+                    else -> "-Xcompiler-plugin=$jar=${options.joinToString(",")}"
+                }
+            )
+        }
+        for (constraint in directives.pluginOrderConstraints()) {
+            add("-Xcompiler-plugin-order=$constraint")
+        }
+    }
+
+    override fun buildClasspath(withReflect: Boolean, withFullJdk: Boolean): List<File> =
+        super.buildClasspath(withReflect, withFullJdk) + pluginsRuntimeClasspath
+
+    override fun runtimeClasspath(withReflect: Boolean): List<File> = super.runtimeClasspath(withReflect) + pluginsRuntimeClasspath
+
+}

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/GenerateNativeImageTests.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/GenerateNativeImageTests.kt
@@ -19,5 +19,19 @@ fun main(args: Array<String>) {
                 model("box")
             }
         }
+        testGroup(testsRoot = args[0], testDataRoot = "prepare/compiler-native-image/testData/projects/box") {
+            testClass<AbstractNativeImagePluginBoxTest> {
+                model("")
+            }
+            testClass<AbstractNativeImageLegacyPluginBoxTest> {
+                model("")
+            }
+            testClass<AbstractNativeImagePluginReachabilityMetadataTest> {
+                model("")
+            }
+            testClass<AbstractNativeImageLegacyPluginReachabilityMetadataTest> {
+                model("")
+            }
+        }
     }
 }

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImagePluginDirectives.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImagePluginDirectives.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.compiler.nativeimage
+
+import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
+import org.jetbrains.kotlin.test.directives.model.SimpleDirectivesContainer
+import org.jetbrains.kotlin.utils.graalvm.BundledCompilerPlugins
+
+object NativeImagePluginDirectives : SimpleDirectivesContainer() {
+    val COMPILER_PLUGIN by stringDirective(
+        description = """
+            Usage: // COMPILER_PLUGIN: kotlin-allopen-compiler-plugin.jar annotation=MyOpen
+            Declares a plugin compiler (with options) to load.
+    """.trimIndent(),
+        multiLine = true,
+    )
+
+    val COMPILER_PLUGIN_ORDER by stringDirective(
+        description = """
+            Usage: // COMPILER_PLUGIN_ORDER: org.jetbrains.kotlin.noarg>org.jetbrains.kotlin.allopen
+            Declares an execution-order constraint between plugins
+    """.trimIndent(),
+        multiLine = true,
+    )
+
+    val EXPECTED_PLUGIN_ORDER by stringDirective(
+        description = """
+            Usage: // EXPECTED_PLUGIN_ORDER: org.jetbrains.kotlin.noarg org.jetbrains.kotlin.allopen
+            The plugin ids in the order they are expected to be loaded
+    """.trimIndent()
+    )
+}
+
+data class PluginSpec(
+    val pluginId: String,
+    val jarName: String,
+    val options: List<String>,
+)
+
+private val WHITESPACE = Regex("""\s+""")
+
+fun RegisteredDirectives.pluginSpecs(): List<PluginSpec> =
+    this[NativeImagePluginDirectives.COMPILER_PLUGIN].mapNotNull { entry ->
+        val tokens = entry.split(WHITESPACE).filter { it.isNotBlank() }
+        val jarName = tokens.firstOrNull() ?: return@mapNotNull null
+        val options = tokens.drop(1).flatMap { it.split(",") }.filter { it.isNotBlank() }
+        val pluginId = BundledCompilerPlugins.lookupByClasspathEntry(jarName)?.pluginId ?: return@mapNotNull null
+        PluginSpec(pluginId, jarName, options)
+    }
+
+fun RegisteredDirectives.pluginOrderConstraints(): List<String> =
+    this[NativeImagePluginDirectives.COMPILER_PLUGIN_ORDER]
+
+fun RegisteredDirectives.expectedPluginOrder(): List<String> =
+    this[NativeImagePluginDirectives.EXPECTED_PLUGIN_ORDER]

--- a/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/ReachabilityMetadataGeneratingCompilerRunner.kt
+++ b/prepare/compiler-native-image/testFixtures/kotlin/org/jetbrains/kotlin/compiler/nativeimage/ReachabilityMetadataGeneratingCompilerRunner.kt
@@ -38,9 +38,8 @@ class ReachabilityMetadataGeneratingCompilerRunner(private val javaHome: String)
             add("-agentlib:native-image-agent=config-merge-dir=$reachabilityMetadataPath")
             add("-Djava.home=$javaHome")
             add("-Dkotlin.home=${kotlinHome.absolutePath}")
-            // We simulate how the native image compiler runs, so we set this flag
-            // Otherwise reachability metadata will contain plugins info which is not necessary
-            add("-Dorg.graalvm.nativeimage.runtime=true")
+            // Simulate the native image runtime environment
+            add("-Dorg.graalvm.nativeimage.imagecode=runtime")
             addAll(jvmArgs)
             add("-cp"); add(embeddableClasspath.joinToString(File.pathSeparator) { it.absolutePath })
             add("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")

--- a/prepare/compiler-native-image/tests/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImageSmokeTest.kt
+++ b/prepare/compiler-native-image/tests/kotlin/org/jetbrains/kotlin/compiler/nativeimage/NativeImageSmokeTest.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.compiler.nativeimage
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -28,5 +30,28 @@ class NativeImageSmokeTest {
         )
 
         assertEquals(0, exitCode, "compilation failed:\n$output")
+    }
+
+    @Test
+    fun `test non-bundled plugin fails with an error`() {
+        val source = File("testData/projects/smoke/Smoke.kt").absoluteFile
+        val outDir = File(workingDir, "out").apply { mkdirs() }
+        val unknownPluginJar = File(workingDir, "kotlin-foo-bar-compiler-plugin-1.0.jar")
+
+        val [exitCode, output] = runner.run(
+            workingDir = workingDir,
+            arguments = listOf(
+                source.absolutePath,
+                "-d", outDir.absolutePath,
+                "-Xcompiler-plugin=${unknownPluginJar.absolutePath}",
+            ),
+            classpath = emptyList(),
+        )
+
+        assertNotEquals(0, exitCode, "compilation unexpectedly succeeded with a non-bundled plugin:\n$output")
+        assertTrue(
+            "cannot be loaded by the native-image compiler" in output,
+            "expected a clear 'not bundled' diagnostic, got:\n$output",
+        )
     }
 }


### PR DESCRIPTION
Native image currently does not support dynamic class loading. Therefore, it does not support compiler plugins. This commit tries to overcoma that limitation by bundling core plugins into the native image at the build time

^KT-86765 Fixed