### PR TITLE
[Tests][JS,Wasm] Avoid Windows MAX_PATH limit in fun TestServices.compiledTestOutputDirectory()

### DIFF
--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/utils/RunnerUtils.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/utils/RunnerUtils.kt
@@ -301,8 +301,27 @@ fun TestServices.compiledTestOutputDirectory(
     require(suffixPathSequence.size < fullPathSequence.size) {
         "Folder $stopFile (which is set by PATH_TO_TEST_DIR directive) must contain $parentAbsoluteFile"
     }
-    return suffixPathSequence
+    val pathParts = suffixPathSequence
         .map { it.name }
         .toList().asReversed()
-        .fold(testGroupOutputDir, ::File)
+
+    return maybeShortenWindowsPath(pathParts).fold(testGroupOutputDir, ::File)
+}
+
+// --- Shared Windows path shortener -------------------------------------------------------------
+
+/**
+ * Shorten very long output directory paths on Windows by hashing the deep test subpath to avoid MAX_PATH (~260) limitation
+ * in runners that write deeply nested `box/...` directories. No effect on non-Windows.
+ *
+ * Example: path construction without shortening:
+ *   ...\build\out\WasmJsCodegenBoxTestGenerated2.4\box\inference\pcla\...\oneTypeInfoOriginSourceSinkFeedContexts
+ * with shortening becomes:
+ *   ...\build\out\WasmJsCodegenBoxTestGenerated2.4\3f2a9d1c\SourceSinkFeedContexts
+ */
+private fun maybeShortenWindowsPath(pathParts: List<String>): List<String> {
+    val osName = System.getProperty("os.name") ?: ""
+    if (!osName.startsWith("Windows", ignoreCase = true)) return pathParts
+    if (pathParts.size <= 2) return pathParts
+    return listOf(pathParts.joinToString().hashCode().toHexString(), pathParts.last())
 }


### PR DESCRIPTION
During work on grouping test infra, there were numerous Windows fails due to hit MAX_PATH limit. 
Example of failed build: https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_Aggregate/972013185
> ======= Failed test run #1 ==========
  java.lang.AssertionError: Command "'Z:\BuildAgent\system\.persistent_cache\gradle\d8\v8-win64-rel-15.0.45\d8.exe' '--module' './test.mjs'" terminated with exit code 1 in working dir "Z:\BuildAgent\work\17e640964edd2053\kotlin\wasm\wasm.tests\build\out\WasmJsCodegenInlinedBoxTestGenerated2.4\box\inference\pcla\oneParameter\oneTypeVariable\oneTypeInfoOrigin\sourceSinkFeedContexts\ByAssignmentToALocalVariableMaterializeCase\dev"
  OUTPUT:
  undefined:0: Error: d8: Error reading module from Z:/BuildAgent/work/17e640964edd2053/kotlin/wasm/wasm.tests/build/out/WasmJsCodegenInlinedBoxTestGenerated2.4/box/inference/pcla/oneParameter/oneTypeVariable/oneTypeInfoOrigin/sourceSinkFeedContexts/ByAssignmentToALocalVariableMaterializeCase/dev/index.import-object.mjs
    at kotlin.test.junit.JUnitAsserter.fail(JUnitSupport.kt:56)
    at kotlin.test.AssertionsKt__AssertionsKt.fail(Assertions.kt:565)
    at kotlin.test.AssertionsKt.fail(Unknown Source)
    at org.jetbrains.kotlin.wasm.test.tools.ExternalTool.run(WasmVM.kt:170)
    at org.jetbrains.kotlin.wasm.test.tools.WasmVM$V8.run(WasmVM.kt:40)
    at org.jetbrains.kotlin.wasm.test.tools.WasmVM.run$default(WasmVM.kt:24)
    at org.jetbrains.kotlin.wasm.test.handlers.WasmBoxRunnerBaseKt.runWithCaughtExceptions(WasmBoxRunnerBase.kt:211)
    at org.jetbrains.kotlin.wasm.test.handlers.WasmBoxRunnerBase.saveAdditionalFilesAndRun(WasmBoxRunnerBase.kt:185)
    at org.jetbrains.kotlin.wasm.test.handlers.WasmBoxRunner.runWasmCode$writeToFilesAndRunTest(WasmBoxRunner.kt:72)
    at org.jetbrains.kotlin.wasm.test.handlers.WasmBoxRunner.runWasmCode(WasmBoxRunner.kt:91)

^KT-85850