### PR TITLE
[IR] Move IrSignaturesExtractor to a common compiler module

### DIFF
--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/IrSignaturesExtractor.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/IrSignaturesExtractor.kt
@@ -1,9 +1,9 @@
 /*
- * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.cli.klib
+package org.jetbrains.kotlin.backend.common
 
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.backend.common.serialization.IrLibraryFileFromBytes.Companion.extensionRegistryLite
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.backend.common.serialization.proto.IrProperty as Pro
  * Note: [extractOnlyTopLevelPublicSignatures] is written in way to do even lesser amount of IO reads. So, it's
  * supposed to be even more robust than [extractAllPublicSignatures].
  */
-internal class IrSignaturesExtractor(library: KotlinLibrary) {
+class IrSignaturesExtractor(library: KotlinLibrary) {
     private val interner = IrInterningService()
     private val ir = library.irOrFail
 
@@ -261,8 +261,8 @@ internal class IrSignaturesExtractor(library: KotlinLibrary) {
         }
 
         return ExtractedSignatures(
-                declaredSignatures = ownDeclarationSignatures,
-                importedSignatures = importedSignatures,
+            declaredSignatures = ownDeclarationSignatures,
+            importedSignatures = importedSignatures,
         )
     }
 }

--- a/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/IrSignaturesRenderer.kt
+++ b/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/IrSignaturesRenderer.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.cli.klib
 
+import org.jetbrains.kotlin.backend.common.IrSignaturesExtractor
 import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.IdSignatureRenderer
 import org.jetbrains.kotlin.ir.util.render

--- a/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolCommands.kt
+++ b/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolCommands.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.cli.klib
 
 import org.jetbrains.kotlin.backend.common.DumpIrReferenceRenderingAsSignatureStrategy
+import org.jetbrains.kotlin.backend.common.IrSignaturesExtractor
 import org.jetbrains.kotlin.backend.common.serialization.IrInterningService
 import org.jetbrains.kotlin.backend.common.serialization.IrModuleDeserializer
 import org.jetbrains.kotlin.backend.common.serialization.NonLinkingIrInlineFunctionDeserializer


### PR DESCRIPTION
Extract `IrSignaturesExtractor` from a KLIB tool-module to a common IR serialization module to make it possible to use the component in Native backend.