### PR TITLE
[KGP] Add compileKotlin output to GroovyCompile classpath

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/Kotlin2JvmSourceSetProcessor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/Kotlin2JvmSourceSetProcessor.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.AbstractCompile
+import org.gradle.api.tasks.compile.GroovyCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.internal.Kapt3GradleSubplugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginLifecycle.Stage.AfterEvaluateBuildscript
@@ -62,6 +63,11 @@ internal class Kotlin2JvmSourceSetProcessor(
                 javaTask.configure { javaCompile ->
                     javaCompile.classpath += project.files(kotlinTask.flatMap { it.destinationDirectory })
                 }
+                project.tasks.withType<GroovyCompile>()
+                    .configureEach { groovyCompile ->
+                        if (groovyCompile.name != java.getCompileTaskName("groovy")) return@configureEach
+                        groovyCompile.classpath += project.files(kotlinTask.map { it.destinationDirectory.get() })
+                    }
                 kotlinTask.configure { kotlinCompile ->
                     kotlinCompile.javaOutputDir.set(javaTask.flatMap { it.destinationDirectory })
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT17153GroovyCompileClasspathTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT17153GroovyCompileClasspathTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:Suppress("FunctionName")
+
+package org.jetbrains.kotlin.gradle.regressionTests
+
+import org.gradle.api.tasks.compile.GroovyCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.util.buildProjectWithJvm
+import org.jetbrains.kotlin.gradle.util.enableDefaultStdlibDependency
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class KT17153GroovyCompileClasspathTest {
+
+    @Test
+    fun `test - groovy compile classpath contains kotlin compile output`() {
+        val project = buildProjectWithJvm(
+            preApplyCode = { enableDefaultStdlibDependency(false) }
+        ) {
+            plugins.apply("groovy")
+        }
+
+        project.evaluate()
+
+        val kotlinTask = project.tasks.withType(KotlinCompile::class.java).named("compileKotlin").get()
+        val groovyTask = project.tasks.withType(GroovyCompile::class.java).named("compileGroovy").get()
+
+        val kotlinOutput = kotlinTask.destinationDirectory.asFile.get()
+        assertTrue(
+            groovyTask.classpath.files.contains(kotlinOutput),
+            "compileGroovy classpath should contain compileKotlin output directory.\n" +
+                    "Expected: $kotlinOutput\nActual classpath: ${groovyTask.classpath.files}"
+        )
+    }
+
+    @Test
+    fun `test - groovy compile depends on kotlin compile`() {
+        val project = buildProjectWithJvm(
+            preApplyCode = { enableDefaultStdlibDependency(false) }
+        ) {
+            plugins.apply("groovy")
+        }
+
+        project.evaluate()
+
+        val kotlinTask = project.tasks.named("compileKotlin").get()
+        val groovyTask = project.tasks.named("compileGroovy").get()
+
+        assertTrue(
+            groovyTask.taskDependencies.getDependencies(groovyTask).contains(kotlinTask),
+            "compileGroovy should depend on compileKotlin"
+        )
+    }
+}


### PR DESCRIPTION
KGP added compileKotlin output to compileJava classpath, but not to GroovyCompile. This caused compilation errors when Groovy classes referenced Kotlin classes.

^KT-17153 Fixed