### PR TITLE
JVM: Do not materialize defaults in exposed no-arg constructor

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmDefaultParameterInjector.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmDefaultParameterInjector.kt
@@ -23,7 +23,12 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.render
 
-@PhasePrerequisites(FunctionReferenceLowering::class, PrepareCallableReferencesForInlining::class)
+@PhasePrerequisites(
+    FunctionReferenceLowering::class,
+    PrepareCallableReferencesForInlining::class,
+    // @JvmExposeBoxed forces generation no-arg constructor
+    JvmInlineClassLowering::class,
+)
 internal class JvmDefaultParameterInjector(context: JvmBackendContext) : DefaultParameterInjector<JvmBackendContext>(
     context = context,
     factory = JvmDefaultArgumentFunctionFactory(context),

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
@@ -367,11 +367,6 @@ internal class JvmInlineClassLowering(private val context: JvmBackendContext) : 
             annotations = original.annotations.withJvmExposeBoxedAnnotation(original, context)
             body = context.createIrBuilder(this.symbol).irBlockBody(this) {
                 +irDelegatingConstructorCall(constructor).apply {
-                    for (index in original.parameters.indices) {
-                        // Copy already lowered default values
-                        arguments[index] = constructor.parameters[index].defaultValue!!
-                            .deepCopyWithSymbols(this@noArg).expression
-                    }
                     arguments[constructor.parameters.size - 1] = irNull()
                 }
             }

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/kt86523.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/kt86523.kt
@@ -1,0 +1,12 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+// JVM_EXPOSE_BOXED
+
+@JvmInline
+value class IC(val c: String)
+
+class Test(val v: IC = IC("OK"), b: Boolean = true, c: Boolean = b)
+
+fun box(): String {
+    return Test().v.c
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/kt86523.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/kt86523.kt
@@ -1,0 +1,14 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmInline
+value class IC(val c: String)
+
+@JvmExposeBoxed
+class Test(val v: IC = IC("OK"), b: Boolean = true, c: Boolean = b)
+
+fun box(): String {
+    return Test().v.c
+}


### PR DESCRIPTION
If JvmInlineClassLowering materializes default arguments there, the resulting IR can still reference constructor parameters when one default value depends on another parameter.

Instead, leave the delegating constructor call arguments omitted and let JvmDefaultParameterInjector materialize them with the usual default argument remapping.
 #KT-86523 Fixed