### PR TITLE
[Gradle] Make commonizeNativeDistribution depend on downloadKotlinNativeDistribution

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/KGPBaseTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/KGPBaseTest.kt
@@ -54,6 +54,10 @@ abstract class KGPBaseTest {
     @BeforeEach
     fun setUpNewCounter() {
         counter.set(Counter())
+        if (isTeamCityRun) {
+            val userHomeDir = System.getProperty("user.home")
+            assumeDirectoryDoesNotExist(Paths.get("$userHomeDir/.konan"))
+        }
     }
 
     class Counter(var counter: Int = 0)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/fileAssertions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/fileAssertions.kt
@@ -7,6 +7,8 @@ package org.jetbrains.kotlin.gradle.testbase
 
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import org.jetbrains.kotlin.test.Assertions
+import org.junit.jupiter.api.Assumptions
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -232,6 +234,23 @@ fun assertDirectoryDoesNotExist(
     message: String? = null,
 ) {
     assert(!Files.exists(dirPath)) {
+        message ?: buildString {
+            append("Directory $dirPath is expected to not exist. ")
+            if (Files.isDirectory(dirPath)) {
+                appendLine("The directory contents: ")
+                appendDirectory(dirPath)
+            } else {
+                append("However, it is not even a directory.")
+            }
+        }
+    }
+}
+
+fun assumeDirectoryDoesNotExist(
+    dirPath: Path,
+    message: String? = null,
+) {
+    Assumptions.assumeTrue(!Files.exists(dirPath)) {
         message ?: buildString {
             append("Directory $dirPath is expected to not exist. ")
             if (Files.isDirectory(dirPath)) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CommonizerTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CommonizerTasks.kt
@@ -189,6 +189,8 @@ internal val Project.commonizeNativeDistributionTask: TaskProvider<NativeDistrib
             KotlinNativeBundleBuildService.registerIfAbsent(this)
         }
 
+        val nativeDownloadTask = getOrRegisterDownloadKotlinNativeDistributionTask()
+
         return locateOrRegisterTask(
             "commonizeNativeDistribution",
             invokeWhenRegistered = {
@@ -214,6 +216,8 @@ internal val Project.commonizeNativeDistributionTask: TaskProvider<NativeDistrib
                 kotlinCompilerArgumentsLogLevel
                     .value(kotlinPropertiesProvider.kotlinCompilerArgumentsLogLevel)
                     .finalizeValueOnRead()
+
+                dependsOn(nativeDownloadTask)
             }
         )
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/uklibs/UklibInterprojectResolutionTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/uklibs/UklibInterprojectResolutionTests.kt
@@ -693,6 +693,7 @@ class UklibInterprojectResolutionTests {
         enableCInteropCommonization = false,
         resolveIdeDependencies = mutableSetOf(
             "consumer:commonizeNativeDistribution",
+            "consumer:downloadKotlinNativeDistribution",
             "producer:serializeUklibManifestWithoutCompilationDependency",
         ),
         compileCommonMainKotlinMetadata = mutableSetOf(
@@ -701,6 +702,7 @@ class UklibInterprojectResolutionTests {
             "producer:compileCommonMainKotlinMetadata",
             "producer:compileLinuxMainKotlinMetadata",
             "producer:compileNativeMainKotlinMetadata",
+            "producer:downloadKotlinNativeDistribution",
             "producer:serializeUklibManifestWithoutCompilationDependency",
             "producer:transformCommonMainDependenciesMetadata",
             "producer:transformLinuxMainDependenciesMetadata",


### PR DESCRIPTION
Previously, commonizeNativeDistribution had a transitive dependency on downloadKotlinNativeDistribution via commonizeCInterop, however the latter can be turned off using the enableCInteropCommonization flag, breaking the dependency chain. This commit adds a direct dependency to ensure correct behaviour.

^KT-83710 Verification Pending