### PR TITLE
[Gradle] Ensure Kotlin ecosystem plugin brings Kotlin Gradle plugin classes into build classpath

### DIFF
--- a/libraries/tools/gradle/kotlin-gradle-ecosystem-plugin/build.gradle.kts
+++ b/libraries/tools/gradle/kotlin-gradle-ecosystem-plugin/build.gradle.kts
@@ -18,6 +18,7 @@ gradlePlugin {
 
 dependencies {
     commonApi(platform(project(":kotlin-gradle-plugins-bom")))
+    commonApi(project(":kotlin-gradle-plugin"))
 }
 
 tasks.named<KotlinApiBuildTask>("apiBuild") {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
@@ -33,6 +33,7 @@ import  org.jetbrains.kotlin.build.report.metrics.*
 import org.jetbrains.kotlin.gradle.internals.asFinishLogMessage
 import org.jetbrains.kotlin.gradle.report.data.BuildExecutionData
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
+import org.jetbrains.kotlin.gradle.testbase.TestVersions.ThirdPartyDependencies.GRADLE_DEVELOCITY_PLUGIN_VERSION
 import kotlin.test.assertContains
 
 @DisplayName("Build reports")
@@ -779,6 +780,17 @@ class BuildReportsIT : KGPBaseTest() {
 
             val initScript = projectPath.resolve("init.gradle").createFile()
             initScript.modify {
+                val develocityClasspath = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_5)) {
+                    "classpath 'com.gradle:gradle-enterprise-gradle-plugin:$GRADLE_ENTERPRISE_PLUGIN_VERSION'"
+                } else {
+                    "classpath 'com.gradle:develocity-gradle-plugin:$GRADLE_DEVELOCITY_PLUGIN_VERSION'"
+                }
+                val applyPlugin = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_5)) {
+                    "it.pluginManager.apply(com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin)"
+                } else {
+                    "it.pluginManager.apply(com.gradle.develocity.agent.gradle.DevelocityPlugin)"
+                }
+
                 """
                     initscript {
                         repositories {
@@ -786,12 +798,12 @@ class BuildReportsIT : KGPBaseTest() {
                         }
 
                         dependencies {
-                            classpath 'com.gradle:gradle-enterprise-gradle-plugin:$GRADLE_ENTERPRISE_PLUGIN_VERSION'
+                            $develocityClasspath
                         }
                     }
 
                     beforeSettings {
-                        it.pluginManager.apply(com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin)
+                        $applyPlugin
                     }
                 """.trimIndent()
             }
@@ -803,7 +815,7 @@ class BuildReportsIT : KGPBaseTest() {
 
             build(
                 "compileKotlin",
-                "-I", "init.gradle",
+                "-I", "init.gradle", "-Dscan.dump",
                 enableBuildScan = true,
             )
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppMetadataResolutionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppMetadataResolutionIT.kt
@@ -287,9 +287,6 @@ class MppMetadataResolutionIT : KGPBaseTest() {
             }
 
             includeOtherProjectAsSubmodule("empty", newSubmoduleName = "androidxCollectionWrapper") {
-                plugins {
-                    kotlin("multiplatform")
-                }
                 buildScriptInjection {
                     project.applyMultiplatform {
                         applyKmpTargets()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/settings/EcosystemPluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/settings/EcosystemPluginIT.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.settings
+
+import org.gradle.kotlin.dsl.withType
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import org.jetbrains.kotlin.gradle.testbase.GradleTest
+import org.jetbrains.kotlin.gradle.testbase.JvmGradlePluginTests
+import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
+import org.jetbrains.kotlin.gradle.testbase.TestVersions
+import org.jetbrains.kotlin.gradle.testbase.addDefaultSettingsToSettingsGradle
+import org.jetbrains.kotlin.gradle.testbase.addEcosystemPluginToBuildScriptCompilationClasspath
+import org.jetbrains.kotlin.gradle.testbase.build
+import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
+import org.jetbrains.kotlin.gradle.testbase.plugins
+import org.jetbrains.kotlin.gradle.testbase.project
+import org.jetbrains.kotlin.gradle.testbase.settingsBuildScriptInjection
+import org.jetbrains.kotlin.gradle.testbase.source
+import org.junit.jupiter.api.DisplayName
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+
+@DisplayName("Kotlin ecosystem plugin")
+@JvmGradlePluginTests
+class EcosystemPluginIT : KGPBaseTest() {
+
+    @DisplayName("Works in buildSrc")
+    @GradleTest
+    fun testWithBuildSrc(
+        gradleVersion: GradleVersion
+    ) {
+        project("emptyKts", gradleVersion) {
+            addEcosystemPluginToBuildScriptCompilationClasspath()
+
+            settingsBuildScriptInjection {
+                settings.plugins.apply("org.jetbrains.kotlin.ecosystem")
+            }
+
+            with(subProject("buildSrc")) {
+                projectPath.createDirectories()
+                buildGradleKts.createFile()
+                settingsGradleKts.createFile()
+                projectPath.addDefaultSettingsToSettingsGradle(gradleVersion)
+
+                addEcosystemPluginToBuildScriptCompilationClasspath(buildOptions.kotlinVersion)
+
+                settingsBuildScriptInjection {
+                    settings.plugins.apply("org.jetbrains.kotlin.ecosystem")
+                    settings.dependencyResolutionManagement.repositories {
+                        it.mavenLocal()
+                        it.mavenCentral()
+                    }
+                }
+
+                plugins {
+                    id("kotlin-dsl")
+                }
+
+                if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_0)) {
+                    buildScriptInjection {
+                        @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
+                        kotlinJvm.compilerVersion.set("2.1.0")
+
+                        // this code can be unwrapped from afterEvaluate after upgrading minimal supported Gradle version to 8.2 or newer
+                        project.afterEvaluate {
+                            project.tasks.withType<KotlinJvmCompile>().configureEach {
+                                @Suppress("DEPRECATION_ERROR")
+                                it.compilerOptions {
+                                    apiVersion.set(KotlinVersion.KOTLIN_1_8)
+                                    languageVersion.set(KotlinVersion.KOTLIN_1_8)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                kotlinSourcesDir().source("test.kt") {
+                    """
+                    fun test() = Unit
+                    """.trimIndent()
+                }
+            }
+
+
+            build("help")
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testDsl.kt
@@ -263,7 +263,7 @@ private fun TestProject.buildWithAction(
     action: GradleRunner.() -> BuildResult = GradleRunner::build,
 ) {
     with(parameters) {
-        if (enableBuildScan) agreeToBuildScanService()
+        if (enableBuildScan) agreeToBuildScanService(gradleVersion)
         ensureKotlinCompilerArgumentsPluginAppliedCorrectly(buildOptions)
 
         val runWithDebug = enableGradleDebug.toBooleanFlag()
@@ -1091,20 +1091,33 @@ internal fun Path.addDependencyManagementToSettings(
     }
 }
 
-private fun TestProject.agreeToBuildScanService() {
+private fun TestProject.agreeToBuildScanService(gradleVersion: GradleVersion) {
     val settingsFile = if (Files.exists(settingsGradle)) settingsGradle else settingsGradleKts
-    settingsFile.append(
-        """
-            
-        gradleEnterprise {
-            buildScan {
-                termsOfServiceUrl = "https://gradle.com/terms-of-service"
-                termsOfServiceAgree = "yes"
-            }
-        }
-
-        """.trimIndent()
-    )
+    if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_5)) {
+        settingsFile.appendText(
+            """
+            |                    
+            |gradleEnterprise {
+            |    buildScan {
+            |        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            |         termsOfServiceAgree = "yes"
+            |    }
+            |}
+            """.trimMargin()
+        )
+    } else {
+        settingsFile.appendText(
+            """
+            |
+            |develocity {
+            |    buildScan {
+            |        termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+            |        termsOfUseAgree = "yes"
+            |    }
+            |}
+            """.trimMargin()
+        )
+    }
 }
 
 private fun BuildResult.printBuildScanUrl() {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testGradleBuildInjection.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testGradleBuildInjection.kt
@@ -544,7 +544,12 @@ fun TestProject.addAgpToBuildScriptCompilationClasspath(androidVersion: String) 
 }
 
 fun TestProject.addEcosystemPluginToBuildScriptCompilationClasspath() {
-    val kotlinVersion = buildOptions.kotlinVersion
+    addEcosystemPluginToBuildScriptCompilationClasspath(buildOptions.kotlinVersion)
+}
+
+fun GradleProject.addEcosystemPluginToBuildScriptCompilationClasspath(
+    kotlinVersion: String
+) {
     settingsBuildScriptBuildscriptBlockInjection {
         settings.buildscript.configurations.getByName("classpath").dependencies.add(
             settings.buildscript.dependencies.create("org.jetbrains.kotlin:kotlin-gradle-ecosystem-plugin:$kotlinVersion")
@@ -555,7 +560,7 @@ fun TestProject.addEcosystemPluginToBuildScriptCompilationClasspath() {
 /**
  * This helper method works similar to "plugins {}" block in the build script; it resolves the POM pointer to the plugin jar and applies the plugin
  */
-fun TestProject.plugins(build: PluginDependenciesSpec.() -> Unit) {
+fun GradleProject.plugins(build: PluginDependenciesSpec.() -> Unit) {
     val spec = TestPluginDependenciesSpec()
     spec.build()
     transferPluginRepositoriesIntoBuildScript()

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/kotlin-gradle-ecosystem-plugin.module
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/kotlin-gradle-ecosystem-plugin.module
@@ -27,6 +27,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -120,6 +153,39 @@
                 "org.gradle.plugin.api-version": "8.0"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -252,6 +318,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -380,6 +479,39 @@
                 "org.gradle.plugin.api-version": "8.11"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -512,6 +644,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -640,6 +805,39 @@
                 "org.gradle.plugin.api-version": "8.13"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -772,6 +970,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -900,6 +1131,39 @@
                 "org.gradle.plugin.api-version": "8.1"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -1032,6 +1296,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -1160,6 +1457,39 @@
                 "org.gradle.plugin.api-version": "8.2"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -1292,6 +1622,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -1420,6 +1783,39 @@
                 "org.gradle.plugin.api-version": "8.5"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -1552,6 +1948,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -1680,6 +2109,39 @@
                 "org.gradle.plugin.api-version": "8.6"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -1812,6 +2274,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -1942,6 +2437,39 @@
             "dependencies": [
                 {
                     "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
                     "version": {
                         "requires": "ArtifactsTest.version"
@@ -2070,6 +2598,39 @@
                 "org.gradle.plugin.api-version": "8.8"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",
@@ -2219,6 +2780,39 @@
                 "org.gradle.libraryelements": "jar"
             },
             "dependencies": [
+                {
+                    "group": "org.jetbrains.kotlin",
+                    "module": "kotlin-gradle-plugin",
+                    "version": {
+                        "requires": "ArtifactsTest.version"
+                    },
+                    "excludes": [
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-reflect"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-script-runtime"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-common"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk7"
+                        },
+                        {
+                            "group": "org.jetbrains.kotlin",
+                            "module": "kotlin-stdlib-jdk8"
+                        }
+                    ]
+                },
                 {
                     "group": "org.jetbrains.kotlin",
                     "module": "kotlin-gradle-plugin-api",

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/kotlin-gradle-ecosystem-plugin.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/kotlin-gradle-ecosystem-plugin.pom
@@ -74,5 +74,37 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-gradle-plugin</artifactId>
+      <version>ArtifactsTest.version</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-reflect</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk7</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-script-runtime</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Due to Gradle classloaders hierarchy - depending only on Kotlin Gradle
plugins, bom is not enough, as BOM is not applied to child classloaders.
To fix it, ecosystem plugin should bring Kotlin Gradle plugin as direct
dependency, so it will override any versions from child sub-classloaders.

This change should be fine as now we allow users to just override Kotlin
 compiler version via 'kotlin.compilerVersion', so pinning KGP version
 should not be a problem for them.

 ^KT-78294 Verification Pending
