### PR TITLE
Refine the value of `CallArgumentMeta.stability` for arguments that are cast `IrExpression`s

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.StabilityPropagationTransformTests/testCastStabilityPropagation.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.StabilityPropagationTransformTests/testCastStabilityPropagation.txt
@@ -1,0 +1,45 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.Composable
+
+
+@Composable
+fun Test(p: Parent) {
+    A(p as Child)
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+@Composable
+@FunctionKeyMeta(key = -1264695314, startOffset = 57, endOffset = 98)
+fun Test(p: Parent, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(Test)N(p)<A(p>:Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+      %composer.changed(p)
+    } else {
+      %composer.changedInstance(p)
+    }
+    ) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    A(p as Child, %composer, Child.%stable or 0b1110 and %dirty)
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Test(p, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.StabilityPropagationTransformTests/testSmartCastStabilityPropagation.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.StabilityPropagationTransformTests/testSmartCastStabilityPropagation.txt
@@ -1,0 +1,55 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.Composable
+
+
+@Composable
+fun Test(p: Parent) {
+    if (p is Child) {
+        A(p)
+    }
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+@Composable
+@FunctionKeyMeta(key = -1264695314, startOffset = 57, endOffset = 121)
+fun Test(p: Parent, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(Test)N(p):Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+      %composer.changed(p)
+    } else {
+      %composer.changedInstance(p)
+    }
+    ) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    if (p is Child) {
+      %composer.startReplaceGroup(<>)
+      sourceInformation(%composer, "<A(p)>")
+      A(p as Child, %composer, Child.%stable or 0b1110 and %dirty)
+      %composer.endReplaceGroup()
+    } else {
+      %composer.startReplaceGroup(<>)
+      %composer.endReplaceGroup()
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Test(p, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/StabilityPropagationTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/StabilityPropagationTransformTests.kt
@@ -90,4 +90,50 @@ class StabilityPropagationTransformTests : AbstractIrTransformTest() {
             }
         """
     )
+
+    /**
+     * This test ensures that `Child.$stable` is used to compute the `$changed` mask passed to `A`
+     * and not `Parent.$stable`. This test serves as a regression test against
+     * https://issuetracker.google.com/issues/522127447.
+     */
+    @Test
+    fun testCastStabilityPropagation(): Unit = stabilityPropagation(
+        """
+            class Parent
+
+            class Child : Parent()
+
+            @Composable fun A(c: Child) {}
+        """,
+        """
+            @Composable
+            fun Test(p: Parent) {
+                A(p as Child)
+            }
+        """
+    )
+
+    /**
+     * This test ensures that `Child.$stable` is used to compute the `$changed` mask passed to `A`
+     * and not `Parent.$stable`. This test serves as a regression test against
+     * https://issuetracker.google.com/issues/522127447.
+     */
+    @Test
+    fun testSmartCastStabilityPropagation(): Unit = stabilityPropagation(
+        """
+            class Parent
+
+            class Child : Parent()
+
+            @Composable fun A(c: Child) {}
+        """,
+        """
+            @Composable
+            fun Test(p: Parent) {
+                if (p is Child) {
+                    A(p)
+                }
+            }
+        """
+    )
 }

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CastTargetTypeStabilityNeglectedTestEntrypoint.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CastTargetTypeStabilityNeglectedTestEntrypoint.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.compiler.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+
+// This function and [ParentState] need to be in different files so that the stability of
+// [ParentState] is `Stability.Runtime` from the perspective of this function.
+@Composable
+internal fun CastTargetTypeStabilityNeglectedTestEntrypoint(state: ParentState, result: MutableState<Boolean>) {
+    when (state) {
+        is ChildState ->
+            ConsumeChildState(state, result)
+    }
+}

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
@@ -535,6 +535,26 @@ class CompositionTests {
         advance()
         assertEquals(true, result.value)
     }
+
+    /**
+     * This is a regression test against a bug that made it possible for the `$changed` mask passed
+     * to [ConsumeChildState] to incorrectly say that the `state` parameter is of an unstable type,
+     * causing the function to skip too often. For more details, see
+     * https://issuetracker.google.com/issues/522127447.
+     */
+    @Test
+    fun castTargetTypeStabilityNeglectedTest() = compositionTest {
+        val state = mutableStateOf<ParentState>(ChildState(0))
+        val result = mutableStateOf(false)
+
+        compose {
+            CastTargetTypeStabilityNeglectedTestEntrypoint(state.value, result)
+        }
+
+        state.value = ChildState(1)
+        advance()
+        assertEquals(true, result.value)
+    }
 }
 
 @Composable
@@ -707,6 +727,21 @@ internal sealed class LoadingState<T> {
 internal fun <T> LoadingContent(state: LoadingState<T>, result: MutableState<Boolean>) {
     LaunchedEffect(state) {
         if (state is LoadingState.Content<*>) {
+            result.value = true
+        }
+    }
+}
+
+internal open class ParentState
+
+internal class ChildState(val value: Int) : ParentState()
+
+// This function and [ChildState] need to be in the same file so that the stability of [ChildState]
+// is `Stability.Stable` from the perspective of this function.
+@Composable
+internal fun ConsumeChildState(state: ChildState, result: MutableState<Boolean>) {
+    LaunchedEffect(state) {
+        if (state.value > 0) {
             result.value = true
         }
     }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -2864,6 +2864,9 @@ class ComposableFunctionBodyTransformer(
                     IrTypeOperator.CAST,
                     IrTypeOperator.IMPLICIT_CAST -> {
                         populateArgumentMeta(arg.argument, meta)
+                        // `arg.type` is the target type of the cast, and we want `meta.stability`
+                        // to store the stability of that type.
+                        meta.stability = stabilityInferencer.stabilityOf(arg, fileContainingDependent = meta.fileContainingArg)
                     }
                     else -> {
                         // Do nothing


### PR DESCRIPTION
This PR makes `CallArgumentMeta.stability` store the stability of the post-cast type for arguments that are cast `IrExpression`s.

Relnote: "Fixed a bug that was making the stability of pre-cast types be
  used in certain skipping checks instead of the stability of post-cast
  types"

Bug: 511102714