### PR TITLE
[Build] Remove usage of deprecated `-no-endorsed-libs`

### DIFF
--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
@@ -101,8 +101,6 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
         configuration.konanNoDefaultLibs = arguments.nodefaultlibs
         configuration.konanPurgeUserLibs = arguments.purgeUserLibs
 
-        @Suppress("DEPRECATION")
-        configuration.konanNoEndorsedLibs = arguments.noendorsedlibs
         configuration.konanDontCompressKlib = arguments.nopack
 
         arguments.outputName?.let { configuration.konanOutputPath = it }

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/resolve/KonanLibrariesResolveSupport.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/resolve/KonanLibrariesResolveSupport.kt
@@ -57,7 +57,6 @@ class KonanLibrariesResolveSupport(
             unresolvedLibraries + additionalLibraryFiles.map { RequiredUnresolvedLibrary(it.absolutePath) },
             noStdLib = configuration.konanNoStdlib,
             noDefaultLibs = configuration.konanNoDefaultLibs,
-            noEndorsedLibs = configuration.konanNoEndorsedLibs,
             duplicatedUniqueNameStrategy = configuration.get(
                 KlibConfigurationKeys.DUPLICATED_UNIQUE_NAME_STRATEGY,
                 DuplicatedUniqueNameStrategy.DENY

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
@@ -46,7 +46,6 @@ object NativeConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.ko
     val KONAN_GENERATED_HEADER_KLIB_PATH by key<String>("Path to file where header klib should be produced.")
     val KONAN_NATIVE_LIBRARIES by key<List<String>>()
     val KONAN_NO_DEFAULT_LIBS by key<Boolean>("Don't link with the default libraries.")
-    val KONAN_NO_ENDORSED_LIBS by key<Boolean>("Don't link with the endorsed libraries.")
     val NOMAIN by key<Boolean>("Assume 'main' entry point to be provided by external libraries.")
     val KONAN_NO_STDLIB by key<Boolean>("Don't link with stdlib.")
     val KONAN_DONT_COMPRESS_KLIB by key<Boolean>("Don't pack the library into a klib file.")

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/KotlinLibraryResolver.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/KotlinLibraryResolver.kt
@@ -11,6 +11,25 @@ interface KotlinLibraryResolver<L : KotlinLibrary> {
 
     val searchPathResolver: SearchPathResolver<L>
 
+    @Deprecated(
+        "noEndorsedLibs is deprecated since 1.9.20",
+        ReplaceWith("resolveWithoutDependencies(unresolvedLibraries, noStdLib, noDefaultLibs, duplicatedUniqueNameStrategy)"),
+        DeprecationLevel.HIDDEN,
+    )
+    fun resolveWithDependencies(
+        unresolvedLibraries: List<UnresolvedLibrary>,
+        noStdLib: Boolean = false,
+        noDefaultLibs: Boolean = false,
+        noEndorsedLibs: Boolean = false,
+        duplicatedUniqueNameStrategy: DuplicatedUniqueNameStrategy = DuplicatedUniqueNameStrategy.DENY,
+    ): KotlinLibraryResolveResult =
+        resolveWithDependencies(
+            unresolvedLibraries,
+            noStdLib,
+            noDefaultLibs,
+            duplicatedUniqueNameStrategy,
+        )
+
     /**
      * Given the list of Kotlin/Native library names, ABI version and other parameters
      * resolves libraries and evaluates dependencies between them.
@@ -19,14 +38,12 @@ interface KotlinLibraryResolver<L : KotlinLibrary> {
         unresolvedLibraries: List<UnresolvedLibrary>,
         noStdLib: Boolean = false,
         noDefaultLibs: Boolean = false,
-        noEndorsedLibs: Boolean = false,
         duplicatedUniqueNameStrategy: DuplicatedUniqueNameStrategy = DuplicatedUniqueNameStrategy.DENY,
     ): KotlinLibraryResolveResult =
         resolveWithoutDependencies(
             unresolvedLibraries,
             noStdLib,
             noDefaultLibs,
-            noEndorsedLibs,
             duplicatedUniqueNameStrategy,
         ).resolveDependencies()
 
@@ -41,15 +58,26 @@ interface KotlinLibraryResolver<L : KotlinLibrary> {
             unresolvedLibraries,
             noStdLib,
             noDefaultLibs,
-            noEndorsedLibs,
             DuplicatedUniqueNameStrategy.DENY
         )
 
+    @Deprecated(
+        "noEndorsedLibs is deprecated since 1.9.20",
+        ReplaceWith("resolveWithoutDependencies(unresolvedLibraries, noStdLib, noDefaultLibs, duplicatedUniqueNameStrategy)"),
+        DeprecationLevel.HIDDEN,
+    )
     fun resolveWithoutDependencies(
         unresolvedLibraries: List<UnresolvedLibrary>,
         noStdLib: Boolean = false,
         noDefaultLibs: Boolean = false,
         noEndorsedLibs: Boolean = false,
+        duplicatedUniqueNameStrategy: DuplicatedUniqueNameStrategy,
+    ): List<KotlinLibrary> = resolveWithoutDependencies(unresolvedLibraries, noStdLib, noDefaultLibs, duplicatedUniqueNameStrategy)
+
+    fun resolveWithoutDependencies(
+        unresolvedLibraries: List<UnresolvedLibrary>,
+        noStdLib: Boolean = false,
+        noDefaultLibs: Boolean = false,
         duplicatedUniqueNameStrategy: DuplicatedUniqueNameStrategy,
     ): List<KotlinLibrary>
 

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/impl/KotlinLibraryResolverImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/impl/KotlinLibraryResolverImpl.kt
@@ -64,14 +64,13 @@ class KotlinLibraryResolverImpl<L : KotlinLibrary> internal constructor(
         unresolvedLibraries: List<UnresolvedLibrary>,
         noStdLib: Boolean,
         noDefaultLibs: Boolean,
-        noEndorsedLibs: Boolean,
         duplicatedUniqueNameStrategy: DuplicatedUniqueNameStrategy,
-    ) = findLibraries(unresolvedLibraries, noStdLib, noDefaultLibs, noEndorsedLibs)
+    ) = findLibraries(unresolvedLibraries, noStdLib, noDefaultLibs)
         .leaveDistinct()
         .omitDuplicateNames(duplicatedUniqueNameStrategy)
 
     /**
-     * Returns the list of libraries based on [libraryNames], [noStdLib], [noDefaultLibs] and [noEndorsedLibs] criteria.
+     * Returns the list of libraries based on [libraryNames], [noStdLib] and [noDefaultLibs] criteria.
      *
      * This method does not return any libraries that might be available via transitive dependencies
      * from the original library set (root set).
@@ -80,7 +79,6 @@ class KotlinLibraryResolverImpl<L : KotlinLibrary> internal constructor(
         unresolvedLibraries: List<UnresolvedLibrary>,
         noStdLib: Boolean,
         noDefaultLibs: Boolean,
-        noEndorsedLibs: Boolean,
     ): List<KotlinLibrary> {
 
         val userProvidedLibraries = unresolvedLibraries.asSequence()
@@ -95,7 +93,7 @@ class KotlinLibraryResolverImpl<L : KotlinLibrary> internal constructor(
                 }
         }.orEmpty()
 
-        val defaultLibraries = searchPathResolver.defaultLinks(noStdLib, noDefaultLibs, noEndorsedLibs)
+        val defaultLibraries = searchPathResolver.defaultLinks(noStdLib, noDefaultLibs)
 
         // Make sure the user provided ones appear first, so that
         // they have precedence over defaults when duplicates are eliminated.

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/SearchPathResolver.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/SearchPathResolver.kt
@@ -80,7 +80,15 @@ interface SearchPathResolver<L : KotlinLibrary> : WithLogger {
     fun resolve(unresolved: LenientUnresolvedLibrary): L?
     fun resolve(unresolved: RequiredUnresolvedLibrary): L
     fun resolve(givenPath: String): L
-    fun defaultLinks(noStdLib: Boolean, noDefaultLibs: Boolean, noEndorsedLibs: Boolean): List<L>
+
+    @Deprecated(
+        "noEndorsedLibs is deprecated since 1.9.20",
+        ReplaceWith("defaultLinks(noStdLib, noDefaultLibs)"),
+        DeprecationLevel.HIDDEN,
+    )
+    fun defaultLinks(noStdLib: Boolean, noDefaultLibs: Boolean, noEndorsedLibs: Boolean): List<L> = defaultLinks(noStdLib, noDefaultLibs)
+    fun defaultLinks(noStdLib: Boolean, noDefaultLibs: Boolean): List<L>
+
     fun libraryMatch(candidate: L, unresolved: UnresolvedLibrary): Boolean
     fun isProvidedByDefault(unresolved: UnresolvedLibrary): Boolean = false
 }
@@ -230,7 +238,7 @@ abstract class KotlinLibrarySearchPathResolver<L : KotlinLibrary>(
                 .onEach { it.isImplicitlyLoadedFromKotlinNativeDistribution = true }
         } else emptySequence()
 
-    override fun defaultLinks(noStdLib: Boolean, noDefaultLibs: Boolean, noEndorsedLibs: Boolean): List<L> {
+    override fun defaultLinks(noStdLib: Boolean, noDefaultLibs: Boolean): List<L> {
 
         val result = mutableListOf<L>()
 
@@ -240,12 +248,6 @@ abstract class KotlinLibrarySearchPathResolver<L : KotlinLibrary>(
             result.add(library)
         }
 
-        // Endorsed libraries in distHead.
-        if (!noEndorsedLibs) {
-            distHead?.let {
-                result.addAll(getDefaultLibrariesFromDir(it))
-            }
-        }
         // Platform libraries resolve.
         if (!noDefaultLibs) {
             distPlatformHead?.let {

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
@@ -25,7 +25,6 @@ import org.jetbrains.kotlin.native.interop.indexer.MacroNamesCollectingMode
 const val HEADER_FILTER_ADDITIONAL_SEARCH_PREFIX = "headerFilterAdditionalSearchPrefix"
 const val NODEFAULTLIBS_DEPRECATED = "nodefaultlibs"
 const val NODEFAULTLIBS = "no-default-libs"
-const val NOENDORSEDLIBS = "no-endorsed-libs"
 const val PURGE_USER_LIBS = "Xpurge-user-libs"
 const val TEMP_DIR = "Xtemporary-files-dir"
 const val PROJECT_DIR = "Xproject-dir"
@@ -60,8 +59,6 @@ open class CommonInteropArguments(val argParser: ArgParser) {
     val nodefaultlibsDeprecated by argParser.option(ArgType.Boolean, NODEFAULTLIBS_DEPRECATED,
             description = "don't link the libraries from dist/klib automatically",
             deprecatedWarning = "Old form of flag. Please, use $NODEFAULTLIBS.").default(false)
-    val noendorsedlibs by argParser.option(ArgType.Boolean, NOENDORSEDLIBS,
-            description = "don't link the endorsed libraries from dist automatically").default(false)
     val purgeUserLibs by argParser.option(ArgType.Boolean, PURGE_USER_LIBS,
             description = "don't link unused libraries even explicitly specified").default(false)
     val nopack by argParser.option(ArgType.Boolean, fullName = NOPACK,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -434,7 +434,6 @@ class CacheBuilder(
             checkDependencies = true
             konanLibraryToAddToCache = libraryPath
             konanNoDefaultLibs = true
-            konanNoEndorsedLibs = true
             konanNoStdlib = true
             konanLibraries = libraries
             val generateTestRunner = this@CacheBuilder.generateTestRunner

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
@@ -43,8 +43,6 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
     arguments.kotlinHome?.let { put(KONAN_HOME, it) }
 
     konanNoDefaultLibs = arguments.nodefaultlibs || !arguments.libraryToAddToCache.isNullOrEmpty()
-    @Suppress("DEPRECATION")
-    konanNoEndorsedLibs = arguments.noendorsedlibs || !arguments.libraryToAddToCache.isNullOrEmpty()
     konanNoStdlib = arguments.nostdlib || !arguments.libraryToAddToCache.isNullOrEmpty()
     konanDontCompressKlib = arguments.nopack
     put(NOMAIN, arguments.nomain)

--- a/kotlin-native/platformLibs/build.gradle.kts
+++ b/kotlin-native/platformLibs/build.gradle.kts
@@ -107,7 +107,6 @@ enabledTargets(platformManager).forEach { target ->
                     "-Xshort-module-name", df.name,
                     "-Xdisable-experimental-annotation",
                     "-no-default-libs",
-                    "-no-endorsed-libs",
                     "-Xccall-mode", "indirect", // Default is `-Xccall-mode both`, but platform libs use `indirect` for now. See KT-82062.
                     *reproducibilityCompilerFlags,
             )

--- a/kotlin-native/runtime/build.gradle.kts
+++ b/kotlin-native/runtime/build.gradle.kts
@@ -747,7 +747,6 @@ val stdlibBuildTask by tasks.registering(KonanCompileTask::class) {
 
     this.extraOpts.addAll(listOfNotNull(
             "-no-default-libs",
-            "-no-endorsed-libs",
             "-nostdlib",
             "-Werror".takeIf { !kotlinBuildProperties.disableWerror },
             "-Xallow-kotlin-package",

--- a/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
+++ b/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
@@ -268,7 +268,7 @@ private fun generateLibrary(
                 "-target", target.visibleName,
                 "-def", defFile.absolutePath,
                 "-compiler-option", "-fmodules-cache-path=${tmpDirectory.child("clangModulesCache").absolutePath}",
-                "-no-default-libs", "-no-endorsed-libs", "-Xpurge-user-libs", "-nopack",
+                "-no-default-libs", "-Xpurge-user-libs", "-nopack",
                 "-Xdisable-experimental-annotation",
                 *cinteropOptions.additionalArguments.toTypedArray(),
                 "-$SHORT_MODULE_NAME", def.shortLibraryName,

--- a/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/InteropCompiler.kt
+++ b/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/InteropCompiler.kt
@@ -28,7 +28,6 @@ fun invokeInterop(flavor: String, args: Array<String>, runFromDaemon: Boolean): 
     arguments.argParser.parse(args)
     val outputFileName = arguments.output
     val noDefaultLibs = arguments.nodefaultlibs || arguments.nodefaultlibsDeprecated
-    val noEndorsedLibs = arguments.noendorsedlibs
     val purgeUserLibs = arguments.purgeUserLibs
     val nopack = arguments.nopack
     val temporaryFilesDir = arguments.tempDir
@@ -69,7 +68,6 @@ fun invokeInterop(flavor: String, args: Array<String>, runFromDaemon: Boolean): 
         cinteropArgsToCompiler +
         libraries.flatMap { listOf("-library", it) } +
         (if (noDefaultLibs) arrayOf("-$NODEFAULTLIBS") else emptyArray()) +
-        (if (noEndorsedLibs) arrayOf("-$NOENDORSEDLIBS") else emptyArray()) +
         (if (purgeUserLibs) arrayOf("-$PURGE_USER_LIBS") else emptyArray()) +
         (if (nopack) arrayOf("-$NOPACK") else emptyArray()) +
         moduleName?.let { arrayOf("-module-name", it) }.orEmpty() +

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeCompilerArgBuilder.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeCompilerArgBuilder.kt
@@ -84,7 +84,6 @@ private fun buildKotlinNativeCommonArgs(
     compilerPlugins: List<CompilerPluginData>,
 ): List<String> = mutableListOf<String>().apply {
     add("-Xmulti-platform")
-    addKey("-no-endorsed-libs", true)
 
     compilerPlugins.forEach { plugin ->
         plugin.files.map { it.absolutePath }.sorted().forEach { add("-Xplugin=$it") }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeLink.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeLink.kt
@@ -313,8 +313,6 @@ constructor(
             args.target = konanTarget.name
             args.produce = outputKind.name.toLowerCaseAsciiOnly()
             args.multiPlatform = true
-            @Suppress("DEPRECATION")
-            args.noendorsedlibs = true
             args.nostdlib = true
             args.exportKDoc = exportKdoc.get()
             args.pluginOptions = compilerPlugins.flatMap { it.options.arguments }.toTypedArray()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
@@ -469,8 +469,6 @@ internal constructor(
             args.moduleName = compilerOptions.moduleName.get()
             args.shortModuleName = shortModuleName
             args.multiPlatform = true
-            @Suppress("DEPRECATION")
-            args.noendorsedlibs = true
             args.outputName = outputFile.get().absolutePath
             args.optimization = optimized
             args.debug = debuggable

--- a/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
+++ b/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
@@ -130,10 +130,6 @@ object NativeConfigurationKeys {
     @JvmField
     val KONAN_NO_DEFAULT_LIBS = CompilerConfigurationKey.create<Boolean>("KONAN_NO_DEFAULT_LIBS")
 
-    // Don't link with the endorsed libraries.
-    @JvmField
-    val KONAN_NO_ENDORSED_LIBS = CompilerConfigurationKey.create<Boolean>("KONAN_NO_ENDORSED_LIBS")
-
     // Assume 'main' entry point to be provided by external libraries.
     @JvmField
     val NOMAIN = CompilerConfigurationKey.create<Boolean>("NOMAIN")
@@ -407,10 +403,6 @@ var CompilerConfiguration.konanNativeLibraries: List<String>
 var CompilerConfiguration.konanNoDefaultLibs: Boolean
     get() = getBoolean(NativeConfigurationKeys.KONAN_NO_DEFAULT_LIBS)
     set(value) { put(NativeConfigurationKeys.KONAN_NO_DEFAULT_LIBS, value) }
-
-var CompilerConfiguration.konanNoEndorsedLibs: Boolean
-    get() = getBoolean(NativeConfigurationKeys.KONAN_NO_ENDORSED_LIBS)
-    set(value) { put(NativeConfigurationKeys.KONAN_NO_ENDORSED_LIBS, value) }
 
 var CompilerConfiguration.nomain: Boolean
     get() = getBoolean(NativeConfigurationKeys.NOMAIN)

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/LegacyKlibResolverUserTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/LegacyKlibResolverUserTest.kt
@@ -175,7 +175,6 @@ class LegacyKlibResolverUserTest : AbstractNativeSimpleTest() {
             unresolvedLibraries = library.unresolvedDependencies,
             noStdLib = !isForKotlinNative,
             noDefaultLibs = !isForKotlinNative,
-            noEndorsedLibs = !isForKotlinNative,
         ).getFullList()
     }
 }


### PR DESCRIPTION
Deprecate old signatures that have `noEndorsedLibs` parameter. We can't just remove them because it breaks ABI compatibility (related to KT-71414)

KT-86451