### PR TITLE
[Swift Export] KT-66890: Limit interfaces default implementations for cross language inheritance

### DIFF
--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/SirDeclarationFromKtSymbolProvider.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/SirDeclarationFromKtSymbolProvider.kt
@@ -46,6 +46,7 @@ public class SirDeclarationFromKtSymbolProvider(
                             declaration = protocol,
                             bridgedImplementation = SirBridgedProtocolImplementationFromKtSymbol(protocol),
                             markerDeclaration = protocol.existentialMarker,
+                            implementationMarkerDeclaration = protocol.implementationMarker,
                             penBoxMarkerConformance = protocol.penBoxMarkerConformance,
                             existentialExtension = protocol.existentialExtension,
                             auxExtension = protocol.auxExtension,

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirProtocolFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirProtocolFromKtSymbol.kt
@@ -15,8 +15,10 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaNamedClassSymbol
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.sir.*
+import org.jetbrains.kotlin.sir.builder.buildFunctionCopy
 import org.jetbrains.kotlin.sir.builder.buildTypealias
 import org.jetbrains.kotlin.sir.providers.*
+import org.jetbrains.kotlin.sir.providers.source.KotlinImplementationMarkerProtocol
 import org.jetbrains.kotlin.sir.providers.source.KotlinMarkerProtocol
 import org.jetbrains.kotlin.sir.providers.source.KotlinSource
 import org.jetbrains.kotlin.sir.providers.source.kaSymbolOrNull
@@ -103,6 +105,20 @@ internal open class SirProtocolFromKtSymbol(
     }
 
     /**
+     * Per-interface "implementation marker" `__P` used to constrain the witness extension
+     * ([SirBridgedProtocolImplementationFromKtSymbol]) that delegates protocol requirements to the
+     * Kotlin counterpart. Only the wrappers we generate for Kotlin classes that conform to this
+     * interface (and [KotlinRuntimeSupportModule.kotlinExistential]) declare conformance to it, so a
+     * user's Swift subclass that conforms to this interface without its Kotlin supertype implementing
+     * it does NOT inherit the (erroneous) delegating default. Unlike [existentialMarker], it is NOT
+     * `@objc` and is NOT refined by the public protocol.
+     */
+    internal val implementationMarker: SirProtocol by lazy {
+        SirImplementationMarkerProtocolFromKtSymbol(this)
+            .also { it.parent = this.parent }
+    }
+
+    /**
      * Per-interface extension conforming [KotlinRuntimeSupportModule.kotlinExistentialPenBox] to this
      * protocol's [existentialMarker]. This is what lets `_KotlinExistential<Wrapped>` inherit
      * @objc marker conformances through its non-generic PenBox ancestor, sidestepping Swift's
@@ -162,6 +178,37 @@ internal class SirMarkerProtocolFromKtSymbol(
 }
 
 /**
+ * "Implementation marker" protocol declaration `__[target]`, used to constrain the witness extension
+ * ([SirBridgedProtocolImplementationFromKtSymbol]) that satisfies [target]'s requirements by delegating
+ * to the Kotlin counterpart. Only the wrappers we generate for Kotlin classes that conform to [target]
+ * on the Kotlin side declare conformance to it, so it is never inherited by a user's Swift subclass that
+ * conforms to [target] without its Kotlin supertype implementing it.
+ *
+ * Differs from the existential marker [SirMarkerProtocolFromKtSymbol] (`_[target]`): it is NOT `@objc`
+ * (it is only a Swift generic constraint, never resolved by the ObjC runtime — which is also why the
+ * generic `_KotlinExistential<Wrapped>` can conform to it directly, without the PenBox indirection), it
+ * refines [KotlinRuntimeSupportModule.kotlinBridgeable] so witness bodies can call `__externalRCRef()`,
+ * and it is NOT refined by the public protocol [target].
+ */
+internal class SirImplementationMarkerProtocolFromKtSymbol(
+    val target: SirProtocolFromKtSymbol
+) : SirProtocol(), SirFromKtSymbol<KaNamedClassSymbol> {
+    override val ktSymbol: KaNamedClassSymbol get() = target.ktSymbol
+    override val sirSession: SirSession get() = target.sirSession
+
+    override lateinit var parent: SirDeclarationParent
+    override val origin: KotlinSource get() = KotlinImplementationMarkerProtocol(ktSymbol)
+    override val visibility: SirVisibility = SirVisibility.PUBLIC
+    override val documentation: String? = null
+    override val attributes: List<SirAttribute> by lazy { translatedOptInAttributes }
+    override val name: String get() = "__${target.name}"
+    override val declarations: MutableList<SirDeclaration> get() = mutableListOf()
+    override val superClass: SirNominalType? get() = null
+    override val protocols: List<SirProtocol> get() = listOf(KotlinRuntimeSupportModule.kotlinBridgeable)
+    override val bridges: List<SirBridge> = emptyList()
+}
+
+/**
  * A supporting extension declaration providing bridges for interface/protocol requirements for classes exported from kotlin.
  * Exporting a Kotlin class to Swift can result in overridden members from an inherited interface not aligning correctly with their
  * counterparts in the exported Swift protocol due to differences in Swift’s subtyping rules compared to Kotlin.
@@ -173,8 +220,9 @@ internal class SirBridgedProtocolImplementationFromKtSymbol(
     override val ktSymbol: KaNamedClassSymbol,
     override val sirSession: SirSession,
     val targetProtocol: SirProtocol,
+    private val implementationMarker: SirProtocol,
 ) : SirExtension(), SirFromKtSymbol<KaNamedClassSymbol> {
-    constructor(protocol: SirProtocolFromKtSymbol) : this(protocol.ktSymbol, protocol.sirSession, protocol)
+    constructor(protocol: SirProtocolFromKtSymbol) : this(protocol.ktSymbol, protocol.sirSession, protocol, protocol.implementationMarker)
 
     override val origin: SirOrigin = KotlinSource(ktSymbol)
 
@@ -195,7 +243,7 @@ internal class SirBridgedProtocolImplementationFromKtSymbol(
 
     override val constraints: List<SirTypeConstraint> by lazy {
         listOf(
-            SirTypeConstraint.Conformance(SirNominalType(KotlinRuntimeSupportModule.kotlinBridgeable))
+            SirTypeConstraint.Conformance(SirNominalType(implementationMarker))
         )
     }
 
@@ -341,7 +389,8 @@ internal open class SirExistentialProtocolImplementationFromKtSymbol(
     override val extendedType: SirType
         get() = SirNominalType(KotlinRuntimeSupportModule.kotlinExistential)
 
-    override open val protocols: List<SirProtocol> get() = listOf(targetProtocol)
+    override open val protocols: List<SirProtocol>
+        get() = listOf(targetProtocol, targetProtocol.implementationMarker)
 
     override val constraints: List<SirTypeConstraint> by lazy {
         listOf(
@@ -457,11 +506,12 @@ internal class SirAuxiliaryProtocolDeclarationsFromKtSymbol(
     override val extendedType: SirType = SirNominalType(targetProtocol)
 
     override val declarations: MutableList<SirDeclaration> by lazyWithSessions {
-        ktSymbol.combinedDeclaredMemberScope
-            .extractDeclarations()
+        val members = ktSymbol.combinedDeclaredMemberScope.extractDeclarations().toList()
+
+        val typeAliases = members
             .filterIsInstance<SirScopeDefiningDeclaration>()
             .filter { it.visibility == SirVisibility.PUBLIC }
-            .filter { it.origin !is KotlinMarkerProtocol }
+            .filter { it.origin !is KotlinMarkerProtocol && it.origin !is KotlinImplementationMarkerProtocol }
             .map { declaration ->
                 buildTypealias {
                     origin = SirOrigin.Trampoline(declaration)
@@ -471,7 +521,25 @@ internal class SirAuxiliaryProtocolDeclarationsFromKtSymbol(
                     type = SirNominalType(declaration) // Has to be nominal even for protocol declarations
                 }.also { it.parent = this }
             }
-            .toMutableList()
+
+        // Per swift rules, @_spi-requirements in non-@_spi protocols require default implementations.
+        val protocolSpiGroups = targetProtocol.attributes
+            .filterIsInstance<SirAttribute.SPI>()
+            .mapTo(mutableSetOf()) { it.name }
+        val spiRequirementTraps = members
+            .filterIsInstance<SirFunction>()
+            .filter { function -> function.attributes.any { it is SirAttribute.SPI && it.name !in protocolSpiGroups } }
+            .map { function ->
+                buildFunctionCopy(function) {
+                    origin = SirOrigin.Trampoline(function)
+                    isOverride = false
+                    modality = SirModality.UNSPECIFIED
+                    bridges.clear() // pure Swift trap, no Kotlin bridge (avoids duplicating the witness's bridge)
+                    body = SirFunctionBody(listOf("fatalError(\"'${function.name}' is an @_spi requirement that must be implemented by Swift conformers\")"))
+                }.also { it.parent = this }
+            }
+
+        (typeAliases + spiRequirementTraps).toMutableList()
     }
 }
 

--- a/native/swift/sir-light-classes/test/org/jetbrains/kotlin/sir/providers/SirKaClassReferenceHandlerTests.kt
+++ b/native/swift/sir-light-classes/test/org/jetbrains/kotlin/sir/providers/SirKaClassReferenceHandlerTests.kt
@@ -75,7 +75,7 @@ class SirKaClassReferenceHandlerTests : SirTranslationTest() {
             val A = declarations.classNamed("A")
             val MyNumber = declarations.classNamed("MyNumber")
             // _KotlinBridged + CharSequence + _CharSequence(existential marker)
-            assertEquals(2, A.protocols.size)
+            assertEquals(3, A.protocols.size)
             assertContains(referencedTypes, fqName("kotlin", "CharSequence"))
             assert(MyNumber.superClass != null)
             assertContains(referencedTypes, fqName("kotlin", "Number"))

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/SirSession.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/SirSession.kt
@@ -252,17 +252,21 @@ public sealed interface SirTranslationResult {
         public val declaration: SirProtocol,
         public val bridgedImplementation: SirExtension?,
         public val markerDeclaration: SirProtocol,
+        public val implementationMarkerDeclaration: SirProtocol,
         public val penBoxMarkerConformance: SirExtension,
         public val existentialExtension: SirExtension,
         public val auxExtension: SirExtension,
         public val samConverter: SirDeclaration?,
     ) : SirTranslationResult {
         override val primaryDeclaration: SirDeclaration get() = declaration
+        // `declaration` MUST stay first: callers use `allDeclarations.firstIsInstanceOrNull<SirProtocol>()`
+        // to recover the public protocol. The markers are appended after it.
         override val allDeclarations: List<SirDeclaration> =
             listOfNotNull(
                 declaration,
                 bridgedImplementation,
                 markerDeclaration,
+                implementationMarkerDeclaration,
                 penBoxMarkerConformance,
                 existentialExtension,
                 auxExtension,

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/source/KotlinSource.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/source/KotlinSource.kt
@@ -32,6 +32,8 @@ public class KotlinRuntimeElement : SirOrigin.Foreign.SourceCode
 
 public class KotlinMarkerProtocol(symbol: KaNamedClassSymbol) : KotlinSource(symbol)
 
+public class KotlinImplementationMarkerProtocol(symbol: KaNamedClassSymbol) : KotlinSource(symbol)
+
 public sealed class KotlinParameterOrigin : SirParameter.Origin {
     public class ValueParameter(public val parameter: KaValueParameterSymbol) : KotlinParameterOrigin()
     public class ReceiverParameter(public val parameter: KaReceiverParameterSymbol) : KotlinParameterOrigin()

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.swift
@@ -4,11 +4,11 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlinx.coroutines.flow.Flow where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.Flow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__Flow {
 }
 extension ExportedKotlinPackages.kotlinx.coroutines.flow.Flow {
 }
-extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__FlowCollector {
     public func emit(
         value: (any KotlinRuntimeSupport._KotlinBridgeable)?
     ) async throws -> Swift.Void {
@@ -25,7 +25,7 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector where Sel
 }
 extension ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector {
 }
-extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableSharedFlow {
     public var subscriptionCount: any KotlinCoroutineSupport.KotlinTypedStateFlow<Swift.Int32> {
         get {
             return KotlinCoroutineSupport._KotlinTypedStateFlowImpl<Swift.Int32>(KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_coroutines_flow_MutableSharedFlow_subscriptionCount_get(self.__externalRCRef())) as! any ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow)
@@ -55,8 +55,12 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow where
     }
 }
 extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow {
+    @_spi(kotlinx$coroutines$ExperimentalCoroutinesApi)
+    public func resetReplayCache() -> Swift.Void {
+        fatalError("'resetReplayCache' is an @_spi requirement that must be implemented by Swift conformers")
+    }
 }
-extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableStateFlow {
     public var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
         get {
             return { switch kotlinx_coroutines_flow_MutableStateFlow_value_get(self.__externalRCRef()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
@@ -74,7 +78,7 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow where 
 }
 extension ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow {
 }
-extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__SharedFlow {
     public var replayCache: [(any KotlinRuntimeSupport._KotlinBridgeable)?] {
         get {
             return kotlinx_coroutines_flow_SharedFlow_replayCache_get(self.__externalRCRef()) as! Swift.Array<Swift.Optional<any KotlinRuntimeSupport._KotlinBridgeable>>
@@ -83,7 +87,7 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow where Self :
 }
 extension ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow {
 }
-extension ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow where Self : ExportedKotlinPackages.kotlinx.coroutines.flow.__StateFlow {
     public var value: (any KotlinRuntimeSupport._KotlinBridgeable)? {
         get {
             return { switch kotlinx_coroutines_flow_StateFlow_value_get(self.__externalRCRef()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
@@ -92,17 +96,17 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow where Self : 
 }
 extension ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, KotlinCoroutineSupport.KotlinFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._Flow {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.Flow, ExportedKotlinPackages.kotlinx.coroutines.flow.__Flow, KotlinCoroutineSupport.KotlinFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._Flow {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow, KotlinCoroutineSupport.KotlinMutableSharedFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._MutableSharedFlow {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableSharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableSharedFlow, KotlinCoroutineSupport.KotlinMutableSharedFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._MutableSharedFlow {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow, KotlinCoroutineSupport.KotlinMutableStateFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._MutableStateFlow {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.MutableStateFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__MutableStateFlow, KotlinCoroutineSupport.KotlinMutableStateFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._MutableStateFlow {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, KotlinCoroutineSupport.KotlinSharedFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.SharedFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__SharedFlow, KotlinCoroutineSupport.KotlinSharedFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, KotlinCoroutineSupport.KotlinStateFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._StateFlow {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.StateFlow, ExportedKotlinPackages.kotlinx.coroutines.flow.__StateFlow, KotlinCoroutineSupport.KotlinStateFlow where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._StateFlow {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._FlowCollector {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.coroutines.flow.FlowCollector, ExportedKotlinPackages.kotlinx.coroutines.flow.__FlowCollector where Wrapped : ExportedKotlinPackages.kotlinx.coroutines.flow._FlowCollector {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.coroutines.flow._Flow {
 }
@@ -174,6 +178,18 @@ extension ExportedKotlinPackages.kotlinx.coroutines.flow {
     }
     @objc(_StateFlow)
     public protocol _StateFlow: ExportedKotlinPackages.kotlinx.coroutines.flow._SharedFlow {
+    }
+    public protocol __Flow: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __FlowCollector: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __MutableSharedFlow: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __MutableStateFlow: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __SharedFlow: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __StateFlow: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public static func flowCollector(
         function: @escaping ((any KotlinRuntimeSupport._KotlinBridgeable)?) async throws -> Swift.Void

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/flow_overrides/flow_overrides.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/flow_overrides/flow_overrides.swift
@@ -10,18 +10,20 @@ public protocol _ExportedKotlinPackages_namespace_I1_I2: KotlinRuntime.KotlinBas
 @objc(__ExportedKotlinPackages_namespace_I1_I2)
 public protocol __ExportedKotlinPackages_namespace_I1_I2: ExportedKotlinPackages.namespace._I1 {
 }
-extension ExportedKotlinPackages.namespace.I1 where Self : KotlinRuntimeSupport._KotlinBridgeable {
+public protocol ___ExportedKotlinPackages_namespace_I1_I2: KotlinRuntimeSupport._KotlinBridgeable {
+}
+extension ExportedKotlinPackages.namespace.I1 where Self : ExportedKotlinPackages.namespace.__I1 {
 }
 extension ExportedKotlinPackages.namespace.I1 {
     typealias I2 = flow_overrides._ExportedKotlinPackages_namespace_I1_I2
 }
-extension flow_overrides._ExportedKotlinPackages_namespace_I1_I2 where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension flow_overrides._ExportedKotlinPackages_namespace_I1_I2 where Self : flow_overrides.___ExportedKotlinPackages_namespace_I1_I2 {
 }
 extension flow_overrides._ExportedKotlinPackages_namespace_I1_I2 {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.namespace.I1 where Wrapped : ExportedKotlinPackages.namespace._I1 {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.namespace.I1, ExportedKotlinPackages.namespace.__I1 where Wrapped : ExportedKotlinPackages.namespace._I1 {
 }
-extension KotlinRuntimeSupport._KotlinExistential: flow_overrides._ExportedKotlinPackages_namespace_I1_I2 where Wrapped : flow_overrides.__ExportedKotlinPackages_namespace_I1_I2 {
+extension KotlinRuntimeSupport._KotlinExistential: flow_overrides._ExportedKotlinPackages_namespace_I1_I2, flow_overrides.___ExportedKotlinPackages_namespace_I1_I2 where Wrapped : flow_overrides.__ExportedKotlinPackages_namespace_I1_I2 {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.namespace._I1 {
 }
@@ -32,6 +34,8 @@ extension ExportedKotlinPackages.namespace {
     }
     @objc(_I1)
     public protocol _I1 {
+    }
+    public protocol __I1: KotlinRuntimeSupport._KotlinBridgeable {
     }
     open class Bar: ExportedKotlinPackages.namespace.Foo {
         @_nonoverride

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.swift
@@ -12,6 +12,8 @@ public protocol FunctionalInterfaceWithSuspendFunction: KotlinRuntime.KotlinBase
 @objc(_FunctionalInterfaceWithSuspendFunction)
 public protocol _FunctionalInterfaceWithSuspendFunction {
 }
+public protocol __FunctionalInterfaceWithSuspendFunction: KotlinRuntimeSupport._KotlinBridgeable {
+}
 public final class Foo: KotlinRuntime.KotlinBase {
     public init() {
         let __kt = __root___Foo_init_allocate()
@@ -302,7 +304,7 @@ public func returnsListOfSuspendNullables() async throws -> [(() async throws ->
         }(), cancellation.__externalRCRef())
     }
 }
-extension main.FunctionalInterfaceWithSuspendFunction where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.FunctionalInterfaceWithSuspendFunction where Self : main.__FunctionalInterfaceWithSuspendFunction {
     public func emit() async throws -> Swift.Void {
         try await withKotlinContinuation { continuation, exception, cancellation in
             let _: Bool = FunctionalInterfaceWithSuspendFunction_emit(self.__externalRCRef(), {
@@ -317,7 +319,7 @@ extension main.FunctionalInterfaceWithSuspendFunction where Self : KotlinRuntime
 }
 extension main.FunctionalInterfaceWithSuspendFunction {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.FunctionalInterfaceWithSuspendFunction where Wrapped : main._FunctionalInterfaceWithSuspendFunction {
+extension KotlinRuntimeSupport._KotlinExistential: main.FunctionalInterfaceWithSuspendFunction, main.__FunctionalInterfaceWithSuspendFunction where Wrapped : main._FunctionalInterfaceWithSuspendFunction {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._FunctionalInterfaceWithSuspendFunction {
 }

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinSerialization/KotlinSerialization.swift
@@ -11,21 +11,27 @@ public typealias builtins = ExportedKotlinPackages.kotlinx.serialization.builtin
 public typealias encoding = ExportedKotlinPackages.kotlinx.serialization.encoding
 public typealias BinaryFormat = ExportedKotlinPackages.kotlinx.serialization.BinaryFormat
 public typealias _BinaryFormat = ExportedKotlinPackages.kotlinx.serialization._BinaryFormat
+public typealias __BinaryFormat = ExportedKotlinPackages.kotlinx.serialization.__BinaryFormat
 public typealias ContextualSerializer = ExportedKotlinPackages.kotlinx.serialization.ContextualSerializer
 public typealias DeserializationStrategy = ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy
 public typealias _DeserializationStrategy = ExportedKotlinPackages.kotlinx.serialization._DeserializationStrategy
+public typealias __DeserializationStrategy = ExportedKotlinPackages.kotlinx.serialization.__DeserializationStrategy
 public typealias KSerializer = ExportedKotlinPackages.kotlinx.serialization.KSerializer
 public typealias _KSerializer = ExportedKotlinPackages.kotlinx.serialization._KSerializer
+public typealias __KSerializer = ExportedKotlinPackages.kotlinx.serialization.__KSerializer
 public typealias MissingFieldException = ExportedKotlinPackages.kotlinx.serialization.MissingFieldException
 public typealias PolymorphicSerializer = ExportedKotlinPackages.kotlinx.serialization.PolymorphicSerializer
 public typealias SealedClassSerializer = ExportedKotlinPackages.kotlinx.serialization.SealedClassSerializer
 public typealias SerialFormat = ExportedKotlinPackages.kotlinx.serialization.SerialFormat
 public typealias _SerialFormat = ExportedKotlinPackages.kotlinx.serialization._SerialFormat
+public typealias __SerialFormat = ExportedKotlinPackages.kotlinx.serialization.__SerialFormat
 public typealias SerializationException = ExportedKotlinPackages.kotlinx.serialization.SerializationException
 public typealias SerializationStrategy = ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy
 public typealias _SerializationStrategy = ExportedKotlinPackages.kotlinx.serialization._SerializationStrategy
+public typealias __SerializationStrategy = ExportedKotlinPackages.kotlinx.serialization.__SerializationStrategy
 public typealias StringFormat = ExportedKotlinPackages.kotlinx.serialization.StringFormat
 public typealias _StringFormat = ExportedKotlinPackages.kotlinx.serialization._StringFormat
+public typealias __StringFormat = ExportedKotlinPackages.kotlinx.serialization.__StringFormat
 public final class _ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Companion: KotlinRuntime.KotlinBase {
     public var DECODE_DONE: Swift.Int32 {
         get {
@@ -101,6 +107,8 @@ extension ExportedKotlinPackages.kotlinx.serialization {
     @objc(_BinaryFormat)
     public protocol _BinaryFormat: ExportedKotlinPackages.kotlinx.serialization._SerialFormat {
     }
+    public protocol __BinaryFormat: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol DeserializationStrategy: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization._DeserializationStrategy {
         var descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
             get
@@ -112,6 +120,8 @@ extension ExportedKotlinPackages.kotlinx.serialization {
     @objc(_DeserializationStrategy)
     public protocol _DeserializationStrategy {
     }
+    public protocol __DeserializationStrategy: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol KSerializer: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy, ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy, ExportedKotlinPackages.kotlinx.serialization._KSerializer {
         var descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
             get
@@ -120,6 +130,8 @@ extension ExportedKotlinPackages.kotlinx.serialization {
     @objc(_KSerializer)
     public protocol _KSerializer: ExportedKotlinPackages.kotlinx.serialization._SerializationStrategy, ExportedKotlinPackages.kotlinx.serialization._DeserializationStrategy {
     }
+    public protocol __KSerializer: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol SerialFormat: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization._SerialFormat {
         var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
             get
@@ -127,6 +139,8 @@ extension ExportedKotlinPackages.kotlinx.serialization {
     }
     @objc(_SerialFormat)
     public protocol _SerialFormat {
+    }
+    public protocol __SerialFormat: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public protocol SerializationStrategy: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization._SerializationStrategy {
         var descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
@@ -140,10 +154,14 @@ extension ExportedKotlinPackages.kotlinx.serialization {
     @objc(_SerializationStrategy)
     public protocol _SerializationStrategy {
     }
+    public protocol __SerializationStrategy: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol StringFormat: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.SerialFormat, ExportedKotlinPackages.kotlinx.serialization._StringFormat {
     }
     @objc(_StringFormat)
     public protocol _StringFormat: ExportedKotlinPackages.kotlinx.serialization._SerialFormat {
+    }
+    public protocol __StringFormat: KotlinRuntimeSupport._KotlinBridgeable {
     }
     @_spi(kotlinx$serialization$ExperimentalSerializationApi)
     public final class ContextualSerializer: KotlinRuntime.KotlinBase {
@@ -402,6 +420,9 @@ extension ExportedKotlinPackages.kotlinx.serialization.`internal` {
     public protocol _GeneratedSerializer: ExportedKotlinPackages.kotlinx.serialization._KSerializer {
     }
     @_spi(kotlinx$serialization$InternalSerializationApi)
+    public protocol __GeneratedSerializer: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    @_spi(kotlinx$serialization$InternalSerializationApi)
     open class AbstractCollectionSerializer: KotlinRuntime.KotlinBase {
         @_spi(kotlinx$serialization$InternalSerializationApi)
         open func deserialize(
@@ -568,7 +589,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.`internal` {
         }
     }
     @_spi(kotlinx$serialization$InternalSerializationApi)
-    open class TaggedDecoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder {
+    open class TaggedDecoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeDecoder {
         @_spi(kotlinx$serialization$InternalSerializationApi)
         open var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
             @_spi(kotlinx$serialization$InternalSerializationApi)
@@ -726,7 +747,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.`internal` {
         }
     }
     @_spi(kotlinx$serialization$InternalSerializationApi)
-    open class TaggedEncoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder {
+    open class TaggedEncoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeEncoder {
         @_spi(kotlinx$serialization$InternalSerializationApi)
         open var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
             @_spi(kotlinx$serialization$InternalSerializationApi)
@@ -941,6 +962,9 @@ extension ExportedKotlinPackages.kotlinx.serialization.modules {
     @objc(_SerializersModuleCollector)
     public protocol _SerializersModuleCollector {
     }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public protocol __SerializersModuleCollector: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public final class PolymorphicModuleBuilder: KotlinRuntime.KotlinBase {
         package override init(
             __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
@@ -964,7 +988,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.modules {
         }
     }
     @_spi(kotlinx$serialization$ExperimentalSerializationApi)
-    public final class SerializersModuleBuilder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleCollector, ExportedKotlinPackages.kotlinx.serialization.modules._SerializersModuleCollector {
+    public final class SerializersModuleBuilder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleCollector, ExportedKotlinPackages.kotlinx.serialization.modules._SerializersModuleCollector, ExportedKotlinPackages.kotlinx.serialization.modules.__SerializersModuleCollector {
         @_spi(kotlinx$serialization$ExperimentalSerializationApi)
         public func include(
             module: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule
@@ -1062,6 +1086,8 @@ extension ExportedKotlinPackages.kotlinx.serialization.descriptors {
     }
     @objc(_SerialDescriptor)
     public protocol _SerialDescriptor {
+    }
+    public protocol __SerialDescriptor: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public final class ClassSerialDescriptorBuilder: KotlinRuntime.KotlinBase {
         @_spi(kotlinx$serialization$ExperimentalSerializationApi)
@@ -1741,6 +1767,9 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
     @objc(_ChunkedDecoder)
     public protocol _ChunkedDecoder {
     }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public protocol __ChunkedDecoder: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol CompositeDecoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder {
         var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
             get
@@ -1799,6 +1828,8 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
     }
     @objc(_CompositeDecoder)
     public protocol _CompositeDecoder {
+    }
+    public protocol __CompositeDecoder: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public protocol CompositeEncoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder {
         var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
@@ -1865,6 +1896,8 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
     @objc(_CompositeEncoder)
     public protocol _CompositeEncoder {
     }
+    public protocol __CompositeEncoder: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol Decoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder {
         var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
             get
@@ -1894,6 +1927,8 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
     }
     @objc(_Decoder)
     public protocol _Decoder {
+    }
+    public protocol __Decoder: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public protocol Encoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder {
         var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
@@ -1948,8 +1983,10 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
     @objc(_Encoder)
     public protocol _Encoder {
     }
+    public protocol __Encoder: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     @_spi(kotlinx$serialization$ExperimentalSerializationApi)
-    open class AbstractDecoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder {
+    open class AbstractDecoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeDecoder {
         @_spi(kotlinx$serialization$ExperimentalSerializationApi)
         open func beginStructure(
             descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor
@@ -2104,7 +2141,7 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
         }
     }
     @_spi(kotlinx$serialization$ExperimentalSerializationApi)
-    open class AbstractEncoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder {
+    open class AbstractEncoder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder, ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeEncoder {
         @_spi(kotlinx$serialization$ExperimentalSerializationApi)
         open func beginStructure(
             descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor
@@ -2323,15 +2360,15 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding {
         }()); return () }()
     }
 }
-extension ExportedKotlinPackages.kotlinx.serialization.BinaryFormat where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.BinaryFormat where Self : ExportedKotlinPackages.kotlinx.serialization.__BinaryFormat {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization._BinaryFormat {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.BinaryFormat where Wrapped : ExportedKotlinPackages.kotlinx.serialization._BinaryFormat {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.BinaryFormat, ExportedKotlinPackages.kotlinx.serialization.__BinaryFormat where Wrapped : ExportedKotlinPackages.kotlinx.serialization._BinaryFormat {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.BinaryFormat {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy where Self : ExportedKotlinPackages.kotlinx.serialization.__DeserializationStrategy {
     public var descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
         get {
             return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_serialization_DeserializationStrategy_descriptor_get(self.__externalRCRef())) as! any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor
@@ -2345,11 +2382,11 @@ extension ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy w
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization._DeserializationStrategy {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy where Wrapped : ExportedKotlinPackages.kotlinx.serialization._DeserializationStrategy {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy, ExportedKotlinPackages.kotlinx.serialization.__DeserializationStrategy where Wrapped : ExportedKotlinPackages.kotlinx.serialization._DeserializationStrategy {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.DeserializationStrategy {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.KSerializer where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.KSerializer where Self : ExportedKotlinPackages.kotlinx.serialization.__KSerializer {
     public var descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
         get {
             return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_serialization_KSerializer_descriptor_get(self.__externalRCRef())) as! any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor
@@ -2358,11 +2395,11 @@ extension ExportedKotlinPackages.kotlinx.serialization.KSerializer where Self : 
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization._KSerializer {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.KSerializer where Wrapped : ExportedKotlinPackages.kotlinx.serialization._KSerializer {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.KSerializer, ExportedKotlinPackages.kotlinx.serialization.__KSerializer where Wrapped : ExportedKotlinPackages.kotlinx.serialization._KSerializer {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.KSerializer {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.SerialFormat where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.SerialFormat where Self : ExportedKotlinPackages.kotlinx.serialization.__SerialFormat {
     public var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
         get {
             return ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule.__createClassWrapper(externalRCRef: kotlinx_serialization_SerialFormat_serializersModule_get(self.__externalRCRef()))
@@ -2371,11 +2408,11 @@ extension ExportedKotlinPackages.kotlinx.serialization.SerialFormat where Self :
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization._SerialFormat {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.SerialFormat where Wrapped : ExportedKotlinPackages.kotlinx.serialization._SerialFormat {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.SerialFormat, ExportedKotlinPackages.kotlinx.serialization.__SerialFormat where Wrapped : ExportedKotlinPackages.kotlinx.serialization._SerialFormat {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.SerialFormat {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy where Self : ExportedKotlinPackages.kotlinx.serialization.__SerializationStrategy {
     public var descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
         get {
             return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlinx_serialization_SerializationStrategy_descriptor_get(self.__externalRCRef())) as! any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor
@@ -2390,19 +2427,19 @@ extension ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy whe
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization._SerializationStrategy {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy where Wrapped : ExportedKotlinPackages.kotlinx.serialization._SerializationStrategy {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy, ExportedKotlinPackages.kotlinx.serialization.__SerializationStrategy where Wrapped : ExportedKotlinPackages.kotlinx.serialization._SerializationStrategy {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.SerializationStrategy {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.StringFormat where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.StringFormat where Self : ExportedKotlinPackages.kotlinx.serialization.__StringFormat {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization._StringFormat {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.StringFormat where Wrapped : ExportedKotlinPackages.kotlinx.serialization._StringFormat {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.StringFormat, ExportedKotlinPackages.kotlinx.serialization.__StringFormat where Wrapped : ExportedKotlinPackages.kotlinx.serialization._StringFormat {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.StringFormat {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.`internal`.GeneratedSerializer where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.`internal`.GeneratedSerializer where Self : ExportedKotlinPackages.kotlinx.serialization.`internal`.__GeneratedSerializer {
     @_spi(kotlinx$serialization$InternalSerializationApi)
     public func childSerializers() -> ExportedKotlinPackages.kotlin.Array {
         return ExportedKotlinPackages.kotlin.Array.__createClassWrapper(externalRCRef: kotlinx_serialization_internal_GeneratedSerializer_childSerializers(self.__externalRCRef()))
@@ -2415,20 +2452,20 @@ extension ExportedKotlinPackages.kotlinx.serialization.`internal`.GeneratedSeria
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.`internal`._GeneratedSerializer {
 }
 @_spi(kotlinx$serialization$InternalSerializationApi)
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.`internal`.GeneratedSerializer where Wrapped : ExportedKotlinPackages.kotlinx.serialization.`internal`._GeneratedSerializer {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.`internal`.GeneratedSerializer, ExportedKotlinPackages.kotlinx.serialization.`internal`.__GeneratedSerializer where Wrapped : ExportedKotlinPackages.kotlinx.serialization.`internal`._GeneratedSerializer {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.`internal`.GeneratedSerializer {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleCollector where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleCollector where Self : ExportedKotlinPackages.kotlinx.serialization.modules.__SerializersModuleCollector {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.modules._SerializersModuleCollector {
 }
 @_spi(kotlinx$serialization$ExperimentalSerializationApi)
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleCollector where Wrapped : ExportedKotlinPackages.kotlinx.serialization.modules._SerializersModuleCollector {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleCollector, ExportedKotlinPackages.kotlinx.serialization.modules.__SerializersModuleCollector where Wrapped : ExportedKotlinPackages.kotlinx.serialization.modules._SerializersModuleCollector {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModuleCollector {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor where Self : ExportedKotlinPackages.kotlinx.serialization.descriptors.__SerialDescriptor {
     @_spi(kotlinx$serialization$ExperimentalSerializationApi)
     public var annotations: [any ExportedKotlinPackages.kotlin.Annotation] {
         @_spi(kotlinx$serialization$ExperimentalSerializationApi)
@@ -2502,11 +2539,41 @@ extension ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescrip
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.descriptors._SerialDescriptor {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor where Wrapped : ExportedKotlinPackages.kotlinx.serialization.descriptors._SerialDescriptor {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor, ExportedKotlinPackages.kotlinx.serialization.descriptors.__SerialDescriptor where Wrapped : ExportedKotlinPackages.kotlinx.serialization.descriptors._SerialDescriptor {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func getElementAnnotations(
+        index: Swift.Int32
+    ) -> [any ExportedKotlinPackages.kotlin.Annotation] {
+        fatalError("'getElementAnnotations' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func getElementDescriptor(
+        index: Swift.Int32
+    ) -> any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor {
+        fatalError("'getElementDescriptor' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func getElementIndex(
+        name: Swift.String
+    ) -> Swift.Int32 {
+        fatalError("'getElementIndex' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func getElementName(
+        index: Swift.Int32
+    ) -> Swift.String {
+        fatalError("'getElementName' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func isElementOptional(
+        index: Swift.Int32
+    ) -> Swift.Bool {
+        fatalError("'isElementOptional' is an @_spi requirement that must be implemented by Swift conformers")
+    }
 }
-extension ExportedKotlinPackages.kotlinx.serialization.encoding.ChunkedDecoder where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.encoding.ChunkedDecoder where Self : ExportedKotlinPackages.kotlinx.serialization.encoding.__ChunkedDecoder {
     @_spi(kotlinx$serialization$ExperimentalSerializationApi)
     public func decodeStringChunked(
         consumeChunk: @escaping (Swift.String) -> Swift.Void
@@ -2520,11 +2587,11 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding.ChunkedDecoder w
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.encoding._ChunkedDecoder {
 }
 @_spi(kotlinx$serialization$ExperimentalSerializationApi)
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.ChunkedDecoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._ChunkedDecoder {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.ChunkedDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__ChunkedDecoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._ChunkedDecoder {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.encoding.ChunkedDecoder {
 }
-extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder where Self : ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeDecoder {
     public var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
         get {
             return ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule.__createClassWrapper(externalRCRef: kotlinx_serialization_encoding_CompositeDecoder_serializersModule_get(self.__externalRCRef()))
@@ -2612,12 +2679,16 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeDecoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeDecoder {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeDecoder {
     typealias Companion = KotlinSerialization._ExportedKotlinPackages_kotlinx_serialization_encoding_CompositeDecoder_Companion
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func decodeSequentially() -> Swift.Bool {
+        fatalError("'decodeSequentially' is an @_spi requirement that must be implemented by Swift conformers")
+    }
 }
-extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder where Self : ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeEncoder {
     public var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
         get {
             return ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule.__createClassWrapper(externalRCRef: kotlinx_serialization_encoding_CompositeEncoder_serializersModule_get(self.__externalRCRef()))
@@ -2707,11 +2778,18 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__CompositeEncoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._CompositeEncoder {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.encoding.CompositeEncoder {
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func shouldEncodeElementDefault(
+        descriptor: any ExportedKotlinPackages.kotlinx.serialization.descriptors.SerialDescriptor,
+        index: Swift.Int32
+    ) -> Swift.Bool {
+        fatalError("'shouldEncodeElementDefault' is an @_spi requirement that must be implemented by Swift conformers")
+    }
 }
-extension ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder where Self : ExportedKotlinPackages.kotlinx.serialization.encoding.__Decoder {
     public var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
         get {
             return ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule.__createClassWrapper(externalRCRef: kotlinx_serialization_encoding_Decoder_serializersModule_get(self.__externalRCRef()))
@@ -2770,11 +2848,19 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder where Se
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__Decoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._Decoder {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.encoding.Decoder {
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func decodeNotNullMark() -> Swift.Bool {
+        fatalError("'decodeNotNullMark' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func decodeNull() -> Swift.Never? {
+        fatalError("'decodeNull' is an @_spi requirement that must be implemented by Swift conformers")
+    }
 }
-extension ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder where Self : ExportedKotlinPackages.kotlinx.serialization.encoding.__Encoder {
     public var serializersModule: ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule {
         get {
             return ExportedKotlinPackages.kotlinx.serialization.modules.SerializersModule.__createClassWrapper(externalRCRef: kotlinx_serialization_encoding_Encoder_serializersModule_get(self.__externalRCRef()))
@@ -2858,9 +2944,17 @@ extension ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder where Se
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder, ExportedKotlinPackages.kotlinx.serialization.encoding.__Encoder where Wrapped : ExportedKotlinPackages.kotlinx.serialization.encoding._Encoder {
 }
 extension ExportedKotlinPackages.kotlinx.serialization.encoding.Encoder {
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func encodeNotNullMark() -> Swift.Void {
+        fatalError("'encodeNotNullMark' is an @_spi requirement that must be implemented by Swift conformers")
+    }
+    @_spi(kotlinx$serialization$ExperimentalSerializationApi)
+    public func encodeNull() -> Swift.Void {
+        fatalError("'encodeNull' is an @_spi requirement that must be implemented by Swift conformers")
+    }
 }
 @_cdecl("kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift")
 package func kotlinx_serialization_DeserializationStrategy_deserialize__TypesOfArguments__anyU20ExportedKotlinPackages_kotlinx_serialization_encoding_Decoder____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ decoder: Swift.UnsafeMutableRawPointer) -> Swift.UnsafeMutableRawPointer? {

--- a/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/external/testData/generation/kotlinx-serialization-core/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -9,6 +9,8 @@ extension ExportedKotlinPackages.kotlin {
     @objc(_Annotation)
     public protocol _Annotation {
     }
+    public protocol __Annotation: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol CharSequence: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin._CharSequence {
         var length: Swift.Int32 {
             get
@@ -23,6 +25,8 @@ extension ExportedKotlinPackages.kotlin {
     }
     @objc(_CharSequence)
     public protocol _CharSequence {
+    }
+    public protocol __CharSequence: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public final class Array: KotlinRuntime.KotlinBase {
         public var size: Swift.Int32 {
@@ -4455,7 +4459,7 @@ extension ExportedKotlinPackages.kotlin {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    public final class String: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.CharSequence, ExportedKotlinPackages.kotlin._CharSequence {
+    public final class String: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.CharSequence, ExportedKotlinPackages.kotlin._CharSequence, ExportedKotlinPackages.kotlin.__CharSequence {
         public final class Companion: KotlinRuntime.KotlinBase {
             public static var shared: ExportedKotlinPackages.kotlin.String.Companion {
                 get {
@@ -6688,12 +6692,16 @@ extension ExportedKotlinPackages.kotlin.collections {
     @objc(_Iterable)
     public protocol _Iterable {
     }
+    public protocol __Iterable: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     public protocol Iterator: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.collections._Iterator {
         func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)?
         func hasNext() -> Swift.Bool
     }
     @objc(_Iterator)
     public protocol _Iterator {
+    }
+    public protocol __Iterator: KotlinRuntimeSupport._KotlinBridgeable {
     }
     open class IntIterator: KotlinRuntime.KotlinBase {
         public final func next() -> Swift.Int32 {
@@ -7222,22 +7230,22 @@ extension ExportedKotlinPackages.kotlin.time {
         }
     }
 }
-extension ExportedKotlinPackages.kotlin.Annotation where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.Annotation where Self : ExportedKotlinPackages.kotlin.__Annotation {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin._Annotation {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.Annotation where Wrapped : ExportedKotlinPackages.kotlin._Annotation {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.Annotation, ExportedKotlinPackages.kotlin.__Annotation where Wrapped : ExportedKotlinPackages.kotlin._Annotation {
 }
 extension ExportedKotlinPackages.kotlin.Annotation {
 }
-extension ExportedKotlinPackages.kotlin.collections.Iterable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterable where Self : ExportedKotlinPackages.kotlin.collections.__Iterable {
     public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_Iterable_iterator(self.__externalRCRef())) as! any ExportedKotlinPackages.kotlin.collections.Iterator
     }
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Iterable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterable where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterable {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterable, ExportedKotlinPackages.kotlin.collections.__Iterable where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterable {
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterable {
 }
@@ -7702,7 +7710,7 @@ extension ExportedKotlinPackages.kotlin.ranges {
         }
     }
 }
-extension ExportedKotlinPackages.kotlin.CharSequence where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.CharSequence where Self : ExportedKotlinPackages.kotlin.__CharSequence {
     public var length: Swift.Int32 {
         get {
             return kotlin_CharSequence_length_get(self.__externalRCRef())
@@ -7729,11 +7737,11 @@ extension ExportedKotlinPackages.kotlin.CharSequence where Self : KotlinRuntimeS
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin._CharSequence {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.CharSequence where Wrapped : ExportedKotlinPackages.kotlin._CharSequence {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.CharSequence, ExportedKotlinPackages.kotlin.__CharSequence where Wrapped : ExportedKotlinPackages.kotlin._CharSequence {
 }
 extension ExportedKotlinPackages.kotlin.CharSequence {
 }
-extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : ExportedKotlinPackages.kotlin.collections.__Iterator {
     public func next() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
         return { switch kotlin_collections_Iterator_next(self.__externalRCRef()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
     }
@@ -7743,7 +7751,7 @@ extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : Kotlin
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Iterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections.__Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterator {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/inheritance.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/inheritance.swift
@@ -94,6 +94,32 @@ func swiftOverrideDispatchesViaParentInterface() throws {
     #expect(callBark(d: husky) == "swift-woof")
 }
 
+@Test
+func swiftSubclassOfKotlinClassConformsToUnrelatedKotlinInterface() throws {
+    // Regression for the implementation-marker fix: a Swift class subclasses an exported Kotlin
+    // class (Base) whose Kotlin type does NOT implement Speaker, and separately conforms to the
+    // Kotlin interface Speaker. Previously the witness extension was constrained on
+    // _KotlinBridgeable (which every KotlinBase subclass satisfies), so Swift would silently supply
+    // a delegating default that calls Speaker_speak on the Base backing — which doesn't implement
+    // Speaker — yielding wrong dispatch / a crash. Now the witness is gated on the implementation
+    // marker `__Speaker`, which Base does not carry, so the Swift class must implement the interface
+    // itself, and Kotlin-side interface dispatch reaches those Swift implementations.
+    class SpeakingBase: Base, Speaker {
+        func speak() -> String { "swift base speaks" }
+        func volume() -> Int32 { 7 }
+    }
+
+    let s = SpeakingBase()
+
+    // Direct Swift dispatch
+    #expect(s.speak() == "swift base speaks")
+    #expect(s.volume() == 7)
+
+    // Kotlin-side interface dispatch lands in the Swift implementations
+    #expect(callSpeak(s: s) == "swift base speaks")
+    #expect(callVolume(s: s) == 7)
+}
+
 // Property reverse bridge test (currently disabled — causes crash, likely surfaces an
 // implementation gap in property reverse-bridge wiring; see plan).
 // @Test

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.swift
@@ -59,6 +59,18 @@ public protocol _SubDeprecatedInterface: main._DeprecatedInterface {
 @objc(_SwiftInterfaceC)
 public protocol _SwiftInterfaceC {
 }
+public protocol __DeprecatedInterface: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __InterfaceWithDeprecatedMembers: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __NonDeprecatedInterface: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __SomeInterface: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __SubDeprecatedInterface: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __SwiftInterfaceC: KotlinRuntimeSupport._KotlinBridgeable {
+}
 @_spi(Barnnotation) @_spi(Foonnotation)
 public final class Bar: main.Foo {
     @_spi(Barnnotation) @_spi(Foonnotation)
@@ -74,7 +86,7 @@ public final class Bar: main.Foo {
         super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
     }
 }
-public final class ClassWithDeprecatedMembersFromInterface: KotlinRuntime.KotlinBase, main.InterfaceWithDeprecatedMembers, main._InterfaceWithDeprecatedMembers {
+public final class ClassWithDeprecatedMembersFromInterface: KotlinRuntime.KotlinBase, main.InterfaceWithDeprecatedMembers, main._InterfaceWithDeprecatedMembers, main.__InterfaceWithDeprecatedMembers {
     public init() {
         let __kt = __root___ClassWithDeprecatedMembersFromInterface_init_allocate()
         super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -234,7 +246,7 @@ public final class OptInConstructor: KotlinRuntime.KotlinBase {
         super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
     }
 }
-public final class PublicClassImplDeprecatedInterface: KotlinRuntime.KotlinBase, main._DeprecatedInterface {
+public final class PublicClassImplDeprecatedInterface: KotlinRuntime.KotlinBase, main._DeprecatedInterface, main.__DeprecatedInterface {
     public init() {
         let __kt = __root___PublicClassImplDeprecatedInterface_init_allocate()
         super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -270,7 +282,7 @@ open class PublicClassImplHiddenInterface: KotlinRuntime.KotlinBase {
     }
 }
 @available(*, unavailable, message: "Obsoleted")
-public final class PublicDeprecatedClassImplDeprecatedInterface: KotlinRuntime.KotlinBase, main.DeprecatedInterface, main._DeprecatedInterface {
+public final class PublicDeprecatedClassImplDeprecatedInterface: KotlinRuntime.KotlinBase, main.DeprecatedInterface, main._DeprecatedInterface, main.__DeprecatedInterface {
     public init() {
         let __kt = __root___PublicDeprecatedClassImplDeprecatedInterface_init_allocate()
         super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -1235,7 +1247,7 @@ public func unrenamed() -> Swift.Never {
     return { __root___unrenamed(); fatalError() }()
 }
 @available(*, unavailable, message: "Unavailable type(s): main.DeprecatedInterface")
-extension main.DeprecatedInterface where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.DeprecatedInterface where Self : main.__DeprecatedInterface {
     public func foo() -> Swift.Void {
         return { DeprecatedInterface_foo(self.__externalRCRef()); return () }()
     }
@@ -1243,7 +1255,7 @@ extension main.DeprecatedInterface where Self : KotlinRuntimeSupport._KotlinBrid
 @available(*, unavailable, message: "Unavailable type(s): main.DeprecatedInterface")
 extension main.DeprecatedInterface {
 }
-extension main.InterfaceWithDeprecatedMembers where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.InterfaceWithDeprecatedMembers where Self : main.__InterfaceWithDeprecatedMembers {
     @available(*, deprecated, message: "Deprecated")
     public func deprecatedWarningFunction() -> Swift.Void {
         return { InterfaceWithDeprecatedMembers_deprecatedWarningFunction(self.__externalRCRef()); return () }()
@@ -1254,14 +1266,14 @@ extension main.InterfaceWithDeprecatedMembers where Self : KotlinRuntimeSupport.
 }
 extension main.InterfaceWithDeprecatedMembers {
 }
-extension main.NonDeprecatedInterface where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.NonDeprecatedInterface where Self : main.__NonDeprecatedInterface {
     public func bar() -> Swift.Void {
         return { NonDeprecatedInterface_bar(self.__externalRCRef()); return () }()
     }
 }
 extension main.NonDeprecatedInterface {
 }
-extension main.SomeInterface where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.SomeInterface where Self : main.__SomeInterface {
     public var barC: Swift.String {
         get {
             return SomeInterface_barC_get(self.__externalRCRef())
@@ -1277,7 +1289,7 @@ extension main.SomeInterface where Self : KotlinRuntimeSupport._KotlinBridgeable
 extension main.SomeInterface {
 }
 @available(*, unavailable, message: "Unavailable type(s): main.SubDeprecatedInterface")
-extension main.SubDeprecatedInterface where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.SubDeprecatedInterface where Self : main.__SubDeprecatedInterface {
     public func baz() -> Swift.Void {
         return { SubDeprecatedInterface_baz(self.__externalRCRef()); return () }()
     }
@@ -1285,7 +1297,7 @@ extension main.SubDeprecatedInterface where Self : KotlinRuntimeSupport._KotlinB
 @available(*, unavailable, message: "Unavailable type(s): main.SubDeprecatedInterface")
 extension main.SubDeprecatedInterface {
 }
-extension main.SwiftInterfaceC where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.SwiftInterfaceC where Self : main.__SwiftInterfaceC {
     public func kotlinFunE(
         _ kotlinParamE: Swift.String
     ) -> Swift.Void {
@@ -1299,19 +1311,19 @@ extension main.SwiftInterfaceC where Self : KotlinRuntimeSupport._KotlinBridgeab
 }
 extension main.SwiftInterfaceC {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.InterfaceWithDeprecatedMembers where Wrapped : main._InterfaceWithDeprecatedMembers {
+extension KotlinRuntimeSupport._KotlinExistential: main.InterfaceWithDeprecatedMembers, main.__InterfaceWithDeprecatedMembers where Wrapped : main._InterfaceWithDeprecatedMembers {
 }
 @available(*, unavailable, message: "Unavailable type(s): main.DeprecatedInterface")
-extension KotlinRuntimeSupport._KotlinExistential: main.DeprecatedInterface where Wrapped : main._DeprecatedInterface {
+extension KotlinRuntimeSupport._KotlinExistential: main.DeprecatedInterface, main.__DeprecatedInterface where Wrapped : main._DeprecatedInterface {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.NonDeprecatedInterface where Wrapped : main._NonDeprecatedInterface {
+extension KotlinRuntimeSupport._KotlinExistential: main.NonDeprecatedInterface, main.__NonDeprecatedInterface where Wrapped : main._NonDeprecatedInterface {
 }
 @available(*, unavailable, message: "Unavailable type(s): main.SubDeprecatedInterface")
-extension KotlinRuntimeSupport._KotlinExistential: main.SubDeprecatedInterface where Wrapped : main._SubDeprecatedInterface {
+extension KotlinRuntimeSupport._KotlinExistential: main.SubDeprecatedInterface, main.__SubDeprecatedInterface where Wrapped : main._SubDeprecatedInterface {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.SomeInterface where Wrapped : main._SomeInterface {
+extension KotlinRuntimeSupport._KotlinExistential: main.SomeInterface, main.__SomeInterface where Wrapped : main._SomeInterface {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.SwiftInterfaceC where Wrapped : main._SwiftInterfaceC {
+extension KotlinRuntimeSupport._KotlinExistential: main.SwiftInterfaceC, main.__SwiftInterfaceC where Wrapped : main._SwiftInterfaceC {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._InterfaceWithDeprecatedMembers {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,11 +3,11 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlinx.cinterop.ObjCObject where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlinx.cinterop.ObjCObject where Self : ExportedKotlinPackages.kotlinx.cinterop.__ObjCObject {
 }
 extension ExportedKotlinPackages.kotlinx.cinterop.ObjCObject {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.cinterop.ObjCObject where Wrapped : ExportedKotlinPackages.kotlinx.cinterop._ObjCObject {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlinx.cinterop.ObjCObject, ExportedKotlinPackages.kotlinx.cinterop.__ObjCObject where Wrapped : ExportedKotlinPackages.kotlinx.cinterop._ObjCObject {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlinx.cinterop._ObjCObject {
 }
@@ -17,7 +17,9 @@ extension ExportedKotlinPackages.kotlinx.cinterop {
     @objc(_ObjCObject)
     public protocol _ObjCObject {
     }
-    open class ObjCObjectBase: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.cinterop.ObjCObject, ExportedKotlinPackages.kotlinx.cinterop._ObjCObject {
+    public protocol __ObjCObject: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    open class ObjCObjectBase: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlinx.cinterop.ObjCObject, ExportedKotlinPackages.kotlinx.cinterop._ObjCObject, ExportedKotlinPackages.kotlinx.cinterop.__ObjCObject {
         package override init(
             __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
             options: KotlinRuntime.KotlinBaseConstructionOptions

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cross_language_inheritance/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cross_language_inheritance/golden_result/main/main.swift
@@ -11,6 +11,8 @@ public protocol Greeter: KotlinRuntime.KotlinBase, main._Greeter {
 @objc(_Greeter)
 public protocol _Greeter {
 }
+public protocol __Greeter: KotlinRuntimeSupport._KotlinBridgeable {
+}
 open class AbstractBase: KotlinRuntime.KotlinBase {
     package init() {
         fatalError()
@@ -52,7 +54,7 @@ open class Base: KotlinRuntime.KotlinBase {
         return Base_notOpen(self.__externalRCRef())
     }
 }
-open class GreeterBase: KotlinRuntime.KotlinBase, main.Greeter, main._Greeter {
+open class GreeterBase: KotlinRuntime.KotlinBase, main.Greeter, main._Greeter, main.__Greeter {
     public init() {
         let __kt = __root___GreeterBase_init_allocate()
         super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -73,7 +75,7 @@ open class GreeterBase: KotlinRuntime.KotlinBase, main.Greeter, main._Greeter {
         return GreeterBase_salutation(self.__externalRCRef())
     }
 }
-extension main.Greeter where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Greeter where Self : main.__Greeter {
     public func greet(
         name: Swift.String
     ) -> Swift.String {
@@ -85,7 +87,7 @@ extension main.Greeter where Self : KotlinRuntimeSupport._KotlinBridgeable {
 }
 extension main.Greeter {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Greeter where Wrapped : main._Greeter {
+extension KotlinRuntimeSupport._KotlinExistential: main.Greeter, main.__Greeter where Wrapped : main._Greeter {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._Greeter {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/enums/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/enums/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,7 +3,7 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : ExportedKotlinPackages.kotlin.collections.__Iterator {
     public func hasNext() -> Swift.Bool {
         return kotlin_collections_Iterator_hasNext(self.__externalRCRef())
     }
@@ -13,7 +13,7 @@ extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : Kotlin
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections.__Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Iterator {
 }
@@ -24,6 +24,8 @@ extension ExportedKotlinPackages.kotlin.collections {
     }
     @objc(_Iterator)
     public protocol _Iterator {
+    }
+    public protocol __Iterator: KotlinRuntimeSupport._KotlinBridgeable {
     }
 }
 extension ExportedKotlinPackages.kotlin {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functionAndClassWithSameName/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functionAndClassWithSameName/golden_result/main/main.swift
@@ -69,6 +69,12 @@ public protocol _InterfaceWithFactory {
 @objc(_Job)
 public protocol _Job {
 }
+public protocol __CompletableJob: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __InterfaceWithFactory: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __Job: KotlinRuntimeSupport._KotlinBridgeable {
+}
 public final class ClassWithFactoryWithoutParameters: KotlinRuntime.KotlinBase {
     public var value: Swift.Int32 {
         get {
@@ -161,23 +167,23 @@ public func utcOffset(
 ) -> main.UtcOffset {
     return main.UtcOffset.__createClassWrapper(externalRCRef: __root___UtcOffset__TypesOfArguments__Swift_Int32__(x))
 }
-extension main.CompletableJob where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.CompletableJob where Self : main.__CompletableJob {
 }
 extension main.CompletableJob {
 }
-extension main.InterfaceWithFactory where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.InterfaceWithFactory where Self : main.__InterfaceWithFactory {
 }
 extension main.InterfaceWithFactory {
 }
-extension main.Job where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Job where Self : main.__Job {
 }
 extension main.Job {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Job where Wrapped : main._Job {
+extension KotlinRuntimeSupport._KotlinExistential: main.Job, main.__Job where Wrapped : main._Job {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.CompletableJob where Wrapped : main._CompletableJob {
+extension KotlinRuntimeSupport._KotlinExistential: main.CompletableJob, main.__CompletableJob where Wrapped : main._CompletableJob {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.InterfaceWithFactory where Wrapped : main._InterfaceWithFactory {
+extension KotlinRuntimeSupport._KotlinExistential: main.InterfaceWithFactory, main.__InterfaceWithFactory where Wrapped : main._InterfaceWithFactory {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._Job {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functions/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functions/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,7 +3,7 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : ExportedKotlinPackages.kotlin.collections.__Iterator {
     public func hasNext() -> Swift.Bool {
         return kotlin_collections_Iterator_hasNext(self.__externalRCRef())
     }
@@ -13,7 +13,7 @@ extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : Kotlin
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections.__Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Iterator {
 }
@@ -24,6 +24,8 @@ extension ExportedKotlinPackages.kotlin.collections {
     }
     @objc(_Iterator)
     public protocol _Iterator {
+    }
+    public protocol __Iterator: KotlinRuntimeSupport._KotlinBridgeable {
     }
 }
 @_cdecl("kotlin_collections_Iterator_hasNext__reverse_swift")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,7 +3,7 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlin.Comparable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.Comparable where Self : ExportedKotlinPackages.kotlin.__Comparable {
     public static func <(
         this: Self,
         other: (any KotlinRuntimeSupport._KotlinBridgeable)?
@@ -36,7 +36,7 @@ extension ExportedKotlinPackages.kotlin.Comparable where Self : KotlinRuntimeSup
 }
 extension ExportedKotlinPackages.kotlin.Comparable {
 }
-extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : ExportedKotlinPackages.kotlin.collections.__Iterator {
     public func hasNext() -> Swift.Bool {
         return kotlin_collections_Iterator_hasNext(self.__externalRCRef())
     }
@@ -46,9 +46,9 @@ extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : Kotlin
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.Comparable where Wrapped : ExportedKotlinPackages.kotlin._Comparable {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.Comparable, ExportedKotlinPackages.kotlin.__Comparable where Wrapped : ExportedKotlinPackages.kotlin._Comparable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections.__Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin._Comparable {
 }
@@ -62,6 +62,8 @@ extension ExportedKotlinPackages.kotlin.collections {
     @objc(_Iterator)
     public protocol _Iterator {
     }
+    public protocol __Iterator: KotlinRuntimeSupport._KotlinBridgeable {
+    }
 }
 extension ExportedKotlinPackages.kotlin {
     public protocol Comparable: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin._Comparable {
@@ -71,6 +73,8 @@ extension ExportedKotlinPackages.kotlin {
     }
     @objc(_Comparable)
     public protocol _Comparable {
+    }
+    public protocol __Comparable: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public final class Array: KotlinRuntime.KotlinBase {
         public var size: Swift.Int32 {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/f_bounded_type/f_bounded_type.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/f_bounded_type/f_bounded_type.swift
@@ -10,6 +10,8 @@ public protocol MyComparable: KotlinRuntime.KotlinBase, f_bounded_type._MyCompar
 @objc(_MyComparable)
 public protocol _MyComparable {
 }
+public protocol __MyComparable: KotlinRuntimeSupport._KotlinBridgeable {
+}
 public final class ConcreteSelfReferencing: f_bounded_type.SelfReferencing {
     public override init() {
         let __kt = __root___ConcreteSelfReferencing_init_allocate()
@@ -39,7 +41,7 @@ open class SelfReferencing: KotlinRuntime.KotlinBase {
         return SelfReferencing_compareTo__TypesOfArguments__f_bounded_type_SelfReferencing__(self.__externalRCRef(), other.__externalRCRef())
     }
 }
-extension f_bounded_type.MyComparable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension f_bounded_type.MyComparable where Self : f_bounded_type.__MyComparable {
     public func compareTo(
         other: (any KotlinRuntimeSupport._KotlinBridgeable)?
     ) -> Swift.Int32 {
@@ -48,7 +50,7 @@ extension f_bounded_type.MyComparable where Self : KotlinRuntimeSupport._KotlinB
 }
 extension f_bounded_type.MyComparable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: f_bounded_type.MyComparable where Wrapped : f_bounded_type._MyComparable {
+extension KotlinRuntimeSupport._KotlinExistential: f_bounded_type.MyComparable, f_bounded_type.__MyComparable where Wrapped : f_bounded_type._MyComparable {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: f_bounded_type._MyComparable {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.swift
@@ -49,6 +49,18 @@ public protocol _Processor {
 @objc(_Producer)
 public protocol _Producer {
 }
+public protocol __A: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __B: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __Consumer: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __ConsumerProducer: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __Processor: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __Producer: KotlinRuntimeSupport._KotlinBridgeable {
+}
 public final class AnyConsumer: KotlinRuntime.KotlinBase {
     public init() {
         let __kt = __root___AnyConsumer_init_allocate()
@@ -361,7 +373,7 @@ public func takeBoxUpperBoundClosure(
         return { return originalBlock().__externalRCRef() }
     }()); return () }()
 }
-extension main.A where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.A where Self : main.__A {
     public var foo: (any KotlinRuntimeSupport._KotlinBridgeable)? {
         get {
             return { switch A_foo_get(self.__externalRCRef()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
@@ -370,7 +382,7 @@ extension main.A where Self : KotlinRuntimeSupport._KotlinBridgeable {
 }
 extension main.A {
 }
-extension main.B where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.B where Self : main.__B {
     public var foo: (any KotlinRuntimeSupport._KotlinBridgeable)? {
         get {
             return { switch B_foo_get(self.__externalRCRef()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
@@ -379,7 +391,7 @@ extension main.B where Self : KotlinRuntimeSupport._KotlinBridgeable {
 }
 extension main.B {
 }
-extension main.Consumer where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Consumer where Self : main.__Consumer {
     public func consume(
         item: (any KotlinRuntimeSupport._KotlinBridgeable)?
     ) -> Swift.Void {
@@ -388,11 +400,11 @@ extension main.Consumer where Self : KotlinRuntimeSupport._KotlinBridgeable {
 }
 extension main.Consumer {
 }
-extension main.ConsumerProducer where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.ConsumerProducer where Self : main.__ConsumerProducer {
 }
 extension main.ConsumerProducer {
 }
-extension main.Processor where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Processor where Self : main.__Processor {
     public func process(
         input: (any KotlinRuntimeSupport._KotlinBridgeable)?
     ) -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
@@ -401,24 +413,24 @@ extension main.Processor where Self : KotlinRuntimeSupport._KotlinBridgeable {
 }
 extension main.Processor {
 }
-extension main.Producer where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Producer where Self : main.__Producer {
     public func produce() -> (any KotlinRuntimeSupport._KotlinBridgeable)? {
         return { switch Producer_produce(self.__externalRCRef()) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: res); } }()
     }
 }
 extension main.Producer {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Producer where Wrapped : main._Producer {
+extension KotlinRuntimeSupport._KotlinExistential: main.Producer, main.__Producer where Wrapped : main._Producer {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Consumer where Wrapped : main._Consumer {
+extension KotlinRuntimeSupport._KotlinExistential: main.Consumer, main.__Consumer where Wrapped : main._Consumer {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Processor where Wrapped : main._Processor {
+extension KotlinRuntimeSupport._KotlinExistential: main.Processor, main.__Processor where Wrapped : main._Processor {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.ConsumerProducer where Wrapped : main._ConsumerProducer {
+extension KotlinRuntimeSupport._KotlinExistential: main.ConsumerProducer, main.__ConsumerProducer where Wrapped : main._ConsumerProducer {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.A where Wrapped : main._A {
+extension KotlinRuntimeSupport._KotlinExistential: main.A, main.__A where Wrapped : main._A {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.B where Wrapped : main._B {
+extension KotlinRuntimeSupport._KotlinExistential: main.B, main.__B where Wrapped : main._B {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._Producer {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/inheritance/golden_result/override/override.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/inheritance/golden_result/override/override.swift
@@ -8,6 +8,8 @@ public protocol P: KotlinRuntime.KotlinBase, override._P {
 @objc(_P)
 public protocol _P {
 }
+public protocol __P: KotlinRuntimeSupport._KotlinBridgeable {
+}
 open class Base: KotlinRuntime.KotlinBase {
     public init() {
         let __kt = __root___Base_init_allocate()
@@ -44,14 +46,14 @@ open class Sub: override.Base {
         return { Sub_g__TypesOfArguments__anyU20override_P__(self.__externalRCRef(), x.__externalRCRef()); return () }()
     }
 }
-extension override.P where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension override.P where Self : override.__P {
     public func f() -> Swift.Void {
         return { P_f(self.__externalRCRef()); return () }()
     }
 }
 extension override.P {
 }
-extension KotlinRuntimeSupport._KotlinExistential: override.P where Wrapped : override._P {
+extension KotlinRuntimeSupport._KotlinExistential: override.P, override.__P where Wrapped : override._P {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: override._P {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/list/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/list/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,7 +3,7 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlin.collections.Collection where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Collection where Self : ExportedKotlinPackages.kotlin.collections.__Collection {
     public var size: Swift.Int32 {
         get {
             return kotlin_collections_Collection_size_get(self.__externalRCRef())
@@ -29,14 +29,14 @@ extension ExportedKotlinPackages.kotlin.collections.Collection where Self : Kotl
 }
 extension ExportedKotlinPackages.kotlin.collections.Collection {
 }
-extension ExportedKotlinPackages.kotlin.collections.Iterable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterable where Self : ExportedKotlinPackages.kotlin.collections.__Iterable {
     public func iterator() -> any ExportedKotlinPackages.kotlin.collections.Iterator {
         return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_collections_Iterable_iterator(self.__externalRCRef())) as! any ExportedKotlinPackages.kotlin.collections.Iterator
     }
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterable {
 }
-extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : ExportedKotlinPackages.kotlin.collections.__Iterator {
     public func hasNext() -> Swift.Bool {
         return kotlin_collections_Iterator_hasNext(self.__externalRCRef())
     }
@@ -46,7 +46,7 @@ extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : Kotlin
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterator {
 }
-extension ExportedKotlinPackages.kotlin.collections.List where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.List where Self : ExportedKotlinPackages.kotlin.collections.__List {
     public var size: Swift.Int32 {
         get {
             return kotlin_collections_List_size_get(self.__externalRCRef())
@@ -108,7 +108,7 @@ extension ExportedKotlinPackages.kotlin.collections.List where Self : KotlinRunt
 }
 extension ExportedKotlinPackages.kotlin.collections.List {
 }
-extension ExportedKotlinPackages.kotlin.collections.ListIterator where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.ListIterator where Self : ExportedKotlinPackages.kotlin.collections.__ListIterator {
     public func hasNext() -> Swift.Bool {
         return kotlin_collections_ListIterator_hasNext(self.__externalRCRef())
     }
@@ -130,15 +130,15 @@ extension ExportedKotlinPackages.kotlin.collections.ListIterator where Self : Ko
 }
 extension ExportedKotlinPackages.kotlin.collections.ListIterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.List where Wrapped : ExportedKotlinPackages.kotlin.collections._List {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.List, ExportedKotlinPackages.kotlin.collections.__List where Wrapped : ExportedKotlinPackages.kotlin.collections._List {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Collection where Wrapped : ExportedKotlinPackages.kotlin.collections._Collection {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Collection, ExportedKotlinPackages.kotlin.collections.__Collection where Wrapped : ExportedKotlinPackages.kotlin.collections._Collection {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections.__Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.ListIterator where Wrapped : ExportedKotlinPackages.kotlin.collections._ListIterator {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.ListIterator, ExportedKotlinPackages.kotlin.collections.__ListIterator where Wrapped : ExportedKotlinPackages.kotlin.collections._ListIterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterable where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterable {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterable, ExportedKotlinPackages.kotlin.collections.__Iterable where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterable {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._List {
 }
@@ -217,6 +217,16 @@ extension ExportedKotlinPackages.kotlin.collections {
     }
     @objc(_ListIterator)
     public protocol _ListIterator: ExportedKotlinPackages.kotlin.collections._Iterator {
+    }
+    public protocol __Collection: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __Iterable: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __Iterator: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __List: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __ListIterator: KotlinRuntimeSupport._KotlinBridgeable {
     }
 }
 @_cdecl("kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/list/golden_result/ListExport_2/ListExport_2.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/list/golden_result/ListExport_2/ListExport_2.swift
@@ -4,11 +4,11 @@ import KotlinRuntime
 import KotlinRuntimeSupport
 import KotlinStdlib
 
-extension ExportedKotlinPackages.list2.MyList where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.list2.MyList where Self : ExportedKotlinPackages.list2.__MyList {
 }
 extension ExportedKotlinPackages.list2.MyList {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.list2.MyList where Wrapped : ExportedKotlinPackages.list2._MyList {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.list2.MyList, ExportedKotlinPackages.list2.__MyList where Wrapped : ExportedKotlinPackages.list2._MyList {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.list2._MyList {
 }
@@ -17,6 +17,8 @@ extension ExportedKotlinPackages.list2 {
     }
     @objc(_MyList)
     public protocol _MyList: ExportedKotlinPackages.kotlin.collections._List {
+    }
+    public protocol __MyList: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public static func testListOptAny(
         l: any ExportedKotlinPackages.list2.MyList

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/map/golden_result/MapExport/MapExport.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/map/golden_result/MapExport/MapExport.swift
@@ -7,6 +7,8 @@ public protocol Bar: KotlinRuntime.KotlinBase, MapExport._Bar {
 @objc(_Bar)
 public protocol _Bar {
 }
+public protocol __Bar: KotlinRuntimeSupport._KotlinBridgeable {
+}
 public func testMapAnyLong(
     m: [Swift.AnyHashable: Swift.Int64]
 ) -> [Swift.AnyHashable: Swift.Int64] {
@@ -63,11 +65,11 @@ public func testStarMap(
 ) -> [Swift.AnyHashable: any KotlinRuntimeSupport._KotlinBridgeable] {
     return __root___testStarMap__TypesOfArguments__Swift_Dictionary_Swift_AnyHashable_anyU20KotlinRuntimeSupport__KotlinBridgeable___(m) as! Swift.Dictionary<Swift.AnyHashable,any KotlinRuntimeSupport._KotlinBridgeable>
 }
-extension MapExport.Bar where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension MapExport.Bar where Self : MapExport.__Bar {
 }
 extension MapExport.Bar {
 }
-extension KotlinRuntimeSupport._KotlinExistential: MapExport.Bar where Wrapped : MapExport._Bar {
+extension KotlinRuntimeSupport._KotlinExistential: MapExport.Bar, MapExport.__Bar where Wrapped : MapExport._Bar {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: MapExport._Bar {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/nsobjectConflicts/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/nsobjectConflicts/golden_result/main/main.swift
@@ -7,7 +7,9 @@ public protocol Semaphore: KotlinRuntime.KotlinBase, main._Semaphore {
 @objc(_Semaphore)
 public protocol _Semaphore {
 }
-public final class ClassA: KotlinRuntime.KotlinBase, main.Semaphore, main._Semaphore {
+public protocol __Semaphore: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public final class ClassA: KotlinRuntime.KotlinBase, main.Semaphore, main._Semaphore, main.__Semaphore {
     public init() {
         let __kt = __root___ClassA_init_allocate()
         super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -51,11 +53,11 @@ public func forwardingTarget(
 ) -> Swift.Void {
     return { __root___forwardingTarget__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(`for`.__externalRCRef()); return () }()
 }
-extension main.Semaphore where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Semaphore where Self : main.__Semaphore {
 }
 extension main.Semaphore {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Semaphore where Wrapped : main._Semaphore {
+extension KotlinRuntimeSupport._KotlinExistential: main.Semaphore, main.__Semaphore where Wrapped : main._Semaphore {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._Semaphore {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.swift
@@ -29,19 +29,19 @@ public final class _ExportedKotlinPackages_conflictingTypealiases_Foo_Conflict: 
         super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
     }
 }
-extension ExportedKotlinPackages.conflictingTypealiases.Bar where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.conflictingTypealiases.Bar where Self : ExportedKotlinPackages.conflictingTypealiases.__Bar {
 }
 extension ExportedKotlinPackages.conflictingTypealiases.Bar {
     typealias Conflict = edge_cases._ExportedKotlinPackages_conflictingTypealiases_Bar_Conflict
 }
-extension ExportedKotlinPackages.conflictingTypealiases.Foo where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.conflictingTypealiases.Foo where Self : ExportedKotlinPackages.conflictingTypealiases.__Foo {
 }
 extension ExportedKotlinPackages.conflictingTypealiases.Foo {
     typealias Conflict = edge_cases._ExportedKotlinPackages_conflictingTypealiases_Foo_Conflict
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.conflictingTypealiases.Foo where Wrapped : ExportedKotlinPackages.conflictingTypealiases._Foo {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.conflictingTypealiases.Foo, ExportedKotlinPackages.conflictingTypealiases.__Foo where Wrapped : ExportedKotlinPackages.conflictingTypealiases._Foo {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.conflictingTypealiases.Bar where Wrapped : ExportedKotlinPackages.conflictingTypealiases._Bar {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.conflictingTypealiases.Bar, ExportedKotlinPackages.conflictingTypealiases.__Bar where Wrapped : ExportedKotlinPackages.conflictingTypealiases._Bar {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.conflictingTypealiases._Foo {
 }
@@ -57,5 +57,9 @@ extension ExportedKotlinPackages.conflictingTypealiases {
     }
     @objc(_Foo)
     public protocol _Foo {
+    }
+    public protocol __Bar: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __Foo: KotlinRuntimeSupport._KotlinBridgeable {
     }
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/funinterface/funinterface.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/funinterface/funinterface.swift
@@ -3,52 +3,52 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.funinterface.FunctionalInterface where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.funinterface.FunctionalInterface where Self : ExportedKotlinPackages.funinterface.__FunctionalInterface {
     public func callAsFunction() -> Swift.Int32 {
         return funinterface_FunctionalInterface_invoke(self.__externalRCRef())
     }
 }
 extension ExportedKotlinPackages.funinterface.FunctionalInterface {
 }
-extension ExportedKotlinPackages.funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation where Self : ExportedKotlinPackages.funinterface.__XMLFunctionalInterfaceWithLeadingAbbreviation {
     public func callAsFunction() -> Swift.Int32 {
         return funinterface_XMLFunctionalInterfaceWithLeadingAbbreviation_invoke(self.__externalRCRef())
     }
 }
 extension ExportedKotlinPackages.funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation {
 }
-extension ExportedKotlinPackages.funinterface._123FunctionalInterfaceWithLeadingNumbers where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.funinterface._123FunctionalInterfaceWithLeadingNumbers where Self : ExportedKotlinPackages.funinterface.___123FunctionalInterfaceWithLeadingNumbers {
     public func callAsFunction() -> Swift.Int32 {
         return funinterface__123FunctionalInterfaceWithLeadingNumbers_invoke(self.__externalRCRef())
     }
 }
 extension ExportedKotlinPackages.funinterface._123FunctionalInterfaceWithLeadingNumbers {
 }
-extension ExportedKotlinPackages.funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation where Self : ExportedKotlinPackages.funinterface.___123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation {
     public func callAsFunction() -> Swift.Int32 {
         return funinterface__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation_invoke(self.__externalRCRef())
     }
 }
 extension ExportedKotlinPackages.funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation {
 }
-extension ExportedKotlinPackages.funinterface._FunctionalInterfaceWithLeadingUnderscore where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.funinterface._FunctionalInterfaceWithLeadingUnderscore where Self : ExportedKotlinPackages.funinterface.___FunctionalInterfaceWithLeadingUnderscore {
     public func callAsFunction() -> Swift.Int32 {
         return funinterface__FunctionalInterfaceWithLeadingUnderscore_invoke(self.__externalRCRef())
     }
 }
 extension ExportedKotlinPackages.funinterface._FunctionalInterfaceWithLeadingUnderscore {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface.FunctionalInterface where Wrapped : ExportedKotlinPackages.funinterface._FunctionalInterface {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface.FunctionalInterface, ExportedKotlinPackages.funinterface.__FunctionalInterface where Wrapped : ExportedKotlinPackages.funinterface._FunctionalInterface {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface._FunctionalInterfaceWithLeadingUnderscore where Wrapped : ExportedKotlinPackages.funinterface.__FunctionalInterfaceWithLeadingUnderscore {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface._FunctionalInterfaceWithLeadingUnderscore, ExportedKotlinPackages.funinterface.___FunctionalInterfaceWithLeadingUnderscore where Wrapped : ExportedKotlinPackages.funinterface.__FunctionalInterfaceWithLeadingUnderscore {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface._123FunctionalInterfaceWithLeadingNumbers where Wrapped : ExportedKotlinPackages.funinterface.__123FunctionalInterfaceWithLeadingNumbers {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface._123FunctionalInterfaceWithLeadingNumbers, ExportedKotlinPackages.funinterface.___123FunctionalInterfaceWithLeadingNumbers where Wrapped : ExportedKotlinPackages.funinterface.__123FunctionalInterfaceWithLeadingNumbers {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation where Wrapped : ExportedKotlinPackages.funinterface._XMLFunctionalInterfaceWithLeadingAbbreviation {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation, ExportedKotlinPackages.funinterface.__XMLFunctionalInterfaceWithLeadingAbbreviation where Wrapped : ExportedKotlinPackages.funinterface._XMLFunctionalInterfaceWithLeadingAbbreviation {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation where Wrapped : ExportedKotlinPackages.funinterface.__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation, ExportedKotlinPackages.funinterface.___123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation where Wrapped : ExportedKotlinPackages.funinterface.__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface.functionalInterfaceWithAlreadyLowercaseLeading where Wrapped : ExportedKotlinPackages.funinterface._functionalInterfaceWithAlreadyLowercaseLeading {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.funinterface.functionalInterfaceWithAlreadyLowercaseLeading, ExportedKotlinPackages.funinterface.__functionalInterfaceWithAlreadyLowercaseLeading where Wrapped : ExportedKotlinPackages.funinterface._functionalInterfaceWithAlreadyLowercaseLeading {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.funinterface._FunctionalInterface {
 }
@@ -62,7 +62,7 @@ extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.funinterface._functionalInterfaceWithAlreadyLowercaseLeading {
 }
-extension ExportedKotlinPackages.funinterface.functionalInterfaceWithAlreadyLowercaseLeading where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.funinterface.functionalInterfaceWithAlreadyLowercaseLeading where Self : ExportedKotlinPackages.funinterface.__functionalInterfaceWithAlreadyLowercaseLeading {
     public func callAsFunction() -> Swift.Int32 {
         return funinterface_functionalInterfaceWithAlreadyLowercaseLeading_invoke(self.__externalRCRef())
     }
@@ -97,8 +97,20 @@ extension ExportedKotlinPackages.funinterface {
     @objc(__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation)
     public protocol __123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation {
     }
+    public protocol __FunctionalInterface: KotlinRuntimeSupport._KotlinBridgeable {
+    }
     @objc(__FunctionalInterfaceWithLeadingUnderscore)
     public protocol __FunctionalInterfaceWithLeadingUnderscore {
+    }
+    public protocol __XMLFunctionalInterfaceWithLeadingAbbreviation: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol ___123FunctionalInterfaceWithLeadingNumbers: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol ___123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol ___FunctionalInterfaceWithLeadingUnderscore: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __functionalInterfaceWithAlreadyLowercaseLeading: KotlinRuntimeSupport._KotlinBridgeable {
     }
     @objc(_functionalInterfaceWithAlreadyLowercaseLeading)
     public protocol _functionalInterfaceWithAlreadyLowercaseLeading {
@@ -106,7 +118,7 @@ extension ExportedKotlinPackages.funinterface {
     public protocol functionalInterfaceWithAlreadyLowercaseLeading: KotlinRuntime.KotlinBase, ExportedKotlinPackages.funinterface._functionalInterfaceWithAlreadyLowercaseLeading {
         func callAsFunction() -> Swift.Int32
     }
-    public final class FunctorClass: KotlinRuntime.KotlinBase, ExportedKotlinPackages.funinterface.FunctionalInterface, ExportedKotlinPackages.funinterface._FunctionalInterface {
+    public final class FunctorClass: KotlinRuntime.KotlinBase, ExportedKotlinPackages.funinterface.FunctionalInterface, ExportedKotlinPackages.funinterface._FunctionalInterface, ExportedKotlinPackages.funinterface.__FunctionalInterface {
         public init() {
             let __kt = funinterface_FunctorClass_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/main/main.swift
@@ -56,16 +56,36 @@ public protocol _SealedFoeble_SealedBarable: KotlinRuntime.KotlinBase, main.Seal
 @objc(_SiblingProtocol)
 public protocol _SiblingProtocol {
 }
+public protocol __Barable: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __Bazzable: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __ContainerProtocol: KotlinRuntimeSupport._KotlinBridgeable {
+}
 @objc(__ContainerProtocol_NestedProtocol)
 public protocol __ContainerProtocol_NestedProtocol {
 }
 @objc(__ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol)
 public protocol __ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol {
 }
+public protocol __Foeble: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __SealedBazzable: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol __SealedFoeble: KotlinRuntimeSupport._KotlinBridgeable {
+}
 @objc(__SealedFoeble_SealedBarable)
 public protocol __SealedFoeble_SealedBarable: main._SealedFoeble {
 }
-public final class Bar: KotlinRuntime.KotlinBase, main.Barable, main._Barable, main.Foeble, main._Foeble, main.Bazzable, main._Bazzable {
+public protocol __SiblingProtocol: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol ___ContainerProtocol_NestedProtocol: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol ___ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public protocol ___SealedFoeble_SealedBarable: KotlinRuntimeSupport._KotlinBridgeable {
+}
+public final class Bar: KotlinRuntime.KotlinBase, main.Barable, main._Barable, main.__Barable, main.Foeble, main._Foeble, main.__Foeble, main.Bazzable, main._Bazzable, main.__Bazzable {
     public var baz: main.Bar {
         get {
             return main.Bar.__createClassWrapper(externalRCRef: Bar_baz_get(self.__externalRCRef()))
@@ -88,7 +108,7 @@ public final class Bar: KotlinRuntime.KotlinBase, main.Barable, main._Barable, m
         return main.Bar.__createClassWrapper(externalRCRef: Bar_bar__TypesOfArguments__anyU20main_Foeble__(self.__externalRCRef(), arg.__externalRCRef()))
     }
 }
-public final class Foo: KotlinRuntime.KotlinBase, main.Foeble, main._Foeble {
+public final class Foo: KotlinRuntime.KotlinBase, main.Foeble, main._Foeble, main.__Foeble {
     public var baz: any main.Foeble {
         get {
             return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: Foo_baz_get(self.__externalRCRef())) as! any main.Foeble
@@ -127,7 +147,7 @@ public final class MyObject: KotlinRuntime.KotlinBase {
         super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
     }
 }
-public final class SomeBazzable: KotlinRuntime.KotlinBase, main.SealedBazzable, main._SealedBazzable {
+public final class SomeBazzable: KotlinRuntime.KotlinBase, main.SealedBazzable, main._SealedBazzable, main.__SealedBazzable {
     public static var shared: main.SomeBazzable {
         get {
             return main.SomeBazzable.__createClassWrapper(externalRCRef: __root___SomeBazzable_get())
@@ -195,7 +215,7 @@ public final class _ExportedKotlinPackages_packagewithprotocols_SiblingProtocol_
         super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
     }
 }
-public final class _SealedFoeble_SomeBarable: KotlinRuntime.KotlinBase, main._SealedFoeble_SealedBarable, main.__SealedFoeble_SealedBarable {
+public final class _SealedFoeble_SomeBarable: KotlinRuntime.KotlinBase, main._SealedFoeble_SealedBarable, main.__SealedFoeble_SealedBarable, main.___SealedFoeble_SealedBarable {
     public static var shared: main._SealedFoeble_SomeBarable {
         get {
             return main._SealedFoeble_SomeBarable.__createClassWrapper(externalRCRef: SealedFoeble_SomeBarable_get())
@@ -211,7 +231,7 @@ public final class _SealedFoeble_SomeBarable: KotlinRuntime.KotlinBase, main._Se
         super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
     }
 }
-public final class _SealedFoeble_SomeFoeble: KotlinRuntime.KotlinBase, main.SealedFoeble, main._SealedFoeble {
+public final class _SealedFoeble_SomeFoeble: KotlinRuntime.KotlinBase, main.SealedFoeble, main._SealedFoeble, main.__SealedFoeble {
     public static var shared: main._SealedFoeble_SomeFoeble {
         get {
             return main._SealedFoeble_SomeFoeble.__createClassWrapper(externalRCRef: SealedFoeble_SomeFoeble_get())
@@ -338,7 +358,7 @@ public func nullable(
 ) -> (any main.Foeble)? {
     return { switch __root___nullable__TypesOfArguments__Swift_Optional_anyU20main_Foeble___(value.map { it in it.__externalRCRef() } ?? nil) { case nil: .none; case let res: KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: res) as! any main.Foeble; } }()
 }
-extension main.Barable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Barable where Self : main.__Barable {
     public var baz: any main.Foeble {
         get {
             return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: Barable_baz_get(self.__externalRCRef())) as! any main.Foeble
@@ -352,27 +372,27 @@ extension main.Barable where Self : KotlinRuntimeSupport._KotlinBridgeable {
 }
 extension main.Barable {
 }
-extension ExportedKotlinPackages.repeating_conformances.Barable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.repeating_conformances.Barable where Self : ExportedKotlinPackages.repeating_conformances.__Barable {
 }
 extension ExportedKotlinPackages.repeating_conformances.Barable {
 }
-extension main.Bazzable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Bazzable where Self : main.__Bazzable {
 }
 extension main.Bazzable {
 }
-extension main.ContainerProtocol where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.ContainerProtocol where Self : main.__ContainerProtocol {
 }
 extension main.ContainerProtocol {
     typealias NestedClass = main._ContainerProtocol_NestedClass
     typealias NestedProtocol = main._ContainerProtocol_NestedProtocol
 }
-extension ExportedKotlinPackages.packagewithprotocols.ContainerProtocol where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.packagewithprotocols.ContainerProtocol where Self : ExportedKotlinPackages.packagewithprotocols.__ContainerProtocol {
 }
 extension ExportedKotlinPackages.packagewithprotocols.ContainerProtocol {
     typealias NestedClass = main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedClass
     typealias NestedProtocol = main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol
 }
-extension main.Foeble where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.Foeble where Self : main.__Foeble {
     public var baz: any main.Foeble {
         get {
             return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: Foeble_baz_get(self.__externalRCRef())) as! any main.Foeble
@@ -386,68 +406,68 @@ extension main.Foeble where Self : KotlinRuntimeSupport._KotlinBridgeable {
 }
 extension main.Foeble {
 }
-extension ExportedKotlinPackages.repeating_conformances.Foeble where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.repeating_conformances.Foeble where Self : ExportedKotlinPackages.repeating_conformances.__Foeble {
 }
 extension ExportedKotlinPackages.repeating_conformances.Foeble {
 }
-extension main.SealedBazzable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.SealedBazzable where Self : main.__SealedBazzable {
 }
 extension main.SealedBazzable {
 }
-extension main.SealedFoeble where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.SealedFoeble where Self : main.__SealedFoeble {
 }
 extension main.SealedFoeble {
     typealias SealedBarable = main._SealedFoeble_SealedBarable
     typealias SomeBarable = main._SealedFoeble_SomeBarable
     typealias SomeFoeble = main._SealedFoeble_SomeFoeble
 }
-extension main.SiblingProtocol where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.SiblingProtocol where Self : main.__SiblingProtocol {
 }
 extension main.SiblingProtocol {
     typealias NestedClass = main._SiblingProtocol_NestedClass
 }
-extension ExportedKotlinPackages.packagewithprotocols.SiblingProtocol where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.packagewithprotocols.SiblingProtocol where Self : ExportedKotlinPackages.packagewithprotocols.__SiblingProtocol {
 }
 extension ExportedKotlinPackages.packagewithprotocols.SiblingProtocol {
     typealias NestedClass = main._ExportedKotlinPackages_packagewithprotocols_SiblingProtocol_NestedClass
 }
-extension main._ContainerProtocol_NestedProtocol where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main._ContainerProtocol_NestedProtocol where Self : main.___ContainerProtocol_NestedProtocol {
 }
 extension main._ContainerProtocol_NestedProtocol {
     typealias NestedClass = main.__ContainerProtocol_NestedProtocol_NestedClass
 }
-extension main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol where Self : main.___ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol {
 }
 extension main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol {
     typealias NestedClass = main.__ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol_NestedClass
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.ContainerProtocol where Wrapped : main._ContainerProtocol {
+extension KotlinRuntimeSupport._KotlinExistential: main.ContainerProtocol, main.__ContainerProtocol where Wrapped : main._ContainerProtocol {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.SiblingProtocol where Wrapped : main._SiblingProtocol {
+extension KotlinRuntimeSupport._KotlinExistential: main.SiblingProtocol, main.__SiblingProtocol where Wrapped : main._SiblingProtocol {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Foeble where Wrapped : main._Foeble {
+extension KotlinRuntimeSupport._KotlinExistential: main.Foeble, main.__Foeble where Wrapped : main._Foeble {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Barable where Wrapped : main._Barable {
+extension KotlinRuntimeSupport._KotlinExistential: main.Barable, main.__Barable where Wrapped : main._Barable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.Bazzable where Wrapped : main._Bazzable {
+extension KotlinRuntimeSupport._KotlinExistential: main.Bazzable, main.__Bazzable where Wrapped : main._Bazzable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.SealedFoeble where Wrapped : main._SealedFoeble {
+extension KotlinRuntimeSupport._KotlinExistential: main.SealedFoeble, main.__SealedFoeble where Wrapped : main._SealedFoeble {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.SealedBazzable where Wrapped : main._SealedBazzable {
+extension KotlinRuntimeSupport._KotlinExistential: main.SealedBazzable, main.__SealedBazzable where Wrapped : main._SealedBazzable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.packagewithprotocols.ContainerProtocol where Wrapped : ExportedKotlinPackages.packagewithprotocols._ContainerProtocol {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.packagewithprotocols.ContainerProtocol, ExportedKotlinPackages.packagewithprotocols.__ContainerProtocol where Wrapped : ExportedKotlinPackages.packagewithprotocols._ContainerProtocol {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.packagewithprotocols.SiblingProtocol where Wrapped : ExportedKotlinPackages.packagewithprotocols._SiblingProtocol {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.packagewithprotocols.SiblingProtocol, ExportedKotlinPackages.packagewithprotocols.__SiblingProtocol where Wrapped : ExportedKotlinPackages.packagewithprotocols._SiblingProtocol {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.repeating_conformances.Foeble where Wrapped : ExportedKotlinPackages.repeating_conformances._Foeble {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances.__Foeble where Wrapped : ExportedKotlinPackages.repeating_conformances._Foeble {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.repeating_conformances.Barable where Wrapped : ExportedKotlinPackages.repeating_conformances._Barable {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.repeating_conformances.Barable, ExportedKotlinPackages.repeating_conformances.__Barable where Wrapped : ExportedKotlinPackages.repeating_conformances._Barable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main._ContainerProtocol_NestedProtocol where Wrapped : main.__ContainerProtocol_NestedProtocol {
+extension KotlinRuntimeSupport._KotlinExistential: main._ContainerProtocol_NestedProtocol, main.___ContainerProtocol_NestedProtocol where Wrapped : main.__ContainerProtocol_NestedProtocol {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main._SealedFoeble_SealedBarable where Wrapped : main.__SealedFoeble_SealedBarable {
+extension KotlinRuntimeSupport._KotlinExistential: main._SealedFoeble_SealedBarable, main.___SealedFoeble_SealedBarable where Wrapped : main.__SealedFoeble_SealedBarable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol where Wrapped : main.__ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol {
+extension KotlinRuntimeSupport._KotlinExistential: main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol, main.___ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol where Wrapped : main.__ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._ContainerProtocol {
 }
@@ -477,7 +497,7 @@ extension KotlinRuntimeSupport._KotlinExistentialPenBox: main.__SealedFoeble_Sea
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main.__ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedProtocol {
 }
-extension main._SealedFoeble_SealedBarable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main._SealedFoeble_SealedBarable where Self : main.___SealedFoeble_SealedBarable {
 }
 extension main._SealedFoeble_SealedBarable {
 }
@@ -535,7 +555,11 @@ extension ExportedKotlinPackages.packagewithprotocols {
     @objc(_SiblingProtocol)
     public protocol _SiblingProtocol {
     }
-    public final class INHERITANCE_COUPLE: main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedClass, ExportedKotlinPackages.packagewithprotocols.ContainerProtocol, ExportedKotlinPackages.packagewithprotocols._ContainerProtocol {
+    public protocol __ContainerProtocol: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __SiblingProtocol: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public final class INHERITANCE_COUPLE: main._ExportedKotlinPackages_packagewithprotocols_ContainerProtocol_NestedClass, ExportedKotlinPackages.packagewithprotocols.ContainerProtocol, ExportedKotlinPackages.packagewithprotocols._ContainerProtocol, ExportedKotlinPackages.packagewithprotocols.__ContainerProtocol {
         public override init() {
             let __kt = packagewithprotocols_INHERITANCE_COUPLE_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -561,7 +585,7 @@ extension ExportedKotlinPackages.packagewithprotocols {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    public final class OBJECT_WITH_INTERFACE_INHERITANCE: KotlinRuntime.KotlinBase, ExportedKotlinPackages.packagewithprotocols.ContainerProtocol, ExportedKotlinPackages.packagewithprotocols._ContainerProtocol {
+    public final class OBJECT_WITH_INTERFACE_INHERITANCE: KotlinRuntime.KotlinBase, ExportedKotlinPackages.packagewithprotocols.ContainerProtocol, ExportedKotlinPackages.packagewithprotocols._ContainerProtocol, ExportedKotlinPackages.packagewithprotocols.__ContainerProtocol {
         public static var shared: ExportedKotlinPackages.packagewithprotocols.OBJECT_WITH_INTERFACE_INHERITANCE {
             get {
                 return ExportedKotlinPackages.packagewithprotocols.OBJECT_WITH_INTERFACE_INHERITANCE.__createClassWrapper(externalRCRef: packagewithprotocols_OBJECT_WITH_INTERFACE_INHERITANCE_get())
@@ -608,6 +632,10 @@ extension ExportedKotlinPackages.repeating_conformances {
     }
     @objc(_Foeble)
     public protocol _Foeble {
+    }
+    public protocol __Barable: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __Foeble: KotlinRuntimeSupport._KotlinBridgeable {
     }
     open class Child1: ExportedKotlinPackages.repeating_conformances.Parent1 {
         public override init() {
@@ -700,7 +728,7 @@ extension ExportedKotlinPackages.repeating_conformances {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    open class GrandChild3: ExportedKotlinPackages.repeating_conformances.Child3 {
+    open class GrandChild3: ExportedKotlinPackages.repeating_conformances.Child3, ExportedKotlinPackages.repeating_conformances.__Foeble {
         public override init() {
             let __kt = repeating_conformances_GrandChild3_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -713,7 +741,7 @@ extension ExportedKotlinPackages.repeating_conformances {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    open class GrandChild4: ExportedKotlinPackages.repeating_conformances.Child4, ExportedKotlinPackages.repeating_conformances.Barable, ExportedKotlinPackages.repeating_conformances._Barable {
+    open class GrandChild4: ExportedKotlinPackages.repeating_conformances.Child4, ExportedKotlinPackages.repeating_conformances.Barable, ExportedKotlinPackages.repeating_conformances._Barable, ExportedKotlinPackages.repeating_conformances.__Barable {
         public override init() {
             let __kt = repeating_conformances_GrandChild4_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -726,7 +754,7 @@ extension ExportedKotlinPackages.repeating_conformances {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    open class GrandChild5: ExportedKotlinPackages.repeating_conformances.Child5, ExportedKotlinPackages.repeating_conformances.Barable, ExportedKotlinPackages.repeating_conformances._Barable, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble {
+    open class GrandChild5: ExportedKotlinPackages.repeating_conformances.Child5, ExportedKotlinPackages.repeating_conformances.Barable, ExportedKotlinPackages.repeating_conformances._Barable, ExportedKotlinPackages.repeating_conformances.__Barable, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble, ExportedKotlinPackages.repeating_conformances.__Foeble {
         public override init() {
             let __kt = repeating_conformances_GrandChild5_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -739,7 +767,7 @@ extension ExportedKotlinPackages.repeating_conformances {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    open class Parent1: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble {
+    open class Parent1: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble, ExportedKotlinPackages.repeating_conformances.__Foeble {
         public init() {
             let __kt = repeating_conformances_Parent1_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -752,7 +780,7 @@ extension ExportedKotlinPackages.repeating_conformances {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    open class Parent2: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble {
+    open class Parent2: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble, ExportedKotlinPackages.repeating_conformances.__Foeble {
         public init() {
             let __kt = repeating_conformances_Parent2_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -765,7 +793,7 @@ extension ExportedKotlinPackages.repeating_conformances {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    open class Parent3: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Barable, ExportedKotlinPackages.repeating_conformances._Barable {
+    open class Parent3: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Barable, ExportedKotlinPackages.repeating_conformances._Barable, ExportedKotlinPackages.repeating_conformances.__Barable {
         public init() {
             let __kt = repeating_conformances_Parent3_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
@@ -778,7 +806,7 @@ extension ExportedKotlinPackages.repeating_conformances {
             super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
         }
     }
-    open class Parent4: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble {
+    open class Parent4: KotlinRuntime.KotlinBase, ExportedKotlinPackages.repeating_conformances.Foeble, ExportedKotlinPackages.repeating_conformances._Foeble, ExportedKotlinPackages.repeating_conformances.__Foeble {
         public init() {
             let __kt = repeating_conformances_Parent4_init_allocate()
             super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/public_interface/public_interface.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/public_interface/public_interface.swift
@@ -7,11 +7,13 @@ public protocol DemoCrossModuleInterface: KotlinRuntime.KotlinBase, public_inter
 @objc(_DemoCrossModuleInterface)
 public protocol _DemoCrossModuleInterface {
 }
-extension public_interface.DemoCrossModuleInterface where Self : KotlinRuntimeSupport._KotlinBridgeable {
+public protocol __DemoCrossModuleInterface: KotlinRuntimeSupport._KotlinBridgeable {
+}
+extension public_interface.DemoCrossModuleInterface where Self : public_interface.__DemoCrossModuleInterface {
 }
 extension public_interface.DemoCrossModuleInterface {
 }
-extension KotlinRuntimeSupport._KotlinExistential: public_interface.DemoCrossModuleInterface where Wrapped : public_interface._DemoCrossModuleInterface {
+extension KotlinRuntimeSupport._KotlinExistential: public_interface.DemoCrossModuleInterface, public_interface.__DemoCrossModuleInterface where Wrapped : public_interface._DemoCrossModuleInterface {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: public_interface._DemoCrossModuleInterface {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/public_interface_usage/public_interface_usage.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/public_interface_usage/public_interface_usage.swift
@@ -3,7 +3,7 @@ import KotlinRuntime
 import KotlinRuntimeSupport
 import public_interface
 
-public final class DemoCrossModuleInterfaceUsage: KotlinRuntime.KotlinBase, public_interface.DemoCrossModuleInterface, public_interface._DemoCrossModuleInterface {
+public final class DemoCrossModuleInterfaceUsage: KotlinRuntime.KotlinBase, public_interface.DemoCrossModuleInterface, public_interface._DemoCrossModuleInterface, public_interface.__DemoCrossModuleInterface {
     public init() {
         let __kt = __root___DemoCrossModuleInterfaceUsage_init_allocate()
         super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/ranges/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/ranges/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,7 +3,7 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlin.ranges.ClosedRange where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.ranges.ClosedRange where Self : ExportedKotlinPackages.kotlin.ranges.__ClosedRange {
     public var endInclusive: any ExportedKotlinPackages.kotlin.Comparable {
         get {
             return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: kotlin_ranges_ClosedRange_endInclusive_get(self.__externalRCRef())) as! any ExportedKotlinPackages.kotlin.Comparable
@@ -31,7 +31,7 @@ extension ExportedKotlinPackages.kotlin.ranges.ClosedRange where Self : KotlinRu
 }
 extension ExportedKotlinPackages.kotlin.ranges.ClosedRange {
 }
-extension ExportedKotlinPackages.kotlin.Comparable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.Comparable where Self : ExportedKotlinPackages.kotlin.__Comparable {
     public static func <(
         this: Self,
         other: (any KotlinRuntimeSupport._KotlinBridgeable)?
@@ -64,9 +64,9 @@ extension ExportedKotlinPackages.kotlin.Comparable where Self : KotlinRuntimeSup
 }
 extension ExportedKotlinPackages.kotlin.Comparable {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.ranges.ClosedRange where Wrapped : ExportedKotlinPackages.kotlin.ranges._ClosedRange {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.ranges.ClosedRange, ExportedKotlinPackages.kotlin.ranges.__ClosedRange where Wrapped : ExportedKotlinPackages.kotlin.ranges._ClosedRange {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.Comparable where Wrapped : ExportedKotlinPackages.kotlin._Comparable {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.Comparable, ExportedKotlinPackages.kotlin.__Comparable where Wrapped : ExportedKotlinPackages.kotlin._Comparable {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.ranges._ClosedRange {
 }
@@ -80,6 +80,8 @@ extension ExportedKotlinPackages.kotlin {
     }
     @objc(_Comparable)
     public protocol _Comparable {
+    }
+    public protocol __Comparable: KotlinRuntimeSupport._KotlinBridgeable {
     }
 }
 extension ExportedKotlinPackages.kotlin.ranges {
@@ -97,6 +99,8 @@ extension ExportedKotlinPackages.kotlin.ranges {
     }
     @objc(_ClosedRange)
     public protocol _ClosedRange {
+    }
+    public protocol __ClosedRange: KotlinRuntimeSupport._KotlinBridgeable {
     }
 }
 @_cdecl("kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/set/golden_result/SetExport/SetExport.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/set/golden_result/SetExport/SetExport.swift
@@ -7,6 +7,8 @@ public protocol Foo: KotlinRuntime.KotlinBase, SetExport._Foo {
 @objc(_Foo)
 public protocol _Foo {
 }
+public protocol __Foo: KotlinRuntimeSupport._KotlinBridgeable {
+}
 @available(*, unavailable, message: "Declaration uses unsupported types")
 public var testSetFoo: Swift.Never {
     get {
@@ -84,11 +86,11 @@ public func testSetString(
 ) -> Swift.Set<Swift.String> {
     return __root___testSetString__TypesOfArguments__Swift_Set_Swift_String___(s) as! Swift.Set<Swift.String>
 }
-extension SetExport.Foo where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension SetExport.Foo where Self : SetExport.__Foo {
 }
 extension SetExport.Foo {
 }
-extension KotlinRuntimeSupport._KotlinExistential: SetExport.Foo where Wrapped : SetExport._Foo {
+extension KotlinRuntimeSupport._KotlinExistential: SetExport.Foo, SetExport.__Foo where Wrapped : SetExport._Foo {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: SetExport._Foo {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/lib/lib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/lib/lib.swift
@@ -31,6 +31,15 @@ public protocol _InterfaceTwo {
 @objc(_InternalLibInterface)
 public protocol _InternalLibInterface {
 }
+@_spi(InterfaceOptInOne)
+public protocol __InterfaceOne: KotlinRuntimeSupport._KotlinBridgeable {
+}
+@_spi(InterfaceOptInTwo)
+public protocol __InterfaceTwo: KotlinRuntimeSupport._KotlinBridgeable {
+}
+@_spi(InternalLibApi)
+public protocol __InternalLibInterface: KotlinRuntimeSupport._KotlinBridgeable {
+}
 @_spi(ExperimentalLibApi)
 public final class ExperimentalLibClass: KotlinRuntime.KotlinBase {
     @_spi(ExperimentalLibApi)
@@ -200,15 +209,15 @@ public func normalLibFunction() -> Swift.Void {
 public func returnAlias() -> lib.InternalLibAlias {
     return __root___returnAlias()
 }
-extension lib.InterfaceOne where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension lib.InterfaceOne where Self : lib.__InterfaceOne {
 }
 extension lib.InterfaceOne {
 }
-extension lib.InterfaceTwo where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension lib.InterfaceTwo where Self : lib.__InterfaceTwo {
 }
 extension lib.InterfaceTwo {
 }
-extension lib.InternalLibInterface where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension lib.InternalLibInterface where Self : lib.__InternalLibInterface {
     @_spi(InternalLibApi)
     public var foo: Swift.String {
         @_spi(InternalLibApi)
@@ -228,13 +237,13 @@ extension lib.InternalLibInterface where Self : KotlinRuntimeSupport._KotlinBrid
 extension lib.InternalLibInterface {
 }
 @_spi(InternalLibApi)
-extension KotlinRuntimeSupport._KotlinExistential: lib.InternalLibInterface where Wrapped : lib._InternalLibInterface {
+extension KotlinRuntimeSupport._KotlinExistential: lib.InternalLibInterface, lib.__InternalLibInterface where Wrapped : lib._InternalLibInterface {
 }
 @_spi(InterfaceOptInOne)
-extension KotlinRuntimeSupport._KotlinExistential: lib.InterfaceOne where Wrapped : lib._InterfaceOne {
+extension KotlinRuntimeSupport._KotlinExistential: lib.InterfaceOne, lib.__InterfaceOne where Wrapped : lib._InterfaceOne {
 }
 @_spi(InterfaceOptInTwo)
-extension KotlinRuntimeSupport._KotlinExistential: lib.InterfaceTwo where Wrapped : lib._InterfaceTwo {
+extension KotlinRuntimeSupport._KotlinExistential: lib.InterfaceTwo, lib.__InterfaceTwo where Wrapped : lib._InterfaceTwo {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: lib._InternalLibInterface {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/main/main.swift
@@ -8,7 +8,7 @@ public typealias MyAliasAlias = lib.InternalLibAlias
 @_spi(InternalLibApi)
 public typealias MyInterfaceAlias = any lib.InternalLibInterface
 @_spi(InternalLibApi)
-public final class MyImplementation: KotlinRuntime.KotlinBase, lib.InternalLibInterface, lib._InternalLibInterface {
+public final class MyImplementation: KotlinRuntime.KotlinBase, lib.InternalLibInterface, lib._InternalLibInterface, lib.__InternalLibInterface {
     @_spi(InternalLibApi)
     public var foo: Swift.String {
         @_spi(InternalLibApi)
@@ -53,7 +53,7 @@ public final class MyOptInClass: KotlinRuntime.KotlinBase {
     }
 }
 @_spi(InterfaceOptInOne) @_spi(OpenClassOptIn)
-public final class MySubClass: lib.OpenClass, lib.InterfaceOne, lib._InterfaceOne {
+public final class MySubClass: lib.OpenClass, lib.InterfaceOne, lib._InterfaceOne, lib.__InterfaceOne {
     @_spi(InterfaceOptInOne) @_spi(OpenClassOptIn)
     public override init() {
         let __kt = __root___MySubClass_init_allocate()
@@ -68,7 +68,7 @@ public final class MySubClass: lib.OpenClass, lib.InterfaceOne, lib._InterfaceOn
     }
 }
 @_spi(InterfaceOptInTwo)
-public final class MySubInterface: KotlinRuntime.KotlinBase, lib.InterfaceTwo, lib._InterfaceTwo {
+public final class MySubInterface: KotlinRuntime.KotlinBase, lib.InterfaceTwo, lib._InterfaceTwo, lib.__InterfaceTwo {
     @_spi(InterfaceOptInTwo)
     public init() {
         let __kt = __root___MySubInterface_init_allocate()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/stdlibTypes/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/stdlibTypes/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,7 +3,7 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlin.text.Appendable where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.text.Appendable where Self : ExportedKotlinPackages.kotlin.text.__Appendable {
     public func append(
         value: Swift.Unicode.UTF16.CodeUnit
     ) -> any ExportedKotlinPackages.kotlin.text.Appendable {
@@ -24,7 +24,7 @@ extension ExportedKotlinPackages.kotlin.text.Appendable where Self : KotlinRunti
 }
 extension ExportedKotlinPackages.kotlin.text.Appendable {
 }
-extension ExportedKotlinPackages.kotlin.CharSequence where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.CharSequence where Self : ExportedKotlinPackages.kotlin.__CharSequence {
     public var length: Swift.Int32 {
         get {
             return kotlin_CharSequence_length_get(self.__externalRCRef())
@@ -51,9 +51,9 @@ extension ExportedKotlinPackages.kotlin.CharSequence where Self : KotlinRuntimeS
 }
 extension ExportedKotlinPackages.kotlin.CharSequence {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.CharSequence where Wrapped : ExportedKotlinPackages.kotlin._CharSequence {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.CharSequence, ExportedKotlinPackages.kotlin.__CharSequence where Wrapped : ExportedKotlinPackages.kotlin._CharSequence {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.text.Appendable where Wrapped : ExportedKotlinPackages.kotlin.text._Appendable {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.text.Appendable, ExportedKotlinPackages.kotlin.text.__Appendable where Wrapped : ExportedKotlinPackages.kotlin.text._Appendable {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin._CharSequence {
 }
@@ -110,6 +110,8 @@ extension ExportedKotlinPackages.kotlin {
     }
     @objc(_CharSequence)
     public protocol _CharSequence {
+    }
+    public protocol __CharSequence: KotlinRuntimeSupport._KotlinBridgeable {
     }
     public final class ByteArray: KotlinRuntime.KotlinBase {
         public var size: Swift.Int32 {
@@ -225,7 +227,9 @@ extension ExportedKotlinPackages.kotlin.text {
     @objc(_Appendable)
     public protocol _Appendable {
     }
-    public final class StringBuilder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.CharSequence, ExportedKotlinPackages.kotlin._CharSequence, ExportedKotlinPackages.kotlin.text.Appendable, ExportedKotlinPackages.kotlin.text._Appendable {
+    public protocol __Appendable: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public final class StringBuilder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.kotlin.CharSequence, ExportedKotlinPackages.kotlin._CharSequence, ExportedKotlinPackages.kotlin.__CharSequence, ExportedKotlinPackages.kotlin.text.Appendable, ExportedKotlinPackages.kotlin.text._Appendable, ExportedKotlinPackages.kotlin.text.__Appendable {
         public var length: Swift.Int32 {
             get {
                 return kotlin_text_StringBuilder_length_get(self.__externalRCRef())

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/transitiveExport/golden_result/KotlinStdlib/KotlinStdlib.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/transitiveExport/golden_result/KotlinStdlib/KotlinStdlib.swift
@@ -3,7 +3,7 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
-extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : ExportedKotlinPackages.kotlin.collections.__Iterator {
     public func hasNext() -> Swift.Bool {
         return kotlin_collections_Iterator_hasNext(self.__externalRCRef())
     }
@@ -13,7 +13,7 @@ extension ExportedKotlinPackages.kotlin.collections.Iterator where Self : Kotlin
 }
 extension ExportedKotlinPackages.kotlin.collections.Iterator {
 }
-extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.kotlin.collections.Iterator, ExportedKotlinPackages.kotlin.collections.__Iterator where Wrapped : ExportedKotlinPackages.kotlin.collections._Iterator {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.kotlin.collections._Iterator {
 }
@@ -24,6 +24,8 @@ extension ExportedKotlinPackages.kotlin.collections {
     }
     @objc(_Iterator)
     public protocol _Iterator {
+    }
+    public protocol __Iterator: KotlinRuntimeSupport._KotlinBridgeable {
     }
     open class ByteIterator: KotlinRuntime.KotlinBase {
         package init() {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/type_reference/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/type_reference/golden_result/main/main.swift
@@ -8,6 +8,8 @@ public protocol INTERFACE: KotlinRuntime.KotlinBase, main._INTERFACE {
 @objc(_INTERFACE)
 public protocol _INTERFACE {
 }
+public protocol __INTERFACE: KotlinRuntimeSupport._KotlinBridgeable {
+}
 open class ABSTRACT_CLASS: KotlinRuntime.KotlinBase {
     package init() {
         fatalError()
@@ -480,11 +482,11 @@ public func setExtensionVarOnNullableRef(
 ) -> Swift.Void {
     return { __root___extensionVarOnNullableRef_set__TypesOfArgumentsE__Swift_Optional_main_Class_without_package__Swift_String__(receiver.map { it in it.__externalRCRef() } ?? nil, v); return () }()
 }
-extension main.INTERFACE where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.INTERFACE where Self : main.__INTERFACE {
 }
 extension main.INTERFACE {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.INTERFACE where Wrapped : main._INTERFACE {
+extension KotlinRuntimeSupport._KotlinExistential: main.INTERFACE, main.__INTERFACE where Wrapped : main._INTERFACE {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._INTERFACE {
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/typealiases/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/typealiases/golden_result/main/main.swift
@@ -104,6 +104,8 @@ public protocol OUTSIDE_PROTO: KotlinRuntime.KotlinBase, main._OUTSIDE_PROTO {
 @objc(_OUTSIDE_PROTO)
 public protocol _OUTSIDE_PROTO {
 }
+public protocol __OUTSIDE_PROTO: KotlinRuntimeSupport._KotlinBridgeable {
+}
 open class ABSTRACT_CLASS: KotlinRuntime.KotlinBase {
     package init() {
         fatalError()
@@ -398,7 +400,7 @@ public final class OBJECT_WITH_GENERIC_INHERITANCE: KotlinRuntime.KotlinBase {
         return OBJECT_WITH_GENERIC_INHERITANCE_previousIndex(self.__externalRCRef())
     }
 }
-public final class OBJECT_WITH_INTERFACE_INHERITANCE: KotlinRuntime.KotlinBase, main.OUTSIDE_PROTO, main._OUTSIDE_PROTO {
+public final class OBJECT_WITH_INTERFACE_INHERITANCE: KotlinRuntime.KotlinBase, main.OUTSIDE_PROTO, main._OUTSIDE_PROTO, main.__OUTSIDE_PROTO {
     public static var shared: main.OBJECT_WITH_INTERFACE_INHERITANCE {
         get {
             return main.OBJECT_WITH_INTERFACE_INHERITANCE.__createClassWrapper(externalRCRef: __root___OBJECT_WITH_INTERFACE_INHERITANCE_get())
@@ -495,11 +497,11 @@ public func produce_closure() -> main.closure {
         return { return { main_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!); return () }() }
     }()
 }
-extension main.OUTSIDE_PROTO where Self : KotlinRuntimeSupport._KotlinBridgeable {
+extension main.OUTSIDE_PROTO where Self : main.__OUTSIDE_PROTO {
 }
 extension main.OUTSIDE_PROTO {
 }
-extension KotlinRuntimeSupport._KotlinExistential: main.OUTSIDE_PROTO where Wrapped : main._OUTSIDE_PROTO {
+extension KotlinRuntimeSupport._KotlinExistential: main.OUTSIDE_PROTO, main.__OUTSIDE_PROTO where Wrapped : main._OUTSIDE_PROTO {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: main._OUTSIDE_PROTO {
 }


### PR DESCRIPTION
Our current approach to cross-language inheritance suffers from an issue: swift classes inheriting KotlinBase and conforming to Kotlin-exported protocols receive blanket default implementations that are attempting to witness protocol requirements with members of the Kotlin superclass, of which there are none viable. Originally we used that mechanism to bridge Kotlin interface members for exported Kotlin classes that implement those interfaces, but it now leaks into the user code. 

This MR introduces a new separate kind of marker protocols which exported Kotlin interfaces _do not refine_. We then re-target our blanket protocol implementations to those, and use them to mark exported Kotlin classes that should receive bridge implementations in a more precise fashion. This new kind of markers is distinct from pre-existing ExistentialMarker protocols by the fact that the latter has to be refined by its owning protocol, so each adopter is getting marked at runtime.