### PR TITLE
[ObjCExport] Support explicit method family in K2

### DIFF
--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/KtObjCExportConfiguration.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/KtObjCExportConfiguration.kt
@@ -24,5 +24,7 @@ data class KtObjCExportConfiguration(
     val objcGenerics: Boolean = true,
 
     val objcExportBlockExplicitParameterNames: Boolean = false,
+
+    val explicitMethodFamilyName: Boolean = false
 )
 

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyGetter.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyGetter.kt
@@ -19,7 +19,9 @@ import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
  */
 internal fun ObjCExportContext.getObjCPropertyGetter(symbol: KaPropertySymbol, objCName: String): String? {
 
-    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions) return null
+    // `init`-like properties will always need prefixing.
+    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions && !objCName.isSpecialFamilyOrInit(exportSession.configuration.explicitMethodFamilyName))
+        return null
 
     val symbolGetter = symbol.getter
     val getterBridge = if (symbolGetter == null) error("KtPropertySymbol.getter is undefined") else getFunctionMethodBridge(symbolGetter)

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertySetter.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertySetter.kt
@@ -19,7 +19,9 @@ import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
  */
 internal fun ObjCExportContext.getObjCPropertySetter(symbol: KaPropertySymbol, objCName: String): String? {
 
-    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions) return null
+    // `init`-like properties will always need prefixing.
+    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions && !objCName.isSpecialFamilyOrInit(exportSession.configuration.explicitMethodFamilyName))
+        return null
 
     val setterName = symbol.setter?.let {
         val setterSelector = getSelector(it, getFunctionMethodBridge(it))

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/isObjCReservedName.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/isObjCReservedName.kt
@@ -10,7 +10,7 @@ private val reservedPropertyNames = cKeywords + setOf("description") // https://
 /**
  * Following class and object names should be handled in a special way to avoid clashing with NSObject class methods.
  *
- * When processing ["alloc", "copy", "mutableCopy", "new", "init"] names the `get` prefix should be added.
+ * When processing ["alloc", "copy", "mutableCopy", "new", "init"] names, certain prefixes such as `do` or `get` should be added.
  * Other reserved names are mangled by adding `_` suffix.
  */
 private val reservedClassOrObjectNames = setOf(

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/objCSpecialNames.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/objCSpecialNames.kt
@@ -3,9 +3,19 @@ package org.jetbrains.kotlin.objcexport
 internal val objCSpecialNames = listOf("alloc", "copy", "mutableCopy", "new", "init")
 
 internal fun String.handleSpecialNames(prefix: String): String {
-    val trimmed = this.dropWhile { it == '_' }
-    for (name in objCSpecialNames) {
-        if (trimmed.startsWithWords(name)) return prefix + this.replaceFirstChar(Char::uppercaseChar)
+    return if (this.isASpecialName()) {
+        prefix + this.replaceFirstChar(Char::uppercaseChar)
+    } else {
+        this
     }
-    return this
+}
+
+internal fun String.isASpecialName(): Boolean {
+    val trimmed = this.dropWhile { it == '_' }
+    return objCSpecialNames.any { trimmed.startsWithWords(it) }
+}
+
+internal fun String.isSpecialFamilyOrInit(explicitMethodFamilyName: Boolean): Boolean {
+    // We're always interested in names that are/start with "init", irrespective of explicitMethodFamilyName.
+    return !explicitMethodFamilyName && this.isASpecialName() || this == "init" || this.startsWith("initWith")
 }

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCExportStub.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCExportStub.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportStub
+import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
 import org.jetbrains.kotlin.utils.addIfNotNull
 
 internal fun ObjCExportContext.translateToObjCExportStub(symbol: KaCallableSymbol): List<ObjCExportStub> {
@@ -15,6 +16,18 @@ internal fun ObjCExportContext.translateToObjCExportStub(symbol: KaCallableSymbo
         is KaPropertySymbol -> {
             if (analysisSession.isObjCProperty(symbol)) {
                 result.addIfNotNull(translateToObjCProperty(symbol))
+                if (symbol.getter != null) {
+                    val selector = getSelector(
+                        symbol.getter!!,
+                        getFunctionMethodBridge(
+                            symbol.getter!!
+                        )
+                    )
+
+                    if (this.exportSession.configuration.explicitMethodFamilyName && selector.isASpecialName()) {
+                        result.addIfNotNull(translateToObjCMethod(symbol.getter!!))
+                    }
+                }
             } else {
                 symbol.getter?.let { getter ->
                     result.addIfNotNull(translateToObjCMethod(getter))

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCMethod.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCMethod.kt
@@ -85,6 +85,11 @@ internal fun ObjCExportContext.buildObjCMethod(
         } else {
             attributes.addIfNotNull(analysisSession.getObjCDeprecationStatus(symbol))
         }
+
+        if (this.exportSession.configuration.explicitMethodFamilyName && !symbol.isConstructor && selector.isASpecialName()) {
+            attributes += "objc_method_family(none)"
+        }
+
         return attributes
     }
 
@@ -299,10 +304,17 @@ fun ObjCExportContext.getSelector(symbol: KaFunctionSymbol, methodBridge: Method
  * [org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportNamerImpl.getMangledName]
  */
 fun ObjCExportContext.getMangledName(symbol: KaFunctionSymbol, forSwift: Boolean): String {
+    val explicitMethodFamilyName = this.exportSession.configuration.explicitMethodFamilyName
+
     return if (symbol.isConstructor) {
         if (analysisSession.isArrayConstructor(symbol) && !forSwift) "array" else "init"
     } else {
-        getObjCFunctionName(symbol).name(forSwift).handleSpecialNames("do")
+        val name = getObjCFunctionName(symbol).name(forSwift)
+        if (!explicitMethodFamilyName || name == "init" || name.startsWith("initWith")) {
+            name.handleSpecialNames(prefix = "do")
+        } else {
+            name
+        }
     }
 }
 

--- a/native/objcexport-header-generator/impl/analysis-api/testFixtures/org/jetbrains/kotlin/objcexport/testUtils/AnalysisApiHeaderGenerator.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/testFixtures/org/jetbrains/kotlin/objcexport/testUtils/AnalysisApiHeaderGenerator.kt
@@ -59,6 +59,7 @@ object AnalysisApiHeaderGenerator : HeaderGenerator {
                 KtObjCExportConfiguration(
                     frameworkName = configuration.frameworkName,
                     objcExportBlockExplicitParameterNames = configuration.objcExportBlockExplicitParameterNames,
+                    explicitMethodFamilyName = configuration.explicitMethodFamily
                 ),
                 moduleClassifier = { module ->
                     module == useSiteModule || module is KaLibraryModule && module in exportedLibraries

--- a/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
+++ b/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
@@ -322,6 +322,9 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
         doTest(headersTestDataDir.resolve("specialFunctionNames"))
     }
 
+    /**
+     * For equivalent AA-test, see reducedSpecialFunctionNamesExplicitMethodFamily.
+     */
     @Test
     @TodoAnalysisApi
     fun `test - special function names with explicit method family`() {
@@ -719,6 +722,16 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
     @TodoAnalysisApi
     fun `test - conflict upon mangling a property or a method should be handled by the manglers`() {
         doTest(headersTestDataDir.resolve("conflictUponManglingPropertyOrMethod"))
+    }
+
+    /**
+     * This test primarily exercises the AA impl for explicitMethodFamily=true, and not the subsequent conflict
+     * detection and mangling, as that's dependent on the resolution of KT-86289. For such a test (K1), see
+     * specialFunctionNamesExplicitMethodFamily.
+     */
+    @Test
+    fun `test - reduced set of special function names with explicit method family`() {
+        doTest(headersTestDataDir.resolve("reducedSpecialFunctionNamesExplicitMethodFamily"), Configuration(explicitMethodFamily = true))
     }
 
     private fun doTest(root: File, configuration: Configuration = Configuration()) {

--- a/native/objcexport-header-generator/testData/headers/reducedSpecialFunctionNamesExplicitMethodFamily/!reducedSpecialFunctionNamesExplicitMethodFamily.h
+++ b/native/objcexport-header-generator/testData/headers/reducedSpecialFunctionNamesExplicitMethodFamily/!reducedSpecialFunctionNamesExplicitMethodFamily.h
@@ -1,0 +1,43 @@
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSSet.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+
+NS_ASSUME_NONNULL_BEGIN
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wincompatible-property-type"
+#pragma clang diagnostic ignored "-Wnullability"
+
+#pragma push_macro("_Nullable_result")
+#if !__has_feature(nullability_nullable_result)
+#undef _Nullable_result
+#define _Nullable_result _Nullable
+#endif
+
+__attribute__((objc_subclassing_restricted))
+@interface Foo : Base
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (int32_t)__initSomethingElse __attribute__((swift_name("__initSomethingElse()"))) __attribute__((objc_method_family(none)));
+- (int32_t)alloc __attribute__((swift_name("alloc()"))) __attribute__((objc_method_family(none)));
+@property (readonly) int32_t _newBaz __attribute__((swift_name("_newBaz")));
+- (int32_t)_newBaz __attribute__((swift_name("_newBaz()"))) __attribute__((objc_method_family(none)));
+@property (readonly) int32_t copySomething __attribute__((swift_name("copySomething")));
+- (int32_t)copySomething __attribute__((swift_name("copySomething()"))) __attribute__((objc_method_family(none)));
+@property (readonly) int32_t copyWithSomething __attribute__((swift_name("copyWithSomething")));
+- (int32_t)copyWithSomething __attribute__((swift_name("copyWithSomething()"))) __attribute__((objc_method_family(none)));
+@property (getter=doInitWithNothing) int32_t initWithNothing __attribute__((swift_name("initWithNothing")));
+@property (readonly, getter=doInitWithSomething) int32_t initWithSomething __attribute__((swift_name("initWithSomething")));
+@property (readonly) int32_t mutableCopy __attribute__((swift_name("mutableCopy")));
+- (int32_t)mutableCopy __attribute__((swift_name("mutableCopy()"))) __attribute__((objc_method_family(none)));
+@property (readonly) int32_t newBar __attribute__((swift_name("newBar")));
+- (int32_t)newBar __attribute__((swift_name("newBar()"))) __attribute__((objc_method_family(none)));
+@end
+
+#pragma pop_macro("_Nullable_result")
+#pragma clang diagnostic pop
+NS_ASSUME_NONNULL_END

--- a/native/objcexport-header-generator/testData/headers/reducedSpecialFunctionNamesExplicitMethodFamily/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/reducedSpecialFunctionNamesExplicitMethodFamily/Foo.kt
@@ -1,0 +1,18 @@
+class Foo {
+    // When explicitMethodFamily is set to true, an accompanying method is generated for properties whose name is "special",
+    // i.e. starts with one of these words: "alloc", "copy", "mutableCopy", "new", "init".
+    val copySomething = 1
+    val mutableCopy = 2
+    val newBar = 3
+    fun alloc(): Int = 4
+
+    // Irrespective of explicitMethodFamily's value, a property's getter and setter are prefixed with "do" should its name be
+    // be "init" or start with "initWith".
+    val initWithSomething = 5
+    var initWithNothing = 6
+
+    // These names are special too as leading underscores are stripped when checking if a name is special.
+    val _newBaz: Int = 7
+    fun __initSomethingElse(): Int = 8
+    val copyWithSomething = 9
+}

--- a/native/objcexport-header-generator/testData/headers/specialFunctionNames/!specialFunctionNames.h
+++ b/native/objcexport-header-generator/testData/headers/specialFunctionNames/!specialFunctionNames.h
@@ -26,6 +26,7 @@ __attribute__((objc_subclassing_restricted))
 + (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
 - (void)doAlloc __attribute__((swift_name("doAlloc()")));
 - (Foo *)doCopy __attribute__((swift_name("doCopy()")));
+- (Foo *)doCopyWithSomething __attribute__((swift_name("doCopyWithSomething()")));
 - (Foo *)doInit __attribute__((swift_name("doInit()")));
 - (Foo *)doMutableCopy __attribute__((swift_name("doMutableCopy()")));
 - (Foo *)doNew __attribute__((swift_name("doNew()")));

--- a/native/objcexport-header-generator/testData/headers/specialFunctionNames/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/specialFunctionNames/Foo.kt
@@ -4,4 +4,5 @@ class Foo {
     fun mutableCopy(): Foo = Foo()
     fun new(): Foo = Foo()
     fun init(): Foo = Foo()
+    fun copyWithSomething(): Foo = Foo()
 }


### PR DESCRIPTION
For Objective-C header export, in K1, we generate a corresponding method for a property if its name is a "special" one (one of `"alloc", "copy", "mutableCopy", "new", "init"`) and the configuration allows it, as denoted by the boolean `explicitMethodFamily`. This PR implements the same for K2 and enables the tests that were disabled for it.

Might need to wire in the `boolean` configuration for outside tests, too.