### PR TITLE
[CRI] explicitly disable CRI generation for non-JVM targets to avoid false-positive warnings

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerReferenceIndexIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerReferenceIndexIT.kt
@@ -21,12 +21,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.name.FqName
 import org.junit.jupiter.api.DisplayName
-import kotlin.io.path.*
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import kotlin.io.path.div
+import kotlin.io.path.invariantSeparatorsPathString
+import kotlin.io.path.readBytes
+import kotlin.io.path.relativeTo
+import kotlin.test.*
 
 @OptIn(ExperimentalBuildToolsApi::class)
 @DisplayName("Gradle / Compiler Reference Index")
@@ -214,6 +213,23 @@ class CompilerReferenceIndexIT : KGPDaemonsBaseTest() {
     fun testEnablingCriDoesNotFailNativeCompile(gradleVersion: GradleVersion) {
         nativeProject("native-simple-project", gradleVersion) {
             build("assemble") {
+                assertNoDiagnostic(KotlinToolingDiagnostics.GeneratingCompilerRefIndexWithoutBuildToolsApi)
+            }
+        }
+    }
+
+    @GradleTest
+    @DisplayName("CRI warning without BTA is only emitted for JVM targets in KMP")
+    fun testCriWarningWithoutBtaOnlyForJvmInKmp(gradleVersion: GradleVersion) {
+        val options = defaultBuildOptions.copy(
+            runViaBuildToolsApi = false,
+            generateCompilerRefIndex = true,
+        ).disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
+        project("jvm-and-js-hmpp", gradleVersion, buildOptions = options) {
+            build("compileKotlinJvm") {
+                assertHasDiagnostic(KotlinToolingDiagnostics.GeneratingCompilerRefIndexWithoutBuildToolsApi)
+            }
+            build("compileKotlinJs") {
                 assertNoDiagnostic(KotlinToolingDiagnostics.GeneratingCompilerRefIndexWithoutBuildToolsApi)
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/Kotlin2JsCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/Kotlin2JsCompileConfig.kt
@@ -60,6 +60,7 @@ internal open class BaseKotlin2JsCompileConfig<TASK : Kotlin2JsCompile>(
                 KotlinPlatformType.wasm -> task.runViaBuildToolsApi.convention(propertiesProvider.runKotlinWasmCompilerViaBuildToolsApi)
                 else -> task.runViaBuildToolsApi.value(false).disallowChanges()
             }
+            task.generateCompilerRefIndex.value(false).disallowChanges()
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileCommonConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileCommonConfig.kt
@@ -24,6 +24,7 @@ internal class KotlinCompileCommonConfig(
             task.moduleName.set(providers.provider { compilationInfo.moduleName })
             task.incrementalModuleInfoProvider.disallowChanges()
             task.runViaBuildToolsApi.convention(propertiesProvider.runKotlinMetadataCompilerViaBuildToolsApi)
+            task.generateCompilerRefIndex.value(false).disallowChanges()
         }
     }
 }


### PR DESCRIPTION
[CRI] explicitly disable CRI generation for non-JVM targets to avoid false-positive warnings

^KT-87084 Verification Pending