### PR TITLE
KT-86057: Force yarn install when upgrading lock file

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PackageManagerGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PackageManagerGradlePluginIT.kt
@@ -159,6 +159,36 @@ class YarnGradlePluginIT : PackageManagerGradlePluginIT() {
     override val setProperty: (String) -> String = { " = $it" }
 
     override val mismatchReportMessage: String = YarnPlugin.yarnLockMismatchMessage(upgradeTaskName)
+
+    @DisplayName("js composite build works with lock file persistence")
+    @GradleTest
+    @JsGradlePluginTests
+    fun yarnStoreLockAlwaysTriggersNpmInstall(gradleVersion: GradleVersion) {
+        project(
+            "js-composite-build",
+            gradleVersion,
+            // `:compileKotlinJs` task is not compatible with CC on Gradle 7
+            buildOptions = defaultBuildOptions.disableConfigurationCacheForGradle7(gradleVersion),
+        ) {
+            // 1st run
+            build(upgradeTaskName) {
+                assertTasksExecuted(":kotlinNpmInstall")
+            }
+
+            // 1st run, npmInstall should be up to date
+            // --force flag is not set because upgradeTaskName is not requested
+            // all input/outputs didn't change since last run
+            build(storeTaskName) {
+                assertTasksUpToDate(":kotlinNpmInstall")
+            }
+
+            // 3rd run, npmInstall must re-run
+            // upgradeTaskName is requested, so --force flag is set
+            build(upgradeTaskName) {
+                assertTasksExecuted(":kotlinNpmInstall")
+            }
+        }
+    }
 }
 
 abstract class PackageManagerGradlePluginIT : KGPBaseTest() {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinNpmInstallTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinNpmInstallTask.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.targets.js.npm.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.work.NormalizeLineEndings
@@ -16,6 +17,7 @@ import org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager
 import org.jetbrains.kotlin.gradle.targets.js.npm.NodeJsEnvironmentTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.PackageJsonFilesTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.UsesKotlinNpmResolutionManager
+import org.jetbrains.kotlin.gradle.utils.property
 
 @DisableCachingByDefault
 abstract class KotlinNpmInstallTask :
@@ -46,11 +48,21 @@ abstract class KotlinNpmInstallTask :
 
     private val isOffline = project.gradle.startParameter.isOffline()
 
+    @get:Internal // tracks below
+    internal val withForce: Property<Boolean> = project.objects.property<Boolean>().convention(false)
+
+    init {
+        // When --force flag is set, task must re-run; when not set, use previous state
+        outputs.upToDateWhen { !withForce.get() }
+        outputs.doNotCacheIf("--force flag set, task must re-run") { withForce.get() }
+    }
+
     @TaskAction
     fun resolve() {
         val args = buildList {
             addAll(args)
             if (isOffline) add("--offline")
+            if (withForce.get()) add("--force")
         }
 
         npmResolutionManager.get()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPluginApplier.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPluginApplier.kt
@@ -103,10 +103,22 @@ internal class YarnPluginApplier(
             }
         }
 
+        val upgradeLockTaskName = platformDisambiguate.extensionName(UPGRADE_YARN_LOCK_BASE_NAME)
+
         val kotlinNpmInstall = project.tasks.named(platformDisambiguate.extensionName(KotlinNpmInstallTask.BASE_NAME))
-        kotlinNpmInstall.configure {
-            it.dependsOn(setupTask)
-            it.inputs.property("yarnIgnoreScripts", yarnRootExtension.ignoreScriptsProperty)
+        kotlinNpmInstall.configure { task ->
+            task.dependsOn(setupTask)
+            task.inputs.property("yarnIgnoreScripts", yarnRootExtension.ignoreScriptsProperty)
+
+            if (task is KotlinNpmInstallTask) {
+                // This works around the problem when yarn upgrade changes lock file format, but not the content.
+                // And the same yarn version, package.json and package.lock files can produce different results:
+                // 1. old lock file + provisioned node_modules + yarn install -> lock remained untouched
+                // 2. old lock file + empty node_modules + yarn install -> lock file format changed
+                // So when `kotlinUpgradeYarnLock` is requested we should yarn install with --force to have a consistent lock file
+                // FIXME: This property should be removed during KT-84782 (Improve KGP JS UX)
+                task.withForce.set(project.provider { project.gradle.taskGraph.hasTask(":$upgradeLockTaskName") })
+            }
         }
 
         yarnRootExtension.nodeJsEnvironment.value(
@@ -128,7 +140,7 @@ internal class YarnPluginApplier(
 
         val upgradeYarnLock =
             project.tasks.register(
-                platformDisambiguate.extensionName(UPGRADE_YARN_LOCK_BASE_NAME),
+                upgradeLockTaskName,
                 YarnLockUpgradeTask::class.java
             ) { task ->
                 task.dependsOn(kotlinNpmInstall)

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/WebTargetTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/WebTargetTests.kt
@@ -5,12 +5,17 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
+import org.jetbrains.kotlin.gradle.dependencyResolutionTests.configureRepositoriesForTests
+import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 import org.jetbrains.kotlin.gradle.util.assertDependsOn
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
 import org.jetbrains.kotlin.gradle.util.kotlin
+import org.jetbrains.kotlin.gradle.util.populateTaskGraph
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@Suppress("FunctionName")
 class WebTargetTests {
 
     @Test
@@ -84,5 +89,42 @@ class WebTargetTests {
         val kotlinWasmYarnSetup = project.tasks.named("kotlinWasmYarnSetup").get()
         kotlinWasmToolingSetup.assertDependsOn(kotlinWasmYarnSetup)
 
+    }
+
+    @Test
+    fun `yarn install should run with force when upgradeYarnLock task is requested`() {
+        val project = buildProjectWithMPP {
+            configureRepositoriesForTests()
+            kotlin { js { nodejs() } }
+        }
+        project.evaluate()
+
+        val upgradeYarnLock = project.tasks.findByName("kotlinUpgradeYarnLock")
+        assertNotNull(upgradeYarnLock, "kotlinUpgradeYarnLock task should exist")
+        project.populateTaskGraph(upgradeYarnLock)
+
+        val kotlinNpmInstall = project.tasks.named("kotlinNpmInstall").get() as KotlinNpmInstallTask
+        assertTrue(kotlinNpmInstall.withForce.get(), "kotlinNpmInstall must run with force")
+    }
+
+    @Test
+    fun `yarn install should not run with force when storeYarnLock task is requested`() {
+        val project = buildProjectWithMPP {
+            configureRepositoriesForTests()
+
+            kotlin {
+                js {
+                    nodejs()
+                }
+            }
+        }
+        project.evaluate()
+
+        val storeYarnLock = project.tasks.findByName("kotlinStoreYarnLock")
+        assertNotNull(storeYarnLock, "kotlinStoreYarnLock task should exist")
+        project.populateTaskGraph(storeYarnLock)
+
+        val kotlinNpmInstall = project.tasks.named("kotlinNpmInstall").get() as KotlinNpmInstallTask
+        assertTrue(!kotlinNpmInstall.withForce.get(), "kotlinNpmInstall must not run with force")
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/taskGraphUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/taskGraphUtils.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.util
+
+import org.gradle.api.Task
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.execution.plan.ExecutionPlanFactory
+
+/**
+ * This utility should be used when task graph is checked in KGP
+ * Most likely project will require Repositories to resolve dependencies
+ * This will not execute tasks though.
+ */
+fun ProjectInternal.populateTaskGraph(vararg entryTasks: Task) {
+    evaluate()
+
+    val executionPlanFactory = gradle.services.get(ExecutionPlanFactory::class.java)
+    val plan = executionPlanFactory.createPlan()
+
+    plan.addEntryTasks(entryTasks.toList())
+
+    // this unwraps the plan from entryTasks
+    plan.determineExecutionPlan()
+    val final = plan.finalizePlan()
+
+    gradle.taskGraph.populate(final)
+}


### PR DESCRIPTION
Yarn install without --force can produce different results depening on presence of node_modules.

This complicates life of developers that upgrades their lock files locally (with populated node modules) and they suddenly hit lock file mismatches on CI where node_modules were not pre-populated.

`--force` makes this work consistently.