### PR TITLE
[Wasm] Mute multi-module testInitializersInParentInAnotherModule

### DIFF
--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInParentInAnotherModule.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInParentInAnotherModule.kt
@@ -1,5 +1,6 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
 // IGNORE_IR_DESERIALIZATION_TEST: JS_IR, NATIVE
+// WASM_IGNORE_FOR: mode=multi-module
 // ^^^ KT-86953 K2: Fake overrides are generated for inherited companion-block static members
 
 // MODULE: lib


### PR DESCRIPTION
Youtrack: [KT-87109](https://youtrack.jetbrains.com/issue/KT-87109)