### PR TITLE
[FIR2IR] Substitute context parameter type in callable-reference adapter ^KT-87035

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/AdapterGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/AdapterGenerator.kt
@@ -126,6 +126,8 @@ class AdapterGenerator(
     ) {
         val firAdaptee: FirCallableDeclaration =
             callableReferenceAccess.toResolvedCallableReference()?.resolvedSymbol?.fir as FirCallableDeclaration
+        val substitutor: ConeSubstitutor =
+            callableReferenceAccess.createConeSubstitutorFromTypeArguments(session) ?: ConeSubstitutor.Empty
         val boundDispatchReceiver: IrExpression? =
             callableReferenceAccess.findBoundReceiver(explicitReceiverExpression, isDispatch = true)
         val boundExtensionReceiver: IrExpression? =
@@ -325,7 +327,7 @@ class AdapterGenerator(
                     this += createAdapterParameter(
                         irAdapterFunction,
                         Name.identifier("c$index"),
-                        contextParameter.returnTypeRef.toIrType(),
+                        substitutor.substituteOrSelf(contextParameter.returnTypeRef.coneType).toIrType(),
                         IrDeclarationOrigin.ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE,
                         IrParameterKind.Regular,
                     )
@@ -402,7 +404,6 @@ class AdapterGenerator(
         adapterFunction: IrFunction,
         isSetter: Boolean,
     ): IrExpression = callableReferenceAccess.convertWithOffsets { startOffset, endOffset ->
-        val substitutor = callableReferenceAccess.createConeSubstitutorFromTypeArguments(session) ?: ConeSubstitutor.Empty
         val type = if (isSetter) {
             builtins.unitType
         } else {

--- a/compiler/testData/ir/irText/expressions/callableReferences/contextual/generic.ir.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/contextual/generic.ir.txt
@@ -18,17 +18,17 @@ FILE fqName:<root> fileName:/generic.kt
           overriddenFunctionSymbol: public abstract fun invoke (p1: P1 of kotlin.reflect.KFunction2, p2: P2 of kotlin.reflect.KFunction2): R of kotlin.reflect.KFunction2 declared in kotlin.reflect.KFunction2
           bound c0: GET_VAR '<this>: kotlin.String declared in <root>.test' type=kotlin.String origin=IMPLICIT_ARGUMENT
           invoke: FUN LOCAL_FUNCTION_FOR_LAMBDA name:foo visibility:local modality:FINAL returnType:kotlin.Long?
-            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:A of <root>.foo
+            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:kotlin.String
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:p0 index:1 type:kotlin.Int
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:p1 index:2 type:@[ParameterName(name = "p")] kotlin.Boolean
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='local final fun foo (c0: A of <root>.foo, p0: kotlin.Int, p1: @[ParameterName(name = "p")] kotlin.Boolean): kotlin.Long? declared in <root>.test'
+              RETURN type=kotlin.Nothing from='local final fun foo (c0: kotlin.String, p0: kotlin.Int, p1: @[ParameterName(name = "p")] kotlin.Boolean): kotlin.Long? declared in <root>.test'
                 CALL 'public final fun foo <A, B, C, D> (t: A of <root>.foo, <this>: B of <root>.foo, p: C of <root>.foo): D of <root>.foo? declared in <root>' type=kotlin.Long? origin=null
                   TYPE_ARG A: kotlin.String
                   TYPE_ARG B: kotlin.Int
                   TYPE_ARG C: kotlin.Boolean
                   TYPE_ARG D: kotlin.Long?
-                  ARG t: GET_VAR 'c0: A of <root>.foo declared in <root>.test.foo' type=A of <root>.foo origin=ADAPTED_FUNCTION_REFERENCE
+                  ARG t: GET_VAR 'c0: kotlin.String declared in <root>.test.foo' type=kotlin.String origin=ADAPTED_FUNCTION_REFERENCE
                   ARG <this>: GET_VAR 'p0: kotlin.Int declared in <root>.test.foo' type=kotlin.Int origin=null
                   ARG p: GET_VAR 'p1: @[ParameterName(name = "p")] kotlin.Boolean declared in <root>.test.foo' type=@[ParameterName(name = "p")] kotlin.Boolean origin=null
       VAR name:y type:kotlin.reflect.KMutableProperty0<kotlin.Long?> [val]
@@ -36,18 +36,18 @@ FILE fqName:<root> fileName:/generic.kt
           bound c0: GET_VAR '<this>: kotlin.String declared in <root>.test' type=kotlin.String origin=IMPLICIT_ARGUMENT
           bound receiver: CONST Int type=kotlin.Int value=1
           getter: FUN LOCAL_FUNCTION_FOR_LAMBDA name:bar visibility:local modality:FINAL returnType:kotlin.Long?
-            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:A of <root>.<get-bar>
+            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:kotlin.String
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:receiver index:1 type:kotlin.Int
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='local final fun bar (c0: A of <root>.<get-bar>, receiver: kotlin.Int): kotlin.Long? declared in <root>.test'
+              RETURN type=kotlin.Nothing from='local final fun bar (c0: kotlin.String, receiver: kotlin.Int): kotlin.Long? declared in <root>.test'
                 CALL 'public final fun <get-bar> <A, B, C> (t: A of <root>.<get-bar>, <this>: B of <root>.<get-bar>): C of <root>.<get-bar>? declared in <root>' type=kotlin.Long? origin=null
                   TYPE_ARG A: kotlin.String
                   TYPE_ARG B: kotlin.Int
                   TYPE_ARG C: kotlin.Long
-                  ARG t: GET_VAR 'c0: A of <root>.<get-bar> declared in <root>.test.bar' type=A of <root>.<get-bar> origin=ADAPTED_FUNCTION_REFERENCE
+                  ARG t: GET_VAR 'c0: kotlin.String declared in <root>.test.bar' type=kotlin.String origin=ADAPTED_FUNCTION_REFERENCE
                   ARG <this>: GET_VAR 'receiver: kotlin.Int declared in <root>.test.bar' type=kotlin.Int origin=ADAPTED_FUNCTION_REFERENCE
           setter: FUN LOCAL_FUNCTION_FOR_LAMBDA name:bar visibility:local modality:FINAL returnType:kotlin.Unit
-            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:A of <root>.<get-bar>
+            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:kotlin.String
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:receiver index:1 type:kotlin.Int
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:value index:2 type:kotlin.Long?
             BLOCK_BODY
@@ -55,25 +55,25 @@ FILE fqName:<root> fileName:/generic.kt
                 TYPE_ARG A: kotlin.String
                 TYPE_ARG B: kotlin.Int
                 TYPE_ARG C: kotlin.Long
-                ARG t: GET_VAR 'c0: A of <root>.<get-bar> declared in <root>.test.bar' type=A of <root>.<get-bar> origin=ADAPTED_FUNCTION_REFERENCE
+                ARG t: GET_VAR 'c0: kotlin.String declared in <root>.test.bar' type=kotlin.String origin=ADAPTED_FUNCTION_REFERENCE
                 ARG <this>: GET_VAR 'receiver: kotlin.Int declared in <root>.test.bar' type=kotlin.Int origin=ADAPTED_FUNCTION_REFERENCE
                 ARG v: GET_VAR 'value: kotlin.Long? declared in <root>.test.bar' type=kotlin.Long? origin=ADAPTED_FUNCTION_REFERENCE
       VAR name:z type:kotlin.reflect.KMutableProperty1<kotlin.Int, kotlin.Long?> [val]
         RICH_PROPERTY_REFERENCE type=kotlin.reflect.KMutableProperty1<kotlin.Int, kotlin.Long?> origin=null reflectionTarget='public final bar: C of <root>.<get-bar>? declared in <root>'
           bound c0: GET_VAR '<this>: kotlin.String declared in <root>.test' type=kotlin.String origin=IMPLICIT_ARGUMENT
           getter: FUN LOCAL_FUNCTION_FOR_LAMBDA name:bar visibility:local modality:FINAL returnType:kotlin.Long?
-            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:A of <root>.<get-bar>
+            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:kotlin.String
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:p0 index:1 type:kotlin.Int
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='local final fun bar (c0: A of <root>.<get-bar>, p0: kotlin.Int): kotlin.Long? declared in <root>.test'
+              RETURN type=kotlin.Nothing from='local final fun bar (c0: kotlin.String, p0: kotlin.Int): kotlin.Long? declared in <root>.test'
                 CALL 'public final fun <get-bar> <A, B, C> (t: A of <root>.<get-bar>, <this>: B of <root>.<get-bar>): C of <root>.<get-bar>? declared in <root>' type=kotlin.Long? origin=null
                   TYPE_ARG A: kotlin.String
                   TYPE_ARG B: kotlin.Int
                   TYPE_ARG C: kotlin.Long
-                  ARG t: GET_VAR 'c0: A of <root>.<get-bar> declared in <root>.test.bar' type=A of <root>.<get-bar> origin=ADAPTED_FUNCTION_REFERENCE
+                  ARG t: GET_VAR 'c0: kotlin.String declared in <root>.test.bar' type=kotlin.String origin=ADAPTED_FUNCTION_REFERENCE
                   ARG <this>: GET_VAR 'p0: kotlin.Int declared in <root>.test.bar' type=kotlin.Int origin=null
           setter: FUN LOCAL_FUNCTION_FOR_LAMBDA name:bar visibility:local modality:FINAL returnType:kotlin.Unit
-            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:A of <root>.<get-bar>
+            VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:c0 index:0 type:kotlin.String
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:p0 index:1 type:kotlin.Int
             VALUE_PARAMETER ADAPTER_PARAMETER_FOR_CALLABLE_REFERENCE kind:Regular name:value index:2 type:kotlin.Long?
             BLOCK_BODY
@@ -81,7 +81,7 @@ FILE fqName:<root> fileName:/generic.kt
                 TYPE_ARG A: kotlin.String
                 TYPE_ARG B: kotlin.Int
                 TYPE_ARG C: kotlin.Long
-                ARG t: GET_VAR 'c0: A of <root>.<get-bar> declared in <root>.test.bar' type=A of <root>.<get-bar> origin=ADAPTED_FUNCTION_REFERENCE
+                ARG t: GET_VAR 'c0: kotlin.String declared in <root>.test.bar' type=kotlin.String origin=ADAPTED_FUNCTION_REFERENCE
                 ARG <this>: GET_VAR 'p0: kotlin.Int declared in <root>.test.bar' type=kotlin.Int origin=null
                 ARG v: GET_VAR 'value: kotlin.Long? declared in <root>.test.bar' type=kotlin.Long? origin=ADAPTED_FUNCTION_REFERENCE
   PROPERTY name:bar visibility:public modality:FINAL [var]

--- a/compiler/testData/ir/irText/expressions/callableReferences/contextual/generic.kt.txt
+++ b/compiler/testData/ir/irText/expressions/callableReferences/contextual/generic.kt.txt
@@ -6,27 +6,27 @@ fun <A : Any?, B : Any?, C : Any?, D : Any?> B.foo(p: C): D? {
 fun String.test() {
   val x: @ExtensionFunctionType Function2<Int, Boolean, Long?> = @ExtensionFunctionType KFunction2<Int, @ParameterName(name = "p") Boolean, Long?>(
     /* bound = */ [<this>],
-    /* invoke = */    local fun(c0: A, p0: Int, p1: @ParameterName(name = "p") Boolean): Long? {
+    /* invoke = */    local fun(c0: String, p0: Int, p1: @ParameterName(name = "p") Boolean): Long? {
       return foo<String, Int, Boolean, Long?>(/* t = c0, <this> = p0, */ p = p1)
     }
   )
 
   val y: KMutableProperty0<Long?> = KMutableProperty0<Long?>(
     /* bound = */ [<this>,1],
-    /* getter = */    local fun(c0: A, receiver: Int): Long? {
+    /* getter = */    local fun(c0: String, receiver: Int): Long? {
       return <get-bar><String, Int, Long>(/* t = c0, <this> = receiver */)
     }
-    /* setter = */    local fun(c0: A, receiver: Int, value: Long?) {
+    /* setter = */    local fun(c0: String, receiver: Int, value: Long?) {
       <set-bar><String, Int, Long>(/* t = c0, <this> = receiver, */ v = value)
     }
   )
 
   val z: KMutableProperty1<Int, Long?> = KMutableProperty1<Int, Long?>(
     /* bound = */ [<this>],
-    /* getter = */    local fun(c0: A, p0: Int): Long? {
+    /* getter = */    local fun(c0: String, p0: Int): Long? {
       return <get-bar><String, Int, Long>(/* t = c0, <this> = p0 */)
     }
-    /* setter = */    local fun(c0: A, p0: Int, value: Long?) {
+    /* setter = */    local fun(c0: String, p0: Int, value: Long?) {
       <set-bar><String, Int, Long>(/* t = c0, <this> = p0, */ v = value)
     }
   )


### PR DESCRIPTION
When building a rich callable reference to a contextual declaration, the adapter's bound-context parameter was created from the adaptee's declared type, leaking the referenced declaration's type parameter.

^KT-87035 Fixed