### PR TITLE
[KMP] Support in-place KLIB writes for incremental compilation

### DIFF
--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmSerializeCommonMetadataPipelinePhase.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmSerializeCommonMetadataPipelinePhase.kt
@@ -36,7 +36,7 @@ object JvmSerializeCommonMetadataPipelinePhase : PipelinePhase<JvmFrontendPipeli
                 AllModulesFrontendOutput(listOf(output)),
                 configuration = configuration,
                 sourceFiles = input.sourceFiles,
-                isForIncrementalCompilation = true
+                isIncremental = true
             )
             val metadataInMemory = MetadataKlibInMemorySerializerPhase.executePhase(inputForPhase)
             MetadataKlibFileWriterPhase.writeToDisc(

--- a/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/metadata/MetadataUtils.kt
+++ b/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/metadata/MetadataUtils.kt
@@ -18,7 +18,12 @@ import org.jetbrains.kotlin.library.writer.includeMetadata
 import org.jetbrains.kotlin.util.metadataVersion
 import java.io.File
 
-fun buildKotlinMetadataLibrary(configuration: CompilerConfiguration, serializedMetadata: SerializedMetadata, destDir: File) {
+fun buildKotlinMetadataLibrary(
+    configuration: CompilerConfiguration,
+    serializedMetadata: SerializedMetadata,
+    destDir: File,
+    isIncremental: Boolean,
+) {
     val versions = KotlinLibraryVersioning(
         abiVersion = KotlinAbiVersion.CURRENT,
         compilerVersion = KotlinCompilerVersion.getVersion(),
@@ -31,6 +36,7 @@ fun buildKotlinMetadataLibrary(configuration: CompilerConfiguration, serializedM
             versions(versions)
             platformAndTargets(BuiltInsPlatform.COMMON)
         }
+        allowIncrementalOverwriting(isIncremental)
         includeMetadata(serializedMetadata, configuration.fileMappingTracker?.toICMetadataMappingTracker())
     }.writeTo(destDir.absolutePath)
 }

--- a/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataKlibSerializerPhase.kt
+++ b/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataKlibSerializerPhase.kt
@@ -35,7 +35,7 @@ object MetadataKlibInMemorySerializerPhase : PipelinePhase<MetadataFrontendPipel
     postActions = setOf(CheckCompilationErrors.CheckDiagnosticCollector)
 ) {
     override fun executePhase(input: MetadataFrontendPipelineArtifact): MetadataInMemorySerializationArtifact {
-        (val firResult = frontendOutput, val configuration, val _ = sourceFiles) = input
+        (val firResult = frontendOutput, val configuration, val _ = sourceFiles, val isIncremental) = input
         val metadataVersion = configuration.metadataVersion()
         val fragments = mutableMapOf<String, MutableList<SerializedFragment>>()
 
@@ -58,7 +58,7 @@ object MetadataKlibInMemorySerializerPhase : PipelinePhase<MetadataFrontendPipel
                     languageVersionSettings,
                 )
                 fragments.getOrPut(firFile.packageFqName.asString()) { mutableListOf() }
-                    .add(createSerializedFragment(input.isForIncrementalCompilation, packageFragment.toByteArray(), firFile))
+                    .add(createSerializedFragment(isIncremental, packageFragment.toByteArray(), firFile))
             }
         }
 
@@ -81,7 +81,7 @@ object MetadataKlibInMemorySerializerPhase : PipelinePhase<MetadataFrontendPipel
 
         val module = header.build().toByteArray()
         val serializedMetadata = SerializedMetadata(module, fragmentParts, fragmentNames, metadataVersion.toArray())
-        return MetadataInMemorySerializationArtifact(serializedMetadata, configuration)
+        return MetadataInMemorySerializationArtifact(serializedMetadata, configuration, isIncremental)
     }
 
     private fun createSerializedFragment(isForIncrementalCompilation: Boolean, content: ByteArray, firFile: FirFile) =
@@ -109,7 +109,7 @@ object MetadataKlibFileWriterPhase : PipelinePhase<MetadataInMemorySerialization
     }
 
     fun writeToDisc(input: MetadataInMemorySerializationArtifact, destDir: java.io.File) {
-        buildKotlinMetadataLibrary(input.configuration, input.metadata, destDir)
+        buildKotlinMetadataLibrary(input.configuration, input.metadata, destDir, input.isIncremental)
 
         loadSizeInfo(File(destDir.absolutePath))?.flatten()?.let { stats ->
             input.configuration.perfManager?.registerKlibElementStats(stats)

--- a/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataPipelineArtifacts.kt
+++ b/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataPipelineArtifacts.kt
@@ -17,7 +17,7 @@ data class MetadataFrontendPipelineArtifact(
     override val frontendOutput: AllModulesFrontendOutput,
     override val configuration: CompilerConfiguration,
     val sourceFiles: List<KtSourceFile>,
-    val isForIncrementalCompilation: Boolean = false,
+    val isIncremental: Boolean = false,
 ) : FrontendPipelineArtifact() {
     @CliPipelineInternals(OPT_IN_MESSAGE)
     override fun withCompilerConfiguration(newConfiguration: CompilerConfiguration): MetadataFrontendPipelineArtifact {
@@ -32,6 +32,7 @@ data class MetadataFrontendPipelineArtifact(
 data class MetadataInMemorySerializationArtifact(
     val metadata: SerializedMetadata,
     override val configuration: CompilerConfiguration,
+    val isIncremental: Boolean = false,
 ) : PipelineArtifact() {
     @CliPipelineInternals(OPT_IN_MESSAGE)
     override fun withCompilerConfiguration(newConfiguration: CompilerConfiguration): MetadataInMemorySerializationArtifact {

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/writer/KlibWriter.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/writer/KlibWriter.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.library.impl.KlibManifestComponentWriterImpl
 import org.jetbrains.kotlin.library.impl.KlibManifestComponentWriterImpl.Companion.NON_CUSTOMIZED_PROPERTY_NAMES
 import org.jetbrains.kotlin.library.impl.KlibManifestComponentWriterImpl.Companion.getPropertyNameForListOfTargetNames
 import org.jetbrains.kotlin.library.impl.KlibResourcesComponentWriterImpl
-import java.util.Properties
+import java.util.*
 import org.jetbrains.kotlin.konan.file.File as KlibFile
 
 /**
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.konan.file.File as KlibFile
  */
 class KlibWriter(init: KlibWriterSpec.() -> Unit) {
     private var format: KlibFormat = KlibFormat.Directory
+    private var allowIncrementalOverwriting: Boolean = false
     private val componentWriters = mutableListOf<KlibComponentWriter>()
 
     private var moduleName: String? = null
@@ -45,6 +46,10 @@ class KlibWriter(init: KlibWriterSpec.() -> Unit) {
 
             override fun format(format: KlibFormat) {
                 this@KlibWriter.format = format
+            }
+
+            override fun allowIncrementalOverwriting(allowed: Boolean) {
+                this@KlibWriter.allowIncrementalOverwriting = allowed
             }
 
             override fun include(vararg writers: KlibComponentWriter) {
@@ -82,6 +87,10 @@ class KlibWriter(init: KlibWriterSpec.() -> Unit) {
     }
 
     fun writeTo(destinationPath: String) {
+        check(!allowIncrementalOverwriting || format != KlibFormat.ZipArchive) {
+            "Writing a KLIB in ZIP format if `allowIncrementalOverwriting` is set to `true` is not supported."
+        }
+
         val allComponentWriters: List<KlibComponentWriter> = buildList {
             this += componentWriters
 
@@ -94,10 +103,13 @@ class KlibWriter(init: KlibWriterSpec.() -> Unit) {
 
         val destination = KlibFile(destinationPath).absoluteFile
 
-        if (destination.exists) {
-            destination.deleteRecursively()
-        } else {
-            destination.parentFile.mkdirs()
+        when {
+            !destination.exists -> {
+                destination.parentFile.mkdirs()
+            }
+            !allowIncrementalOverwriting -> {
+                destination.deleteRecursively()
+            }
         }
 
         when (format) {
@@ -157,6 +169,7 @@ class KlibWriter(init: KlibWriterSpec.() -> Unit) {
 
 interface KlibWriterSpec {
     fun format(format: KlibFormat)
+    fun allowIncrementalOverwriting(allowed: Boolean)
     fun include(vararg writers: KlibComponentWriter)
     fun include(writers: Collection<KlibComponentWriter>)
     fun manifest(init: KlibManifestWriterSpec.() -> Unit)

--- a/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibWriterTest.kt
+++ b/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibWriterTest.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.library.writer.KlibWrittenMetadataPackageFragmentTra
 import org.jetbrains.kotlin.library.writer.includeIr
 import org.jetbrains.kotlin.library.writer.includeMetadata
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.File
@@ -241,6 +241,27 @@ class KlibWriterTest : AbstractKlibWriterTest<NewKlibWriterParameters>(::NewKlib
             expectedMappings.map { (source, output) -> source to output },
             recordedMappings.map { (source, output) -> source to output },
         )
+    }
+
+    @Test
+    fun `Existing files removal control`() {
+        fun newWriter(allowIncrementalOverwriting: Boolean) = KlibWriter {
+            manifest {
+                moduleName("sample")
+                versions(MOCK_VERSIONS)
+                platformAndTargets(BuiltInsPlatform.COMMON)
+            }
+            allowIncrementalOverwriting(allowIncrementalOverwriting)
+        }
+
+        val klibDir = createNewKlibDir()
+        val staleFile = File(klibDir, "stale.txt").apply { writeText("stale") }
+
+        newWriter(true).writeTo(klibDir.path)
+        assertTrue(staleFile.exists(), "Pre-existing file must be preserved when allowIncrementalOverwriting = true")
+
+        newWriter(false).writeTo(klibDir.path)
+        assertFalse(staleFile.exists(), "Pre-existing file must be removed when allowIncrementalOverwriting = false")
     }
 
     override fun writeKlib(parameters: NewKlibWriterParameters): File {


### PR DESCRIPTION
During incremental compilation the metadata KLIB output directory must be updated in place so that content written for source files that were not recompiled is preserved across runs. `KlibWriter` previously always wiped the destination directory before writing, which made such in-place
 updates impossible.

^KT-87085 Verification Pending