### PR TITLE
[stdlib] Add text-specific sample for elementAtOrElse

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -27,7 +27,7 @@ public expect fun CharSequence.elementAt(index: Int): Char
 /**
  * Returns a character at the given [index] or the result of calling the [defaultValue] function if the [index] is out of bounds of this char sequence.
  * 
- * @sample samples.collections.Collections.Elements.elementAtOrElse
+ * @sample samples.text.Strings.elementAtOrElse
  */
 @kotlin.internal.InlineOnly
 public inline fun CharSequence.elementAtOrElse(index: Int, defaultValue: (Int) -> Char): Char {

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -113,6 +113,15 @@ class Strings {
     }
 
     @Sample
+    fun elementAtOrElse() {
+        val phone = "+263783"
+        assertPrints(phone.elementAtOrElse(0) { 'X' }, "+")
+        assertPrints(phone.elementAtOrElse(2) { 'X' }, "6")
+        assertPrints(phone.elementAtOrElse(8) { 'X' }, "X")
+        assertPrints("".elementAtOrElse(0) { 'X' }, "X")
+    }
+
+    @Sample
     fun filter() {
         val text = "a1b2c3d4e5"
 

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -115,9 +115,16 @@ class Strings {
     @Sample
     fun elementAtOrElse() {
         val phone = "+263783"
+
+        // in-bounds indices return the character at that position
         assertPrints(phone.elementAtOrElse(0) { 'X' }, "+")
-        assertPrints(phone.elementAtOrElse(2) { 'X' }, "6")
-        assertPrints(phone.elementAtOrElse(8) { 'X' }, "X")
+        assertPrints(phone.elementAtOrElse(phone.lastIndex) { 'X' }, "3")
+
+        // an out-of-bounds index evaluates the fallback lambda
+        assertPrints(phone.elementAtOrElse(-1) { if (it < 0) '<' else '>' }, "<")
+        assertPrints(phone.elementAtOrElse(8) { if (it < 0) '<' else '>' }, ">")
+
+        // empty string always evaluates the fallback lambda
         assertPrints("".elementAtOrElse(0) { 'X' }, "X")
     }
 

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
@@ -400,6 +400,9 @@ object Elements : TemplateGroupBase() {
                 """
             }
         }
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.elementAtOrElse")
+        }
     }
 
     val f_getOrElse = fn("getOrElse(index: Int, defaultValue: (Int) -> T)") {


### PR DESCRIPTION
Replace the generic collection sample with a text-focused example that demonstrates character access with fallback value. This makes the documentation clearer for text operations.

Related issue: [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867/kotlin.text-extension-function-samples-should-be-specialized-for-strings) 