### PR TITLE
[K/JS] Initialize inherited companion objects before child one

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ObjectLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ObjectLowering.kt
@@ -37,16 +37,8 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 /**
  * Creates lazy object instance generator functions.
- *
- * @param initializeParentCompanions When true, companion objects will initialize their enclosing
- * class's superclass companion first, so the initialization order matches the JVM (parent companion
- * before child companion). JS leaves this false to preserve existing behavior.
- * But see KT-40768 and KT-86422.
  */
-class ObjectDeclarationLowering(
-    val context: JsCommonBackendContext,
-    private val initializeParentCompanions: Boolean = false
-) : DeclarationTransformer {
+class ObjectDeclarationLowering(val context: JsCommonBackendContext) : DeclarationTransformer {
     override fun transformFlat(declaration: IrDeclaration): List<IrDeclaration>? {
         if (declaration !is IrClass || declaration.kind != ClassKind.OBJECT || declaration.isEffectivelyExternal())
             return null
@@ -67,12 +59,12 @@ class ObjectDeclarationLowering(
 
         val primaryConstructor = declaration.primaryConstructor ?: declaration.syntheticPrimaryConstructor!!
 
-        // When initializeParentCompanions is enabled, a companion object's getInstance() will first
-        // ensure the enclosing class's superclass companion is initialized. This matches the JVM
-        // class-initialization protocol where a superclass is always initialized before its subclass.
+        // A companion object's getInstance() will first ensure the enclosing class's superclass
+        // companion is initialized. This matches the JVM class-initialization protocol where a superclass
+        // is always initialized before its subclass.
         // We walk up the superclass chain to find the nearest ancestor that has a companion, because
         // intermediate classes without companions must not block the chain.
-        val parentCompanionGetInstanceFun = if (initializeParentCompanions && declaration.isCompanion) {
+        val parentCompanionGetInstanceFun = if (declaration.isCompanion) {
             var superClass = declaration.parent.safeAs<IrClass>()?.superClass
             var result: IrSimpleFunction? = null
             while (superClass != null && result == null) {

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ObjectLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ObjectLowering.kt
@@ -44,18 +44,7 @@ class ObjectDeclarationLowering(val context: JsCommonBackendContext) : Declarati
             return null
 
         val getInstanceFun = getOrCreateGetInstanceFunction(declaration)
-
-        val instanceField = context.irFactory.buildField {
-            name = Name.identifier(declaration.name.asString() + "_instance")
-            type = declaration.defaultType.makeNullable()
-            isStatic = true
-            origin = IrDeclarationOrigin.FIELD_FOR_OBJECT_INSTANCE
-        }.apply {
-            parent = declaration.parent
-            initializer = null  // Initialized with 'undefined'
-        }
-
-        declaration.objectInstanceField = instanceField
+        val instanceField = getOrCreateInstanceField(declaration)
 
         val primaryConstructor = declaration.primaryConstructor ?: declaration.syntheticPrimaryConstructor!!
 
@@ -164,8 +153,25 @@ class ObjectUsageLowering(val context: JsCommonBackendContext) : BodyLoweringPas
     }
 }
 
+private fun getOrCreateInstanceField(obj: IrClass): IrField =
+    obj::objectInstanceField.getOrSetIfNull {
+        obj.factory.buildField {
+            name = Name.identifier(obj.name.asString() + "_instance")
+            type = obj.defaultType.makeNullable()
+            isStatic = true
+            origin = IrDeclarationOrigin.FIELD_FOR_OBJECT_INSTANCE
+        }.apply {
+            parent = obj.parent
+            initializer = null  // Initialized with 'undefined'
+        }
+    }
+
+
 private fun getOrCreateGetInstanceFunction(obj: IrClass): IrSimpleFunction =
     obj::objectGetInstanceFunction.getOrSetIfNull {
+        // There is need to initialize _instance field together with _getInstance, so the outer restrictTo call would properly assign
+        // signature and tags for JS namer. It prevents name clashes during the JS namer phase.
+        getOrCreateInstanceField(obj)
         obj.factory.buildFun {
             name = Name.identifier(obj.name.asString() + "_getInstance")
             returnType = obj.defaultType

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/PurifyObjectInstanceGettersLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/PurifyObjectInstanceGettersLowering.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.ir.backend.js.lower
 
 import org.jetbrains.kotlin.backend.common.DeclarationTransformer
 import org.jetbrains.kotlin.backend.common.ir.isPure
-import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
 import org.jetbrains.kotlin.ir.backend.js.hasPureInitialization
@@ -96,20 +95,20 @@ open class PurifyObjectInstanceGettersLowering(val context: JsCommonBackendConte
     }
 
     private fun IrStatement.isPureStatementForObjectInitialization(owner: IrClass): Boolean {
-        return (
-                (this is IrReturn && value.isPureStatementForObjectInitialization(owner)) ||
-                        // Only objects which don't have a class parent
-                        (this is IrDelegatingConstructorCall && symbol.owner.parent == context.irBuiltIns.anyClass.owner) ||
-                        (this is IrExpression && isPure(anyVariable = true, checkFields = false, symbols = context.symbols)) ||
-                        (this is IrContainerExpression && statements.all { it.isPureStatementForObjectInitialization(owner) }) ||
-                        (this is IrVariable && (isEs6DelegatingConstructorCallReplacement || initializer?.isPureStatementForObjectInitialization(owner) != false)) ||
-                        // Only fields of the objects are safe to not save an intermediate state of another class/object/global
-                        (this is IrGetField && receiver?.isPureStatementForObjectInitialization(owner) == true) ||
-                        (this is IrSetField && receiver?.isPureStatementForObjectInitialization(owner) == true && value.isPureStatementForObjectInitialization(owner)) ||
-                        // Only current object could be initialized inside the object constructor, so we need to ignore it as an effect
-                        (this is IrSetField && symbol.owner.isObjectInstanceField()) ||
-                        (this is IrSetValue && symbol.owner.isOriginallyLocal && value.isPureStatementForObjectInitialization(owner))
-                )
-
+        return when (this) {
+            is IrReturn if value.isPureStatementForObjectInitialization(owner) -> true
+            // Only objects which don't have a class parent
+            is IrDelegatingConstructorCall if symbol.owner.parent == context.irBuiltIns.anyClass.owner -> true
+            is IrExpression if isPure(anyVariable = true, checkFields = false, symbols = context.symbols) -> true
+            is IrContainerExpression if statements.all { it.isPureStatementForObjectInitialization(owner) } -> true
+            is IrVariable if (isEs6DelegatingConstructorCallReplacement || initializer?.isPureStatementForObjectInitialization(owner) != false) -> true
+            // Only fields of the objects are safe to not save an intermediate state of another class/object/global
+            is IrGetField if receiver?.isPureStatementForObjectInitialization(owner) == true -> true
+            is IrSetField if receiver?.isPureStatementForObjectInitialization(owner) == true && value.isPureStatementForObjectInitialization(owner) -> true
+            // Only current object could be initialized inside the object constructor, so we need to ignore it as an effect
+            is IrSetField if symbol.owner.isObjectInstanceField() -> true
+            is IrSetValue if symbol.owner.isOriginallyLocal && value.isPureStatementForObjectInitialization(owner) -> true
+            else -> false
+        }
     }
 }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
@@ -95,10 +95,6 @@ private fun createAutoboxingTransformerPhase(context: JsCommonBackendContext): A
     return AutoboxingTransformer(context)
 }
 
-private fun createObjectDeclarationLoweringPhase(context: JsCommonBackendContext): ObjectDeclarationLowering {
-    return ObjectDeclarationLowering(context, initializeParentCompanions = true)
-}
-
 //@PhasePrerequisites(FunctionInlining::class) // This prerequisite is hard to represent for common lowering
 private fun createConstEvaluationPhase(context: CommonBackendContext): ConstEvaluationLowering {
     val configuration = IrInterpreterConfiguration(
@@ -190,7 +186,7 @@ val wasmLowerings: List<NamedCompilerPhase<WasmBackendContext, IrModuleFragment,
 
     ::JsInteropFunctionsLowering,
 
-    ::createObjectDeclarationLoweringPhase, // Also depends on `WasmCallableReferenceLowering`, but it is hard to represent in the common phase
+    ::ObjectDeclarationLowering, // Also depends on `WasmCallableReferenceLowering`, but it is hard to represent in the common phase
     ::WebStaticInitializersDeclarationLowering,
     ::WasmStaticInitializersUsageLowering,
 

--- a/compiler/testData/codegen/box/objects/companionObjectAccess/companionInitOrderWithSuperclassCrossModule.kt
+++ b/compiler/testData/codegen/box/objects/companionObjectAccess/companionInitOrderWithSuperclassCrossModule.kt
@@ -1,5 +1,3 @@
-// ISSUE: KT-40768 KJS: initialization order for companion objects (inherited classes) different from K/JVM
-// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 // ISSUE: KT-86521 Native: init order of companion objects is different from JVM
 // IGNORE_BACKEND: NATIVE
 // ISSUE: KT-84267 K/Wasm: init order of companion objects is different from JVM

--- a/compiler/testData/codegen/box/objects/companionObjectAccess/companionObjectInitOrderWithSuperclass.kt
+++ b/compiler/testData/codegen/box/objects/companionObjectAccess/companionObjectInitOrderWithSuperclass.kt
@@ -1,5 +1,3 @@
-// ISSUE: KT-40768 KJS: initialization order for companion objects (inherited classes) different from K/JVM
-// IGNORE_BACKEND: JS_IR, JS_IR_ES6
 // ISSUE: KT-86521 Native: init order of companion objects is different from JVM
 // IGNORE_BACKEND: NATIVE
 // ISSUE: KT-84267 K/Wasm: init order of companion objects is different from JVM


### PR DESCRIPTION
Initialize inherited companion objects before child one. Adjust the behavior with the JVM.

^KT-40768 Fixed