### PR TITLE
[Tests] Mute cinterop tests that are not supposed to be run with LV<=2.4

### DIFF
--- a/native/native.tests/testData/codegen/cinterop/threadStates/forceNativeThreadStateAnnotation.kt
+++ b/native/native.tests/testData/codegen/cinterop/threadStates/forceNativeThreadStateAnnotation.kt
@@ -2,7 +2,7 @@
  * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
-// IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.3
+// IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.3,2.4
 // ^^^ KT-86026 TODO: Rework testdata to move functions/globals definitions from .def/.h into separate source files
 
 // TARGET_BACKEND: NATIVE

--- a/native/native.tests/testData/codegen/cinterop/threadStates/forceNativeThreadStateAnnotationException.kt
+++ b/native/native.tests/testData/codegen/cinterop/threadStates/forceNativeThreadStateAnnotationException.kt
@@ -2,7 +2,7 @@
  * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
-// IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.3
+// IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.3,2.4
 // ^^^ KT-86026 TODO: Rework testdata to move functions/globals definitions from .def/.h into separate source files
 
 // TARGET_BACKEND: NATIVE


### PR DESCRIPTION
KT-77616 is available in `2.4.20-Beta2`