### PR TITLE
[Wasm]: Fix some companion block related issues.

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/EraseVirtualDispatchReceiverParametersTypes.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/EraseVirtualDispatchReceiverParametersTypes.kt
@@ -67,7 +67,8 @@ class EraseVirtualDispatchReceiverParametersTypes(val context: CommonBackendCont
         if (irFunction !is IrSimpleFunction) return
         if (!irFunction.isOverridableOrOverrides) return
 
-        val dispatchReceiver = irFunction.dispatchReceiverParameter!!
+        // Companion block functions are static and have no receiver
+        val dispatchReceiver = irFunction.dispatchReceiverParameter ?: return
         val originalReceiverType = dispatchReceiver.type
 
         // Interfaces in Wasm are erased to Any, so they already have appropriate type

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/EraseVirtualDispatchReceiverParametersTypes.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/EraseVirtualDispatchReceiverParametersTypes.kt
@@ -67,7 +67,9 @@ class EraseVirtualDispatchReceiverParametersTypes(val context: CommonBackendCont
         if (irFunction !is IrSimpleFunction) return
         if (!irFunction.isOverridableOrOverrides) return
 
-        // Companion block functions are static and have no receiver
+        // Functions with no dispatch receivers should just be ignored. This shouldn't normally
+        // happen anyway given the preconditions, but some language extension may change this in the
+        // future.
         val dispatchReceiver = irFunction.dispatchReceiverParameter ?: return
         val originalReceiverType = dispatchReceiver.type
 

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInitializersLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInitializersLowering.kt
@@ -20,4 +20,7 @@ import org.jetbrains.kotlin.ir.backend.js.lower.PrimaryConstructorLowering
 internal class WasmInitializersLowering(context: WasmBackendContext) : InitializersLowering(context)
 
 @PhasePrerequisites(WasmInitializersLowering::class)
-internal class WasmInitializersCleanupLowering(context: CommonBackendContext) : InitializersCleanupLowering(context)
+internal class WasmInitializersCleanupLowering(context: CommonBackendContext) : InitializersCleanupLowering(
+    context,
+    shouldEraseFieldInitializer = { it.correspondingPropertySymbol?.owner?.isConst != true && !it.isStatic }
+)

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInitializersLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmInitializersLowering.kt
@@ -22,5 +22,6 @@ internal class WasmInitializersLowering(context: WasmBackendContext) : Initializ
 @PhasePrerequisites(WasmInitializersLowering::class)
 internal class WasmInitializersCleanupLowering(context: CommonBackendContext) : InitializersCleanupLowering(
     context,
+    // TODO: Remove this hack once https://github.com/JetBrains/kotlin/pull/6165 is merged.
     shouldEraseFieldInitializer = { it.correspondingPropertySymbol?.owner?.isConst != true && !it.isStatic }
 )

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/abstractClasses.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/abstractClasses.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: WASM, WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 
 abstract class Base {
     companion {

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/basicBlockAndExtension.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/basicBlockAndExtension.kt
@@ -1,10 +1,9 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
 // DUMP_KLIB_ABI: DEFAULT
 // DUMP_IR
-// IGNORE_BACKEND: JS_IR, JS_IR_ES6, WASM, WASM_JS, WASM_WASI
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 // Notes:
 // JS compBlockVal is undefined
-// WASM dereferencing a null pointer
 
 class A {
     companion {

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/callableReferences_block.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/callableReferences_block.kt
@@ -1,7 +1,7 @@
 // WITH_STDLIB
 // LANGUAGE: +CompanionBlocksAndExtensions
 // DUMP_KLIB_ABI: DEFAULT
-// IGNORE_BACKEND: WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 import kotlin.test.assertEquals
 import kotlin.reflect.*
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/companionBlock.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/companionBlock.kt
@@ -1,6 +1,6 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
 // DUMP_KLIB_ABI: DEFAULT
-// IGNORE_BACKEND: WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 import C.func
 
 class C {

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritance.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritance.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: WASM, WASM_JS, WASM_WASI, NATIVE, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: NATIVE, JS_IR, JS_IR_ES6
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultiLevel.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultiLevel.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: WASM, WASM_JS, WASM_WASI, NATIVE, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: NATIVE, JS_IR, JS_IR_ES6
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/inline_block.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/inline_block.kt
@@ -1,8 +1,7 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
 // DUMP_KLIB_ABI: DEFAULT
-// IGNORE_BACKEND: WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 // Notes:
-// WASM gets 0 from A.compBlockValI instead of 1
 // JS fails because static vals are undefined
 
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/multipleBlocks.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/multipleBlocks.kt
@@ -1,8 +1,7 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
 // DUMP_KLIB_ABI: DEFAULT
-// IGNORE_BACKEND: WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 // Notes:
-// WASM "Onull"
 // JS "Oundefined"
 
 class A {

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/propertyDelegation_block.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/propertyDelegation_block.kt
@@ -1,6 +1,6 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
 // DUMP_KLIB_ABI: DEFAULT
-// IGNORE_BACKEND: WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 object Delegate {
     var value = ""
     operator fun getValue(a: Any?, b: Any?) = value

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/resolutionPriority.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/resolutionPriority.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: WASM, WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 
 class Example {
     companion {

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/visibility.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/visibility.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: WASM, WASM_JS, WASM_WASI, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 
 class C {
     companion {

--- a/compiler/testData/codegen/box/multiplatform/k2/expectStatic.kt
+++ b/compiler/testData/codegen/box/multiplatform/k2/expectStatic.kt
@@ -1,9 +1,8 @@
 // LANGUAGE: +MultiPlatformProjects, +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: WASM_WASI, WASM_JS, JS_IR, JS_IR_ES6
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 // IGNORE_HMPP: JS_IR
 // Notes:
 // JS: "NOT OK: undefinedundefined1ObjObj2"
-// WASM: "RuntimeError: dereferencing a null pointer"
 
 // MODULE: common
 // FILE: common.kt

--- a/compiler/testData/klib/syntheticAccessors/outerThis/crossFileLeak/leakingCompanionBlockPrivateValThroughInnerAndNestedClasses.kt
+++ b/compiler/testData/klib/syntheticAccessors/outerThis/crossFileLeak/leakingCompanionBlockPrivateValThroughInnerAndNestedClasses.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JS_IR, WASM_JS
+// IGNORE_BACKEND: JS_IR
 // Static property is undefined on JS backend
 // FILE: Outer.kt
 class Outer {

--- a/compiler/testData/klib/syntheticAccessors/outerThis/crossModuleLeak/leakingCompanionBlockPrivateValThroughInnerAndNestedClasses.kt
+++ b/compiler/testData/klib/syntheticAccessors/outerThis/crossModuleLeak/leakingCompanionBlockPrivateValThroughInnerAndNestedClasses.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JS_IR, WASM_JS
+// IGNORE_BACKEND: JS_IR
 // Static property is undefined on JS backend
 // MODULE: lib
 // FILE: Outer.kt

--- a/compiler/testData/klib/syntheticAccessors/outerThis/singleFile/leakingCompanionBlockPrivateValThroughInnerAndNestedClasses.kt
+++ b/compiler/testData/klib/syntheticAccessors/outerThis/singleFile/leakingCompanionBlockPrivateValThroughInnerAndNestedClasses.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JS_IR, WASM_JS
+// IGNORE_BACKEND: JS_IR
 // Static property is undefined on JS backend
 class Outer {
     companion {

--- a/compiler/testData/klib/syntheticAccessors/privateMember/crossFilePrivateLeak/leakingCompanionBlockPrivateValThroughClassMethods.kt
+++ b/compiler/testData/klib/syntheticAccessors/privateMember/crossFilePrivateLeak/leakingCompanionBlockPrivateValThroughClassMethods.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JS_IR, WASM_JS
+// IGNORE_BACKEND: JS_IR
 // Static property is undefined on JS backend
 // FILE: A.kt
 class A {

--- a/compiler/testData/klib/syntheticAccessors/privateMember/crossModulePrivateLeak/leakingCompanionBlockPrivateValThroughClassMethods.kt
+++ b/compiler/testData/klib/syntheticAccessors/privateMember/crossModulePrivateLeak/leakingCompanionBlockPrivateValThroughClassMethods.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JS_IR, WASM_JS
+// IGNORE_BACKEND: JS_IR
 // Static property is undefined on JS backend
 // MODULE: lib
 // FILE: A.kt

--- a/compiler/testData/klib/syntheticAccessors/privateMember/singleFile/leakingCompanionBlockPrivateValThroughClassMethods.kt
+++ b/compiler/testData/klib/syntheticAccessors/privateMember/singleFile/leakingCompanionBlockPrivateValThroughClassMethods.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JS_IR, WASM_JS
+// IGNORE_BACKEND: JS_IR
 // Static property is undefined on JS backend
 class A {
     companion {


### PR DESCRIPTION
* Fix erasing virtual dispatch receivers for companion block functions.

They are static and have no dispatch receiver.

* Relatedly, make static members lowering set the modality of static functions to final.

Since they are by definition no longer overridable, which makes it so that codegen doesn't get confused during translation of companion block functions inside e.g. interfaces. This fix applies to the JS backend as well.

* Fix static initialization of companion block members.

This code path was not exercised before because static fields of classes usually had an associated companion object to be constructed with. However, companion blocks make it so that these static fields can be standalone. Therefore, make sure not to clean up the associated initializer for these fields. Later lowerings can already handle them correctly.

Doing this makes the companion block tests pass on Wasm which do not rely on initialization order. Initialization order behavior as defined by the companion block box tests still needs to be finalized/clarified as discussed with Andrii Rublov. Most likely, initialization order behavior will still be coordinated with corresponding future changes in JS/JVM.

^KT-85772 Fixed