### PR TITLE
[KMP] Name KLIB metadata fragments after source files

### DIFF
--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibMetadataComponentWriterImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibMetadataComponentWriterImpl.kt
@@ -11,7 +11,9 @@ import org.jetbrains.kotlin.library.SerializedMetadata
 import org.jetbrains.kotlin.library.components.KlibMetadataComponentLayout
 import org.jetbrains.kotlin.library.writer.KlibComponentWriter
 import org.jetbrains.kotlin.library.writer.KlibWrittenMetadataPackageFragmentTracker
+import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.nameWithoutExtension
 import org.jetbrains.kotlin.konan.file.File as KlibFile
 
 /**
@@ -32,25 +34,37 @@ internal class KlibMetadataComponentWriterImpl(
             packageFragmentDir.mkdirs()
 
             val shortPackageName: String = packageFqName.substringAfterLast(".")
-            val packageFragmentParts: List<SerializedFragment> = metadata.fragments[index]
+            val (packageFragmentWithSourceParts, packageFragmentWithoutSourceParts) =
+                metadata.fragments[index].partition { it.sourceFilePathOrNull != null }
 
-            val padding: Int = packageFragmentParts.size.toString().length
-            fun withPadding(packageFragmentPartIndex: Int) = String.format("%0${padding}d", packageFragmentPartIndex)
+            val padding: Int = packageFragmentWithoutSourceParts.size.toString().length
+            packageFragmentWithoutSourceParts.forEachIndexed { partIndex, packageFragmentPart ->
+                val partName = "${partIndex.toString().padStart(padding, '0')}_$shortPackageName"
+                layout.writeFragment(packageFqName, partName, packageFragmentPart.content, sourceFile = null)
+            }
 
-            packageFragmentParts.forEachIndexed { packageFragmentPartIndex, packageFragmentPart ->
-                val packageFragmentFile = layout.getPackageFragmentFile(
-                    packageFqName = packageFqName,
-                    partName = "${withPadding(packageFragmentPartIndex)}_$shortPackageName"
-                )
-                packageFragmentFile.writeBytes(packageFragmentPart.content)
+            packageFragmentWithSourceParts.forEach { packageFragmentPart ->
+                val sourceFile = Path(requireNotNull(packageFragmentPart.sourceFilePathOrNull))
+                val sourceFileName = sourceFile.nameWithoutExtension
 
-                if (fragmentTracker != null && packageFragmentPart is SerializedFragmentWithSource) {
-                    fragmentTracker.recordSourceFile(
-                        packageFragmentPart.sourceFilePath?.let { Path(it) },
-                        packageFragmentFile.javaPath()
-                    )
-                }
+                layout.writeFragment(packageFqName, sourceFileName, packageFragmentPart.content, sourceFile)
             }
         }
+    }
+
+    private val SerializedFragment.sourceFilePathOrNull: String?
+        get() = (this as? SerializedFragmentWithSource)?.sourceFilePath
+
+    private fun KlibMetadataComponentLayout.writeFragment(
+        packageFqName: String,
+        partName: String,
+        content: ByteArray,
+        sourceFile: Path?,
+    ) {
+        val packageFragmentFile = getPackageFragmentFile(packageFqName = packageFqName, partName = partName)
+        check(packageFragmentFile.exists.not()) { "Duplicate package fragment name '${packageFragmentFile.path}'" }
+        packageFragmentFile.writeBytes(content)
+
+        fragmentTracker?.recordSourceFile(sourceFile, packageFragmentFile.javaPath())
     }
 }

--- a/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibWriterTest.kt
+++ b/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibWriterTest.kt
@@ -233,7 +233,8 @@ class KlibWriterTest : AbstractKlibWriterTest<NewKlibWriterParameters>(::NewKlib
 
         val layout = KlibMetadataComponentLayout(KlibFile(klibDir.path))
         val expectedMappings = listOf(
-            Path("/src/a.kt") to layout.getPackageFragmentFile(packageFqName = "", partName = "0_").javaPath(),
+            null to layout.getPackageFragmentFile(packageFqName = "", partName = "0_").javaPath(),
+            Path("/src/a.kt") to layout.getPackageFragmentFile(packageFqName = "", partName = "a").javaPath(),
             null to layout.getPackageFragmentFile(packageFqName = "foo.bar", partName = "0_bar").javaPath(),
         )
 
@@ -241,6 +242,29 @@ class KlibWriterTest : AbstractKlibWriterTest<NewKlibWriterParameters>(::NewKlib
             expectedMappings.map { (source, output) -> source to output },
             recordedMappings.map { (source, output) -> source to output },
         )
+    }
+
+    @Test
+    fun `Fragments source file with the same name and package reports`() {
+        val content = ByteArray(10)
+
+        assertThrows<IllegalStateException> {
+            writeKlib(
+                NewKlibWriterParameters().apply {
+                    metadata = SerializedMetadata(
+                        module = content,
+                        fragments = listOf(
+                            listOf(
+                                SerializedFragmentWithSource(content, "/src/x/a.kt"),
+                                SerializedFragmentWithSource(content, "/src/y/a.kt"),
+                            ),
+                        ),
+                        fragmentNames = listOf("foo.bar"),
+                        metadataVersion = MetadataVersion.INSTANCE.toArray(),
+                    )
+                }
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Use the source file name (instead of a padded index) for metadata fragments that have one, giving a stable source-to-fragment mapping for in-place incremental KLIB writes, and reject duplicate fragment names.

^KT-87110 Verification Pending