### PR TITLE
[Serialization] Fix leaking type parameters

### DIFF
--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
@@ -492,10 +492,7 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
 
     // create serializers for type arguments if all arguments are classes, `null` otherwise
     private fun IrBuilderWithScope.createSerializerOnlyForClasses(type: IrSimpleType, serializableClass: IrClass): List<IrExpression>? {
-        // arguments contain star projections or type parameter
-        if (!type.arguments.all { it is IrSimpleType && it.typeOrNull?.isTypeParameter() != true }) {
-            return null
-        }
+        if (type.containsTypeParameter()) return null
 
         return type.arguments.map { argumentType ->
             if (argumentType !is IrSimpleType) return null
@@ -511,6 +508,12 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
                 null
             ) ?: return null // we can't create serializer
         }
+    }
+
+    private fun IrType.containsTypeParameter(): Boolean {
+        if (this !is IrSimpleType) return false
+        if (isTypeParameter()) return true
+        return arguments.any { it.typeOrNull?.containsTypeParameter() == true }
     }
 
     private fun IrSimpleType.checkTypeArgumentsHasSelf(itselfClass: IrClassSymbol): Boolean {

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
@@ -189,16 +189,18 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
         cachedChildSerializerByIndex: (Int) -> IrExpression?,
         genericGetter: ((Int, IrType) -> IrExpression)?
     ) {
+        val ownerType = objectToSerialize.type
 
-        fun IrSerializableProperty.irGet(): IrExpression {
-            val ownerType = objectToSerialize.symbol.owner.type
-            val propertyType = this.type
-            return getProperty(irGet(ownerType, objectToSerialize.symbol), ir, propertyType)
-        }
+        fun IrSerializableProperty.irGet(substitutedPropertyType: IrType): IrExpression = getProperty(
+            receiver = irGet(ownerType, objectToSerialize.symbol),
+            property = ir,
+            expectedPropertyType = substitutedPropertyType
+        )
 
         for ([index, property] in serializableProperties.withIndex()) {
             if (index < ignoreIndexTo) continue
             // output.writeXxxElementValue(classDesc, index, value)
+            val substitutedPropertyType = property.getSubstitutedType(ownerType.classOrFail.owner, currentClass)
             val elementCall = formEncodeDecodePropertyCall(
                 irGet(localOutput),
                 property, { innerSerial, sti ->
@@ -208,17 +210,18 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
                         irGet(localSerialDesc),
                         irInt(index),
                         innerSerial,
-                        property.irGet()
+                        property.irGet(substitutedPropertyType)
                     )
                 }, {
                     val f =
                         kOutputClass.functionByName("${CallingConventions.encode}${it.elementMethodPrefix}${CallingConventions.elementPostfix}")
                     val args: MutableList<IrExpression> = mutableListOf(irGet(localSerialDesc), irInt(index))
-                    if (it.elementMethodPrefix != "Unit") args.add(property.irGet())
+                    if (it.elementMethodPrefix != "Unit") args.add(property.irGet(substitutedPropertyType))
                     f to args
                 },
                 cachedChildSerializerByIndex(index),
-                genericGetter
+                genericGetter,
+                substitutedPropertyType = substitutedPropertyType,
             )
 
             // check for call to .shouldEncodeElementDefault
@@ -230,7 +233,7 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
                 // emit call right away
                 +elementCall
             } else {
-                val partB = irNotEquals(property.irGet(), initializerAdapter(initializer))
+                val partB = irNotEquals(property.irGet(substitutedPropertyType), initializerAdapter(initializer))
 
                 val condition = if (encodeDefaults == false) {
                     // drop default without call to .shouldEncodeElementDefault
@@ -258,19 +261,20 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
         whenDoNot: (sti: IrSerialTypeInfo) -> FunctionWithArgs,
         cachedSerializer: IrExpression?,
         genericGetter: ((Int, IrType) -> IrExpression)? = null,
-        returnTypeHint: IrType? = null
+        returnTypeHint: IrType? = null,
+        substitutedPropertyType: IrType,
     ): IrExpression {
         val sti = getIrSerialTypeInfo(property, compilerContext)
         val innerSerial = cachedSerializer ?: serializerInstance(
             sti.serializer,
             compilerContext,
-            property.type,
+            substitutedPropertyType,
             property.genericIndex,
             property.ir.parentClassOrNull,
             genericGetter
         )
         val [functionToCall, args: List<IrExpression>] = if (innerSerial != null) whenHaveSerializer(innerSerial, sti) else whenDoNot(sti)
-        val typeArgs = if (functionToCall.owner.typeParameters.isNotEmpty()) listOf(property.type) else listOf()
+        val typeArgs = if (functionToCall.owner.typeParameters.isNotEmpty()) listOf(substitutedPropertyType) else listOf()
         return irInvoke(functionToCall, listOf(encoder) + args, typeArgs, returnTypeHint)
     }
 
@@ -332,7 +336,8 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
         generator: SerializerIrGenerator,
         dispatchReceiverParameter: IrValueParameter,
         property: IrSerializableProperty,
-        cachedSerializer: IrExpression?
+        cachedSerializer: IrExpression?,
+        substitutedPropertyType: IrType,
     ): IrExpression? {
         val nullableSerClass = compilerContext.finderForBuiltins().findProperties(SerialEntityNames.wrapIntoNullableCallableId).single()
 
@@ -349,7 +354,7 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
             serializerInstance(
                 serializerClassSymbol,
                 compilerContext,
-                property.type,
+                substitutedPropertyType,
                 genericIndex = property.genericIndex,
                 property.ir.parentClassOrNull,
             ) { it, _ ->
@@ -358,7 +363,7 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
             }
         }
 
-        return serializerExpression?.let { expr -> wrapWithNullableSerializerIfNeeded(property.type, expr, nullableSerClass) }
+        return serializerExpression?.let { expr -> wrapWithNullableSerializerIfNeeded(substitutedPropertyType, expr, nullableSerClass) }
     }
 
     context(irBuilder: IrBuilderWithScope) internal fun wrapWithNullableSerializerIfNeeded(

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
@@ -309,6 +309,7 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
                 symbol,
                 listOf(irBuilder.irGetObject(companionClass)) + adjustedArgs.takeIf { it.size == nonDispatchParameters.size }.orEmpty(),
                 adjustedTypeArgs.takeIf { it.size == typeParameters.size }.orEmpty(),
+                kSerializerType(thisIrType)
             )
         }
     }
@@ -441,7 +442,13 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
 
         return { index: Int ->
             if (cacheableSerializers[index]) {
-                val lazyDelegate = irInvoke(compilerContext.arrayValueGetter.symbol, irGet(variable), irInt(index))
+                val arrayType = (variable.type as IrSimpleType).arguments.last().typeOrFail
+                val lazyDelegate = irInvoke(
+                    compilerContext.arrayValueGetter.symbol,
+                    irGet(variable),
+                    irInt(index),
+                    returnTypeHint = arrayType
+                )
                 irInvoke(
                     compilerContext.lazyValueGetter,
                     lazyDelegate,

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/Instantiator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/Instantiator.kt
@@ -373,7 +373,8 @@ internal class Instantiator(
                                 }
                             }
                         }!!
-                        generator.wrapWithNullableSerializerIfNeeded(type, expr, nullableSerClass)
+                        expr.type = expr.getSubstitutedType(type, kType, path ?: emptyList())
+                        generator.wrapWithNullableSerializerIfNeeded(expr.type, expr, nullableSerClass)
                     }
                 )
             )
@@ -382,6 +383,14 @@ internal class Instantiator(
 
         val ctor = findConstructorWithoutTypeParameters(serializerClass, needToCopyAnnotations).owner
         return callConstructor(ctor, typeArgs, newArgs)
+    }
+
+    private fun IrExpression.getSubstitutedType(subclassType: IrSimpleType, kType: IrSimpleType, path: List<IrSimpleType>): IrType {
+        val subclass = subclassType.getClass() ?: return type
+        val substitutions = kType.argumentTypesOrUpperBounds()
+        return type.substitute(subclass.typeParameters, subclass.typeParameters.map {
+            mapTypeParameterIndex(it.index, path)?.let(substitutions::getOrNull) ?: it.representativeUpperBound
+        })
     }
 
     context(irBuilder: IrBuilderWithScope)

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/IrSerializableProperties.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/IrSerializableProperties.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlinx.serialization.compiler.resolve.*
@@ -30,6 +31,9 @@ class IrSerializableProperty(
     val genericIndex = type.genericIndex
     fun serializableWith(ctx: SerializationBaseContext) =
         ir.annotations.serializableWith() ?: analyzeSpecialSerializers(ctx, ir.annotations)
+
+    fun getSubstitutedType(serializableClass: IrClass, originalClass: IrClass): IrType =
+        type.remapTypeParameters(serializableClass, originalClass)
 
     override val optional = !ir.annotations.hasAnnotation(SerializationAnnotations.requiredAnnotationFqName) && declaresDefaultValue
     override val transient = ir.annotations.hasAnnotation(SerializationAnnotations.serialTransientFqName) || !hasBackingField

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializableCompanionIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializableCompanionIrGenerator.kt
@@ -182,7 +182,8 @@ class SerializableCompanionIrGenerator(
     private fun generateSerializerGetter(serializer: IrClassSymbol, methodDescriptor: IrSimpleFunction) {
         addFunctionBody(methodDescriptor) { getter ->
             val args: List<IrExpression> = getter.nonDispatchParameters.map { irGet(it) }
-            val expr = serializerInstance(serializer, compilerContext, serializableIrClass.defaultType) { it, _ -> args[it] }
+            val serializerGetterType = serializableIrClass.defaultType.remapTypeParameters(serializableIrClass, getter)
+            val expr = serializerInstance(serializer, compilerContext, serializerGetterType) { it, _ -> args[it] }
             +irReturn(requireNotNull(expr))
         }
     }

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerForInlineClassGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerForInlineClassGenerator.kt
@@ -38,7 +38,7 @@ class SerializerForInlineClassGenerator(
         val inlineEncoder = irTemporary(encodeInlineCall, nameHint = "inlineEncoder")
 
         val property = serializableProperties.first()
-        val value = getProperty(irGet(saveFunc.parameters[2]), property.ir, property.type)
+        val value = getProperty(irGet(saveFunc.parameters[2]), property.ir, property.getTypeInScope())
 
         // inlineEncoder.encodeInt/String/SerializableValue
         val elementCall = formEncodeDecodePropertyCall(irGet(inlineEncoder), saveFunc.dispatchReceiverParameter!!, property, {innerSerial, sti ->
@@ -72,7 +72,7 @@ class SerializerForInlineClassGenerator(
         val inlineDecoder: IrExpression = irInvoke(decodeInline, irGet(loadFunc.parameters[1]), serialDescGetter)
 
         val property = serializableProperties.first()
-        val inlinedType = property.type
+        val inlinedType = property.getTypeInScope()
         val actualCall = formEncodeDecodePropertyCall(inlineDecoder, loadFunc.dispatchReceiverParameter!!, property, { innerSerial, sti ->
             decoderClass.functionByName( "${CallingConventions.decode}${sti.elementMethodPrefix}SerializableValue") to listOf(innerSerial)
         }, {

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerForInlineClassGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerForInlineClassGenerator.kt
@@ -100,6 +100,7 @@ class SerializerForInlineClassGenerator(
             serializableIrClass.constructors.single { it.isPrimary }.symbol,
             listOf(expression),
             (inlineClassBoxType as IrSimpleType).arguments.map { it.typeOrNull },
+            returnTypeHint = inlineClassBoxType,
         )
 
 }

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerIrGenerator.kt
@@ -233,7 +233,8 @@ open class SerializerIrGenerator(
                     this@SerializerIrGenerator,
                     irFun.dispatchReceiverParameter!!,
                     property,
-                    cachedChildSerializerByIndex(index)
+                    cachedChildSerializerByIndex(index),
+                    property.getTypeInScope()
                 )
             ) { "Property ${property.name} must have a serializer" }
         }
@@ -338,7 +339,8 @@ open class SerializerIrGenerator(
             val ir = localSerializersFieldsDescriptors[it]
             irGetField(irGet(dispatchReceiver), ir.backingField!!)
         },
-        returnTypeHint
+        returnTypeHint,
+        substitutedPropertyType = property.getTypeInScope(),
     )
 
     // returns null: Any? for boxed types and 0: <number type> for primitives
@@ -403,7 +405,7 @@ open class SerializerIrGenerator(
         // var local0 = null, local1 = null ...
         val serialPropertiesMap = serializableProperties.mapIndexed { i, prop -> i to prop }.associate { [i, serializableProp] ->
             val ir = serializableProp.ir
-            val [expr, type] = defaultValueAndType(ir, serializableProp.type)
+            val [expr, type] = defaultValueAndType(ir, serializableProp.getTypeInScope())
             ir to irTemporary(expr, "local$i", type, isMutable = true)
         }
         // var transient0 = null, transient1 = null ...
@@ -445,7 +447,7 @@ open class SerializerIrGenerator(
                                                              it.owner.name.asString() == "${CallingConventions.decode}${sti.elementMethodPrefix}${CallingConventions.elementPostfix}" &&
                                                                      it.owner.hasShape(dispatchReceiver = true, regularParameters = 2)
                                                          } to listOf(localSerialDesc.get(), irInt(index))
-                                                     }, cachedChildSerializerByIndex(index), returnTypeHint = property.type)
+                                                     }, cachedChildSerializerByIndex(index), returnTypeHint = property.getTypeInScope())
                     // local$i = localInput.decode...(...)
                     +irSet(
                         serialPropertiesMap.getValue(property.ir).symbol,
@@ -628,6 +630,8 @@ open class SerializerIrGenerator(
         }
     }
 
+    protected fun IrSerializableProperty.getTypeInScope() =
+        getSubstitutedType(serializableIrClass, irClass)
 
     companion object {
         @OptIn(ValueClassBackendAgnosticApi::class)

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerializerIrGenerator.kt
@@ -514,7 +514,7 @@ open class SerializerIrGenerator(
         if (serializableIrClass.shouldHaveGeneratedMethods() && deserCtor != null) {
             var args: List<IrExpression> = serializableProperties.map { serialPropertiesMap.getValue(it.ir).get() }
             args = bitMasks.map { irGet(it) } + args + irNull()
-            +irReturn(irInvoke(deserCtor, args, typeArgs))
+            +irReturn(irInvoke(deserCtor, args, typeArgs, loadFunc.returnType))
         } else {
             if (irClass.isLocal) {
                 // if the serializer is local, then the serializable class too, since they must be in the same scope


### PR DESCRIPTION
KT-86224

To validate changes, please uncomment [this line](https://github.com/JetBrains/kotlin/blob/c057418a8228d087526a844fbd58651153bc6ae9/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt#L508) and run `SerializationJsBoxTestGenerated`.

It should be enough, but as an extra, before my changes also these tests were failing:
- `SerializationJdk11FirLightTreeBoxTestGenerated`                                                                                                                                             
- `SerializationJsBoxWithInlinedFunInKlibTestGenerated`                                                                                                                                     
- `SerializationFirLightTreeAsmLikeInstructionsListingTestGenerated`                                                                                                                           
- `SerializationFirLightTreeBlackBoxTestGenerated`