### PR TITLE
[Gradle] Sync default value of js.browser.test.timeout with docs

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
@@ -128,7 +128,7 @@ internal abstract class KotlinJsBrowserTestImpl
         .apply {
             testsLocation.convention(defaultTestsLocation)
             headless.convention(true)
-            timeout.convention(Duration.ofSeconds(2))
+            timeout.convention(Duration.ofMinutes(2))
         }
 
     override fun browserDefaults(configure: Action<BrowserTestRunnerConfigDsl>) =


### PR DESCRIPTION
The documentation for this property states that the default value is 2 minutes, however the code sets it to 2 seconds. This change sets the value according to what's documented.

^KT-86922 Verification Pending