### PR TITLE
KT-86410, KT-75654…: Actualize common symbols for IC providers and refactor incremental providers setup

### DIFF
--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsConfigurator.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsConfigurator.kt
@@ -60,6 +60,7 @@ open class CommonCompilerArgumentsConfigurator {
             putAnalysisFlag(AnalysisFlags.headerMode, headerMode)
             putAnalysisFlag(AnalysisFlags.headerModeType, headerModeType)
             putAnalysisFlag(AnalysisFlags.hierarchicalMultiplatformCompilation, separateKmpCompilationScheme && multiPlatform)
+            putAnalysisFlag(AnalysisFlags.kmpJvmIncrementalCompilationEnabled, fragmentIncrementalClasspath.isNotEmpty() && multiPlatform)
             fillWarningLevelMap(arguments, reporter)
             ReturnValueCheckerMode.fromString(returnValueChecker)?.also { putAnalysisFlag(AnalysisFlags.returnValueCheckerMode, it) }
                 ?: reporter.reportError(

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/FirJKlibSessionFactory.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/FirJKlibSessionFactory.kt
@@ -163,18 +163,18 @@ object FirJKlibSessionFactory : FirAbstractSessionFactory<FirJKlibSessionFactory
                     JavaSymbolProvider(session, projectEnvironment.getFirJavaFacade(session, moduleData, javaSourcesScope))
                 session.register(JavaSymbolProvider::class, javaSymbolProvider)
 
-                val incrementalCompilationSymbolProviders = createIncrementalCompilationSymbolProviders(session)
-
                 val providers = listOfNotNull(
                     symbolProvider,
                     generatedSymbolsProvider,
-                    incrementalCompilationSymbolProviders?.symbolProviderForBinariesFromIncrementalCompilation,
                     javaSymbolProvider,
                     initializeForStdlibIfNeeded(projectEnvironment, session, kotlinScopeProvider),
                 )
+
+                val incrementalCompilationSymbolProviders = createIncrementalCompilationSymbolProviders(session)
                 SourceProviders(
                     providers,
-                    incrementalCompilationSymbolProviders?.optionalAnnotationClassesProviderForBinariesFromIncrementalCompilation
+                    incrementalProvider = incrementalCompilationSymbolProviders?.symbolProviderForBinariesFromIncrementalCompilation,
+                    additionalOptionalAnnotationsProvider = incrementalCompilationSymbolProviders?.optionalAnnotationClassesProviderForBinariesFromIncrementalCompilation
                 )
             }
         ).also {

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/FirJKlibSessionFactory.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/FirJKlibSessionFactory.kt
@@ -168,7 +168,6 @@ object FirJKlibSessionFactory : FirAbstractSessionFactory<FirJKlibSessionFactory
                 val providers = listOfNotNull(
                     symbolProvider,
                     generatedSymbolsProvider,
-                    *(incrementalCompilationSymbolProviders?.previousFirSessionsSymbolProviders?.toTypedArray() ?: emptyArray()),
                     incrementalCompilationSymbolProviders?.symbolProviderForBinariesFromIncrementalCompilation,
                     javaSymbolProvider,
                     initializeForStdlibIfNeeded(projectEnvironment, session, kotlinScopeProvider),

--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmFrontendPipelinePhase.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmFrontendPipelinePhase.kt
@@ -138,7 +138,6 @@ object JvmFrontendPipelinePhase : PipelinePhase<ConfigurationPipelineArtifact, J
         val [librariesScope, incrementalCompilationContext] = prepareIncrementalCompilationContextAndLibrariesScope(
             configuration,
             environment,
-            previousStepsSymbolProviders = emptyList(),
             incrementalExcludesScope = sourceScope
         )
 

--- a/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataFrontendPipelinePhase.kt
+++ b/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataFrontendPipelinePhase.kt
@@ -11,7 +11,10 @@ import org.jetbrains.kotlin.backend.common.loadMetadataKlibs
 import org.jetbrains.kotlin.cli.common.*
 import org.jetbrains.kotlin.cli.common.fir.FirDiagnosticsCompilerResultsReporter
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
-import org.jetbrains.kotlin.cli.jvm.compiler.*
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.prepareIncrementalCompilationContextAndLibrariesScope
+import org.jetbrains.kotlin.cli.jvm.compiler.toVfsBasedProjectEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.JvmClasspathRoot
 import org.jetbrains.kotlin.cli.jvm.config.K2MetadataConfigurationKeys
 import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
@@ -77,7 +80,6 @@ object MetadataFrontendPipelinePhase : PipelinePhase<ConfigurationPipelineArtifa
         val [librariesScope, incrementalCompilationContext] = prepareIncrementalCompilationContextAndLibrariesScope(
             configuration,
             projectEnvironment,
-            previousStepsSymbolProviders = emptyList(),
             incrementalExcludesScope = null
         )
 

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/IncrementalCompilationContextUtils.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/IncrementalCompilationContextUtils.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.cli.jvm.compiler
 
 import org.jetbrains.kotlin.config.*
-import org.jetbrains.kotlin.fir.resolve.providers.FirSymbolProvider
 import org.jetbrains.kotlin.fir.session.IncrementalCompilationContext
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope
 import org.jetbrains.kotlin.load.kotlin.incremental.IncrementalPackagePartProvider
@@ -30,18 +29,16 @@ private fun createIncrementalCompilationScope(
 fun prepareIncrementalCompilationContextAndLibrariesScope(
     configuration: CompilerConfiguration,
     projectEnvironment: VfsBasedProjectEnvironment,
-    previousStepsSymbolProviders: List<FirSymbolProvider>,
     incrementalExcludesScope: AbstractProjectFileSearchScope?
 ): Pair<AbstractProjectFileSearchScope, IncrementalCompilationContext?> {
     val incrementalCompilationScope = createIncrementalCompilationScope(configuration, projectEnvironment, incrementalExcludesScope)
 
     val originalLibrariesScope = projectEnvironment.getSearchScopeForProjectLibraries()
-    if (incrementalCompilationScope == null && previousStepsSymbolProviders.isEmpty()) return originalLibrariesScope to null
+    if (incrementalCompilationScope == null) return originalLibrariesScope to null
     val targetIds = configuration.modules.map(::TargetId)
     val incrementalComponents = configuration.incrementalCompilationComponents!!
 
     val context = IncrementalCompilationContext(
-        previousFirSessionsSymbolProviders = previousStepsSymbolProviders,
         precompiledBinariesPackagePartProvider = IncrementalPackagePartProvider(
             configuration.languageVersionSettings,
             targetIds.map(incrementalComponents::getIncrementalCache)
@@ -59,10 +56,6 @@ fun prepareIncrementalCompilationContextAndLibrariesScope(
      *
      * See also the corresponding comment in `IncrementalJvmCompilerRunnerBase.performWorkBeforeCompilation`
      */
-    val librariesScope = if (incrementalCompilationScope != null) {
-        originalLibrariesScope - incrementalCompilationScope
-    } else {
-        originalLibrariesScope
-    }
+    val librariesScope = originalLibrariesScope - incrementalCompilationScope
     return librariesScope to context
 }

--- a/compiler/config/src/org/jetbrains/kotlin/config/AnalysisFlags.kt
+++ b/compiler/config/src/org/jetbrains/kotlin/config/AnalysisFlags.kt
@@ -95,8 +95,12 @@ object AnalysisFlags {
     val lenientMode by AnalysisFlag.Delegates.Boolean
 
     val hierarchicalMultiplatformCompilation by AnalysisFlag.Delegates.Boolean(defaultValue = false)
+    val kmpJvmIncrementalCompilationEnabled by AnalysisFlag.Delegates.Boolean(defaultValue = false)
 
     val headerMode by AnalysisFlag.Delegates.Boolean
 
     val headerModeType by AnalysisFlag.Delegates.HeaderModeTypeAnyByDefault
 }
+
+val LanguageVersionSettings.hmppProvidersEnabled: Boolean
+    get() = getFlag(AnalysisFlags.hierarchicalMultiplatformCompilation) || getFlag(AnalysisFlags.kmpJvmIncrementalCompilationEnabled)

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/IrCommonToPlatformDependencyActualizerMapContributor.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/IrCommonToPlatformDependencyActualizerMapContributor.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.common.actualizer.IrActualizerMapContributor
 import org.jetbrains.kotlin.fir.FirModuleData
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.backend.Fir2IrComponents
+import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.fullyExpandedClass
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.resolve.providers.impl.FirCachingCompositeSymbolProvider
@@ -18,16 +19,10 @@ import org.jetbrains.kotlin.fir.session.NativeForwardDeclarationsSymbolProvider
 import org.jetbrains.kotlin.fir.session.structuredProviders
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.*
-import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
-import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
-import org.jetbrains.kotlin.ir.symbols.IrSymbol
-import org.jetbrains.kotlin.ir.symbols.IrTypeAliasSymbol
-import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.types.classOrFail
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.StandardClassIds
-import org.jetbrains.kotlin.utils.addIfNotNull
-import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
 
 
@@ -45,10 +40,10 @@ class IrCommonToPlatformDependencyActualizerMapContributor private constructor(
             val mappingProviders = mutableListOf<FirCommonDeclarationsMappingSymbolProvider>()
 
             fun process(session: FirSession) {
-                val mappingProvider = (session.symbolProvider as FirCachingCompositeSymbolProvider)
+                val mappingProvidersOfSesssion = (session.symbolProvider as FirCachingCompositeSymbolProvider)
                     .providers
-                    .firstIsInstanceOrNull<FirCommonDeclarationsMappingSymbolProvider>()
-                mappingProviders.addIfNotNull(mappingProvider)
+                    .filterIsInstance<FirCommonDeclarationsMappingSymbolProvider>()
+                mappingProviders.addAll(mappingProvidersOfSesssion)
                 for (dependency in session.moduleData.dependsOnDependencies) {
                     process(dependency.session)
                 }
@@ -180,7 +175,10 @@ class IrCommonToPlatformDependencyActualizerMapContributor private constructor(
     }
 
     private fun FirBasedSymbol<*>.properComponents(): Fir2IrComponents {
-        val sourceSession = dependencyToSourceSession.getValue(moduleData)
+        val sourceSession = when (origin) {
+            is FirDeclarationOrigin.Precompiled -> moduleData.session
+            else -> dependencyToSourceSession.getValue(moduleData)
+        }
         return componentsPerSession.getValue(sourceSession)
     }
 

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
@@ -301,7 +301,6 @@ private class Fir2IrPipeline(
                     outputs.last().session,
                     componentsStoragePerSourceSession,
                 ),
-                hmppSchemeEnabled = componentsStorage.session.languageVersionSettings.getFlag(AnalysisFlags.hierarchicalMultiplatformCompilation)
             )
         }
     }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/referenceAllCommonDependencies.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/referenceAllCommonDependencies.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.fir.pipeline
 
-import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.hmppProvidersEnabled
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.expressions.FirExpression
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitorVoid
 
 fun referenceAllCommonDependencies(outputs: List<SingleModuleFrontendOutput>) {
     val platformSession = outputs.last().session
-    if (!platformSession.languageVersionSettings.getFlag(AnalysisFlags.hierarchicalMultiplatformCompilation)) return
+    if (!platformSession.languageVersionSettings.hmppProvidersEnabled) return
     val visitor = Visitor(platformSession)
 
     val dependantFragments = outputs.dropLast(1)

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/AbstractFirKlibSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/AbstractFirKlibSessionFactory.kt
@@ -124,7 +124,7 @@ abstract class AbstractFirKlibSessionFactory<CONTEXT> : FirAbstractSessionFactor
             init,
             createProviders = { session, kotlinScopeProvider, symbolProvider, generatedSymbolsProvider ->
                 SourceProviders(
-                    listOfNotNull(
+                    sourceProviders = listOfNotNull(
                         symbolProvider,
                         generatedSymbolsProvider,
                         icData?.let {
@@ -136,7 +136,8 @@ abstract class AbstractFirKlibSessionFactory<CONTEXT> : FirAbstractSessionFactor
                                 flexibleTypeFactory = createFlexibleTypeFactory(session),
                             )
                         },
-                    )
+                    ),
+                    incrementalProvider = null,
                 )
             }
         )

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirAbstractSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirAbstractSessionFactory.kt
@@ -213,6 +213,7 @@ abstract class FirAbstractSessionFactory<CONTEXT> {
                 StructuredProviders::class,
                 StructuredProviders(
                     sourceProviders = emptyList(),
+                    incrementalProvider = null,
                     dependencyProviders = providers,
                     sharedProvider = when {
                         createSeparateSharedProviders -> FirEmptySymbolProvider(this)
@@ -299,7 +300,7 @@ abstract class FirAbstractSessionFactory<CONTEXT> {
             )
             val generatedSymbolsProvider = FirSwitchableExtensionDeclarationsSymbolProvider.createIfNeeded(this)
 
-            val (sourceProviders, additionalOptionalAnnotationsProvider) = createProviders(
+            val (sourceProviders, incrementalProvider, additionalOptionalAnnotationsProvider) = createProviders(
                 this,
                 kotlinScopeProvider,
                 firProvider.symbolProvider,
@@ -317,8 +318,16 @@ abstract class FirAbstractSessionFactory<CONTEXT> {
                 addIfNotNull(additionalOptionalAnnotationsProvider)
             }
 
+            val incrementalProviderCommonsMapping = computeIncrementalSymbolProvider(
+                session = this,
+                moduleData,
+                incrementalProviderOfCurrentModule = incrementalProvider,
+                properKmpIcIsEnabled = configuration.languageVersionSettings.getFlag(AnalysisFlags.kmpJvmIncrementalCompilationEnabled),
+            )
+
             val structuredProvidersForModule = StructuredProviders(
                 sourceProviders = sourceProviders,
+                incrementalProvider = incrementalProviderCommonsMapping,
                 dependencyProviders = allLibrariesProviders,
                 sharedProvider = structuredDependencyProvidersWithoutSource.sharedProvider,
             ).also {
@@ -330,7 +339,11 @@ abstract class FirAbstractSessionFactory<CONTEXT> {
                 addAll(structuredProvidersForModule.sharedProvider.flattenAndFilterOwnProviders())
             }.distinct()
 
-            val providersList = structuredProvidersForModule.sourceProviders + providersListWithoutSources
+            val providersList = buildList {
+                addAll(structuredProvidersForModule.sourceProviders)
+                addIfNotNull(incrementalProviderCommonsMapping)
+                addAll(providersListWithoutSources)
+            }
 
             register(
                 FirSymbolProvider::class,
@@ -350,6 +363,7 @@ abstract class FirAbstractSessionFactory<CONTEXT> {
 
     protected data class SourceProviders(
         val sourceProviders: List<FirSymbolProvider>,
+        val incrementalProvider: FirSymbolProvider?,
         val additionalOptionalAnnotationsProvider: FirSymbolProvider? = null,
     )
 
@@ -462,9 +476,36 @@ abstract class FirAbstractSessionFactory<CONTEXT> {
 
         return StructuredProviders(
             sourceProviders = emptyList(),
+            incrementalProvider = null,
             dependencyProviders,
             sharedProvider
         )
+    }
+
+    private fun computeIncrementalSymbolProvider(
+        session: FirSession,
+        moduleData: FirModuleData,
+        incrementalProviderOfCurrentModule: FirSymbolProvider?,
+        properKmpIcIsEnabled: Boolean,
+    ): FirSymbolProvider? {
+        return when {
+            incrementalProviderOfCurrentModule == null -> null
+            properKmpIcIsEnabled -> {
+                val structuredProvidersFromDependsOnFragments = moduleData.dependsOnDependencies
+                    .filter { it.session.kind == FirSession.Kind.Source }
+                    .mapNotNull { it.session.structuredProviders.incrementalProvider }
+                when {
+                    structuredProvidersFromDependsOnFragments.isEmpty() -> incrementalProviderOfCurrentModule
+                    else -> FirCommonDeclarationsMappingSymbolProvider(
+                        session,
+                        commonSymbolProvider = createCachingCompositeProviderIfNeeded(session, structuredProvidersFromDependsOnFragments.distinct()),
+                        platformSymbolProvider = incrementalProviderOfCurrentModule
+                    )
+                }
+            }
+            else -> incrementalProviderOfCurrentModule
+        }
+
     }
 
     /* It eliminates dependency and composite providers since the current dependency provider is composite in fact.

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmIncrementalCompilationSymbolProviders.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmIncrementalCompilationSymbolProviders.kt
@@ -75,7 +75,8 @@ fun createIncrementalProvidersForNonLeafMppModules(
         session,
         moduleDataProvider = SingleModuleDataProvider(moduleData),
         kotlinScopeProvider = session.kotlinScopeProvider,
-        resolvedLibraries
+        resolvedLibraries,
+        defaultDeserializationOrigin = FirDeclarationOrigin.Precompiled,
     )
     return FirJvmIncrementalCompilationSymbolProviders(
         symbolProviderForBinariesFromIncrementalCompilation = provider,

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmIncrementalCompilationSymbolProviders.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmIncrementalCompilationSymbolProviders.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
 data class FirJvmIncrementalCompilationSymbolProviders(
     val symbolProviderForBinariesFromIncrementalCompilation: FirSymbolProvider?,
-    val previousFirSessionsSymbolProviders: Collection<FirSymbolProvider>,
     val optionalAnnotationClassesProviderForBinariesFromIncrementalCompilation: OptionalAnnotationClassesProvider?,
 )
 
@@ -56,7 +55,6 @@ fun IncrementalCompilationContext.createSymbolProviders(
     }
     return FirJvmIncrementalCompilationSymbolProviders(
         symbolProviderForBinariesFromIncrementalCompilation,
-        previousFirSessionsSymbolProviders,
         optionalAnnotationClassesProviderForBinariesFromIncrementalCompilation
     )
 }
@@ -80,7 +78,6 @@ fun createIncrementalProvidersForNonLeafMppModules(
     )
     return FirJvmIncrementalCompilationSymbolProviders(
         symbolProviderForBinariesFromIncrementalCompilation = provider,
-        previousFirSessionsSymbolProviders = emptyList(),
         optionalAnnotationClassesProviderForBinariesFromIncrementalCompilation = null,
     )
 }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmSessionFactory.kt
@@ -165,12 +165,12 @@ object FirJvmSessionFactory : FirAbstractSessionFactory<FirJvmSessionFactory.Con
                 val providers = listOfNotNull(
                     symbolProvider,
                     generatedSymbolsProvider,
-                    incrementalCompilationSymbolProviders?.symbolProviderForBinariesFromIncrementalCompilation,
                     javaSymbolProvider,
                     initializeForStdlibIfNeeded(projectEnvironment, session, kotlinScopeProvider),
                 )
                 SourceProviders(
                     providers,
+                    incrementalProvider = incrementalCompilationSymbolProviders?.symbolProviderForBinariesFromIncrementalCompilation,
                     incrementalCompilationSymbolProviders?.optionalAnnotationClassesProviderForBinariesFromIncrementalCompilation
                 )
             }

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirJvmSessionFactory.kt
@@ -165,7 +165,6 @@ object FirJvmSessionFactory : FirAbstractSessionFactory<FirJvmSessionFactory.Con
                 val providers = listOfNotNull(
                     symbolProvider,
                     generatedSymbolsProvider,
-                    *(incrementalCompilationSymbolProviders?.previousFirSessionsSymbolProviders?.toTypedArray() ?: emptyArray()),
                     incrementalCompilationSymbolProviders?.symbolProviderForBinariesFromIncrementalCompilation,
                     javaSymbolProvider,
                     initializeForStdlibIfNeeded(projectEnvironment, session, kotlinScopeProvider),

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirMetadataSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirMetadataSessionFactory.kt
@@ -162,29 +162,25 @@ abstract class AbstractFirMetadataSessionFactory(
             kmpModuleKind,
             init,
             createProviders = { session, kotlinScopeProvider, symbolProvider, generatedSymbolsProvider ->
-                var symbolProviderForBinariesFromIncrementalCompilation: MetadataSymbolProvider? = null
-                incrementalCompilationContext?.let {
-                    val precompiledBinariesPackagePartProvider = it.precompiledBinariesPackagePartProvider
-                    if (it.precompiledBinariesFileScope != null) {
+                val symbolProviderForBinariesFromIncrementalCompilation = incrementalCompilationContext?.let { (precompiledBinariesPackagePartProvider, precompiledBinariesFileScope) -> // ->
+                        if (precompiledBinariesFileScope == null) return@let null
                         val moduleDataProvider = SingleModuleDataProvider(moduleData)
-                        symbolProviderForBinariesFromIncrementalCompilation =
-                            MetadataSymbolProvider(
-                                session,
-                                moduleDataProvider,
-                                kotlinScopeProvider,
-                                precompiledBinariesPackagePartProvider as PackageAndMetadataPartProvider,
-                                projectEnvironment.getKotlinClassFinder(it.precompiledBinariesFileScope) as KotlinMetadataFinder,
-                                defaultDeserializationOrigin = FirDeclarationOrigin.Precompiled
-                            )
+                        MetadataSymbolProvider(
+                            session,
+                            moduleDataProvider,
+                            kotlinScopeProvider,
+                            precompiledBinariesPackagePartProvider as PackageAndMetadataPartProvider,
+                            projectEnvironment.getKotlinClassFinder(precompiledBinariesFileScope) as KotlinMetadataFinder,
+                            defaultDeserializationOrigin = FirDeclarationOrigin.Precompiled
+                        )
                     }
-                }
 
                 SourceProviders(
-                    listOfNotNull(
+                    sourceProviders = listOfNotNull(
                         symbolProvider,
-                        symbolProviderForBinariesFromIncrementalCompilation,
                         generatedSymbolsProvider,
-                    )
+                    ),
+                    incrementalProvider = symbolProviderForBinariesFromIncrementalCompilation,
                 )
             }
         )

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirMetadataSessionFactory.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/FirMetadataSessionFactory.kt
@@ -26,14 +26,8 @@ import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchSco
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.load.kotlin.PackageAndMetadataPartProvider
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.platform.JsPlatform
-import org.jetbrains.kotlin.platform.NativePlatform
-import org.jetbrains.kotlin.platform.TargetPlatform
-import org.jetbrains.kotlin.platform.WasmPlatform
-import org.jetbrains.kotlin.platform.has
+import org.jetbrains.kotlin.platform.*
 import org.jetbrains.kotlin.platform.jvm.JvmPlatform
-import org.jetbrains.kotlin.platform.subplatformsOfType
-import org.jetbrains.kotlin.platform.toTargetPlatform
 import org.jetbrains.kotlin.platform.wasm.WasmPlatforms
 import org.jetbrains.kotlin.serialization.deserialization.KotlinMetadataFinder
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
@@ -188,7 +182,6 @@ abstract class AbstractFirMetadataSessionFactory(
                 SourceProviders(
                     listOfNotNull(
                         symbolProvider,
-                        *(incrementalCompilationContext?.previousFirSessionsSymbolProviders?.toTypedArray() ?: emptyArray()),
                         symbolProviderForBinariesFromIncrementalCompilation,
                         generatedSymbolsProvider,
                     )

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/IncrementalCompilationContext.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/IncrementalCompilationContext.kt
@@ -5,15 +5,10 @@
 
 package org.jetbrains.kotlin.fir.session
 
-import org.jetbrains.kotlin.fir.resolve.providers.FirSymbolProvider
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope
 import org.jetbrains.kotlin.load.kotlin.PackagePartProvider
 
 data class IncrementalCompilationContext(
-    // assuming that providers here do not intersect with the one being built from precompiled binaries
-    // (maybe easiest way to achieve is to delete libraries
-    // TODO: consider passing something more abstract instead of precompiler component, in order to avoid file ops here
-    val previousFirSessionsSymbolProviders: Collection<FirSymbolProvider>,
     val precompiledBinariesPackagePartProvider: PackagePartProvider,
     val precompiledBinariesFileScope: AbstractProjectFileSearchScope?
 )

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/StructuredProviders.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/StructuredProviders.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.fir.resolve.providers.FirSymbolProvider
  */
 class StructuredProviders(
     val sourceProviders: List<FirSymbolProvider>,
+    val incrementalProvider: FirSymbolProvider?,
     val dependencyProviders: List<FirSymbolProvider>,
     val sharedProvider: FirSymbolProvider
 ) : FirSessionComponent

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/FirDeclarationsContentCleaner.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/FirDeclarationsContentCleaner.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.fir.backend
 
-import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.hmppProvidersEnabled
 import org.jetbrains.kotlin.fir.FirImplementationDetail
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.*
@@ -37,7 +37,7 @@ sealed class FirDeclarationsContentCleaner {
                 configuration.allowNonCachedDeclarations || // IDE debugger mode
                         configuration.skipBodies || // KAPT mode
                         // In HMPP mode we need to iterate over FIR bodies once again, after all modules are converted to IR in [referenceAllCommonDependencies]
-                        configuration.languageVersionSettings.getFlag(AnalysisFlags.hierarchicalMultiplatformCompilation)
+                        configuration.languageVersionSettings.hmppProvidersEnabled
                     -> DoNothing
 
                 else -> CleanBodies(c.session)

--- a/compiler/ir/ir.actualization/src/main/kotlin/org/jetbrains/kotlin/backend/common/actualizer/ExpectActualCollector.kt
+++ b/compiler/ir/ir.actualization/src/main/kotlin/org/jetbrains/kotlin/backend/common/actualizer/ExpectActualCollector.kt
@@ -5,8 +5,8 @@
 
 package org.jetbrains.kotlin.backend.common.actualizer
 
-import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.config.LanguageVersionSettings
+import org.jetbrains.kotlin.config.hmppProvidersEnabled
 import org.jetbrains.kotlin.incremental.components.ExpectActualTracker
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.IrElement
@@ -501,9 +501,7 @@ internal class ExpectActualLinkCollector {
                 for (actualSymbol in actualMemberSymbols) {
                     require(actualSymbol is IrSymbol)
 
-                    if ((expectSymbol.owner as IrDeclaration).fileOrNull == null
-                        && languageVersionSettings.getFlag(AnalysisFlags.hierarchicalMultiplatformCompilation)
-                    ) {
+                    if (languageVersionSettings.hmppProvidersEnabled && (expectSymbol.owner as IrDeclaration).fileOrNull == null) {
                         throw IllegalStateException("Actualization of common dependencies failed on '$expectSymbol'.")
                     }
 

--- a/compiler/ir/ir.actualization/src/main/kotlin/org/jetbrains/kotlin/backend/common/actualizer/IrActualizer.kt
+++ b/compiler/ir/ir.actualization/src/main/kotlin/org/jetbrains/kotlin/backend/common/actualizer/IrActualizer.kt
@@ -8,12 +8,12 @@ package org.jetbrains.kotlin.backend.common.actualizer
 import org.jetbrains.kotlin.backend.common.actualizer.checker.IrExpectActualChecker
 import org.jetbrains.kotlin.backend.common.actualizer.checker.IrExpectActualCheckers
 import org.jetbrains.kotlin.config.LanguageVersionSettings
+import org.jetbrains.kotlin.config.hmppProvidersEnabled
 import org.jetbrains.kotlin.incremental.components.ExpectActualTracker
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
-import org.jetbrains.kotlin.ir.types.classOrFail
 import org.jetbrains.kotlin.ir.util.SymbolRemapper
 import org.jetbrains.kotlin.ir.util.classId
 
@@ -39,7 +39,6 @@ class IrActualizer(
     extraActualClassExtractors: List<IrExtraActualDeclarationExtractor> = emptyList(),
     private val missingActualProvider: IrMissingActualDeclarationProvider?,
     actualizerMapContributor: IrActualizerMapContributor?,
-    private val hmppSchemeEnabled: Boolean,
 ) {
     private val collector = ExpectActualCollector(
         mainFragment,
@@ -56,9 +55,10 @@ class IrActualizer(
     val classActualizationInfo: ClassActualizationInfo = collector.collectClassActualizationInfo()
 
     fun actualizeClassifiers() {
+        val hmppProvidersEnabled = languageVersionSettings.hmppProvidersEnabled
         val classSymbolRemapper = object : SymbolRemapper.Empty() {
             override fun getReferencedClass(symbol: IrClassSymbol): IrClassSymbol {
-                if (!hmppSchemeEnabled && !symbol.owner.isExpect) return symbol
+                if (!hmppProvidersEnabled && !symbol.owner.isExpect) return symbol
                 if (symbol.owner.containsOptionalExpectation()) return symbol
                 val classId = symbol.owner.classId ?: return symbol
                 classActualizationInfo.actualClasses[classId]?.let { return it }
@@ -157,4 +157,3 @@ class IrActualizer(
         mainFragment.files.addAll(newFiles)
     }
 }
-

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/ScriptJvmCompilerImpls.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/ScriptJvmCompilerImpls.kt
@@ -353,7 +353,6 @@ private fun doCompileWithK2(
     val [librariesScope, incrementalCompilationContext] = prepareIncrementalCompilationContextAndLibrariesScope(
         configuration,
         projectEnvironment,
-        previousStepsSymbolProviders = emptyList(),
         incrementalExcludesScope = null
     )
 

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/sessionUtils.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/sessionUtils.kt
@@ -27,13 +27,9 @@ import org.jetbrains.kotlin.fir.resolve.providers.impl.syntheticFunctionInterfac
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.resolve.scopes.wrapScopeWithJvmMapped
 import org.jetbrains.kotlin.fir.scopes.FirKotlinScopeProvider
-import org.jetbrains.kotlin.fir.session.FirJvmSessionFactory
+import org.jetbrains.kotlin.fir.session.*
 import org.jetbrains.kotlin.fir.session.FirJvmSessionFactory.flattenAndFilterOwnProviders
 import org.jetbrains.kotlin.fir.session.FirJvmSessionFactory.registerLibrarySessionComponents
-import org.jetbrains.kotlin.fir.session.FirSessionConfigurator
-import org.jetbrains.kotlin.fir.session.StructuredProviders
-import org.jetbrains.kotlin.fir.session.registerCliCompilerAndCommonComponents
-import org.jetbrains.kotlin.fir.session.registerCommonComponentsAfterExtensionsAreConfigured
 import org.jetbrains.kotlin.load.kotlin.KotlinClassFinder
 import java.io.File
 
@@ -78,6 +74,7 @@ internal fun createScriptingAdditionalLibrariesSession(
         StructuredProviders::class,
         StructuredProviders(
             sourceProviders = emptyList(),
+            incrementalProvider = null,
             dependencyProviders = providers,
             sharedProvider = sharedLibrarySession.symbolProvider,
         )


### PR DESCRIPTION
For the changes description see the last commit message.

If you want to check the test, please checkout the branch `demiurg906/actualize-metadata-ic-classpath-with-test` and run the following test:
```
:kotlin-gradle-plugin-integration-tests:kgpMppTests --tests "org.jetbrains.kotlin.gradle.mpp.JvmClasspathMetadataIncrementalIT.testWithJvmClasspathMetadataEnabled"
```