### PR TITLE
KT-87033: Decouple ObjC selector mappings from CodeSpec generation

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/NativeCompilerDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/NativeCompilerDriver.kt
@@ -68,16 +68,13 @@ internal class NativeCompilerDriver(private val performanceManager: PerformanceM
                 engine.runPhase(CreateObjCFrameworkPhase, CreateObjCFrameworkInput(frontendOutput.moduleDescriptor, it))
             }
         }
-        if (config.omitFrameworkBinary && config.dumpObjcSelectorToSignatureMapping == null) {
+        if (config.omitFrameworkBinary) {
             return
         }
         val [linkKlibsOutput, objCCodeSpec] = performanceManager.tryMeasurePhaseTime(PhaseType.IrLinking) {
             engine.linkKlibs(frontendOutput) {
                 it.runPhase(CreateObjCExportCodeSpecPhase, objCExportedInterface)
             }
-        }
-        if (config.omitFrameworkBinary) {
-            return
         }
 
         val backendContext = createBackendContext(config, frontendOutput, linkKlibsOutput) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/ObjCExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/ObjCExport.kt
@@ -15,7 +15,11 @@ import org.jetbrains.kotlin.backend.konan.objcexport.createCodeSpec
 import org.jetbrains.kotlin.backend.konan.objcexport.createObjCFramework
 import org.jetbrains.kotlin.backend.konan.objcexport.dumpSelectorToSignatureMapping
 import org.jetbrains.kotlin.backend.konan.objcexport.produceObjCExportInterface
+import org.jetbrains.kotlin.backend.konan.serialization.KonanIdSignaturer
+import org.jetbrains.kotlin.backend.konan.serialization.KonanManglerDesc
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
+import org.jetbrains.kotlin.ir.util.SymbolTable
 
 /**
  * Create internal representation of Objective-C wrapper.
@@ -24,7 +28,18 @@ internal val ProduceObjCExportInterfacePhase = createSimpleNamedCompilerPhase<Na
         "ObjCExportInterface",
         outputIfNotEnabled = { _, _, _, _ -> error("Cannot disable `ObjCExportInterface` phase when producing ObjC framework") }
 ) { context, input ->
-    produceObjCExportInterface(context, input.moduleDescriptor, input.frontendServices)
+    produceObjCExportInterface(context, input.moduleDescriptor, input.frontendServices).also {
+        if (context.config.omitFrameworkBinary) {
+            // Dump selector -> signature mapping before IR linking if omitFrameworkBinary is true.
+            context.config.dumpObjcSelectorToSignatureMapping?.let { path ->
+                // Use a temporary SymbolTable here to generate the signatures because the main SymbolTable
+                // is not available at this point (it's initialized in the LinkKlibs phase).
+                val isolatedSymbolTable = SymbolTable(KonanIdSignaturer(KonanManglerDesc), IrFactoryImpl)
+                val objCCodeSpec = it.createCodeSpec(isolatedSymbolTable)
+                objCCodeSpec.dumpSelectorToSignatureMapping(path, isolatedSymbolTable.signaturer!!, it.mapper)
+            }
+        }
+    }
 }
 
 internal data class CreateObjCFrameworkInput(
@@ -52,7 +67,9 @@ internal val CreateObjCExportCodeSpecPhase = createSimpleNamedCompilerPhase<Link
         outputIfNotEnabled = { _, _, _, _, -> ObjCExportCodeSpec(emptyList(), emptyList()) }
 ) { context, input ->
     input.createCodeSpec(context.symbolTable!!).also {
+        // Dump selector -> signature mapping using the SymbolTable from the linking phase.
         context.config.dumpObjcSelectorToSignatureMapping?.let { path ->
+            check(!context.config.omitFrameworkBinary)
             it.dumpSelectorToSignatureMapping(path, context.symbolTable!!.signaturer!!, input.mapper)
         }
     }


### PR DESCRIPTION
Generate Objective-C selector mappings directly from the exported interface. This avoids requiring full CodeSpec generation and IR linking when omitting framework binaries.