### PR TITLE
[K/N] Changed the workaround message to include incremental compilation

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin.backend.konan
 
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.util.toObsoleteKind
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.nativeBinaryOptions.AndroidProgramType
 import org.jetbrains.kotlin.config.nativeBinaryOptions.BinaryOptions
 import org.jetbrains.kotlin.konan.KonanExternalToolFailure
@@ -164,15 +165,20 @@ internal fun runLinkerCommands(context: NativeBackendPhaseContext, commands: Lis
         it.execute()
     }
 } catch (e: KonanExternalToolFailure) {
-    val extraUserInfo = if (cachingInvolved)
+    val extraUserInfo = if (cachingInvolved) {
+        val incrementalCompilationEnabled = context.config.configuration[CommonConfigurationKeys.INCREMENTAL_COMPILATION] == true
+        val workaround = when {
+            incrementalCompilationEnabled ->
+                "incremental compilation (kotlin.incremental.native=false)"
+            else ->
+                "compiler caches (https://kotl.in/disable-native-cache)"
+        }
         """
-                    Please try to disable compiler caches and rerun the build.
-                    To disable compiler caches, use `disableNativeCache` in the binary declaration in the Gradle build script.
-                    See https://kotl.in/disable-native-cache for specific instructions.
+            Please try to disable $workaround and rerun the build.
 
-                    Also, consider filing an issue with full Gradle log here: https://kotl.in/issue
-                    """.trimIndent()
-    else null
+            Also, consider filing an issue with full Gradle log here: https://kotl.in/issue
+            """.trimIndent()
+    } else null
 
     val extraUserSetupInfo = run {
         context.config.resolvedLibraries.getFullList()

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CompilerOutputTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CompilerOutputTest.kt
@@ -174,9 +174,7 @@ abstract class CompilerOutputTestBase : AbstractNativeSimpleTest() {
             assertContains(
                 output,
                 """
-                |Please try to disable compiler caches and rerun the build.
-                |To disable compiler caches, use `disableNativeCache` in the binary declaration in the Gradle build script.
-                |See https://kotl.in/disable-native-cache for specific instructions.
+                |Please try to disable compiler caches (https://kotl.in/disable-native-cache) and rerun the build.
                 |
                 |Also, consider filing an issue with full Gradle log here: https://kotl.in/issue""".trimMargin()
             )


### PR DESCRIPTION
When a compilation fails, there is a helper message with possible work- arounds (like turning off the caches). With incremental compilation turned on by default, this message now includes the suggestion to turn it off.

 #KT-58983