### PR TITLE
Use AfterEach in KGPBaseTest to catch leftover .konan directory

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/KGPBaseTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/KGPBaseTest.kt
@@ -9,7 +9,7 @@ import com.intellij.testFramework.TestDataPath
 import org.jetbrains.kotlin.gradle.BrokenMacosTestInterceptor
 import org.jetbrains.kotlin.gradle.util.isTeamCityRun
 import org.jetbrains.kotlin.test.WithMuteInDatabase
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.TestInstance
@@ -43,7 +43,7 @@ abstract class KGPBaseTest {
     @TempDir
     lateinit var workingDir: Path
 
-    @AfterAll
+    @AfterEach
     fun checkThatDefaultKonanHasNotBeenCreated() {
         if (isTeamCityRun) {
             val userHomeDir = System.getProperty("user.home")


### PR DESCRIPTION
The issue with AfterAll is that it doesn't make it clear which test left a .konan directory behind it, making it hard to diagnose unexpected Native distribution downloads. AfterEach will perform the check after every test, simplifying troubleshooting. konan

---

Here's a comparison for a failing test suite:

With `@AfterAll` ([CI build](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_Aggregate/977683295)). There's a generic `executionError` entry per class.

<img width="865" height="663" alt="image" src="https://github.com/user-attachments/assets/e02ba5b4-6b92-4a23-8fd4-d6ab968e192c" />

With `@AfterEach` ([CI build](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_Aggregate/978471813)). There's an entry for every test that failed the `@AfterEach` check.

<img width="1516" height="903" alt="image" src="https://github.com/user-attachments/assets/e38dae1b-1429-45a8-9ec1-74a7e37c179e" />
