### PR TITLE
[Gradle] Remove outdated test

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
@@ -260,18 +260,6 @@ abstract class IncrementalCompilationJvmMultiProjectIT : BaseIncrementalCompilat
 
     override val defaultProjectName: String = "incrementalMultiproject"
 
-    @DisplayName("'inspectClassesForKotlinIC' task is added to execution plan")
-    open fun testInspectClassesForKotlinICTask(gradleVersion: GradleVersion) {
-        defaultProject(gradleVersion) {
-            build("assemble") {
-                assertTasksSkipped(
-                    ":lib:inspectClassesForKotlinIC",
-                    ":app:inspectClassesForKotlinIC"
-                )
-            }
-        }
-    }
-
     // todo: do the same for js backend
     @DisplayName("Duplicated class")
     @GradleTest


### PR DESCRIPTION
'inspectClassesForKotlinIC' task was used for old history-based
incremental compilation which is not available anymore for JVM.
