### PR TITLE
[IR] Create new `Field` implementation for map in generator

### DIFF
--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/IrTree.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/IrTree.kt
@@ -47,6 +47,7 @@ import org.jetbrains.kotlin.ir.generator.model.Element.Category.*
 import org.jetbrains.kotlin.ir.generator.model.ListField
 import org.jetbrains.kotlin.ir.generator.model.ListField.Mutability.MutableList
 import org.jetbrains.kotlin.ir.generator.model.ListField.Mutability.Var
+import org.jetbrains.kotlin.ir.generator.model.MapField
 import org.jetbrains.kotlin.ir.generator.model.SimpleField
 import org.jetbrains.kotlin.ir.generator.model.symbol.Symbol
 import org.jetbrains.kotlin.name.FqName
@@ -748,10 +749,7 @@ object IrTree : AbstractTreeBuilder() {
         parent(type<AnnotationMarker>())
 
         +referencedSymbol("classSymbol", classSymbol, mutable = false)
-        +field("argumentMapping", StandardTypes.map.withArgs(type<Name>(), expression.copy(nullable = true)), mutable = false) {
-            // TODO KT-55928 remove when we migrate from `arguments`
-            deepCopyExcludeFromApply = true
-        }
+        +mapField("argumentMapping", type<Name>(), expression.copy(nullable = true), mutability = MapField.Mutability.ImmutableMap)
         +referencedSymbol("symbol", type = constructorSymbol) {
             optInAnnotation = deprecatedCompilerApi.withArgument("deprecatedSince", "org.jetbrains.kotlin.CompilerVersionOfApiDeprecation._2_4_20")
         }

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/config/AbstractTreeBuilder.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/config/AbstractTreeBuilder.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.generators.tree.config.AbstractElementConfigurator
 import org.jetbrains.kotlin.ir.generator.model.Element
 import org.jetbrains.kotlin.ir.generator.model.Field
 import org.jetbrains.kotlin.ir.generator.model.ListField
+import org.jetbrains.kotlin.ir.generator.model.MapField
 import org.jetbrains.kotlin.ir.generator.model.SimpleField
 
 abstract class AbstractTreeBuilder : AbstractElementConfigurator<Element, Field, Element.Category>() {
@@ -57,6 +58,23 @@ abstract class AbstractTreeBuilder : AbstractElementConfigurator<Element, Field,
     ): ListField = ListField(
         name = name,
         baseType = baseType,
+        isNullable = nullable,
+        mutability = mutability,
+        isChild = isChild,
+    ).apply(initializer)
+
+    protected fun mapField(
+        name: String,
+        keyType: TypeRef,
+        valueType: TypeRef,
+        nullable: Boolean = false,
+        mutability: MapField.Mutability,
+        isChild: Boolean = true,
+        initializer: MapField.() -> Unit = {}
+    ): MapField = MapField(
+        name = name,
+        keyType = keyType,
+        valueType = valueType,
         isNullable = nullable,
         mutability = mutability,
         isChild = isChild,

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/model/Field.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/model/Field.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ir.generator.model
 import org.jetbrains.kotlin.generators.tree.*
 import org.jetbrains.kotlin.ir.generator.model.symbol.Symbol
 import org.jetbrains.kotlin.generators.tree.ListField as AbstractListField
+import org.jetbrains.kotlin.generators.tree.MapField as AbstractMapField
 
 sealed class Field(
     override val name: String,
@@ -98,5 +99,39 @@ class ListField(
         Var,
         MutableList,
         Array
+    }
+}
+
+class MapField(
+    name: String,
+    override var keyType: TypeRef,
+    override var valueType: TypeRef,
+    private val isNullable: Boolean,
+    val mutability: Mutability,
+    override val isChild: Boolean,
+) : Field(name, mutability == Mutability.Var), AbstractMapField {
+    override val mapType: ClassRef<PositionTypeParameterRef> = when (mutability) {
+        Mutability.MutableMap -> StandardTypes.mutableMap
+        Mutability.Var, Mutability.ImmutableMap -> StandardTypes.map
+    }
+
+    override val typeRef: ClassRef<PositionTypeParameterRef>
+        get() = mapType.withArgs(keyType, valueType).copy(isNullable)
+
+    override val symbolClass: Symbol? = null
+
+    override fun substituteType(map: TypeParameterSubstitutionMap) {
+        keyType = keyType.substitute(map)
+        valueType = valueType.substitute(map)
+    }
+
+    override fun internalCopy(): Field {
+        return MapField(name, keyType, valueType, isNullable, mutability, isChild)
+    }
+
+    enum class Mutability {
+        Var,
+        MutableMap,
+        ImmutableMap
     }
 }

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/DeepCopyIrTreeWithSymbolsPrinter.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/DeepCopyIrTreeWithSymbolsPrinter.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ir.generator.*
 import org.jetbrains.kotlin.ir.generator.model.Element
 import org.jetbrains.kotlin.ir.generator.model.Field
 import org.jetbrains.kotlin.ir.generator.model.ListField
+import org.jetbrains.kotlin.ir.generator.model.MapField
 import org.jetbrains.kotlin.ir.generator.model.symbol.symbolRemapperMethodName
 import org.jetbrains.kotlin.utils.withIndent
 
@@ -143,22 +144,28 @@ internal class DeepCopyIrTreeWithSymbolsPrinter(
     }
 
     private fun ImportCollectingPrinter.copyField(element: Element, field: Field) {
-        if (field is ListField) {
-            print(element.visitorParameterName, ".", field.name, field.call(), "memoryOptimizedMap")
-            print(" { ")
-            copyValue(field, "it")
-            print(" }")
-        } else {
-            copyValue(field, element.visitorParameterName, ".", field.name)
+        when (field) {
+            is ListField -> {
+                print(element.visitorParameterName, ".", field.name, field.call(), "memoryOptimizedMap")
+                print(" { ")
+                copyValue(field, field.baseType,"it")
+                print(" }")
+            }
+            is MapField -> {
+                print(element.visitorParameterName, ".", field.name, field.call(), "map")
+                print(" { ")
+                copyValue(field, field.keyType,"it.key")
+                print(" to ")
+                copyValue(field, field.valueType,"it.value")
+                print(" }.toMap()")
+            }
+            else -> {
+                copyValue(field, field.typeRef, element.visitorParameterName, ".", field.name)
+            }
         }
     }
 
-    private fun ImportCollectingPrinter.copyValue(field: Field, vararg valueArgs: Any?) {
-        val typeRef = if (field is ListField) {
-            field.baseType
-        } else {
-            field.typeRef
-        }
+    private fun ImportCollectingPrinter.copyValue(field: Field, typeRef: TypeRef, vararg valueArgs: Any?) {
         val symbolFieldClass = field.symbolClass
         val safeCall = if (typeRef.nullable) "?." else "."
         when {
@@ -215,7 +222,7 @@ internal class DeepCopyIrTreeWithSymbolsPrinter(
                     field is ListField && field.mutability == ListField.Mutability.MutableList -> {
                         addImport(ArbitraryImportable("org.jetbrains.kotlin.utils.addToStdlib", "assignFrom"))
                         print("${field.name}.assignFrom(${element.visitorParameterName}.${field.name}) { it")
-                        copyValue(field)
+                        copyValue(field, field.baseType)
                         println(" }")
                     }
                 }

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/ElementPrinter.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/ElementPrinter.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.ir.generator.print
 
 import org.jetbrains.kotlin.generators.tree.AbstractElementPrinter
 import org.jetbrains.kotlin.generators.tree.AbstractFieldPrinter
+import org.jetbrains.kotlin.generators.tree.ElementOrRef
 import org.jetbrains.kotlin.generators.tree.StandardTypes
 import org.jetbrains.kotlin.generators.tree.imports.ArbitraryImportable
 import org.jetbrains.kotlin.generators.tree.nullable
@@ -18,6 +19,7 @@ import org.jetbrains.kotlin.ir.generator.irVisitorType
 import org.jetbrains.kotlin.ir.generator.model.Element
 import org.jetbrains.kotlin.ir.generator.model.Field
 import org.jetbrains.kotlin.ir.generator.model.ListField
+import org.jetbrains.kotlin.ir.generator.model.MapField
 import org.jetbrains.kotlin.ir.generator.model.SimpleField
 import org.jetbrains.kotlin.generators.tree.ElementRef as GenericElementRef
 
@@ -77,6 +79,23 @@ internal class ElementPrinter(printer: ImportCollectingPrinter) : AbstractElemen
                                 }
                                 println(".accept(visitor, data) }")
                             }
+                            is MapField -> {
+                                println("forEach { [key, value] -> ")
+                                if (child.keyType is ElementOrRef<*>) {
+                                    print("key")
+                                    if (child.keyType.nullable) {
+                                        print("?")
+                                    }
+                                    println(".accept(visitor, data) }")
+                                }
+                                if (child.valueType is ElementOrRef<*>) {
+                                    print("value")
+                                    if (child.valueType.nullable) {
+                                        print("?")
+                                    }
+                                    println(".accept(visitor, data) }")
+                                }
+                            }
                         }
                     }
                 }
@@ -117,6 +136,7 @@ internal class ElementPrinter(printer: ImportCollectingPrinter) : AbstractElemen
                                     println("transformInPlace(transformer, data)")
                                 }
                             }
+                            is MapField -> error("Not supported. Please implement if required.")
                         }
                     }
                 }

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/TypeVisitorPrinter.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/TypeVisitorPrinter.kt
@@ -73,11 +73,12 @@ internal open class TypeVisitorPrinter(
 
         val irTypeFields = this.fields
             .filter {
-                val type = when (it) {
-                    is SimpleField -> it.typeRef
-                    is ListField -> it.baseType
+                val value = irTypeType.toString()
+                when (it) {
+                    is SimpleField -> it.typeRef.toString() == value
+                    is ListField -> it.baseType.toString() == value
+                    is MapField -> it.keyType.toString() == value || it.valueType.toString() == value
                 }
-                type.toString() == irTypeType.toString()
             }
 
         return irTypeFields + parentsFields
@@ -243,6 +244,7 @@ internal open class TypeVisitorPrinter(
                         println(") }")
                     }
                 }
+                is MapField -> error("Not supported. Please implement if required.")
             }
         }
         when (element) {

--- a/generators/tree-generator-common/src/org/jetbrains/kotlin/generators/tree/MapField.kt
+++ b/generators/tree-generator-common/src/org/jetbrains/kotlin/generators/tree/MapField.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.generators.tree
+
+/**
+ * A field that is used to store a map with arbitrary elements.
+ */
+interface MapField {
+
+    /**
+     * The key type of the map.
+     */
+    val keyType: TypeRef
+
+    /**
+     * The value type of the map.
+     */
+    val valueType: TypeRef
+
+    /**
+     * The list type of the field, e.g. [Map] or [MutableMap].
+     */
+    val mapType: ClassRef<PositionTypeParameterRef>
+
+    val typeRef: ClassRef<PositionTypeParameterRef>
+        get() = mapType.withArgs(keyType, valueType)
+}

--- a/generators/tree-generator-common/src/org/jetbrains/kotlin/generators/tree/StandardTypes.kt
+++ b/generators/tree-generator-common/src/org/jetbrains/kotlin/generators/tree/StandardTypes.kt
@@ -16,5 +16,6 @@ object StandardTypes {
     val mutableList = type("kotlin.collections", "MutableList")
     val collection = type<Collection<*>>()
     val map = type<Map<*, *>>()
+    val mutableMap = type<MutableMap<*, *>>()
     val hashMap = type("kotlin.collections", "HashMap", TypeKind.Class)
 }


### PR DESCRIPTION
This change is required to we can support proper deep copy of a map argument in the IR node (in particular for IrAnnotation)