### PR TITLE
[PowerAssert] Allow changing unspecified last parameter type

### DIFF
--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/PowerAssertCallTransformer.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/PowerAssertCallTransformer.kt
@@ -260,18 +260,28 @@ class PowerAssertCallTransformer(
 
             fun IrType.remap(): IrType = remapTypeParameters(overload.owner, function)
 
-            // Value parameters must be compatible.
             val parameters = overload.owner.parameters
+            val messageParameter = parameters.lastOrNull()
+            if (messageParameter?.kind != IrParameterKind.Regular) return@mapNotNull null
+
+            // Value parameters must be compatible.
             if (parameters.size !in values.size..values.size + 1) return@mapNotNull null
             for (i in values.indices) {
                 val value = values[i]
                 val parameter = parameters[i]
+
+                // The signature shape (count of each type of parameter) must be the same.
                 if (value.kind != parameter.kind) return@mapNotNull null
 
                 when (value.kind) {
-                    // Regular parameters may only be assignable.
-                    IrParameterKind.Regular,
-                        -> if (!value.type.isAssignableTo(parameter.type.remap())) return@mapNotNull null
+                    IrParameterKind.Regular -> {
+                        // It is allowed for the message parameter to change type if it is not specified.
+                        // Otherwise, the parameter type must be assignable.
+                        if (
+                            !(parameter === messageParameter && original.arguments[value] == null) &&
+                            !value.type.isAssignableTo(parameter.type.remap())
+                        ) return@mapNotNull null
+                    }
 
                     // All other parameter kinds must match exactly.
                     IrParameterKind.DispatchReceiver,
@@ -281,8 +291,6 @@ class PowerAssertCallTransformer(
                 }
             }
 
-            val messageParameter = parameters.last()
-            if (messageParameter.kind != IrParameterKind.Regular) return@mapNotNull null
             val messageType = messageParameter.type
             return@mapNotNull when {
                 isStringSupertype(messageType) -> SimpleCallBuilder(overload, original)

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.box.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.box.txt
@@ -1,0 +1,15 @@
+test1: ---
+powerAssert("test".length == 5)
+                   |      |
+                   4      false
+---
+test2: ---bad
+powerAssert("test".length == 5, msg = "bad")
+                   |      |
+                   4      false
+---
+test3: ---bad
+powerAssert("test".length == 5, msg = { "bad" })
+                   |      |
+                   4      false
+---

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.kt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.kt
@@ -1,0 +1,28 @@
+// FUNCTION: powerAssert
+// DUMP_KT_IR
+
+fun box(): String = runAll(
+    "test1" to { test1() },
+    "test2" to { test2() },
+    "test3" to { test3() },
+)
+
+fun powerAssert(condition: Boolean, msg: String? = null) {
+    if (!condition) throw AssertionError(msg?.toString() ?: "Assertion failed")
+}
+
+fun powerAssert(condition: Boolean, msg: () -> String) {
+    if (!condition) throw AssertionError(msg.invoke())
+}
+
+fun test1() {
+    powerAssert("test".length == 5)
+}
+
+fun test2() {
+    powerAssert("test".length == 5, msg = "bad")
+}
+
+fun test3() {
+    powerAssert("test".length == 5, msg = { "bad" })
+}

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.kt.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.kt.txt
@@ -41,7 +41,10 @@ fun test1() {
     val tmp1_Explain: Int = tmp0_Explain.<get-length>()
     val tmp2_Explain: Int = 5
     val tmp3_Explain: Boolean = EQEQ(arg0 = tmp1_Explain, arg1 = tmp2_Explain)
-    powerAssert(condition = tmp3_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 426, source = "    powerAssert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [Argument(startOffset = 16, endOffset = 34, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 16, endOffset = 22, displayOffset = 16, value = tmp0_Explain), ValueExpression(startOffset = 16, endOffset = 29, displayOffset = 23, value = tmp1_Explain), LiteralExpression(startOffset = 33, endOffset = 34, displayOffset = 33, value = tmp2_Explain), EqualityExpression(startOffset = 16, endOffset = 34, displayOffset = 30, value = tmp3_Explain, lhs = tmp1_Explain, rhs = tmp2_Explain)])), null])) */))
+    powerAssert(condition = tmp3_Explain, msg = local fun <anonymous>(): String {
+      return "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 426, source = "    powerAssert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [Argument(startOffset = 16, endOffset = 34, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 16, endOffset = 22, displayOffset = 16, value = tmp0_Explain), ValueExpression(startOffset = 16, endOffset = 29, displayOffset = 23, value = tmp1_Explain), LiteralExpression(startOffset = 33, endOffset = 34, displayOffset = 33, value = tmp2_Explain), EqualityExpression(startOffset = 16, endOffset = 34, displayOffset = 30, value = tmp3_Explain, lhs = tmp1_Explain, rhs = tmp2_Explain)])), null])) */)
+    }
+)
   }
 }
 

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.kt.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/DefaultArgumentWithOverload.kt.txt
@@ -1,0 +1,72 @@
+fun box(): String {
+  return runAll(tests = [to<String, Function0<Unit>>(/* <this> = "test1", */ that = local fun <anonymous>() {
+    test1()
+  }
+), to<String, Function0<Unit>>(/* <this> = "test2", */ that = local fun <anonymous>() {
+    test2()
+  }
+), to<String, Function0<Unit>>(/* <this> = "test3", */ that = local fun <anonymous>() {
+    test3()
+  }
+)])
+}
+
+fun powerAssert(condition: Boolean, msg: Function0<String>) {
+  when {
+    condition.not() -> throw AssertionError(p0 = msg.invoke())
+  }
+}
+
+fun powerAssert(condition: Boolean, msg: String? = null) {
+  when {
+    condition.not() -> throw AssertionError(p0 = { // BLOCK
+      val tmp_0: String? = { // BLOCK
+        val tmp_1: String? = msg
+        when {
+          EQEQ(arg0 = tmp_1, arg1 = null) -> null
+          else -> tmp_1 /*as String */.toString()
+        }
+      }
+      when {
+        EQEQ(arg0 = tmp_0, arg1 = null) -> "Assertion failed"
+        else -> tmp_0
+      }
+    })
+  }
+}
+
+fun test1() {
+  { // BLOCK
+    val tmp0_Explain: String = "test"
+    val tmp1_Explain: Int = tmp0_Explain.<get-length>()
+    val tmp2_Explain: Int = 5
+    val tmp3_Explain: Boolean = EQEQ(arg0 = tmp1_Explain, arg1 = tmp2_Explain)
+    powerAssert(condition = tmp3_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 426, source = "    powerAssert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [Argument(startOffset = 16, endOffset = 34, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 16, endOffset = 22, displayOffset = 16, value = tmp0_Explain), ValueExpression(startOffset = 16, endOffset = 29, displayOffset = 23, value = tmp1_Explain), LiteralExpression(startOffset = 33, endOffset = 34, displayOffset = 33, value = tmp2_Explain), EqualityExpression(startOffset = 16, endOffset = 34, displayOffset = 30, value = tmp3_Explain, lhs = tmp1_Explain, rhs = tmp2_Explain)])), null])) */))
+  }
+}
+
+fun test2() {
+  { // BLOCK
+    val tmp0_Explain: String = "test"
+    val tmp1_Explain: Int = tmp0_Explain.<get-length>()
+    val tmp2_Explain: Int = 5
+    val tmp3_Explain: Boolean = EQEQ(arg0 = tmp1_Explain, arg1 = tmp2_Explain)
+    powerAssert(condition = tmp3_Explain, msg = "bad" + "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 479, source = "    powerAssert(\"test\".length == 5, msg = \"bad\")", arguments = listOf<Argument>(elements = [Argument(startOffset = 16, endOffset = 34, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 16, endOffset = 22, displayOffset = 16, value = tmp0_Explain), ValueExpression(startOffset = 16, endOffset = 29, displayOffset = 23, value = tmp1_Explain), LiteralExpression(startOffset = 33, endOffset = 34, displayOffset = 33, value = tmp2_Explain), EqualityExpression(startOffset = 16, endOffset = 34, displayOffset = 30, value = tmp3_Explain, lhs = tmp1_Explain, rhs = tmp2_Explain)])), null])) */))
+  }
+}
+
+fun test3() {
+  { // BLOCK
+    val tmp0_Explain: String = "test"
+    val tmp1_Explain: Int = tmp0_Explain.<get-length>()
+    val tmp2_Explain: Int = 5
+    val tmp3_Explain: Boolean = EQEQ(arg0 = tmp1_Explain, arg1 = tmp2_Explain)
+    powerAssert(condition = tmp3_Explain, msg = local fun <anonymous>(): String {
+      return local fun <anonymous>(): String {
+        return "bad"
+      }
+.invoke() + "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 545, source = "    powerAssert(\"test\".length == 5, msg = { \"bad\" })", arguments = listOf<Argument>(elements = [Argument(startOffset = 16, endOffset = 34, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 16, endOffset = 22, displayOffset = 16, value = tmp0_Explain), ValueExpression(startOffset = 16, endOffset = 29, displayOffset = 23, value = tmp1_Explain), LiteralExpression(startOffset = 33, endOffset = 34, displayOffset = 33, value = tmp2_Explain), EqualityExpression(startOffset = 16, endOffset = 34, displayOffset = 30, value = tmp3_Explain, lhs = tmp1_Explain, rhs = tmp2_Explain)])), null])) */)
+    }
+)
+  }
+}


### PR DESCRIPTION
When searching for a power-assert capable overload of the called
function, allow changing the last parameter type if the argument is not
specified. This allows the optimization of converting from a String
message type to a String producing lambda type. This helps when a
function without the message parameter doesn't exist and the function
with the String message type is resolved to because of a default
parameter. (More details on specifics in the ticket)

This helps make the performance impact of adding power-assert acceptable
in cases when calculating the diagram is very expensive. Note that if
the message is already specified, power-assert will not change which
override function is called, and a performance impact could still be
observed.

^[KT-86774](https://youtrack.jetbrains.com/issue/KT-86774) Fixed