### PR TITLE
[FIR] Make use of FirAggressivePruningProcessor configurable with a flag

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -4161,6 +4161,51 @@
                         "deprecatedMessage": null
                     },
                     {
+                        "name": "Xfir-aggressive-pruning",
+                        "shortName": null,
+                        "deprecatedName": null,
+                        "description": {
+                            "current": "Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.",
+                            "valueInVersions": []
+                        },
+                        "delimiter": null,
+                        "affectsCompilationOutcome": true,
+                        "restrictedToCompilerPhase": null,
+                        "valueType": {
+                            "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                            "isNullable": {
+                                "current": true,
+                                "valueInVersions": []
+                            },
+                            "defaultValue": {
+                                "current": null,
+                                "valueInVersions": []
+                            }
+                        },
+                        "valueDescription": {
+                            "current": null,
+                            "valueInVersions": []
+                        },
+                        "releaseVersionsMetadata": {
+                            "introducedVersion": "2.4.20",
+                            "stabilizedVersion": null,
+                            "deprecatedVersion": null,
+                            "removedVersion": null
+                        },
+                        "argumentType": {
+                            "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                            "isNullable": {
+                                "current": true,
+                                "valueInVersions": []
+                            },
+                            "defaultValue": {
+                                "current": null,
+                                "valueInVersions": []
+                            }
+                        },
+                        "deprecatedMessage": null
+                    },
+                    {
                         "name": "Xfragment-dependency",
                         "shortName": null,
                         "deprecatedName": null,

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
@@ -1398,6 +1398,17 @@ Warning: this flag is not intended for production use. If you want to configure 
     }
 
     compilerArgument {
+        name = "Xfir-aggressive-pruning"
+        compilerName = "firAggressivePruning"
+        description = "Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.".asReleaseDependent()
+        valueType = BooleanType.defaultNull
+
+        lifecycle(
+            introducedVersion = KotlinReleaseVersion.v2_4_20
+        )
+    }
+
+    compilerArgument {
         name = "Xdont-sort-source-files"
         description = """
             Disable automatic sorting of source files.

--- a/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
+++ b/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
@@ -497,6 +497,7 @@ public abstract interface class org/jetbrains/kotlin/buildtools/api/arguments/Co
 	public static final field X_EXPLICIT_API Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_EXPLICIT_BACKING_FIELDS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_EXPLICIT_CONTEXT_ARGUMENTS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
+	public static final field X_FIR_AGGRESSIVE_PRUNING Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_HEADER_MODE Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_HEADER_MODE_TYPE Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;
 	public static final field X_IGNORE_CONST_OPTIMIZATION_ERRORS Lorg/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments$CommonCompilerArgument;

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments.kt
@@ -455,6 +455,16 @@ public interface CommonCompilerArguments : CommonToolArguments {
         CommonCompilerArgument("X_EXPLICIT_CONTEXT_ARGUMENTS", KotlinReleaseVersion(2, 4, 0))
 
     /**
+     * Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.
+     *
+     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
+     */
+    @JvmField
+    @ExperimentalCompilerArgument
+    public val X_FIR_AGGRESSIVE_PRUNING: CommonCompilerArgument<Boolean?> =
+        CommonCompilerArgument("X_FIR_AGGRESSIVE_PRUNING", KotlinReleaseVersion(2, 4, 20))
+
+    /**
      * Enable header compilation mode.
      * In this mode, the compiler produces class files that only contain the 'skeleton' of the classes to be
      * compiled but the method bodies of all the implementations are empty.  This is used to speed up parallel compilation

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonCompilerArgumentsImpl.kt
@@ -78,6 +78,7 @@ import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgume
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_EXPLICIT_API
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_EXPLICIT_BACKING_FIELDS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_EXPLICIT_CONTEXT_ARGUMENTS
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_FIR_AGGRESSIVE_PRUNING
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_FRAGMENTS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_FRAGMENT_DEPENDENCY
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.CommonCompilerArgumentsImpl.Companion.X_FRAGMENT_FRIEND_DEPENDENCY
@@ -246,6 +247,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     if (X_EXPLICIT_API in this) { arguments.explicitApi = get(X_EXPLICIT_API).stringValue}
     if (X_EXPLICIT_BACKING_FIELDS in this) { arguments.explicitBackingFields = get(X_EXPLICIT_BACKING_FIELDS)}
     if (X_EXPLICIT_CONTEXT_ARGUMENTS in this) { arguments.explicitContextArguments = get(X_EXPLICIT_CONTEXT_ARGUMENTS)}
+    if (X_FIR_AGGRESSIVE_PRUNING in this) { arguments.firAggressivePruning = get(X_FIR_AGGRESSIVE_PRUNING)}
     if (X_FRAGMENT_DEPENDENCY in this) { arguments.fragmentDependencies = get(X_FRAGMENT_DEPENDENCY) ?: emptyArray()}
     if (X_FRAGMENT_FRIEND_DEPENDENCY in this) { arguments.fragmentFriendDependencies = get(X_FRAGMENT_FRIEND_DEPENDENCY) ?: emptyArray()}
     if (X_FRAGMENT_INCREMENTAL_CLASSPATH in this) { arguments.fragmentIncrementalClasspath = get(X_FRAGMENT_INCREMENTAL_CLASSPATH) ?: emptyArray()}
@@ -361,6 +363,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     try { this[X_EXPLICIT_API] = arguments.explicitApi.let { ExplicitApiMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::explicitApi, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xexplicit-api value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPLICIT_BACKING_FIELDS] = arguments.explicitBackingFields } catch (_: NoSuchMethodError) {  }
     try { this[X_EXPLICIT_CONTEXT_ARGUMENTS] = arguments.explicitContextArguments } catch (_: NoSuchMethodError) {  }
+    try { this[X_FIR_AGGRESSIVE_PRUNING] = arguments.firAggressivePruning } catch (_: NoSuchMethodError) {  }
     try { this[X_FRAGMENT_DEPENDENCY] = arguments.fragmentDependencies } catch (_: NoSuchMethodError) {  }
     try { this[X_FRAGMENT_FRIEND_DEPENDENCY] = arguments.fragmentFriendDependencies } catch (_: NoSuchMethodError) {  }
     try { this[X_FRAGMENT_INCREMENTAL_CLASSPATH] = arguments.fragmentIncrementalClasspath } catch (_: NoSuchMethodError) {  }
@@ -471,6 +474,7 @@ internal abstract class CommonCompilerArgumentsImpl(
     if (X_EXPLICIT_API in this) { arguments.explicitApi = get(X_EXPLICIT_API).stringValue}
     if (X_EXPLICIT_BACKING_FIELDS in this) { arguments.explicitBackingFields = get(X_EXPLICIT_BACKING_FIELDS)}
     if (X_EXPLICIT_CONTEXT_ARGUMENTS in this) { arguments.explicitContextArguments = get(X_EXPLICIT_CONTEXT_ARGUMENTS)}
+    if (X_FIR_AGGRESSIVE_PRUNING in this) { arguments.firAggressivePruning = get(X_FIR_AGGRESSIVE_PRUNING)}
     if (X_FRAGMENT_DEPENDENCY in this) { arguments.fragmentDependencies = get(X_FRAGMENT_DEPENDENCY) ?: emptyArray()}
     if (X_FRAGMENT_FRIEND_DEPENDENCY in this) { arguments.fragmentFriendDependencies = get(X_FRAGMENT_FRIEND_DEPENDENCY) ?: emptyArray()}
     if (X_FRAGMENT_INCREMENTAL_CLASSPATH in this) { arguments.fragmentIncrementalClasspath = get(X_FRAGMENT_INCREMENTAL_CLASSPATH) ?: emptyArray()}
@@ -681,6 +685,9 @@ internal abstract class CommonCompilerArgumentsImpl(
 
     public val X_EXPLICIT_CONTEXT_ARGUMENTS: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_EXPLICIT_CONTEXT_ARGUMENTS")
+
+    public val X_FIR_AGGRESSIVE_PRUNING: CommonCompilerArgument<Boolean?> =
+        CommonCompilerArgument("X_FIR_AGGRESSIVE_PRUNING")
 
     public val X_FRAGMENT_DEPENDENCY: CommonCompilerArgument<Array<String>?> =
         CommonCompilerArgument("X_FRAGMENT_DEPENDENCY")

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
@@ -541,6 +541,16 @@ Use the 'warning' level to issue warnings instead of errors.""",
         }
 
     @Argument(
+        value = "-Xfir-aggressive-pruning",
+        description = "Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.",
+    )
+    var firAggressivePruning: Boolean? = null
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xfragment-dependency",
         valueDescription = "<fragment name>:<path>",
         description = """Declare common klib dependencies for the specific fragment.

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
@@ -52,6 +52,7 @@ fun copyCommonCompilerArguments(from: CommonCompilerArguments, to: CommonCompile
     to.explicitBackingFields = from.explicitBackingFields
     to.explicitContextArguments = from.explicitContextArguments
     to.explicitReturnTypes = from.explicitReturnTypes
+    to.firAggressivePruning = from.firAggressivePruning
     to.fragmentDependencies = from.fragmentDependencies.copyOf()
     to.fragmentFriendDependencies = from.fragmentFriendDependencies.copyOf()
     to.fragmentIncrementalClasspath = from.fragmentIncrementalClasspath.copyOf()

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsConfigurator.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsConfigurator.kt
@@ -60,6 +60,7 @@ open class CommonCompilerArgumentsConfigurator {
             putAnalysisFlag(AnalysisFlags.lenientMode, lenientMode)
             putAnalysisFlag(AnalysisFlags.headerMode, headerMode)
             putAnalysisFlag(AnalysisFlags.headerModeType, headerModeType)
+            putAnalysisFlag(AnalysisFlags.firAggressivePruning, firAggressivePruning ?: headerMode)
             putAnalysisFlag(AnalysisFlags.hierarchicalMultiplatformCompilation, separateKmpCompilationScheme && multiPlatform)
             putAnalysisFlag(AnalysisFlags.kmpJvmIncrementalCompilationEnabled, fragmentIncrementalClasspath.isNotEmpty() && multiPlatform)
             fillWarningLevelMap(arguments, reporter)

--- a/compiler/config/src/org/jetbrains/kotlin/config/AnalysisFlags.kt
+++ b/compiler/config/src/org/jetbrains/kotlin/config/AnalysisFlags.kt
@@ -103,6 +103,8 @@ object AnalysisFlags {
     val headerMode by AnalysisFlag.Delegates.Boolean
 
     val headerModeType by AnalysisFlag.Delegates.HeaderModeTypeAnyByDefault
+
+    val firAggressivePruning by AnalysisFlag.Delegates.Boolean
 }
 
 val LanguageVersionSettings.hmppProvidersEnabled: Boolean

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirTotalResolveProcessor.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirTotalResolveProcessor.kt
@@ -92,7 +92,7 @@ fun FirResolvePhase.createCompilerProcessorByPhase(
         ANNOTATION_ARGUMENTS -> FirAnnotationArgumentsProcessor(session, scopeSession)
         BODY_RESOLVE -> {
             val processor = FirBodyResolveProcessor(session, scopeSession)
-            if (session.languageVersionSettings.getFlag(AnalysisFlags.headerMode)) {
+            if (session.languageVersionSettings.getFlag(AnalysisFlags.firAggressivePruning)) {
                 FirAggressivePruningProcessor(processor)
             } else {
                 processor

--- a/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/builders/LanguageVersionSettingsBuilder.kt
+++ b/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/builders/LanguageVersionSettingsBuilder.kt
@@ -116,6 +116,11 @@ class LanguageVersionSettingsBuilder {
             analysisFlag(AnalysisFlags.stdlibCompilation, trueOrNull(LanguageSettingsDirectives.STDLIB_COMPILATION in directives)),
             analysisFlag(AnalysisFlags.lenientMode, trueOrNull(LanguageSettingsDirectives.LENIENT_MODE in directives)),
             analysisFlag(AnalysisFlags.headerMode, trueOrNull(LanguageSettingsDirectives.HEADER_MODE in directives)),
+            analysisFlag(
+                AnalysisFlags.firAggressivePruning,
+                directives[LanguageSettingsDirectives.FIR_AGGRESSIVE_PRUNING].singleOrNull()
+                    ?: trueOrNull(LanguageSettingsDirectives.HEADER_MODE in directives)
+            ),
             analysisFlag(AnalysisFlags.ideMode, trueOrNull(LanguageSettingsDirectives.IDE_MODE in directives)),
 
             analysisFlag(JvmAnalysisFlags.jvmDefaultMode, directives.singleOrZeroValue(LanguageSettingsDirectives.JVM_DEFAULT_MODE)),

--- a/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/directives/LanguageSettingsDirectives.kt
+++ b/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/directives/LanguageSettingsDirectives.kt
@@ -172,6 +172,7 @@ object LanguageSettingsDirectives : SimpleDirectivesContainer() {
     val USE_INLINE_SCOPES_NUMBERS by directive("Use inline scopes numbers for inline marker variables")
     val DONT_WARN_ON_ERROR_SUPPRESSION by directive("Don't emit warning when an error is suppressed")
     val HEADER_MODE by directive("Enable header mode")
+    val FIR_AGGRESSIVE_PRUNING by valueDirective("Enable/disable FIR aggressive pruning: 'true' or 'false'", parser = String::toBoolean)
     val IDE_MODE by directive("Enable ide mode")
 
 

--- a/compiler/testData/cli/js/jsExtraHelp.out
+++ b/compiler/testData/cli/js/jsExtraHelp.out
@@ -183,6 +183,7 @@ where advanced options include:
                              Use the 'warning' level to issue warnings instead of errors.
   -Xexplicit-backing-fields  Enable experimental language support for explicit backing fields.
   -Xexplicit-context-arguments Enable explicit passing of context arguments using named argument syntax.
+  -Xfir-aggressive-pruning   Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.
   -Xfragment-dependency=<fragment name>:<path>
                              Declare common klib dependencies for the specific fragment.
                              This argument is required for any HMPP module except the platform leaf module: it takes dependencies from -cp/-libraries.

--- a/compiler/testData/cli/jvm/extraHelp.out
+++ b/compiler/testData/cli/jvm/extraHelp.out
@@ -219,6 +219,7 @@ where advanced options include:
                              Use the 'warning' level to issue warnings instead of errors.
   -Xexplicit-backing-fields  Enable experimental language support for explicit backing fields.
   -Xexplicit-context-arguments Enable explicit passing of context arguments using named argument syntax.
+  -Xfir-aggressive-pruning   Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.
   -Xfragment-dependency=<fragment name>:<path>
                              Declare common klib dependencies for the specific fragment.
                              This argument is required for any HMPP module except the platform leaf module: it takes dependencies from -cp/-libraries.

--- a/compiler/testData/cli/wasm/wasmExtraHelp.out
+++ b/compiler/testData/cli/wasm/wasmExtraHelp.out
@@ -158,6 +158,7 @@ where advanced options include:
                              Use the 'warning' level to issue warnings instead of errors.
   -Xexplicit-backing-fields  Enable experimental language support for explicit backing fields.
   -Xexplicit-context-arguments Enable explicit passing of context arguments using named argument syntax.
+  -Xfir-aggressive-pruning   Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.
   -Xfragment-dependency=<fragment name>:<path>
                              Declare common klib dependencies for the specific fragment.
                              This argument is required for any HMPP module except the platform leaf module: it takes dependencies from -cp/-libraries.

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOff.ir.txt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOff.ir.txt
@@ -1,0 +1,36 @@
+FILE fqName:<root> fileName:/firAggressivePruningOff.kt
+  PROPERTY name:unusedPrivateProperty visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:unusedPrivateProperty type:kotlin.String visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-unusedPrivateProperty> visibility:private modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:unusedPrivateProperty visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-unusedPrivateProperty> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:unusedPrivateProperty type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
+  PROPERTY name:privatePropertyReferencedByNonInline visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:privatePropertyReferencedByNonInline type:kotlin.String visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-privatePropertyReferencedByNonInline> visibility:private modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:privatePropertyReferencedByNonInline visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-privatePropertyReferencedByNonInline> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:privatePropertyReferencedByNonInline type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
+  PROPERTY name:privatePropertyReferencedByInline visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:privatePropertyReferencedByInline type:kotlin.String visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-privatePropertyReferencedByInline> visibility:private modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:privatePropertyReferencedByInline visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-privatePropertyReferencedByInline> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:privatePropertyReferencedByInline type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
+  FUN name:privateFunReferencedByInline visibility:private modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+  FUN name:privateFunReferencedByNonInline visibility:private modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+  FUN name:publicInlineFun visibility:public modality:FINAL returnType:kotlin.String [inline]
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun publicInlineFun (): kotlin.String declared in <root>'
+        CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUS
+          ARG <this>: CALL 'private final fun privateFunReferencedByInline (): kotlin.String declared in <root>' type=kotlin.String origin=null
+          ARG other: CALL 'private final fun <get-privatePropertyReferencedByInline> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+  FUN name:publicNonInlineFun visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+  FUN name:unusedPrivateFun visibility:private modality:FINAL returnType:kotlin.String
+    BLOCK_BODY

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOff.klib_abi.txt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOff.klib_abi.txt
@@ -1,0 +1,13 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <main>
+final class /Foo { // /Foo|null[0]
+    constructor <init>() // /Foo.<init>|<init>(){}[0]
+    final fun access$<get-privatePropertyReferencedByInline>(/Foo): kotlin/String // /Foo.access$<get-privatePropertyReferencedByInline>|access$<get-privatePropertyReferencedByInline>#static(Foo){}[0]
+    final fun access$privateFunReferencedByInline(/Foo): kotlin/String // /Foo.access$privateFunReferencedByInline|access$privateFunReferencedByInline#static(Foo){}[0]
+    final inline fun publicInlineFun(): kotlin/String // /Foo.publicInlineFun|publicInlineFun(){}[0]
+    final fun publicNonInlineFun(): kotlin/String // /Foo.publicNonInlineFun|publicNonInlineFun(){}[0]
+}

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOff.kt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOff.kt
@@ -1,0 +1,31 @@
+// DISABLE_WITH_PARSER: Psi
+// FIR_AGGRESSIVE_PRUNING: false
+// HEADER_MODE
+
+// Category 1: Completely unused private member.
+// - Kept under HEADER_MODE alone.
+// - Pruned under FIR_AGGRESSIVE_PRUNING.
+private val unusedPrivateProperty = "Unused"
+private fun unusedPrivateFun() = "Unused"
+
+// Category 2: Private member referenced ONLY by a public non-inline function.
+// - Kept under HEADER_MODE alone (even though the referencing body is discarded).
+// - Pruned under FIR_AGGRESSIVE_PRUNING (because the body is discarded, making it unreachable).
+private val privatePropertyReferencedByNonInline = "ReferencedByNonInline"
+private fun privateFunReferencedByNonInline() = "ReferencedByNonInline"
+
+// Category 3: Private member referenced by a public inline function.
+// - Kept under HEADER_MODE alone (inline body is preserved).
+// - Kept under FIR_AGGRESSIVE_PRUNING (inline body is preserved, keeping it reachable).
+private val privatePropertyReferencedByInline = "ReferencedByInline"
+private fun privateFunReferencedByInline() = "ReferencedByInline"
+
+// Public non-inline function (body is discarded in HEADER_MODE)
+fun publicNonInlineFun(): String {
+    return privateFunReferencedByNonInline() + privatePropertyReferencedByNonInline
+}
+
+// Public inline function (body is preserved in HEADER_MODE)
+inline fun publicInlineFun(): String {
+    return privateFunReferencedByInline() + privatePropertyReferencedByInline
+}

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOff.kt.txt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOff.kt.txt
@@ -1,0 +1,24 @@
+private val unusedPrivateProperty: String
+  private get
+
+private val privatePropertyReferencedByNonInline: String
+  private get
+
+private val privatePropertyReferencedByInline: String
+  private get
+
+private fun privateFunReferencedByInline(): String {
+}
+
+private fun privateFunReferencedByNonInline(): String {
+}
+
+inline fun publicInlineFun(): String {
+  return privateFunReferencedByInline().plus(other = <get-privatePropertyReferencedByInline>())
+}
+
+fun publicNonInlineFun(): String {
+}
+
+private fun unusedPrivateFun(): String {
+}

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOn.ir.txt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOn.ir.txt
@@ -1,0 +1,18 @@
+FILE fqName:<root> fileName:/firAggressivePruningOn.kt
+  PROPERTY name:privatePropertyReferencedByInline visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:privatePropertyReferencedByInline type:kotlin.String visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-privatePropertyReferencedByInline> visibility:private modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:privatePropertyReferencedByInline visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-privatePropertyReferencedByInline> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:privatePropertyReferencedByInline type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
+  FUN name:privateFunReferencedByInline visibility:private modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+  FUN name:publicInlineFun visibility:public modality:FINAL returnType:kotlin.String [inline]
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun publicInlineFun (): kotlin.String declared in <root>'
+        CALL 'public final fun plus (other: kotlin.Any?): kotlin.String declared in kotlin.String' type=kotlin.String origin=PLUS
+          ARG <this>: CALL 'private final fun privateFunReferencedByInline (): kotlin.String declared in <root>' type=kotlin.String origin=null
+          ARG other: CALL 'private final fun <get-privatePropertyReferencedByInline> (): kotlin.String declared in <root>' type=kotlin.String origin=GET_PROPERTY
+  FUN name:publicNonInlineFun visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOn.klib_abi.txt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOn.klib_abi.txt
@@ -1,0 +1,13 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <main>
+final class /Foo { // /Foo|null[0]
+    constructor <init>() // /Foo.<init>|<init>(){}[0]
+    final fun access$<get-privatePropertyReferencedByInline>(/Foo): kotlin/String // /Foo.access$<get-privatePropertyReferencedByInline>|access$<get-privatePropertyReferencedByInline>#static(Foo){}[0]
+    final fun access$privateFunReferencedByInline(/Foo): kotlin/String // /Foo.access$privateFunReferencedByInline|access$privateFunReferencedByInline#static(Foo){}[0]
+    final inline fun publicInlineFun(): kotlin/String // /Foo.publicInlineFun|publicInlineFun(){}[0]
+    final fun publicNonInlineFun(): kotlin/String // /Foo.publicNonInlineFun|publicNonInlineFun(){}[0]
+}

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOn.kt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOn.kt
@@ -1,0 +1,31 @@
+// DISABLE_WITH_PARSER: Psi
+// FIR_AGGRESSIVE_PRUNING: true
+// HEADER_MODE
+
+// Category 1: Completely unused private member.
+// - Kept under HEADER_MODE alone.
+// - Pruned under FIR_AGGRESSIVE_PRUNING.
+private val unusedPrivateProperty = "Unused"
+private fun unusedPrivateFun() = "Unused"
+
+// Category 2: Private member referenced ONLY by a public non-inline function.
+// - Kept under HEADER_MODE alone (even though the referencing body is discarded).
+// - Pruned under FIR_AGGRESSIVE_PRUNING (because the body is discarded, making it unreachable).
+private val privatePropertyReferencedByNonInline = "ReferencedByNonInline"
+private fun privateFunReferencedByNonInline() = "ReferencedByNonInline"
+
+// Category 3: Private member referenced by a public inline function.
+// - Kept under HEADER_MODE alone (inline body is preserved).
+// - Kept under FIR_AGGRESSIVE_PRUNING (inline body is preserved, keeping it reachable).
+private val privatePropertyReferencedByInline = "ReferencedByInline"
+private fun privateFunReferencedByInline() = "ReferencedByInline"
+
+// Public non-inline function (body is discarded in HEADER_MODE)
+fun publicNonInlineFun(): String {
+    return privateFunReferencedByNonInline() + privatePropertyReferencedByNonInline
+}
+
+// Public inline function (body is preserved in HEADER_MODE)
+inline fun publicInlineFun(): String {
+    return privateFunReferencedByInline() + privatePropertyReferencedByInline
+}

--- a/compiler/testData/ir/irText/declarations/firAggressivePruningOn.kt.txt
+++ b/compiler/testData/ir/irText/declarations/firAggressivePruningOn.kt.txt
@@ -1,0 +1,12 @@
+private val privatePropertyReferencedByInline: String
+  private get
+
+private fun privateFunReferencedByInline(): String {
+}
+
+inline fun publicInlineFun(): String {
+  return privateFunReferencedByInline().plus(other = <get-privatePropertyReferencedByInline>())
+}
+
+fun publicNonInlineFun(): String {
+}

--- a/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
+++ b/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
@@ -184,6 +184,7 @@ where advanced options include:
                              Use the 'warning' level to issue warnings instead of errors.
   -Xexplicit-backing-fields  Enable experimental language support for explicit backing fields.
   -Xexplicit-context-arguments Enable explicit passing of context arguments using named argument syntax.
+  -Xfir-aggressive-pruning   Enable or disable FirAggressivePruningProcessor, which prunes unreachable private members during body resolve.
   -Xfragment-dependency=<fragment name>:<path>
                              Declare common klib dependencies for the specific fragment.
                              This argument is required for any HMPP module except the platform leaf module: it takes dependencies from -cp/-libraries.


### PR DESCRIPTION
Depending on the source given to -XHeaderMode, FirAggressivePruningProcessor can increase or decrease performance, this flag allows for selective enabling of this functionality