### PR TITLE
Add ios_arm64e Kotlin/Native compilation target

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/InfoPListBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/InfoPListBuilder.kt
@@ -107,7 +107,7 @@ internal class InfoPListBuilder(
             else -> {}
         }
 
-        if (target == KonanTarget.IOS_ARM64) {
+        if (target == KonanTarget.IOS_ARM64 || target == KonanTarget.IOS_ARM64E) {
             contents.append("""
                 |    <key>UIRequiredDeviceCapabilities</key>
                 |    <array>

--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -184,6 +184,30 @@ osVersionMin.ios_arm64 = $minVersion.ios
 sdkVersion.ios_arm64 = $sdkVersion.ios
 osVersionMinFlagLd.ios_arm64 = -ios_version_min
 
+# Apple's 64-bit iOS, arm64e (PAC / pointer authentication).
+targetToolchain.macos_x64-ios_arm64e = target-toolchain-xcode_26.0.1_17A400
+targetToolchain.macos_arm64-ios_arm64e = target-toolchain-xcode_26.0.1_17A400
+
+targetTriple.ios_arm64e = arm64e-apple-ios
+targetSysRoot.ios_arm64e = target-sysroot-xcode_26.0.1_17A400-iphoneos
+# apple-a12 is the first PAC-capable Apple silicon.
+targetCpu.ios_arm64e = apple-a12
+targetCpuFeatures.ios_arm64e = +aes,+fp-armv8,+neon,+pauth,+perfmon,+sha2,+v8.3a,+zcm,+zcz
+clangFlags.ios_arm64e = -cc1 -emit-obj -disable-llvm-passes -x ir
+clangNooptFlags.ios_arm64e = -O1
+clangOptFlags.ios_arm64e = -O3
+# Same fast-isel/global-isel workaround as ios_arm64.
+clangDebugFlags.ios_arm64e = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
+
+linkerNoDebugFlags.ios_arm64e = -S
+stripFlags.ios_arm64e = -S
+linkerDynamicFlags.ios_arm64e = -dylib
+linkerKonanFlags.ios_arm64e = -lSystem -lc++ -lobjc -framework Foundation -framework UIKit
+linkerOptimizationFlags.ios_arm64e = -dead_strip
+osVersionMin.ios_arm64e = $minVersion.ios
+sdkVersion.ios_arm64e = $sdkVersion.ios
+osVersionMinFlagLd.ios_arm64e = -ios_version_min
+
 # Apple's iOS simulators
 target-sysroot-xcode_26.4_17E192-iphonesimulator.default = \
   remote:internal

--- a/kotlin-native/platformLibs/src/platform/ios/darwin.def
+++ b/kotlin-native/platformLibs/src/platform/ios/darwin.def
@@ -11,7 +11,7 @@ headers = AppleTextureEncoder.h AssertMacros.h Availability.h AvailabilityIntern
     fmtmsg.h fstab.h \
     gethostuuid.h glob.h ifaddrs.h inttypes.h iso646.h \
     langinfo.h \
-    libgen.h libunwind.h \
+    libgen.h \
     membership.h monetary.h mpool.h \
     nameser.h ndbm.h nl_types.h \
     notify.h notify_keys.h ntsid.h \
@@ -49,3 +49,12 @@ linkerOpts = -ldl -lz -lbz2 -lcompression -late
 ---
 
 // menu.h is excluded so far due to interop issues.
+//
+// libunwind.h is temporarily dropped from the headers list above (was: `libgen.h libunwind.h`).
+// Apple's <libunwind.h> declares fields like `unw_word_t reg[34]` using the `__ptrauth`
+// qualifier (specifically `ptrauth_restricted_intptr_qualifier`, which Apple's downstream
+// clang accepts on plain integer types such as `unsigned long`). Kotlin's bundled LLVM 19
+// (`kotlin/llvm-19-apple`) does not yet recognize that qualifier, so cinterop fails to
+// parse the header on every ios target — not just arm64e. Restore the header on the
+// `headers = ...` line once `ptrauth_restricted_intptr_qualifier` is cherry-picked into
+// `kotlin/llvm-19-apple` (the qualifier is present in Apple-LLVM 26.4+).

--- a/kotlin-native/runtime/build.gradle.kts
+++ b/kotlin-native/runtime/build.gradle.kts
@@ -93,7 +93,7 @@ bitcode {
             KonanTarget.MACOS_ARM64, KonanTarget.MACOS_X64 -> hashMapOf(
                 "TARGET_OS_OSX" to "1",
             )
-            KonanTarget.IOS_ARM64 -> hashMapOf(
+            KonanTarget.IOS_ARM64, KonanTarget.IOS_ARM64E -> hashMapOf(
                 "TARGET_OS_EMBEDDED" to "1",
                 "TARGET_OS_IPHONE" to "1",
                 "TARGET_OS_IOS" to "1",

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinHierarchyBuilder.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinHierarchyBuilder.kt
@@ -267,6 +267,13 @@ interface KotlinHierarchyBuilder {
     fun withIosArm64()
 
     /**
+     * Only includes Kotlin's Apple/iosArm64e (Pointer Authentication / PAC) target in this [group].
+     *
+     * For more information, see [Native targets overview](https://kotlinlang.org/docs/native-target-support.html).
+     */
+    fun withIosArm64e()
+
+    /**
      * Only includes Kotlin's Apple/iosX64 target in this [group].
      *
      * For more information, see [Native targets overview](https://kotlinlang.org/docs/native-target-support.html).

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinTargetContainerWithPresetFunctions.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinTargetContainerWithPresetFunctions.kt
@@ -173,6 +173,22 @@ interface KotlinTargetContainerWithPresetFunctions : KotlinTargetsContainer {
 
     fun iosArm64(configure: Action<KotlinNativeTarget>) = iosArm64 { configure.execute(this) }
 
+    fun iosArm64e(
+        name: String = "iosArm64e",
+        configure: KotlinNativeTarget.() -> Unit = { }
+    ): KotlinNativeTarget
+
+    fun iosArm64e() = iosArm64e("iosArm64e") { }
+
+    fun iosArm64e(name: String) = iosArm64e(name) { }
+
+    fun iosArm64e(
+        name: String,
+        configure: Action<KotlinNativeTarget>
+    ) = iosArm64e(name) { configure.execute(this) }
+
+    fun iosArm64e(configure: Action<KotlinNativeTarget>) = iosArm64e { configure.execute(this) }
+
     fun iosX64(
         name: String = "iosX64",
         configure: KotlinNativeTargetWithSimulatorTests.() -> Unit = { }
@@ -562,6 +578,16 @@ internal abstract class DefaultKotlinTargetContainerWithPresetFunctions @Inject 
             name,
             presets.getByName("iosArm64") as KotlinNativeTargetPreset,
             project,
+            configure
+        )
+
+    override fun iosArm64e(
+        name: String,
+        configure: KotlinNativeTarget.() -> Unit
+    ): KotlinNativeTarget =
+        configureOrCreate(
+            name,
+            presets.getByName("iosArm64e") as KotlinNativeTargetPreset,
             configure
         )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/hierarchy/KotlinHierarchyBuilderImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/hierarchy/KotlinHierarchyBuilderImpl.kt
@@ -189,6 +189,10 @@ private class KotlinHierarchyBuilderImpl(
         it is KotlinNativeTarget && it.konanTarget == KonanTarget.IOS_ARM64
     }
 
+    override fun withIosArm64e() = withTargets {
+        it is KotlinNativeTarget && it.konanTarget == KonanTarget.IOS_ARM64E
+    }
+
     override fun withIosX64() = withTargets {
         it is KotlinNativeTarget && it.konanTarget == KonanTarget.IOS_X64
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/AppleSdk.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/AppleSdk.kt
@@ -21,7 +21,12 @@ internal object AppleSdk {
             platform.startsWith("iphoneos") -> {
                 targets.addAll(archs.map { arch ->
                     when (arch) {
-                        "arm64", "arm64e" -> KonanTarget.IOS_ARM64
+                        "arm64" -> KonanTarget.IOS_ARM64
+                        // Behavioral fix: previously, requesting `arm64e` from Xcode
+                        // silently produced an `arm64` (KonanTarget.IOS_ARM64) binary.
+                        // With the IOS_ARM64E target available, an `arm64e` request
+                        // now actually produces an arm64e binary with PAC fixups.
+                        "arm64e" -> KonanTarget.IOS_ARM64E
                         else -> throw UnknownArchitectureException(platform, arch)
                     }
                 })
@@ -97,6 +102,7 @@ internal object AppleSdk {
 
 internal enum class AppleArchitecture : Serializable {
     ARM64,
+    ARM64E,
     X86_64,
     ARMV7K,
     ARM64_32;
@@ -105,6 +111,7 @@ internal enum class AppleArchitecture : Serializable {
     val clangArch
         get() = when (this) {
             ARM64 -> "arm64"
+            ARM64E -> "arm64e"
             X86_64 -> "x86_64"
             ARMV7K -> "armv7k"
             ARM64_32 -> "arm64_32"
@@ -121,6 +128,8 @@ internal val KonanTarget.appleArchitecture: AppleArchitecture
         KonanTarget.WATCHOS_DEVICE_ARM64,
         KonanTarget.WATCHOS_SIMULATOR_ARM64,
             -> AppleArchitecture.ARM64
+
+        KonanTarget.IOS_ARM64E -> AppleArchitecture.ARM64E
 
         KonanTarget.IOS_X64,
         KonanTarget.MACOS_X64,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/XCFrameworkTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/XCFrameworkTask.kt
@@ -49,7 +49,7 @@ internal enum class AppleTarget(
     val targets: List<KonanTarget>,
 ) : Serializable {
     MACOS_DEVICE("macos", listOf(KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64)),
-    IPHONE_DEVICE("ios", listOf(KonanTarget.IOS_ARM64)),
+    IPHONE_DEVICE("ios", listOf(KonanTarget.IOS_ARM64, KonanTarget.IOS_ARM64E)),
     IPHONE_SIMULATOR("iosSimulator", listOf(KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64)),
     WATCHOS_DEVICE("watchos", listOf(KonanTarget.WATCHOS_ARM32, KonanTarget.WATCHOS_ARM64, KonanTarget.WATCHOS_DEVICE_ARM64)),
     WATCHOS_SIMULATOR("watchosSimulator", listOf(KonanTarget.WATCHOS_X64, KonanTarget.WATCHOS_SIMULATOR_ARM64)),

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/FatFrameworkTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/FatFrameworkTask.kt
@@ -301,7 +301,7 @@ internal constructor(
             // remove `is ...` after Gradle Configuration Cache deserialization for Objects of a Sealed Class is fixed
             // https://github.com/gradle/gradle/issues/22347
             is MACOS_X64, is MACOS_ARM64 -> "MacOSX"
-            is IOS_ARM64, is IOS_X64, is IOS_SIMULATOR_ARM64 -> "iPhoneOS"
+            is IOS_ARM64, is IOS_ARM64E, is IOS_X64, is IOS_SIMULATOR_ARM64 -> "iPhoneOS"
             is TVOS_ARM64, is TVOS_X64, is TVOS_SIMULATOR_ARM64 -> "AppleTVOS"
             is WATCHOS_ARM32, is WATCHOS_ARM64, is WATCHOS_X64, is WATCHOS_SIMULATOR_ARM64, is WATCHOS_DEVICE_ARM64 -> "WatchOS"
             else -> error("Fat frameworks are not supported for platform `${target.visibleName}`")
@@ -490,7 +490,7 @@ internal constructor(
 
     companion object {
         private val supportedTargets = listOf(
-            IOS_ARM64, IOS_X64,
+            IOS_ARM64, IOS_ARM64E, IOS_X64,
             WATCHOS_ARM32, WATCHOS_ARM64, WATCHOS_X64, WATCHOS_DEVICE_ARM64,
             TVOS_ARM64, TVOS_X64,
             MACOS_X64, MACOS_ARM64

--- a/native/commonizer/src/org/jetbrains/kotlin/commonizer/mergedtree/PlatformWidthIndex.kt
+++ b/native/commonizer/src/org/jetbrains/kotlin/commonizer/mergedtree/PlatformWidthIndex.kt
@@ -20,6 +20,7 @@ enum class PlatformIntWidth {
 object PlatformWidthIndex {
     private val widthByLeafTargets = mapOf(
         LeafCommonizerTarget(KonanTarget.IOS_ARM64) to PlatformIntWidth.LONG,
+        LeafCommonizerTarget(KonanTarget.IOS_ARM64E) to PlatformIntWidth.LONG,
         LeafCommonizerTarget(KonanTarget.IOS_X64) to PlatformIntWidth.LONG,
         LeafCommonizerTarget(KonanTarget.IOS_SIMULATOR_ARM64) to PlatformIntWidth.LONG,
         LeafCommonizerTarget(KonanTarget.WATCHOS_ARM32) to PlatformIntWidth.INT,

--- a/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/FirebaseCloudXCTestExecutor.kt
+++ b/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/FirebaseCloudXCTestExecutor.kt
@@ -46,8 +46,8 @@ class FirebaseCloudXCTestExecutor(
         require(HostManager.host.family.isAppleFamily) {
             "$this executor isn't available for $configurables"
         }
-        require(target == KonanTarget.IOS_ARM64) {
-            "$this executor is available only for iOS arm64 (device-only)"
+        require(target == KonanTarget.IOS_ARM64 || target == KonanTarget.IOS_ARM64E) {
+            "$this executor is available only for iOS arm64 / arm64e (device-only)"
         }
     }
 

--- a/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/XCTestExecutor.kt
+++ b/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/XCTestExecutor.kt
@@ -38,7 +38,7 @@ abstract class AbstractXCTestExecutor(
         val xcodeTarget = when (target) {
             KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64 -> "macosx"
             KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64 -> "iphonesimulator"
-            KonanTarget.IOS_ARM64 -> "iphoneos"
+            KonanTarget.IOS_ARM64, KonanTarget.IOS_ARM64E -> "iphoneos"
             else -> error("Target $target is not supported buy the executor")
         }
 

--- a/native/kotlin-test-native-xctest/build.gradle.kts
+++ b/native/kotlin-test-native-xctest/build.gradle.kts
@@ -62,7 +62,7 @@ abstract class DevFrameworkPathValueSource : ValueSource<String, DevFrameworkPat
         val platform = when (this) {
             KonanTarget.MACOS_ARM64, KonanTarget.MACOS_X64 -> "macosx"
             KonanTarget.IOS_SIMULATOR_ARM64, KonanTarget.IOS_X64 -> "iphonesimulator"
-            KonanTarget.IOS_ARM64 -> "iphoneos"
+            KonanTarget.IOS_ARM64, KonanTarget.IOS_ARM64E -> "iphoneos"
             else -> error("Target $this is not supported here")
         }
 
@@ -110,6 +110,7 @@ kotlin {
         @Suppress("DEPRECATION")
         addIfEnabledOnHost(iosX64())
         addIfEnabledOnHost(iosArm64())
+        addIfEnabledOnHost(iosArm64e())
         addIfEnabledOnHost(iosSimulatorArm64())
 
         forEach {

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCInteropTest.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCInteropTest.kt
@@ -169,6 +169,7 @@ abstract class AbstractNativeCInteropTest : AbstractNativeCInteropBaseTest() {
             KonanTarget.ANDROID_X64 -> "X64"
             KonanTarget.ANDROID_X86 -> "CPointerByteVar"
             KonanTarget.IOS_ARM64 -> "CPointerByteVar"
+            KonanTarget.IOS_ARM64E -> "CPointerByteVar"
             KonanTarget.IOS_SIMULATOR_ARM64 -> "CPointerByteVar"
             KonanTarget.IOS_X64 -> "X64"
             KonanTarget.LINUX_ARM32_HFP -> "ARM32"

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/SettingsExecutor.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/SettingsExecutor.kt
@@ -42,7 +42,7 @@ val Settings.testProcessExecutor: Executor
                     }
                     when (configurables.target) {
                         hostTarget -> XCTestHostExecutor(configurables)
-                        is KonanTarget.IOS_ARM64 -> FirebaseCloudXCTestExecutor(configurables)
+                        is KonanTarget.IOS_ARM64, KonanTarget.IOS_ARM64E -> FirebaseCloudXCTestExecutor(configurables)
                         is KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64 -> XCTestSimulatorExecutor(configurables)
                         else -> JUnit5Assertions.fail { "Running tests for $testTarget on $hostTarget with XCTest is not supported yet." }
                     }

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/TestProcessSettings.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/TestProcessSettings.kt
@@ -338,7 +338,7 @@ internal class XCTestRunner(val isEnabled: Boolean, private val nativeTargets: K
         val xcodeTarget = when (val target = nativeTargets.testTarget) {
             KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64 -> "macosx"
             KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64 -> "iphonesimulator"
-            KonanTarget.IOS_ARM64 -> "iphoneos"
+            KonanTarget.IOS_ARM64, KonanTarget.IOS_ARM64E -> "iphoneos"
             else -> error("Target $target is not supported buy the executor")
         }
 

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/HostManager.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/HostManager.kt
@@ -63,6 +63,7 @@ open class HostManager() {
         MACOS_X64,
         MACOS_ARM64,
         IOS_ARM64,
+        IOS_ARM64E,
         IOS_X64,
         IOS_SIMULATOR_ARM64,
         WATCHOS_ARM32,

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/KonanTarget.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/KonanTarget.kt
@@ -18,6 +18,7 @@ sealed class KonanTarget(override val name: String, val family: Family, val arch
     object ANDROID_ARM32 : KonanTarget("android_arm32", Family.ANDROID, Architecture.ARM32)
     object ANDROID_ARM64 : KonanTarget("android_arm64", Family.ANDROID, Architecture.ARM64)
     object IOS_ARM64 : KonanTarget("ios_arm64", Family.IOS, Architecture.ARM64)
+    object IOS_ARM64E : KonanTarget("ios_arm64e", Family.IOS, Architecture.ARM64)
     object IOS_X64 : KonanTarget("ios_x64", Family.IOS, Architecture.X64)
     object IOS_SIMULATOR_ARM64 : KonanTarget("ios_simulator_arm64", Family.IOS, Architecture.ARM64)
     object WATCHOS_ARM32 : KonanTarget("watchos_arm32", Family.WATCHOS, Architecture.ARM32)
@@ -43,7 +44,7 @@ sealed class KonanTarget(override val name: String, val family: Family, val arch
         val predefinedTargets: Map<String, KonanTarget> by lazy {
             listOf(
                 ANDROID_X64, ANDROID_X86, ANDROID_ARM32, ANDROID_ARM64,
-                IOS_ARM64, IOS_X64, IOS_SIMULATOR_ARM64,
+                IOS_ARM64, IOS_ARM64E, IOS_X64, IOS_SIMULATOR_ARM64,
                 WATCHOS_ARM32, WATCHOS_ARM64, WATCHOS_X64,
                 WATCHOS_SIMULATOR_ARM64, WATCHOS_DEVICE_ARM64,
                 TVOS_ARM64, TVOS_X64, TVOS_SIMULATOR_ARM64,

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/KonanTargetExtenstions.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/KonanTargetExtenstions.kt
@@ -58,6 +58,7 @@ fun KonanTarget.supports64BitMulOverflow(): Boolean = when (this) {
 // TODO: Add explicit WATCHOS_DEVICE_ARM64 after compiler update.
 fun KonanTarget.supportsIosCrashLog(): Boolean = when (this) {
     KonanTarget.IOS_ARM64 -> true
+    KonanTarget.IOS_ARM64E -> true
     KonanTarget.WATCHOS_ARM32 -> true
     KonanTarget.WATCHOS_ARM64 -> true
     KonanTarget.TVOS_ARM64 -> true


### PR DESCRIPTION
Wires the iOS arm64e target (Pointer Authentication Code, FEAT_PAuth) end-to-end through target registration, toolchain configuration, gradle DSL, source-set hierarchy, test infrastructure, and platform libraries.

Produces Mach-O arm64e framework binaries with __auth_got / auth-bind chained fixups, ARM64_RELOC_AUTHENTICATED_POINTER relocations, and full ptrauth-* LLVM function attributes from the bundled kotlin/llvm-19-apple toolchain.

Layer breakdown
---------------
- Target registration: KonanTarget.IOS_ARM64E plus predefinedTargets, HostManager.appleTargets, supportsIosCrashLog.
- Toolchain config (konan.properties): arm64e-apple-ios triple, apple-a12 CPU, +pauth/+v8.3a features, linker flags, SDK paths.
- Compiler build tooling (runtime/build.gradle.kts): TARGET_OS_* defines extended to cover IOS_ARM64E in the same branch as IOS_ARM64. The fixBrokenMacroExpansionInXcode15_3 logic was previously in ExecClang.kt and is now in the runtime build script.
- ObjC export (InfoPListBuilder.kt): UIRequiredDeviceCapabilities emitted for arm64e frameworks.
- Apple SDK / framework (AppleSdk.kt, XCFrameworkTask.kt, FatFrameworkTask.kt): arm64e Xcode arch mapped to IOS_ARM64E; appleArchitecture distinguishes arm64 from arm64e via a new AppleArchitecture.ARM64E enum value; IPHONE_DEVICE and FatFrameworkTask.supportedTargets extended.
- Gradle DSL (KotlinTargetContainerWithPresetFunctions.kt, KotlinHierarchyBuilder.kt + Impl): iosArm64e() factory overloads (5) and withIosArm64e() hierarchy filter.
- Commonizer (PlatformWidthIndex.kt): IOS_ARM64E mapped to LONG (same width class as IOS_ARM64).
- Test infrastructure (SettingsExecutor, TestProcessSettings, AbstractNativeCInteropTest, kotlin-test-native-xctest, XCTestExecutor, FirebaseCloudXCTestExecutor): SDK mapping to iphoneos, cinterop golden-file mapping, XCTest framework copy task wired with iosArm64e().

Behavioral change
-----------------
AppleSdk.kt previously mapped the Xcode-requested arch "arm64e" to KonanTarget.IOS_ARM64 - an Xcode pipeline requesting arm64e silently produced an arm64 binary. The mapping now splits:
    "arm64"  -> KonanTarget.IOS_ARM64
    "arm64e" -> KonanTarget.IOS_ARM64E
Callers that depended on the silent downgrade must now explicitly request arm64 in Xcode. The prior behavior was an unintended footgun.

Carried workaround: libunwind.h in darwin.def
---------------------------------------------
kotlin-native/platformLibs/src/platform/ios/darwin.def temporarily drops libunwind.h from its headers = ... list. Apple's <libunwind.h> declares fields such as unw_word_t reg[34] using __ptrauth qualifiers (specifically ptrauth_restricted_intptr_qualifier, which Apple's downstream clang accepts on plain integer types). Kotlin's bundled LLVM 19 (kotlin/llvm-19-apple) does not yet recognise that qualifier, so cinterop fails to parse the header on every ios target - not just arm64e. Removal condition: cherry-pick the qualifier from Apple-LLVM 26.4+ into kotlin/llvm-19-apple, then revert this hunk.

Dependency: kotlin/llvm-19-apple FunctionSpecialization fix ----------------------------------------------------------- This commit deliberately does NOT include the
StripDirectCallPtrauthBundlesPass workaround that was carried during local bring-up. The workaround masked an LLVM 19 IR-verifier failure: FunctionSpecializationPass devirtualized an indirect call whose body carried a ptrauth operand bundle, producing a direct call that still carried the bundle - which LLVM rejects as "Direct call cannot have a ptrauth bundle". Concrete reproducer: K/N's CallInitGlobalPossiblyLock runtime helper, cloned as @CallInitGlobalPossiblyLock.specialized.1.

The proper fix is in upstream LLVM (FunctionSpecialization.cpp strips ptrauth bundles from devirtualized calls before IPSCCP propagates the constant). That fix MUST be cherry-picked into kotlin/llvm-19-apple and the K/N LLVM dependency rolled forward before this commit will produce a working ios_arm64e build - without it, compiling any arm64e Kotlin program will abort at the verifier when the runtime gets linked.

Bootstrap integration note
--------------------------
The KonanTarget.IOS_ARM64E references in runtime/build.gradle.kts and native/kotlin-test-native-xctest/build.gradle.kts compile against the bootstrap kotlin-native-utils classpath, not the in-tree :native:kotlin-native-utils source. Until bootstrap is bumped to a kotlin-native-utils that exports KonanTarget.IOS_ARM64E, those compiles fail with "Unresolved reference: IOS_ARM64E". The standard workflow is to publish an interim bootstrap first.

Verification baseline
---------------------
Verified during the original bring-up against JetBrains/kotlin f95cb2f76 with the StripDirectCallPtrauthBundlesPass workaround in place. Outcomes were:
- :kotlin-native:ios_arm64eCrossDist - PASS (2m54s)
- :kotlin-native:platformLibs:ios_arm64eInstall - PASS (1m33s)
- konanc hello.kt -target ios_arm64e -produce framework - PASS; Mach-O 64-bit arm64e, 344 ARM64_RELOC_AUTHENTICATED_POINTER relocations, 85 PAC instructions (blraaz, braaz, paci, autia, ...), __DATA_CONST __auth_got auth-bind rows for every imported symbol.

This rebased version (against current master, without the StripDirectCallPtrauthBundlesPass workaround) has not been re-verified end-to-end because verification requires kotlin/llvm-19-apple to ship the FunctionSpecialization fix first. The Kotlin-side change set is unchanged in intent; only the target file for the Xcode15.3 macro- expansion workaround shifted from ExecClang.kt to
runtime/build.gradle.kts to track the upstream code move.