### PR TITLE
[Parcelize] Do not generate IR with out-of-scope type parameters

### DIFF
--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
@@ -53,7 +53,7 @@ class AndroidSymbols(
     private val androidOsBundle: IrClassSymbol =
         createClass(androidOs, "Bundle", ClassKind.CLASS, Modality.FINAL)
 
-    private val androidOsIBinder: IrClassSymbol =
+    val androidOsIBinder: IrClassSymbol =
         createClass(androidOs, "IBinder", ClassKind.INTERFACE, Modality.ABSTRACT)
 
     val androidOsParcel: IrClassSymbol =

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializerFactory.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializerFactory.kt
@@ -5,15 +5,19 @@
 
 package org.jetbrains.kotlin.parcelize
 
-import org.jetbrains.kotlin.ir.util.erasedUpperBound
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.ValueClassBackendAgnosticApi
 import org.jetbrains.kotlin.ir.IrBuiltIns
+import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
 import org.jetbrains.kotlin.ir.declarations.inlineClassRepresentation
 import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyClassBase
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.util.erasedUpperBound
 import org.jetbrains.kotlin.ir.util.getArrayElementType
 import org.jetbrains.kotlin.ir.util.isNullable
 import org.jetbrains.kotlin.name.FqName
@@ -261,9 +265,9 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols, private val
                 val actualSerializer =
                     when (classifierFqName) {
                         in BuiltinParcelableTypes.IMMUTABLE_LIST_FQNAMES ->
-                            listSerializer.withDeserializationPostprocessing(symbols.kotlinIterableToPersistentListExtension)
+                            listSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension)
                         in BuiltinParcelableTypes.IMMUTABLE_SET_FQNAMES ->
-                            listSerializer.withDeserializationPostprocessing(symbols.kotlinIterableToPersistentSetExtension)
+                            listSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentSetExtension)
                         else -> listSerializer
                     }
 
@@ -281,7 +285,7 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols, private val
 
                 val actualSerializer =
                     if (classifierFqName in BuiltinParcelableTypes.IMMUTABLE_MAP_FQNAMES)
-                        mapSerializer.withDeserializationPostprocessing(symbols.kotlinMapToPersistentMapExtension)
+                        mapSerializer.convertDeserializedToPersistent(symbols.kotlinMapToPersistentMapExtension)
                     else
                         mapSerializer
                 return wrapNullableSerializerIfNeeded(irType, actualSerializer)
@@ -358,19 +362,27 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols, private val
     private fun wrapNullableSerializerIfNeeded(irType: IrType, serializer: IrParcelSerializer) =
         if (irType.isNullable()) IrNullAwareParcelSerializer(serializer) else serializer
 
+    private fun IrParcelSerializer.convertDeserializedToPersistent(mapper: IrSimpleFunctionSymbol): IrParcelSerializer =
+        object : IrParcelSerializer by this {
+            override fun AndroidIrBuilder.readParcel(parcel: IrValueDeclaration): IrExpression {
+                val readResult = with(this@convertDeserializedToPersistent) { readParcel(parcel) }
+                return irCall(mapper).apply { arguments[0] = readResult }
+            }
+        }
+
     private val irBuiltIns: IrBuiltIns
         get() = symbols.irBuiltIns
 
     private val stringArraySerializer = IrSimpleParcelSerializer(symbols.parcelCreateStringArray, symbols.parcelWriteStringArray)
     private val stringListSerializer = IrSimpleParcelSerializer(symbols.parcelCreateStringArrayList, symbols.parcelWriteStringList)
     private val stringPersistentListSerializer by lazy {
-        stringListSerializer.withDeserializationPostprocessing(symbols.kotlinIterableToPersistentListExtension)
+        stringListSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension)
     }
     private val iBinderSerializer = IrSimpleParcelSerializer(symbols.parcelReadStrongBinder, symbols.parcelWriteStrongBinder)
     private val iBinderArraySerializer = IrSimpleParcelSerializer(symbols.parcelCreateBinderArray, symbols.parcelWriteBinderArray)
     private val iBinderListSerializer = IrSimpleParcelSerializer(symbols.parcelCreateBinderArrayList, symbols.parcelWriteBinderList)
     private val iBinderPersistentListSerializer by lazy {
-        iBinderListSerializer.withDeserializationPostprocessing(symbols.kotlinIterableToPersistentListExtension)
+        iBinderListSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension)
     }
     private val serializableSerializer = IrSimpleParcelSerializer(symbols.parcelReadSerializable, symbols.parcelWriteSerializable)
     private val stringSerializer = IrSimpleParcelSerializer(symbols.parcelReadString, symbols.parcelWriteString)

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializerFactory.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializerFactory.kt
@@ -265,9 +265,9 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols, private val
                 val actualSerializer =
                     when (classifierFqName) {
                         in BuiltinParcelableTypes.IMMUTABLE_LIST_FQNAMES ->
-                            listSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension)
+                            listSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension, listOf(elementType))
                         in BuiltinParcelableTypes.IMMUTABLE_SET_FQNAMES ->
-                            listSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentSetExtension)
+                            listSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentSetExtension, listOf(elementType))
                         else -> listSerializer
                     }
 
@@ -285,7 +285,7 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols, private val
 
                 val actualSerializer =
                     if (classifierFqName in BuiltinParcelableTypes.IMMUTABLE_MAP_FQNAMES)
-                        mapSerializer.convertDeserializedToPersistent(symbols.kotlinMapToPersistentMapExtension)
+                        mapSerializer.convertDeserializedToPersistent(symbols.kotlinMapToPersistentMapExtension, listOf(keyType, valueType))
                     else
                         mapSerializer
                 return wrapNullableSerializerIfNeeded(irType, actualSerializer)
@@ -362,11 +362,17 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols, private val
     private fun wrapNullableSerializerIfNeeded(irType: IrType, serializer: IrParcelSerializer) =
         if (irType.isNullable()) IrNullAwareParcelSerializer(serializer) else serializer
 
-    private fun IrParcelSerializer.convertDeserializedToPersistent(mapper: IrSimpleFunctionSymbol): IrParcelSerializer =
+    private fun IrParcelSerializer.convertDeserializedToPersistent(
+        mapper: IrSimpleFunctionSymbol,
+        returnTypeArguments: List<IrType>,
+    ): IrParcelSerializer =
         object : IrParcelSerializer by this {
             override fun AndroidIrBuilder.readParcel(parcel: IrValueDeclaration): IrExpression {
                 val readResult = with(this@convertDeserializedToPersistent) { readParcel(parcel) }
-                return irCall(mapper).apply { arguments[0] = readResult }
+                val returnType = mapper.owner.returnType.classifierOrFail.typeWith(returnTypeArguments)
+                return irCall(mapper, returnType).apply {
+                    arguments[0] = readResult
+                }
             }
         }
 
@@ -376,13 +382,13 @@ class IrParcelSerializerFactory(private val symbols: AndroidSymbols, private val
     private val stringArraySerializer = IrSimpleParcelSerializer(symbols.parcelCreateStringArray, symbols.parcelWriteStringArray)
     private val stringListSerializer = IrSimpleParcelSerializer(symbols.parcelCreateStringArrayList, symbols.parcelWriteStringList)
     private val stringPersistentListSerializer by lazy {
-        stringListSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension)
+        stringListSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension, listOf(irBuiltIns.stringType))
     }
     private val iBinderSerializer = IrSimpleParcelSerializer(symbols.parcelReadStrongBinder, symbols.parcelWriteStrongBinder)
     private val iBinderArraySerializer = IrSimpleParcelSerializer(symbols.parcelCreateBinderArray, symbols.parcelWriteBinderArray)
     private val iBinderListSerializer = IrSimpleParcelSerializer(symbols.parcelCreateBinderArrayList, symbols.parcelWriteBinderList)
     private val iBinderPersistentListSerializer by lazy {
-        iBinderListSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension)
+        iBinderListSerializer.convertDeserializedToPersistent(symbols.kotlinIterableToPersistentListExtension, listOf(symbols.androidOsIBinder.defaultType))
     }
     private val serializableSerializer = IrSimpleParcelSerializer(symbols.parcelReadSerializable, symbols.parcelWriteSerializable)
     private val stringSerializer = IrSimpleParcelSerializer(symbols.parcelReadString, symbols.parcelWriteString)

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
@@ -552,15 +552,18 @@ class IrMapParcelSerializer(
             +parcelWriteInt(irGet(parcel), irCall(sizeFunction).apply {
                 dispatchReceiver = irGet(list)
             })
-            val iterator = irTemporary(irCall(iteratorFunction).apply {
-                dispatchReceiver = irCall(entriesFunction).apply {
+            val entryType = elementClass.symbol.typeWith(keyType, valueType)
+            val entriesType = entrySetClass.symbol.typeWith(entryType)
+            val iteratorType = iteratorClass.symbol.typeWith(entryType)
+            val iterator = irTemporary(irCall(iteratorFunction.symbol, iteratorType).apply {
+                dispatchReceiver = irCall(entriesFunction, entriesType).apply {
                     dispatchReceiver = irGet(list)
                 }
             })
             +irWhile().apply {
                 condition = irCall(iteratorHasNext).apply { dispatchReceiver = irGet(iterator) }
                 body = irBlock {
-                    val element = irTemporary(irCall(iteratorNext).apply {
+                    val element = irTemporary(irCall(iteratorNext.symbol, entryType).apply {
                         dispatchReceiver = irGet(iterator)
                     })
                     +writeParcelWith(keySerializer, parcel, flags, irCall(elementKey, keyType).apply {
@@ -620,12 +623,19 @@ class IrMapParcelSerializer(
         return irBlock {
             (val constructorSymbol = constructor, val putSymbol = function) = mapSymbols(androidSymbols)
             val sizeTemporary = irTemporary(parcelReadInt(irGet(parcel)))
-            val map = irTemporary(irCall(constructorSymbol).apply {
+            val constructorCall = if (constructorSymbol.owner.parentAsClass.typeParameters.isEmpty()) {
+                irCall(constructorSymbol)
+            } else {
+                irCallConstructor(constructorSymbol, listOf(keyType, valueType)).apply {
+                    type = constructorSymbol.owner.parentAsClass.symbol.typeWith(keyType, valueType)
+                }
+            }
+            val map = irTemporary(constructorCall.apply {
                 if (constructorSymbol.owner.parameters.isNotEmpty())
                     arguments[0] = irGet(sizeTemporary)
             })
             forUntil(irGet(sizeTemporary)) {
-                +irCall(putSymbol).apply {
+                +irCall(putSymbol, context.irBuiltIns.anyNType).apply {
                     arguments[0] = irGet(map)
                     arguments[1] = readParcelWith(keySerializer, parcel)
                     arguments[2] = readParcelWith(valueSerializer, parcel)

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
@@ -444,7 +444,7 @@ class IrListParcelSerializer(
             +parcelWriteInt(irGet(parcel), irCall(sizeFunction).apply {
                 arguments[0] = irGet(list)
             })
-            val iterator = irTemporary(irCall(iteratorFunction).apply {
+            val iterator = irTemporary(irCall(iteratorFunction.symbol, iteratorClass.symbol.typeWith(elementType)).apply {
                 arguments[0] = irGet(list)
             })
             +irWhile().apply {
@@ -506,7 +506,11 @@ class IrListParcelSerializer(
         return irBlock {
             (val constructorSymbol = constructor, val addSymbol = function) = listSymbols(androidSymbols)
             val sizeTemporary = irTemporary(parcelReadInt(irGet(parcel)))
-            val list = irTemporary(irCall(constructorSymbol).apply {
+            val typeArguments = constructorSymbol.owner.parentAsClass.typeParameters.map { elementType }
+            val constructorCall = irCallConstructor(constructorSymbol, typeArguments).apply {
+                type = constructorSymbol.owner.parentAsClass.symbol.typeWith(typeArguments)
+            }
+            val list = irTemporary(constructorCall.apply {
                 if (constructorSymbol.owner.parameters.isNotEmpty())
                     arguments[0] = irGet(sizeTemporary)
             })

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
@@ -360,7 +360,9 @@ class IrSparseArrayParcelSerializer(
             val constructorCall = if (sparseArrayClass.typeParameters.isEmpty())
                 irCall(sparseArrayConstructor)
             else
-                irCallConstructor(sparseArrayConstructor.symbol, listOf(elementType))
+                irCallConstructor(sparseArrayConstructor.symbol, listOf(elementType)).apply {
+                    type = sparseArrayClass.symbol.typeWith(elementType)
+                }
 
             val arrayTemporary = irTemporary(constructorCall.apply {
                 arguments[0] = irGet(remainingSizeTemporary)

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
@@ -45,14 +45,6 @@ fun AndroidIrBuilder.writeParcelWith(
     return with(serializer) { writeParcel(parcel, flags, value) }
 }
 
-fun IrParcelSerializer.withDeserializationPostprocessing(mapper: IrSimpleFunctionSymbol): IrParcelSerializer =
-    object : IrParcelSerializer by this {
-        override fun AndroidIrBuilder.readParcel(parcel: IrValueDeclaration): IrExpression {
-            val readResult = with(this@withDeserializationPostprocessing) { readParcel(parcel) }
-            return irCall(mapper).apply { arguments[0] = readResult }
-        }
-    }
-
 // Creates a serializer from a pair of parcel methods of the form reader()T and writer(T)V.
 class IrSimpleParcelSerializer(private val reader: IrSimpleFunctionSymbol, private val writer: IrSimpleFunctionSymbol) :
     IrParcelSerializer {

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
@@ -706,7 +706,7 @@ class IrUuidParcelSerializer(
         )
         val toLongs = requireNotNull(irClass.getSimpleFunction("toLongs")) { "method kotlin.uuid.Uuid.toLongs not found" }
         return irBlock {
-            +irCall(toLongs).apply {
+            +irCall(toLongs, context.irBuiltIns.unitType, listOf(context.irBuiltIns.unitType)).apply {
                 arguments[0] = value
                 arguments[1] = lambdaExpr
             }

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelSerializers.kt
@@ -240,11 +240,17 @@ class IrDataClassParcelSerializer(
     override fun AndroidIrBuilder.writeParcel(parcel: IrValueDeclaration, flags: IrValueDeclaration, value: IrExpression): IrExpression =
         irBlock {
             val temporary = irTemporary(value)
+            val substitutionMap = type.classOrFail.owner.typeParameters.map { it.symbol }
+                .zip((type as IrSimpleType).arguments.map { it.typeOrNull ?: context.irBuiltIns.anyNType }).toMap()
             properties.forEach { [member, serializer] ->
                 val receiverValue = irGet(temporary)
-                val propertyValue = member.owner.getter?.let { irCall(it).apply { dispatchReceiver = receiverValue } }
-                    ?: member.owner.backingField?.let { irGetField(receiverValue, it) }
-                    ?: error("$member is a data class property with no backing field?")
+                val propertyType = member.owner.getter?.returnType
+                    ?: member.owner.backingField?.type
+                    ?: error("$member is a data class property with no getter or backing field?")
+                val substitutedType = propertyType.substitute(substitutionMap)
+                val propertyValue = member.owner.getter?.let { irCall(it.symbol, substitutedType).apply { dispatchReceiver = receiverValue } }
+                        ?: member.owner.backingField?.let { irGetField(receiverValue, it, substitutedType) }
+                        ?: error("$member is a data class property with no backing field?")
                 +writeParcelWith(serializer, parcel, flags, propertyValue)
             }
         }

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/irUtils.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/irUtils.kt
@@ -107,7 +107,13 @@ fun IrBuilderWithScope.parcelableCreatorCreateFromParcel(creator: IrExpression, 
         function.name == CREATE_FROM_PARCEL_NAME && function.overridesFunctionIn(CREATOR_FQN)
     }
 
-    return irCall(createFromParcel).apply {
+    val creatorSupertype = buildList {
+        add(creator.type)
+        addAll(creator.type.superTypes())
+    }.first { it.classFqName == CREATOR_FQN } as? IrSimpleType
+    val createdType = creatorSupertype?.arguments?.singleOrNull()?.typeOrNull ?: context.irBuiltIns.anyNType
+
+    return irCall(createFromParcel.symbol, createdType).apply {
         arguments[0] = creator
         arguments[1] = parcel
     }

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/efficientParcelable.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/efficientParcelable.asm.txt
@@ -18,8 +18,8 @@ public final class test/Bar$Creator : java/lang/Object, android/os/Parcelable$Cr
           GETSTATIC (test/Foo, CREATOR, Landroid/os/Parcelable$Creator;)
           ALOAD (1)
           INVOKEINTERFACE (android/os/Parcelable$Creator, createFromParcel, (Landroid/os/Parcel;)Ljava/lang/Object;)
-        LABEL (L3)
           CHECKCAST (test/Foo)
+        LABEL (L3)
           INVOKESPECIAL (test/Bar, <init>, (Ltest/Foo;)V)
           ARETURN
         LABEL (L4)


### PR DESCRIPTION
All Parcelize tests now are green after uncommenting [this](https://github.com/JetBrains/kotlin/blob/8723063d1970a57d7d6c5482d1cec6405cd3839f/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt#L509) line

Corresponding issue: `b/524008575`