### PR TITLE
[JKLIB] Use zipFileSystemAccessor in k2jklibcompiler

### DIFF
--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JKlibCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JKlibCompilerArgumentsCopyGenerated.kt
@@ -21,6 +21,7 @@ fun copyK2JKlibCompilerArguments(from: K2JKlibCompilerArguments, to: K2JKlibComp
     to.jsr305 = from.jsr305?.copyOf()
     to.jvmDefault = from.jvmDefault
     to.klibLibraries = from.klibLibraries
+    to.klibZipFileAccessorCacheLimit = from.klibZipFileAccessorCacheLimit
     to.moduleName = from.moduleName
     to.noJdk = from.noJdk
     to.noReflect = from.noReflect

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/K2JKlibCompilerArguments.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/K2JKlibCompilerArguments.kt
@@ -252,6 +252,17 @@ The default value is 'indy'.""",
             field = value
         }
 
+    // TODO(KT-87172): Remove if we decide to extend CommonKlibBasedCompilerArguments 
+    @Argument(
+        value = "-Xklib-zip-file-accessor-cache-limit",
+        description = "Maximum number of klibs that can be cached during compilation. Default is 500.",
+    )
+    var klibZipFileAccessorCacheLimit: String = "500"
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
     override fun copyOf(): Freezable = TODO() // copyK2JKlibCompilerArguments(this, K2JKlibCompilerArguments())
 
     @get:Transient

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -322,7 +322,11 @@ object JKlibIrCompilationPhase :
     }
 
     private fun loadLibraries(klibFiles: List<String>, configuration: CompilerConfiguration): List<KotlinLibrary> {
-        val loadingResult = KlibLoader { libraryPaths(klibFiles) }.load()
+        val loadingResult =
+            KlibLoader {
+                libraryPaths(klibFiles)
+                configuration.zipFileSystemAccessor?.let { zipFileSystemAccessor(it) }
+            }.load()
         loadingResult.reportLoadingProblemsIfAny(configuration, allAsErrors = true)
         return loadingResult.librariesStdlibFirst
     }

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
@@ -172,6 +172,13 @@ object JKlibConfigurationUpdater : ConfigurationUpdater<K2JKlibCompilerArguments
         arguments.destination?.let { configuration.jklibOutputDestination = it }
         configuration.jklibCompileIr = arguments.compileIr
         arguments.friendModules?.let { configuration.friendPaths = it.split(File.pathSeparator).filterNot(String::isEmpty) }
+
+        // TODO(KT-87172): call configuration.setupCommonKlibArguments() instead of manual setup.
+        configuration.zipFileSystemAccessor = arguments.getZipFileSystemAccessor(
+            zipFileAccessorCacheLimitArgument = K2JKlibCompilerArguments::klibZipFileAccessorCacheLimit,
+            configuration = configuration,
+            rootDisposable = input.rootDisposable,
+        )
     }
 }
 
@@ -198,7 +205,11 @@ object JKlibFrontendPipelinePhase : PipelinePhase<ConfigurationPipelineArtifact,
 
         val klibFiles = configuration.klibPaths
 
-        val klibLoadingResult = KlibLoader { libraryPaths(klibFiles) }.load()
+        val klibLoadingResult =
+            KlibLoader {
+                libraryPaths(klibFiles)
+                configuration.zipFileSystemAccessor?.let { zipFileSystemAccessor(it) }
+            }.load()
         klibLoadingResult.reportLoadingProblemsIfAny { _, message ->
             configuration.report(CLASSPATH_RESOLUTION_ERROR, message)
         }


### PR DESCRIPTION
In order to leverage caching of zips during deserialization. 
This PR adds usage of zipFileSystemAccessor for k2jklibcompiler