### PR TITLE
[Gradle] Add DuplicateJsBrowserTestFrameworkConfiguration diagnostic

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2361,6 +2361,21 @@ internal object KotlinToolingDiagnostics {
             }
         }
     }
+
+    internal object DuplicateJsBrowserTestFrameworkConfiguration : ToolingDiagnosticFactory(
+        predefinedSeverity = ERROR,
+        predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
+    ) {
+        operator fun invoke() = build {
+            title { "Duplicate JS browser test framework configuration" }
+                .description {
+                    "JS browser test framework has been configured using both the new test {} DSL and the old testTask {} " +
+                            "DSL. The behavior in this scenario is undefined."
+                }
+                .solution { "Please use either the old DSL or the new one, but not both" }
+                .documentationLink(URI("https://kotl.in/new-js-browser-test-dsl"))
+        }
+    }
 }
 
 private fun String.indentLines(nSpaces: Int = 4, skipFirstLine: Boolean = true): String {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -8,6 +8,8 @@ package org.jetbrains.kotlin.gradle.targets.js.ir
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginLifecycle
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.plugin.launchInStage
 import org.jetbrains.kotlin.gradle.targets.KotlinTargetSideEffect
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinBrowserTestRunnerDsl
@@ -56,7 +58,9 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
                 }
             )
 
-            // TODO: KT-86707 Report warning if test framework was set with something else.
+            if (testTask.testFramework != null) {
+                project.reportDiagnostic(KotlinToolingDiagnostics.DuplicateJsBrowserTestFrameworkConfiguration())
+            }
             testTask.testFramework = KotlinPlaywrightJsTestFramework(
                 compilation = testCompilation,
                 frameworkTaskInputs = inputs,

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/diagnosticsTests/DuplicateJsBrowserTestFrameworkConfigurationDiagnosticTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/diagnosticsTests/DuplicateJsBrowserTestFrameworkConfigurationDiagnosticTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.unitTests.diagnosticsTests
+
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.util.assertContainsDiagnostic
+import org.jetbrains.kotlin.gradle.util.assertNoDiagnostics
+import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import org.jetbrains.kotlin.gradle.util.kotlin
+import kotlin.test.Test
+
+class DuplicateJsBrowserTestFrameworkConfigurationDiagnosticTest {
+
+    @Test
+    fun `diagnostic not reported if test framework not configured with either DSL`() {
+        val project = buildProjectWithMPP {
+            kotlin {
+                js {
+                    browser {}
+                }
+            }
+        }
+
+        project.evaluate()
+        project.tasks.getByName("jsBrowserTest")
+
+        project.assertNoDiagnostics()
+    }
+
+    @Test
+    fun `diagnostic not reported if test framework is only configured via new DSL`() {
+        val project = buildProjectWithMPP {
+            kotlin {
+                js {
+                    browser {
+                        test {
+                            it.chromium()
+                        }
+                    }
+                }
+            }
+        }
+
+        project.evaluate()
+        project.tasks.getByName("jsBrowserTest")
+
+        project.assertNoDiagnostics()
+    }
+
+    @Test
+    fun `diagnostic not reported if test framework is only configured via old DSL`() {
+        val project = buildProjectWithMPP {
+            kotlin {
+                js {
+                    browser {
+                        testTask {
+                            it.useKarma()
+                        }
+                    }
+                }
+            }
+        }
+
+        project.evaluate()
+        project.tasks.getByName("jsBrowserTest")
+
+        project.assertNoDiagnostics()
+    }
+
+    @Test
+    fun `diagnostic reported if test framework is configured via old DSL after new DSL`() {
+        val project = buildProjectWithMPP {
+            kotlin {
+                js {
+                    browser {
+                        test {
+                            it.chromium()
+                        }
+                        testTask {
+                            it.useKarma()
+                        }
+                    }
+                }
+            }
+        }
+
+        project.evaluate()
+        project.tasks.getByName("jsBrowserTest")
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.DuplicateJsBrowserTestFrameworkConfiguration)
+    }
+
+    @Test
+    fun `diagnostic reported if test framework is configured via new DSL after old DSL`() {
+        val project = buildProjectWithMPP {
+            kotlin {
+                js {
+                    browser {
+                        testTask {
+                            it.useKarma()
+                        }
+                        test {
+                            it.chromium()
+                        }
+                    }
+                }
+            }
+        }
+
+        project.evaluate()
+        project.tasks.getByName("jsBrowserTest")
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.DuplicateJsBrowserTestFrameworkConfiguration)
+    }
+}


### PR DESCRIPTION
New diagnostic that is reported when a KGP user configures JS test framework using both the old testTask
DSL, and the new test DSL.

Note that this implementation reports the diagnostic during jsBrowserTest task configuration. Ideally
we'd report it during the configuration phase, but it's challenging due to how coupled the old DSL
is to the actual test task.

^KT-86707 In Progress