### PR TITLE
[K/N] Add a test for collection literal spread in variadic calls ^KT-82852

### DIFF
--- a/analysis/low-level-api-fir/low-level-api-fir-native-compiler-tests/tests-gen/org/jetbrains/kotlin/analysis/low/level/api/fir/konan/compiler/based/LLNativeDiagnosticsTestGenerated.java
+++ b/analysis/low-level-api-fir/low-level-api-fir-native-compiler-tests/tests-gen/org/jetbrains/kotlin/analysis/low/level/api/fir/konan/compiler/based/LLNativeDiagnosticsTestGenerated.java
@@ -803,6 +803,12 @@ public class LLNativeDiagnosticsTestGenerated extends AbstractLLNativeDiagnostic
       }
 
       @Test
+      @TestMetadata("t65.kt")
+      public void testT65() {
+        run("t65.kt");
+      }
+
+      @Test
       @TestMetadata("t7.kt")
       public void testT7() {
         run("t7.kt");

--- a/analysis/low-level-api-fir/low-level-api-fir-native-compiler-tests/tests-gen/org/jetbrains/kotlin/analysis/low/level/api/fir/konan/compiler/based/LLReversedNativeDiagnosticsTestGenerated.java
+++ b/analysis/low-level-api-fir/low-level-api-fir-native-compiler-tests/tests-gen/org/jetbrains/kotlin/analysis/low/level/api/fir/konan/compiler/based/LLReversedNativeDiagnosticsTestGenerated.java
@@ -803,6 +803,12 @@ public class LLReversedNativeDiagnosticsTestGenerated extends AbstractLLReversed
       }
 
       @Test
+      @TestMetadata("t65.kt")
+      public void testT65() {
+        run("t65.kt");
+      }
+
+      @Test
       @TestMetadata("t7.kt")
       public void testT7() {
         run("t7.kt");

--- a/compiler/testData/diagnostics/nativeTests/specialBackendChecks/objCInterop/t65.kt
+++ b/compiler/testData/diagnostics/nativeTests/specialBackendChecks/objCInterop/t65.kt
@@ -1,0 +1,11 @@
+// LANGUAGE: +CollectionLiterals
+// WITH_PLATFORM_LIBS
+import platform.darwin.*
+import platform.Foundation.*
+
+// Keep these calls passing until KT-81722 changes collection literal desugaring.
+// Fixing the regression will be in scope of KT-82852.
+fun objcNamedSpreadStillWorks() =
+    NSAssertionHandler().handleFailureInFunction("zzz", "zzz", 0, null, args = *[1, 2, 3])
+
+fun cVariadicSpreadStillWorks() = NSLog("zzz", *[1, 2, 3])


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-82852

Adds a Kotlin/Native regression test for using a collection literal in spread position when calling variadic C and Objective-C APIs.

This currently works because `*[...]` is still desugared to `*arrayOf(...)`. KT-81722 will change collection literal desugaring to `Array.of(...)`, so this test records the behavior that should stay supported after that change.

The test comment intentionally documents that this test is expected to break after KT-81722, and that fixing the regression is in scope of KT-82852, as requested in the YouTrack discussion.

The test covers both forms mentioned by the issue:
- a C variadic function call using `NSLog("zzz", *[1, 2, 3])`
- an Objective-C named variadic call using `args = *[1, 2, 3]`

Tests:
- `./gradlew :analysis:low-level-api-fir:low-level-api-fir-native-compiler-tests:generateTests`

Also attempted:
- `./gradlew :analysis:low-level-api-fir:low-level-api-fir-native-compiler-tests:llFirNativeTests --tests '*ObjCInterop.testT65' -Pkotlin.native.enabled=true`

The targeted native test could not be completed locally because this Xcode installation does not provide `bitcode-build-tool`. This is a local toolchain configuration issue rather than a test assertion failure.