### PR TITLE
[Swift Export] Add support for re-exporting Objective-C protocols

### DIFF
--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
@@ -62,6 +62,9 @@ private fun bridgeExistential(type: SirExistentialType, position: SirTypeVarianc
     if (type.protocols.singleOrNull()?.first == KotlinRuntimeSupportModule.kotlinBridgeable) {
         return AsAnyBridgeable
     }
+    if (type.protocols.singleOrNull()?.first?.parent is SirPlatformLikeModule) {
+        return AsObjCProtocol(type)
+    }
     return AsExistential(
         swiftType = type,
         KotlinType.KotlinObject,
@@ -625,6 +628,16 @@ internal sealed interface Bridge {
     class AsNSObject(
         swiftType: SirNominalType,
     ) : AsObjCBridged(swiftType, CType.NSObject) {
+        override val inSwiftSources: ValueConversion = object : ValueConversion {
+            context(session: SirSession)
+            override fun kotlinToSwift(typeNamer: SirTypeNamer, valueExpression: String): String =
+                "$valueExpression as! ${typeNamer.swiftFqName(swiftType)}"
+        }
+    }
+
+    class AsObjCProtocol(
+        swiftType: SirExistentialType,
+    ) : AsObjCBridged(swiftType, CType.id) {
         override val inSwiftSources: ValueConversion = object : ValueConversion {
             context(session: SirSession)
             override fun kotlinToSwift(typeNamer: SirTypeNamer, valueExpression: String): String =

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirDeclarationNamerImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirDeclarationNamerImpl.kt
@@ -8,6 +8,9 @@ package org.jetbrains.kotlin.sir.providers.impl
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.sir.providers.SirDeclarationNamer
 import org.jetbrains.kotlin.sir.providers.utils.objCNameAnnotation
 import org.jetbrains.kotlin.utils.filterIsInstanceAnd
@@ -21,11 +24,22 @@ public class SirDeclarationNamerImpl : SirDeclarationNamer {
     private fun KaDeclarationSymbol.getName(): String? {
         objCNameAnnotation?.name?.let { return it }
         return when (this) {
-            is KaNamedClassSymbol -> this.classId?.shortClassName?.asString()
+            is KaNamedClassSymbol -> this.objCProtocolName() ?: this.classId?.shortClassName?.asString()
             is KaPropertySymbol -> this.name.asString()
             is KaCallableSymbol -> this.mangleCallableName()
             else -> error(this)
         }
+    }
+
+    private fun KaNamedClassSymbol.objCProtocolName(): String? {
+        if (classKind != KaClassKind.INTERFACE || !isExternalObjCProtocol()) return null
+        return classId?.shortClassName?.asString()?.removeSuffix("Protocol")
+    }
+
+    private fun KaNamedClassSymbol.isExternalObjCProtocol(): Boolean {
+        val cInteropPackage = FqName("kotlinx.cinterop")
+        val externalObjCClassClassId = ClassId(cInteropPackage, Name.identifier("ExternalObjCClass"))
+        return externalObjCClassClassId in annotations
     }
 
     private fun KaCallableSymbol.mangleCallableName(): String? {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.kt
@@ -13,7 +13,11 @@ package = foo
 // FILE: Foo.h
 #import <Foundation/Foundation.h>
 
-@interface Foo : NSObject
+@protocol Bar
+- (int)barValue;
+@end
+
+@interface Foo : NSObject <Bar>
 @property (nonatomic, assign) int payload;
 - (instancetype)initWithPayload:(int)payload;
 - (int)doubled;
@@ -35,6 +39,10 @@ package = foo
     return self.payload * 2;
 }
 
+- (int)barValue {
+    return self.payload;
+}
+
 @end
 
 // FILE: module.modulemap
@@ -48,5 +56,10 @@ module FooKit {
 @file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
 
 import foo.Foo
+import foo.BarProtocol
 
 fun payloadTriple(x: Foo): Int = x.payload * 3
+
+// Exercises a re-exported Objective-C protocol: `BarProtocol` (Kotlin) must surface to Swift under
+// its original Objective-C name `FooKit.Bar`, otherwise the generated Swift fails to compile.
+fun barValuePlusOne(x: BarProtocol): Int = x.barValue() + 1

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.swift
@@ -7,4 +7,5 @@ func testReexportedCinteropTypeRoundTrip() {
     let foo = Foo(payload: 7)!
     #expect(payloadTriple(x: foo) == 21)
     #expect(foo.doubled() == 14)
+    #expect(barValuePlusOne(x: foo) == 8)
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/cinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/cinteropReexport.kt
@@ -18,6 +18,10 @@ package = foo
 - (int)someValue;
 @end
 
+@protocol Bar
+- (int)barValue;
+@end
+
 // FILE: module.modulemap
 module FooKit {
     header "Foo.h"
@@ -31,7 +35,12 @@ module FooKit {
 package main
 
 import foo.Foo
+import foo.BarProtocol
 
 fun consumesFoo(x: Foo): Int = 0
 
 fun producesFoo(): Foo? = null
+
+// The cinterop names the Objective-C protocol `Bar` as the Kotlin interface `BarProtocol`; the
+// generated Swift must reference it under its original Objective-C name `FooKit.Bar`.
+fun consumesBar(x: BarProtocol): Int = 0

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.h
@@ -3,6 +3,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+int32_t main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__(id x);
+
 int32_t main_consumesFoo__TypesOfArguments__FooKit_Foo__(id<NSObject> x);
 
 id<NSObject> _Nullable main_producesFoo();

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.kt
@@ -4,6 +4,14 @@ import kotlin.native.internal.ExportedBridge
 import kotlinx.cinterop.*
 import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
 
+@ExportedBridge("main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__")
+@OptIn(kotlinx.cinterop.BetaInteropApi::class, kotlinx.cinterop.ExperimentalForeignApi::class)
+public fun main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__(x: kotlin.native.internal.NativePtr): Int {
+    val __x = interpretObjCPointer<foo.BarProtocol>(x)
+    val _result = run { main.consumesBar(__x) }
+    return _result
+}
+
 @ExportedBridge("main_consumesFoo__TypesOfArguments__FooKit_Foo__")
 @OptIn(kotlinx.cinterop.BetaInteropApi::class, kotlinx.cinterop.ExperimentalForeignApi::class)
 public fun main_consumesFoo__TypesOfArguments__FooKit_Foo__(x: kotlin.native.internal.NativePtr): Int {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.swift
@@ -5,6 +5,11 @@ import KotlinRuntime
 import KotlinRuntimeSupport
 
 extension ExportedKotlinPackages.main {
+    public static func consumesBar(
+        x: any FooKit.Bar
+    ) -> Swift.Int32 {
+        return main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__(x)
+    }
     public static func consumesFoo(
         x: FooKit.Foo
     ) -> Swift.Int32 {


### PR DESCRIPTION
Objective-C import adds Protocol suffix to imported protocols, because Obj-c allows Classes and Protocols to have the same name, and kotlin does not. Objective-C export when sees a Type representing a protocol imported from Objective-C module would try and remove this `Protocol` suffix from the resulted header. This way the resulted header preserves correctness.

This commit introduces the same approach for Swift Export.

^KT-87088 fixed