### PR TITLE
[JS] Treat `@JsImplicitExport` as `@JsExport` when IC is enabled

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ImplicitlyExportedDeclarationsMarkingLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/ImplicitlyExportedDeclarationsMarkingLowering.kt
@@ -51,6 +51,15 @@ class ImplicitlyExportedDeclarationsMarkingLowering(private val context: JsIrBac
     }
 
     override fun transformFlat(declaration: IrDeclaration): List<IrDeclaration>? {
+        if (context.incrementalCacheEnabled) {
+            // With enabled incremental compilation, we always treat @JsImplicitExport as a regular @JsExport.
+            // This is because adding or removing a reference to an implicitly exported declaration doesn't trigger its recompilation,
+            // which can lead to issues like KT-70622.
+            if (declaration.couldBeConvertedToExplicitExport() == true) {
+                declaration.markWithJsImplicitExportOrUpgrade()
+            }
+            return null
+        }
         if (!declaration.isExported(context)) return null
 
         when (declaration) {

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/incremental/AbstractInvalidationTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/incremental/AbstractInvalidationTest.kt
@@ -251,7 +251,7 @@ abstract class AbstractInvalidationTest(
             val expectedDTS: ExpectedFile?,
         )
 
-        protected inner class ExpectedFile(val name: String, val content: String)
+        protected inner class ExpectedFile(val name: String, val file: File)
 
         protected fun setupTestStep(projStep: ProjectInfo.ProjectBuildStep, module: String): TestStepInfo {
             val projStepId = projStep.id
@@ -296,7 +296,7 @@ abstract class AbstractInvalidationTest(
                 outputKlibFile.canonicalPath,
                 friends.map { it.canonicalPath },
                 moduleStep.expectedFileStats,
-                dtsFile?.let { ExpectedFile(moduleStep.expectedDTS.single(), it.readText()) }
+                dtsFile?.let { ExpectedFile(moduleStep.expectedDTS.single(), it) }
             )
         }
 

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/incremental/JsAbstractInvalidationTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/incremental/JsAbstractInvalidationTest.kt
@@ -32,10 +32,10 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.platform.js.JsPlatforms
 import org.jetbrains.kotlin.test.DebugMode
 import org.jetbrains.kotlin.test.TargetBackend
+import org.jetbrains.kotlin.test.testInfraError
 import org.jetbrains.kotlin.test.util.JUnit4Assertions
 import org.jetbrains.kotlin.test.utils.TestDisposable
 import org.junit.ComparisonFailure
-import org.jetbrains.kotlin.test.testInfraError
 import java.io.File
 
 abstract class JsAbstractInvalidationTest(
@@ -242,7 +242,7 @@ abstract class JsAbstractInvalidationTest(
                 }
 
                 val gotDTS = dtsFile.readText()
-                JUnit4Assertions.assertEquals(expectedDTS.content, gotDTS) {
+                JUnit4Assertions.assertEqualsToFile(expectedDTS.file, gotDTS, { it }) {
                     "Mismatched $$dtsFileExtension for module ${info.moduleName} at step $stepId"
                 }
             }

--- a/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.0.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.0.d.ts
@@ -1,3 +1,72 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.2.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.2.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function test2(): string;
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.3.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.3.d.ts
@@ -1,5 +1,74 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function test1(): string;
 export declare function test2(): string;
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.4.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/fileNameClashPerModule/main/m.4.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function test1(): string;
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/lib1/l1.0.kt
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/lib1/l1.0.kt
@@ -1,0 +1,4 @@
+@JsExport
+fun consumeCollection(map: Map<String, String>): String? {
+    return map["foo"]
+}

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/lib1/l1.1.kt
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/lib1/l1.1.kt
@@ -1,0 +1,4 @@
+@JsExport
+fun consumeCollection(list: List<String>): String? {
+    return list.getOrNull(0)
+}

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/lib1/module.info
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/lib1/module.info
@@ -1,0 +1,8 @@
+STEP 0:
+    modifications:
+        U : l1.0.kt -> l1.kt
+    added file: l1.kt
+STEP 1:
+    modifications:
+        U : l1.1.kt -> l1.kt
+    modified ir: l1.kt

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.0.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.0.d.ts
@@ -1,6 +1,24 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
 export declare namespace kotlin.collections {
+    interface KtSet<out E> /* extends kotlin.collections.Collection<E> */ {
+        asJsReadonlySetView(): ReadonlySet<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtSet": unique symbol;
+        };
+    }
+    namespace KtSet {
+        function fromJsSet<E>(set: ReadonlySet<E>): kotlin.collections.KtSet<E>;
+    }
+    interface KtList<out E> /* extends kotlin.collections.Collection<E> */ {
+        asJsReadonlyArrayView(): ReadonlyArray<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtList": unique symbol;
+        };
+    }
+    namespace KtList {
+        function fromJsArray<E>(array: ReadonlyArray<E>): kotlin.collections.KtList<E>;
+    }
     interface KtMap<K, out V> {
         asJsReadonlyMapView(): ReadonlyMap<K, V>;
         readonly __doNotUseOrImplementIt: {
@@ -9,6 +27,50 @@ export declare namespace kotlin.collections {
     }
     namespace KtMap {
         function fromJsMap<K, V>(map: ReadonlyMap<K, V>): kotlin.collections.KtMap<K, V>;
+    }
+    interface KtMutableSet<E> extends kotlin.collections.KtSet<E>/*, kotlin.collections.MutableCollection<E> */ {
+        asJsSetView(): Set<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMutableSet": unique symbol;
+        } & kotlin.collections.KtSet<any>["__doNotUseOrImplementIt"];
+    }
+    namespace KtMutableSet {
+        function fromJsSet<E>(set: ReadonlySet<E>): kotlin.collections.KtMutableSet<E>;
+    }
+    interface KtMutableList<E> extends kotlin.collections.KtList<E>/*, kotlin.collections.MutableCollection<E> */ {
+        asJsArrayView(): Array<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMutableList": unique symbol;
+        } & kotlin.collections.KtList<any>["__doNotUseOrImplementIt"];
+    }
+    namespace KtMutableList {
+        function fromJsArray<E>(array: ReadonlyArray<E>): kotlin.collections.KtMutableList<E>;
+    }
+    interface KtMutableMap<K, V> extends kotlin.collections.KtMap<K, V> {
+        asJsMapView(): Map<K, V>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMutableMap": unique symbol;
+        } & kotlin.collections.KtMap<any, any>["__doNotUseOrImplementIt"];
+    }
+    namespace KtMutableMap {
+        function fromJsMap<K, V>(map: ReadonlyMap<K, V>): kotlin.collections.KtMutableMap<K, V>;
+    }
+}
+export declare namespace kotlin {
+    class Pair<out A, out B> /* implements kotlin.io.Serializable */ {
+        constructor(first: A, second: B);
+        get first(): A;
+        get second(): B;
+        toString(): string;
+        copy(first?: A, second?: B): kotlin.Pair<A, B>;
+        hashCode(): number;
+        equals(other: Nullable<any>): boolean;
+    }
+    namespace Pair {
+        /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+        namespace $metadata$ {
+            const constructor: abstract new <A, B>() => Pair<A, B>;
+        }
     }
 }
 export declare function consumeCollection(map: kotlin.collections.KtMap<string, string>): Nullable<string>;

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.0.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.0.d.ts
@@ -1,0 +1,15 @@
+type Nullable<T> = T | null | undefined
+declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare namespace kotlin.collections {
+    interface KtMap<K, out V> {
+        asJsReadonlyMapView(): ReadonlyMap<K, V>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMap": unique symbol;
+        };
+    }
+    namespace KtMap {
+        function fromJsMap<K, V>(map: ReadonlyMap<K, V>): kotlin.collections.KtMap<K, V>;
+    }
+}
+export declare function consumeCollection(map: kotlin.collections.KtMap<string, string>): Nullable<string>;
+export declare function box(step: number): string;

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.1.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.1.d.ts
@@ -1,6 +1,24 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
 export declare namespace kotlin.collections {
+    interface KtSet<out E> /* extends kotlin.collections.Collection<E> */ {
+        asJsReadonlySetView(): ReadonlySet<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtSet": unique symbol;
+        };
+    }
+    namespace KtSet {
+        function fromJsSet<E>(set: ReadonlySet<E>): kotlin.collections.KtSet<E>;
+    }
+    interface KtList<out E> /* extends kotlin.collections.Collection<E> */ {
+        asJsReadonlyArrayView(): ReadonlyArray<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtList": unique symbol;
+        };
+    }
+    namespace KtList {
+        function fromJsArray<E>(array: ReadonlyArray<E>): kotlin.collections.KtList<E>;
+    }
     interface KtMap<K, out V> {
         asJsReadonlyMapView(): ReadonlyMap<K, V>;
         readonly __doNotUseOrImplementIt: {
@@ -9,6 +27,50 @@ export declare namespace kotlin.collections {
     }
     namespace KtMap {
         function fromJsMap<K, V>(map: ReadonlyMap<K, V>): kotlin.collections.KtMap<K, V>;
+    }
+    interface KtMutableSet<E> extends kotlin.collections.KtSet<E>/*, kotlin.collections.MutableCollection<E> */ {
+        asJsSetView(): Set<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMutableSet": unique symbol;
+        } & kotlin.collections.KtSet<any>["__doNotUseOrImplementIt"];
+    }
+    namespace KtMutableSet {
+        function fromJsSet<E>(set: ReadonlySet<E>): kotlin.collections.KtMutableSet<E>;
+    }
+    interface KtMutableList<E> extends kotlin.collections.KtList<E>/*, kotlin.collections.MutableCollection<E> */ {
+        asJsArrayView(): Array<E>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMutableList": unique symbol;
+        } & kotlin.collections.KtList<any>["__doNotUseOrImplementIt"];
+    }
+    namespace KtMutableList {
+        function fromJsArray<E>(array: ReadonlyArray<E>): kotlin.collections.KtMutableList<E>;
+    }
+    interface KtMutableMap<K, V> extends kotlin.collections.KtMap<K, V> {
+        asJsMapView(): Map<K, V>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMutableMap": unique symbol;
+        } & kotlin.collections.KtMap<any, any>["__doNotUseOrImplementIt"];
+    }
+    namespace KtMutableMap {
+        function fromJsMap<K, V>(map: ReadonlyMap<K, V>): kotlin.collections.KtMutableMap<K, V>;
+    }
+}
+export declare namespace kotlin {
+    class Pair<out A, out B> /* implements kotlin.io.Serializable */ {
+        constructor(first: A, second: B);
+        get first(): A;
+        get second(): B;
+        toString(): string;
+        copy(first?: A, second?: B): kotlin.Pair<A, B>;
+        hashCode(): number;
+        equals(other: Nullable<any>): boolean;
+    }
+    namespace Pair {
+        /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+        namespace $metadata$ {
+            const constructor: abstract new <A, B>() => Pair<A, B>;
+        }
     }
 }
 export declare function consumeCollection(list: kotlin.collections.KtList<string>): Nullable<string>;

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.1.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.1.d.ts
@@ -1,0 +1,15 @@
+type Nullable<T> = T | null | undefined
+declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare namespace kotlin.collections {
+    interface KtMap<K, out V> {
+        asJsReadonlyMapView(): ReadonlyMap<K, V>;
+        readonly __doNotUseOrImplementIt: {
+            readonly "kotlin.collections.KtMap": unique symbol;
+        };
+    }
+    namespace KtMap {
+        function fromJsMap<K, V>(map: ReadonlyMap<K, V>): kotlin.collections.KtMap<K, V>;
+    }
+}
+export declare function consumeCollection(list: kotlin.collections.KtList<string>): Nullable<string>;
+export declare function box(step: number): string;

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.kt
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/main/m.kt
@@ -1,0 +1,6 @@
+@JsModule("test")
+external fun test(step: Int): String
+
+fun box(step: Int): String {
+    return test(step)
+}

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/main/module.info
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/main/module.info
@@ -1,0 +1,7 @@
+STEP 0:
+    dependencies: lib1
+    added file: m.kt
+    expected dts: m.0.d.ts
+STEP 1:
+    dependencies: lib1
+    expected dts: m.1.d.ts

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/project.info
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/project.info
@@ -1,0 +1,12 @@
+TARGET_BACKEND: JS_IR, JS_IR_ES6
+IGNORE_PER_FILE: true
+TYPESCRIPT_DEFINITIONS: true
+MODULES: lib1, main
+MODULE_KIND: commonjs
+
+STEP 0:
+    libs: lib1, main
+    dirty js modules: lib1, main
+STEP 1:
+    libs: lib1, main
+    dirty js modules: lib1

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/test.js
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/test.js
@@ -5,10 +5,6 @@ module.exports = function (step) {
         case 0:
             return lib1.consumeCollection(stdlib.kotlin.collections.KtMap.fromJsMap(new Map([['foo', 'OK']])));
         case 1:
-            // TODO(KT-70622): Delete this 'if'
-            if (typeof stdlib.kotlin.collections.KtList === 'undefined') {
-                return 'OK';
-            }
             return lib1.consumeCollection(stdlib.kotlin.collections.KtList.fromJsArray(['OK']));
         default:
             return 'Fail';

--- a/js/js.translator/testData/incremental/invalidation/implicitExport/test.js
+++ b/js/js.translator/testData/incremental/invalidation/implicitExport/test.js
@@ -1,0 +1,16 @@
+module.exports = function (step) {
+    var stdlib = require("./kotlin-kotlin-stdlib.js");
+    var lib1 = require("./lib1.js");
+    switch (step) {
+        case 0:
+            return lib1.consumeCollection(stdlib.kotlin.collections.KtMap.fromJsMap(new Map([['foo', 'OK']])));
+        case 1:
+            // TODO(KT-70622): Delete this 'if'
+            if (typeof stdlib.kotlin.collections.KtList === 'undefined') {
+                return 'OK';
+            }
+            return lib1.consumeCollection(stdlib.kotlin.collections.KtList.fromJsArray(['OK']));
+        default:
+            return 'Fail';
+    }
+}

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.0.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.0.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function foo(): number;
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.1.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.1.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function bar(): number;
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.2.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.2.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function bar(name: string): string;
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.3.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.3.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function bar(name: string): string;
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.4.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportSurfaceUpdatesPerModule/main/m.4.d.ts
@@ -1,3 +1,72 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function box(): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.0.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.0.d.ts
@@ -1,3 +1,72 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function box(stepId: number, isWasm: boolean): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.1.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.1.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function foo(): number;
 export declare function box(stepId: number, isWasm: boolean): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.2.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.2.d.ts
@@ -1,4 +1,73 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function bar(): number;
 export declare function box(stepId: number, isWasm: boolean): string;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.3.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.3.d.ts
@@ -1,5 +1,74 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare function bar(): number;
 export declare class MyClass {
     constructor(stepId: number);

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.4.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.4.d.ts
@@ -1,5 +1,74 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare class MyClass {
     constructor(stepId: number);
     get stepId(): number;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.5.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.5.d.ts
@@ -1,5 +1,74 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare class MyClass {
     constructor(stepId: number);
     get stepId(): number;

--- a/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.6.d.ts
+++ b/js/js.translator/testData/incremental/invalidation/typeScriptExportsPerModule/main/m.6.d.ts
@@ -1,5 +1,74 @@
 type Nullable<T> = T | null | undefined
 declare function KtSingleton<T>(): T & (abstract new() => any);
+export declare interface KtSet<out E> /* extends Collection<E> */ {
+    asJsReadonlySetView(): ReadonlySet<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtSet": unique symbol;
+    };
+}
+export declare namespace KtSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtSet<E>;
+}
+export declare interface KtList<out E> /* extends Collection<E> */ {
+    asJsReadonlyArrayView(): ReadonlyArray<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtList": unique symbol;
+    };
+}
+export declare namespace KtList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtList<E>;
+}
+export declare interface KtMap<K, out V> {
+    asJsReadonlyMapView(): ReadonlyMap<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMap": unique symbol;
+    };
+}
+export declare namespace KtMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMap<K, V>;
+}
+export declare interface KtMutableSet<E> extends KtSet<E>/*, MutableCollection<E> */ {
+    asJsSetView(): Set<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableSet": unique symbol;
+    } & KtSet<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableSet {
+    function fromJsSet<E>(set: ReadonlySet<E>): KtMutableSet<E>;
+}
+export declare interface KtMutableList<E> extends KtList<E>/*, MutableCollection<E> */ {
+    asJsArrayView(): Array<E>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableList": unique symbol;
+    } & KtList<any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableList {
+    function fromJsArray<E>(array: ReadonlyArray<E>): KtMutableList<E>;
+}
+export declare interface KtMutableMap<K, V> extends KtMap<K, V> {
+    asJsMapView(): Map<K, V>;
+    readonly __doNotUseOrImplementIt: {
+        readonly "kotlin.collections.KtMutableMap": unique symbol;
+    } & KtMap<any, any>["__doNotUseOrImplementIt"];
+}
+export declare namespace KtMutableMap {
+    function fromJsMap<K, V>(map: ReadonlyMap<K, V>): KtMutableMap<K, V>;
+}
+export declare class Pair<out A, out B> /* implements Serializable */ {
+    constructor(first: A, second: B);
+    get first(): A;
+    get second(): B;
+    toString(): string;
+    copy(first?: A, second?: B): Pair<A, B>;
+    hashCode(): number;
+    equals(other: Nullable<any>): boolean;
+}
+export declare namespace Pair {
+    /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+    namespace $metadata$ {
+        const constructor: abstract new <A, B>() => Pair<A, B>;
+    }
+}
 export declare class MyClass {
     constructor(stepId: number);
     get stepId(): number;


### PR DESCRIPTION
Adding or removing a reference to an implicitly exported declaration A
in an explicitly exported declaration B's type signature doesn't trigger
recompilation of the declaration A, which can lead to invalid .d.ts
or runtime errors, because a newly referenced implicitly exported
declarations wouldn't actually be exported.

We fix this by always exporting such declarations in dev mode.

This has the unpleasant side effect that .d.ts file can differ in dev
and production modes. As soon as we switch to the Analysis API-based
TypeScript export, this will no longer be an issue because
Analysis API-based TypeScript export won't support incremental
compilation, operating on the whole world instead.

^KT-70622 Fixed