### PR TITLE
[JKLIB] Fix IR compilation phase and linker setup

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -62,9 +62,9 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
-import org.jetbrains.kotlin.psi2ir.descriptors.IrBuiltInsOverDescriptors
+import org.jetbrains.kotlin.backend.common.IrBuiltInsForLinker
+import org.jetbrains.kotlin.ir.InternalSymbolFinderAPI
 import org.jetbrains.kotlin.psi2ir.generators.DeclarationStubGeneratorImpl
-import org.jetbrains.kotlin.psi2ir.generators.TypeTranslatorImpl
 import org.jetbrains.kotlin.resolve.BindingTraceContext
 import org.jetbrains.kotlin.resolve.CompilerEnvironment
 import org.jetbrains.kotlin.resolve.jvm.JavaDescriptorResolver
@@ -111,31 +111,13 @@ object JKlibIrCompilationPhase :
             MainFunctionDetector(trace.bindingContext, configuration.languageVersionSettings)
         )
         val symbolTable = SymbolTable(IdSignatureDescriptor(mangler), IrFactoryImpl)
-        val typeTranslator = TypeTranslatorImpl(symbolTable, configuration.languageVersionSettings, mainModule)
-        val irBuiltIns = IrBuiltInsOverDescriptors(mainModule.builtIns, typeTranslator, symbolTable)
 
-        val stubGenerator = DeclarationStubGeneratorImpl(
-            mainModule,
-            symbolTable,
-            irBuiltIns,
-            DescriptorByIdSignatureFinderImpl(mainModule, mangler),
-            JvmGeneratorExtensionsImpl(configuration),
-        ).apply { unboundSymbolGeneration = true }
+
         val linker = JKlibIrLinker(
             module = mainModule,
             configuration = configuration,
             symbolTable = symbolTable,
-            stubGenerator = stubGenerator,
             descriptorMangler = mangler,
-        )
-
-        val pluginContext = IrPluginContextImpl(
-            mainModule,
-            configuration.languageVersionSettings,
-            symbolTable,
-            irBuiltIns,
-            linker = linker,
-            messageCollector = @OptIn(MessageCollectorAccess::class) /* deprecated in IrPluginContext */ configuration.messageCollector,
         )
 
         // Deserialize modules
@@ -158,12 +140,32 @@ object JKlibIrCompilationPhase :
             jarDepsModuleDescriptor.name.asString(),
         )
 
-        irBuiltIns.functionFactory = IrDescriptorBasedFunctionFactory(
-            irBuiltIns,
+        @OptIn(InternalSymbolFinderAPI::class) 
+        val irBuiltIns = IrBuiltInsForLinker(
+            linker, 
+            configuration.languageVersionSettings
+        )
+
+        val stubGenerator = DeclarationStubGeneratorImpl(
+            mainModule,
             symbolTable,
-            typeTranslator,
-            getPackageFragment = null,
-            referenceFunctionsWhenKFunctionAreReferenced = true
+            irBuiltIns,
+            DescriptorByIdSignatureFinderImpl(mainModule, mangler),
+            JvmGeneratorExtensionsImpl(configuration),
+        ).apply { unboundSymbolGeneration = true }
+
+        linker.stubGenerator = stubGenerator
+
+        val pluginContext = IrPluginContextImpl(
+            mainModule,
+            configuration.languageVersionSettings,
+            symbolTable,
+            irBuiltIns,
+            linker = linker,
+            messageCollector = 
+            @OptIn(MessageCollectorAccess::class) /* deprecated in IrPluginContext */ 
+            configuration.messageCollector,
+            
         )
 
         linker.init(null)
@@ -337,3 +339,4 @@ private class SourceOrBinaryModuleClassResolver(private val sourceScope: GlobalS
         return resolver.resolveClass(javaClass)
     }
 }
+

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -36,9 +36,9 @@ class JKlibIrLinker(
     module: ModuleDescriptor,
     configuration: CompilerConfiguration,
     symbolTable: SymbolTable,
-    val stubGenerator: DeclarationStubGenerator,
     val descriptorMangler: JKlibDescriptorMangler,
 ) : KotlinIrLinker(module, configuration, symbolTable, emptyList()) {
+    lateinit var stubGenerator: DeclarationStubGenerator
     override val returnUnboundSymbolsIfSignatureNotFound
         get() = false
 


### PR DESCRIPTION
Setup `IrBuiltInsForLinker` and lateinit `stubGenerator` for JKlib IR Linker. This creates the Linker before the IRBuiltins similar to how the JS IR linker loader does it at [code](https://github.com/JetBrains/kotlin/pull/6020/changes#diff-834bae0a29c5e71d359dce563ab3c5d0b2786f22ab1cdc7c8b570e876f7fcc17R210).
This resolves issue from breaking change in [eef85246cbf870890d32fc62720f77d0acb16035](https://github.com/JetBrains/kotlin/commit/eef85246cbf870890d32fc62720f77d0acb16035) introduced at [PR](https://github.com/JetBrains/kotlin/pull/6020).