### PR TITLE
[ObjCExport] K2: Render documentation correctly for receivers

### DIFF
--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCComment.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCComment.kt
@@ -64,8 +64,14 @@ internal fun KaSession.translateToObjCComment(
 
     val visibilityComments = function.buildObjCVisibilityComment("method")
 
-    val paramComments = function.valueParameters.mapNotNull { parameterSymbol ->
-        val param = parameters.find { parameter -> parameter.name == parameterSymbol.name.asString() }
+    val allParams = listOfNotNull(function.receiverParameter) + function.valueParameters
+    val paramComments = allParams.mapNotNull { parameterSymbol ->
+        val parameterSymbolName = when (parameterSymbol) {
+            is KaReceiverParameterSymbol -> "receiver"
+            else -> parameterSymbol.name.asString()
+        }
+
+        val param = parameters.find { parameter -> parameter.name == parameterSymbolName }
         param?.let { renderedObjCDocumentedParamAnnotations(it, parameterSymbol) }
     }
     val annotationsComments = translateToObjCComment(function.annotations)
@@ -75,7 +81,7 @@ internal fun KaSession.translateToObjCComment(
 /**
  * [org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportTranslatorImpl.mustBeDocumentedParamAttributeList]
  */
-private fun KaSession.renderedObjCDocumentedParamAnnotations(parameter: ObjCParameter, parameterSymbol: KaValueParameterSymbol): String? {
+private fun KaSession.renderedObjCDocumentedParamAnnotations(parameter: ObjCParameter, parameterSymbol: KaParameterSymbol): String? {
     val renderedAnnotationsString = getObjCDocumentedAnnotations(parameterSymbol)
         .mapNotNull { annotation -> renderAnnotation(annotation) }
         .ifEmpty { return null }

--- a/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
+++ b/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/ObjCExportHeaderGeneratorTest.kt
@@ -210,13 +210,11 @@ class ObjCExportHeaderGeneratorTest(private val generator: HeaderGenerator) {
     }
 
     @Test
-    @TodoAnalysisApi
     fun `test - receiverWithMustBeDocumentedAnnotation`() {
         doTest(headersTestDataDir.resolve("receiverWithMustBeDocumentedAnnotation"))
     }
 
     @Test
-    @TodoAnalysisApi
     fun `test - dispatchAndExtensionReceiverWithMustBeDocumentedAnnotation`() {
         doTest(headersTestDataDir.resolve("dispatchAndExtensionReceiverWithMustBeDocumentedAnnotation"))
     }


### PR DESCRIPTION
The k1 implementation uses `.allParameters` to iterate over all method parameters when building a comment. While the same was done in k2, this approach erroneously omits the receiver, as in k2, the receiver is stowed as a separate property of `KaFunctionSymbol`.

By including this property, we should now be able to generate the associated documentation appropriately. This change applies this fix and enables the corresponding tests.

^[KT-88153](https://youtrack.jetbrains.com/issue/KT-88153) fixed