### PR TITLE
CLI: do not eagerly load HMPP fragment argument names

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/arguments.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/arguments.kt
@@ -10,6 +10,12 @@ import org.jetbrains.kotlin.cli.CliDiagnostics
 import org.jetbrains.kotlin.cli.CliDiagnostics.COMPILER_ARGUMENTS_ERROR
 import org.jetbrains.kotlin.cli.CliDiagnostics.COMPILER_ARGUMENTS_WARNING
 import org.jetbrains.kotlin.cli.CliDiagnostics.DEPRECATED_CLI_ARG
+import org.jetbrains.kotlin.cli.common.FragmentArgs.FRAGMENTS_ARG_NAME
+import org.jetbrains.kotlin.cli.common.FragmentArgs.FRAGMENT_DEPENDENCIES_ARG_NAME
+import org.jetbrains.kotlin.cli.common.FragmentArgs.FRAGMENT_FRIEND_DEPENDENCIES_ARG_NAME
+import org.jetbrains.kotlin.cli.common.FragmentArgs.FRAGMENT_INCREMENTAL_CLASSPATH_ARG_NAME
+import org.jetbrains.kotlin.cli.common.FragmentArgs.FRAGMENT_REFINES_ARG_NAME
+import org.jetbrains.kotlin.cli.common.FragmentArgs.FRAGMENT_SOURCES_ARG_NAME
 import org.jetbrains.kotlin.cli.common.arguments.*
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -288,12 +294,14 @@ private fun MessageCollector.reportUnsafeInternalArgumentsIfAny(arguments: Commo
     }
 }
 
-private val FRAGMENTS_ARG_NAME = CommonCompilerArguments::fragments.cliArgument
-private val FRAGMENT_REFINES_ARG_NAME = CommonCompilerArguments::fragmentRefines.cliArgument
-private val FRAGMENT_SOURCES_ARG_NAME = CommonCompilerArguments::fragmentSources.cliArgument
-private val FRAGMENT_DEPENDENCIES_ARG_NAME = CommonCompilerArguments::fragmentDependencies.cliArgument
-private val FRAGMENT_FRIEND_DEPENDENCIES_ARG_NAME = CommonCompilerArguments::fragmentFriendDependencies.cliArgument
-private val FRAGMENT_INCREMENTAL_CLASSPATH_ARG_NAME = CommonCompilerArguments::fragmentIncrementalClasspath.cliArgument
+private object FragmentArgs {
+    val FRAGMENTS_ARG_NAME = CommonCompilerArguments::fragments.cliArgument
+    val FRAGMENT_REFINES_ARG_NAME = CommonCompilerArguments::fragmentRefines.cliArgument
+    val FRAGMENT_SOURCES_ARG_NAME = CommonCompilerArguments::fragmentSources.cliArgument
+    val FRAGMENT_DEPENDENCIES_ARG_NAME = CommonCompilerArguments::fragmentDependencies.cliArgument
+    val FRAGMENT_FRIEND_DEPENDENCIES_ARG_NAME = CommonCompilerArguments::fragmentFriendDependencies.cliArgument
+    val FRAGMENT_INCREMENTAL_CLASSPATH_ARG_NAME = CommonCompilerArguments::fragmentIncrementalClasspath.cliArgument
+}
 
 private fun CompilerConfiguration.buildHmppModuleStructure(arguments: CommonCompilerArguments): HmppCliModuleStructure? {
     val rawFragments = arguments.fragments


### PR DESCRIPTION
`cliArgument` invokes `KProperty.javaField`, which leads to kotlin-reflect initialization, which takes some time. So, load these argument names only when requested.

On my machine, this somewhat improves hello-world compilation time.

Before:
  Time (mean ± σ):      2.195 s ±  0.046 s    [User: 5.297 s, System: 0.208 s]
  Range (min … max):    2.144 s …  2.288 s    10 runs

After:
  Time (mean ± σ):      2.074 s ±  0.021 s    [User: 5.110 s, System: 0.195 s]
  Range (min … max):    2.051 s …  2.120 s    10 runs