### PR TITLE
[KLIB API] Use `Path` instead of "konan-File" everywhere in KLIB API

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
@@ -60,6 +60,9 @@ import org.jetbrains.kotlin.util.metadataVersion
 import org.jetbrains.kotlin.utils.KotlinPaths
 import org.jetbrains.kotlin.utils.PathUtil
 import java.io.File
+import kotlin.io.path.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.pathString
 
 
 object JKlibConfigurationPhase : AbstractConfigurationPhase<K2JKlibCompilerArguments>(
@@ -313,7 +316,7 @@ object JKlibKlibSerializationPhase : PipelinePhase<JKlibFir2IrPipelineArtifact, 
         val fir2IrResult = input.result
         val configuration = input.configuration
         val diagnosticsReporter = configuration.diagnosticsCollector
-        val destination = File(configuration.jklibOutputDestination ?: "result.klib")
+        val destination = Path(configuration.jklibOutputDestination ?: "result.klib").absolute()
 
         val serializerOutput = serializeModuleIntoKlib(
             moduleName = fir2IrResult.irModuleFragment.name.asString(),
@@ -352,11 +355,11 @@ object JKlibKlibSerializationPhase : PipelinePhase<JKlibFir2IrPipelineArtifact, 
             }
             includeMetadata(serializerOutput.serializedMetadata ?: error("expected serialized metadata"))
             includeIr(serializerOutput.serializedIr)
-        }.writeTo(destination.absolutePath)
+        }.writeTo(destination)
 
 
         return JKlibSerializationArtifact(
-            destination.absolutePath,
+            destination.pathString,
             configuration,
             input.projectEnvironment,
             input.rootDisposable,

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebKlibSerializationPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebKlibSerializationPipelinePhase.kt
@@ -16,10 +16,12 @@ import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
 import org.jetbrains.kotlin.ir.backend.js.getSerializedData
 import org.jetbrains.kotlin.ir.backend.js.serializeModuleIntoKlib
 import org.jetbrains.kotlin.js.config.*
-import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.library.impl.BuiltInsPlatform
 import org.jetbrains.kotlin.library.loadSizeInfo
 import org.jetbrains.kotlin.wasm.config.wasmTarget
+import java.nio.file.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.pathString
 
 object WebKlibSerializationPipelinePhase : PipelinePhase<WebFir2IrPipelineArtifact, WebSerializedKlibPipelineArtifact>(
     name = "WebKlibSerializationPipelinePhase",
@@ -56,21 +58,18 @@ object WebKlibSerializationPipelinePhase : PipelinePhase<WebFir2IrPipelineArtifa
             performanceManager = configuration.perfManager,
         )
 
-        loadSizeInfo(File(outputKlibPath))?.flatten()?.let { stats ->
+        loadSizeInfo(outputKlibPath)?.flatten()?.let { stats ->
             configuration.perfManager?.registerKlibElementStats(stats)
         }
 
         return WebSerializedKlibPipelineArtifact(
-            outputKlibPath,
+            outputKlibPath.pathString,
             configuration
         )
     }
 }
 
-fun CompilerConfiguration.computeOutputKlibPath(): String {
-    return if (produceKlibFile) {
-        outputDir!!.resolve("${outputName!!}.klib").normalize().absolutePath
-    } else {
-        outputDir!!.absolutePath
-    }
+fun CompilerConfiguration.computeOutputKlibPath(): Path {
+    val basePath = if (produceKlibFile) outputDir!!.resolve("${outputName!!}.klib").normalize() else outputDir!!
+    return basePath.toPath().absolute()
 }

--- a/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataKlibSerializerPhase.kt
+++ b/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataKlibSerializerPhase.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.fir.packageFqName
 import org.jetbrains.kotlin.fir.resolve.providers.firProvider
 import org.jetbrains.kotlin.fir.serialization.FirKLibSerializerExtension
 import org.jetbrains.kotlin.fir.serialization.serializeSingleFirFile
-import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.library.SerializedFragment
 import org.jetbrains.kotlin.library.SerializedFragmentWithSource
 import org.jetbrains.kotlin.library.SerializedMetadata
@@ -28,6 +27,7 @@ import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.library.metadata.KlibMetadataHeaderFlags
 import org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf
 import org.jetbrains.kotlin.util.metadataVersion
+import kotlin.io.path.absolute
 
 object MetadataKlibInMemorySerializerPhase : PipelinePhase<MetadataFrontendPipelineArtifact, MetadataInMemorySerializationArtifact>(
     name = "MetadataKlibInMemorySerializerPhase",
@@ -111,7 +111,7 @@ object MetadataKlibFileWriterPhase : PipelinePhase<MetadataInMemorySerialization
     fun writeToDisc(input: MetadataInMemorySerializationArtifact, destDir: java.io.File) {
         buildKotlinMetadataLibrary(input.configuration, input.metadata, destDir, input.isIncremental)
 
-        loadSizeInfo(File(destDir.absolutePath))?.flatten()?.let { stats ->
+        loadSizeInfo(destDir.toPath().absolute())?.flatten()?.let { stats ->
             input.configuration.perfManager?.registerKlibElementStats(stats)
         }
     }

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/writeKlib.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/writeKlib.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.library.writer.includeIr
 import org.jetbrains.kotlin.library.writer.includeMetadata
 import org.jetbrains.kotlin.util.metadataVersion
 import java.util.Properties
+import kotlin.io.path.Path
 
 fun NativePhaseContext.writeKlib(input: KlibWriterInput) {
     val suffix = ".klib"
@@ -95,6 +96,8 @@ fun NativePhaseContext.writeKlib(input: KlibWriterInput) {
             emptyList()
         } else listOf(target.visibleName)
 
+    val klibPath = Path(klibOutputFileName)
+
     KlibWriter {
         format(if (dontCompressKlib) KlibFormat.Directory else KlibFormat.ZipArchive)
         manifest {
@@ -109,9 +112,9 @@ fun NativePhaseContext.writeKlib(input: KlibWriterInput) {
         includeIr(input.serializerOutput.serializedIr)
         includeBitcode(target, config.nativeLibraries)
         includeNativeIncludedBinaries(target, config.includeBinaries)
-    }.writeTo(klibOutputFileName)
+    }.writeTo(klibPath)
 
-    loadSizeInfo(File(klibOutputFileName))?.flatten()?.let { stats ->
+    loadSizeInfo(klibPath)?.flatten()?.let { stats ->
         performanceManager?.registerKlibElementStats(stats)
     }
 }

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
@@ -10,8 +10,10 @@ import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.library.*
 import java.io.ByteArrayInputStream
+import java.nio.file.Path
 import java.util.jar.Manifest
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readBytes
 
 /** See KT-68322 for details. */
 abstract class LibrarySpecialCompatibilityChecker {
@@ -161,14 +163,14 @@ private class JarManifestComponent(
         }
 
     object Kind : KlibComponent.Kind<JarManifestComponent, JarManifestComponentLayout> {
-        override fun createLayout(root: KlibFile) = JarManifestComponentLayout(root)
+        override fun createLayout(root: Path) = JarManifestComponentLayout(root)
 
         override fun createComponentIfDataInKlibIsAvailable(layoutReader: KlibLayoutReader<JarManifestComponentLayout>) =
-            if (layoutReader.readInPlaceOrFallback(false) { it.jarManifestFile.isFile }) JarManifestComponent(layoutReader) else null
+            if (layoutReader.readInPlaceOrFallback(false) { it.jarManifestFile.isRegularFile() }) JarManifestComponent(layoutReader) else null
     }
 }
 
-private class JarManifestComponentLayout(root: KlibFile) : KlibComponentLayout(root) {
-    val jarManifestFile: KlibFile
-        get() = root.child(KLIB_JAR_MANIFEST_FILE)
+private class JarManifestComponentLayout(root: Path) : KlibComponentLayout(root) {
+    val jarManifestFile: Path
+        get() = root.resolve(KLIB_JAR_MANIFEST_FILE)
 }

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
@@ -43,6 +43,7 @@ import org.jetbrains.kotlin.util.metadataVersion
 import org.jetbrains.kotlin.util.tryMeasurePhaseTime
 import org.jetbrains.kotlin.utils.toSmartList
 import java.io.File
+import java.nio.file.Path
 
 val KotlinLibrary.moduleName: String
     get() = manifestProperties.getProperty(KLIB_PROPERTY_UNIQUE_NAME)
@@ -272,7 +273,7 @@ fun serializeModuleIntoKlib(
     configuration: CompilerConfiguration,
     diagnosticReporter: IrDiagnosticReporter,
     metadataSerializer: KlibSingleFileMetadataSerializer<*>,
-    klibPath: String,
+    klibPath: Path,
     moduleFragment: IrModuleFragment,
     irBuiltIns: IrBuiltIns,
     cleanFiles: List<KotlinFileSerializedData>,

--- a/compiler/util-io/src/org/jetbrains/kotlin/konan/file/ZipFileSystemAccessor.kt
+++ b/compiler/util-io/src/org/jetbrains/kotlin/konan/file/ZipFileSystemAccessor.kt
@@ -6,13 +6,14 @@
 package org.jetbrains.kotlin.konan.file
 
 import java.nio.file.FileSystem
+import java.nio.file.Path
 
 interface ZipFileSystemAccessor {
-    fun <T> withZipFileSystem(zipFile: File, action: (FileSystem) -> T): T
+    fun <T> withZipFileSystem(zipFile: Path, action: (FileSystem) -> T): T
 }
 
 object ZipFileSystemInPlaceAccessor : ZipFileSystemAccessor {
-    override fun <T> withZipFileSystem(zipFile: File, action: (FileSystem) -> T): T {
+    override fun <T> withZipFileSystem(zipFile: Path, action: (FileSystem) -> T): T {
         return zipFile.withZipFileSystem(action)
     }
 }
@@ -21,8 +22,8 @@ class ZipFileSystemCacheableAccessor(private val cacheLimit: Int) : ZipFileSyste
     private val loadFactor = 0.75f
     private val initialCapacity = (1f + cacheLimit.toFloat() / loadFactor).toInt()
 
-    private val openedFileSystems = object : LinkedHashMap<File, FileSystem>(initialCapacity, loadFactor, true) {
-        override fun removeEldestEntry(eldest: Map.Entry<File, FileSystem>?): Boolean {
+    private val openedFileSystems = object : LinkedHashMap<Path, FileSystem>(initialCapacity, loadFactor, true) {
+        override fun removeEldestEntry(eldest: Map.Entry<Path, FileSystem>?): Boolean {
             if (size > cacheLimit) {
                 eldest?.value?.close()
                 return true
@@ -31,7 +32,7 @@ class ZipFileSystemCacheableAccessor(private val cacheLimit: Int) : ZipFileSyste
         }
     }
 
-    override fun <T> withZipFileSystem(zipFile: File, action: (FileSystem) -> T): T {
+    override fun <T> withZipFileSystem(zipFile: Path, action: (FileSystem) -> T): T {
         val fileSystem = openedFileSystems.getOrPut(zipFile) { zipFile.zipFileSystem() }
         return action(fileSystem)
     }

--- a/compiler/util-io/src/org/jetbrains/kotlin/konan/file/ZipUtil.kt
+++ b/compiler/util-io/src/org/jetbrains/kotlin/konan/file/ZipUtil.kt
@@ -24,7 +24,7 @@ import kotlin.io.path.relativeTo
 // See also:
 // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7001822
 // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6994161
-internal fun File.zipFileSystem(create: Boolean = false): FileSystem {
+internal fun Path.zipFileSystem(create: Boolean = false): FileSystem {
     val attributes = hashMapOf("create" to create.toString())
 
     // There is no FileSystems.newFileSystem overload accepting the attribute map.
@@ -33,7 +33,7 @@ internal fun File.zipFileSystem(create: Boolean = false): FileSystem {
         if (fileSystemProvider.scheme != "jar") return@firstNotNullOfOrNull null
 
         try {
-            fileSystemProvider.newFileSystem(this.toPath(), attributes)
+            fileSystemProvider.newFileSystem(this, attributes)
         } catch (e: Exception) {
             when (e) {
                 is UnsupportedOperationException, is IllegalArgumentException -> null
@@ -48,11 +48,10 @@ internal fun File.zipFileSystem(create: Boolean = false): FileSystem {
 
 fun FileSystem.file(file: File) = File(this.getPath(file.path))
 
-fun FileSystem.file(path: String) = File(this.getPath(path))
-
-private fun File.toPath() = Paths.get(this.path)
+fun FileSystem.file(path: String): Path = this.getPath(path)
 
 fun File.zipDirAs(zipFile: File): Unit = zipDirAsInternal(dirPath = this.javaPath, zipFilePath = zipFile.javaPath)
+fun Path.zipDirAs(zipFile: Path): Unit = zipDirAsInternal(dirPath = this, zipFilePath = zipFile)
 
 internal inline fun zipDirAsInternal(dirPath: Path, zipFilePath: Path, shuffle: (MutableList<Path>) -> Unit = {}) {
     val dirPathWithExpandedSymlinks: Path = dirPath.expandSymlinks()
@@ -160,10 +159,10 @@ fun Path.unzipTo(destinationDirectory: Path, fromSubdirectory: Path = Paths.get(
     File(this).unzipTo(File(destinationDirectory), File(fromSubdirectory), resetTimeAttributes)
 }
 
-fun <T> File.withZipFileSystem(create: Boolean, action: (FileSystem) -> T): T {
-    return this.zipFileSystem(create).use(action)
-}
+fun <T> Path.withZipFileSystem(create: Boolean, action: (FileSystem) -> T): T = this.zipFileSystem(create).use(action)
+fun <T> File.withZipFileSystem(create: Boolean, action: (FileSystem) -> T): T = this.javaPath.zipFileSystem(create).use(action)
 
+fun <T> Path.withZipFileSystem(action: (FileSystem) -> T): T = this.withZipFileSystem(false, action)
 fun <T> File.withZipFileSystem(action: (FileSystem) -> T): T = this.withZipFileSystem(false, action)
 
 private fun File.recursiveCopyTo(destination: File, resetTimeAttributes: Boolean = false) {

--- a/compiler/util-io/src/org/jetbrains/kotlin/konan/properties/Properties.kt
+++ b/compiler/util-io/src/org/jetbrains/kotlin/konan/properties/Properties.kt
@@ -7,13 +7,22 @@ package org.jetbrains.kotlin.konan.properties
 
 import org.jetbrains.kotlin.konan.file.*
 import org.jetbrains.kotlin.util.parseSpaceSeparatedArgs
-import java.io.ByteArrayOutputStream
-import java.io.OutputStream
 import java.io.StringWriter
+import java.nio.file.Path
+import kotlin.io.path.bufferedReader
+import kotlin.io.path.outputStream
 
 typealias Properties = java.util.Properties
 
 fun File.loadProperties(): Properties {
+    val properties = java.util.Properties()
+    this.bufferedReader().use { reader ->
+        properties.load(reader)
+    }
+    return properties
+}
+
+fun Path.loadProperties(): Properties {
     val properties = java.util.Properties()
     this.bufferedReader().use { reader ->
         properties.load(reader)
@@ -46,7 +55,24 @@ fun File.saveProperties(properties: Properties) {
     }
 }
 
+fun Path.saveProperties(properties: Properties) {
+    val rawData = StringWriter().apply {
+        properties.store(this, null)
+    }.toString()
+
+    val lines = rawData
+        .split(System.lineSeparator())
+        .filterNot { it.isEmpty() || it.startsWith("#") }
+        .sorted()
+
+    outputStream().use {
+        it.write(lines.joinToString("\n", postfix = "\n").toByteArray())
+    }
+}
+
 fun Properties.saveToFile(file: File) = file.saveProperties(this)
+
+fun Properties.saveToFile(file: Path) = file.saveProperties(this)
 
 fun Properties.propertyString(key: String, suffix: String? = null): String? = getProperty(key.suffix(suffix)) ?: this.getProperty(key)
 

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/Klib.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/Klib.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.library
 import org.jetbrains.kotlin.library.components.KlibIrComponent
 import org.jetbrains.kotlin.library.components.KlibMetadataComponent
 import java.nio.file.Path
-import org.jetbrains.kotlin.konan.file.File as KlibFile
 
 /**
  * [Klib] represents an instance of Kotlin library (Klib) that can be read by the compiler or any other tools.
@@ -61,7 +60,7 @@ interface KlibComponent {
         /**
          * Create an instance [KlibComponentLayout] for the current component.
          */
-        fun createLayout(root: KlibFile): KCL
+        fun createLayout(root: Path): KCL
 
         /**
          * Create an instance of the component.
@@ -80,4 +79,4 @@ interface KlibComponent {
  * In this case [root] points to the root of the virtual file system inside the archive, whereas [Klib.path] points
  * to the archive file itself. So, it is highly important to compute paths exactly based on [root].
  */
-abstract class KlibComponentLayout(val root: KlibFile)
+abstract class KlibComponentLayout(val root: Path)

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KlibFormat.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KlibFormat.kt
@@ -5,7 +5,8 @@
 
 package org.jetbrains.kotlin.library
 
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.isRegularFile
 
 /**
  * The format of a Klib library.
@@ -18,8 +19,8 @@ sealed interface KlibFormat {
         /**
          * This function is made internal because it's semantics can be changed in the future.
          */
-        internal fun guessBy(file: KlibFile): KlibFormat {
-            return if (file.isFile) ZipArchive else Directory
+        internal fun guessBy(path: Path): KlibFormat {
+            return if (path.isRegularFile()) ZipArchive else Directory
         }
     }
 }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KlibLayoutReader.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KlibLayoutReader.kt
@@ -5,13 +5,23 @@
 
 package org.jetbrains.kotlin.library
 
-import org.jetbrains.kotlin.konan.file.File as KlibFile
 import org.jetbrains.kotlin.konan.file.ZipFileSystemAccessor
-import org.jetbrains.kotlin.konan.file.createTempDir
-import org.jetbrains.kotlin.konan.file.createTempFile
 import org.jetbrains.kotlin.konan.file.file
 import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Files.createTempDirectory
+import java.nio.file.Files.createTempFile
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.zip.ZipException
+import kotlin.io.path.copyTo
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
 
 /**
  * A class that allows reading from a specific [KlibComponent] using the corresponding [KlibComponentLayout].
@@ -26,7 +36,7 @@ sealed class KlibLayoutReader<KCL : KlibComponentLayout> {
             fallbackValueInCaseOfException
         }
 
-    abstract fun readExtractingToTemp(readAction: (KCL) -> KlibFile): KlibFile
+    abstract fun readExtractingToTemp(readAction: (KCL) -> Path): Path
 
     /**
      * Read from a directory on the file system.
@@ -35,10 +45,10 @@ sealed class KlibLayoutReader<KCL : KlibComponentLayout> {
      * @param klibDir The Klib directory.
      * @param layoutBuilder A function that builds the [KlibComponentLayout].
      */
-    class FromDirectory<KCL : KlibComponentLayout>(klibDir: KlibFile, layoutBuilder: (KlibFile) -> KCL) : KlibLayoutReader<KCL>() {
+    class FromDirectory<KCL : KlibComponentLayout>(klibDir: Path, layoutBuilder: (Path) -> KCL) : KlibLayoutReader<KCL>() {
         private val layout = layoutBuilder(klibDir)
         override fun <T> readInPlace(readAction: (KCL) -> T): T = readAction(layout)
-        override fun readExtractingToTemp(readAction: (KCL) -> KlibFile): KlibFile = readAction(layout)
+        override fun readExtractingToTemp(readAction: (KCL) -> Path): Path = readAction(layout)
     }
 
     /**
@@ -56,37 +66,56 @@ sealed class KlibLayoutReader<KCL : KlibComponentLayout> {
      * @param layoutBuilder A function that builds the [KlibComponentLayout].
      */
     class FromZipArchive<KCL : KlibComponentLayout>(
-        private val klibArchive: KlibFile,
+        private val klibArchive: Path,
         private val zipFileSystemAccessor: ZipFileSystemAccessor,
-        private val layoutBuilder: (KlibFile) -> KCL
+        private val layoutBuilder: (Path) -> KCL
     ) : KlibLayoutReader<KCL>() {
         override fun <T> readInPlace(readAction: (KCL) -> T): T =
             zipFileSystemAccessor.withZipFileSystem(klibArchive) { zipFileSystem ->
                 readAction(layoutBuilder(zipFileSystem.file("/")))
             }
 
-        override fun readExtractingToTemp(readAction: (KCL) -> KlibFile): KlibFile = readInPlace { layout ->
+        override fun readExtractingToTemp(readAction: (KCL) -> Path): Path = readInPlace { layout ->
             val fileOrDirectory = readAction(layout)
             when {
-                fileOrDirectory.isDirectory -> {
-                    val tempDir = createTempDir(fileOrDirectory.name)
+                fileOrDirectory.isDirectory() -> {
+                    val tempDir = createTempDirectory(fileOrDirectory.name)
                     tempDir.deleteOnExitRecursively()
-                    fileOrDirectory.listFiles.forEach { file -> file.copyTo(tempDir.child(file.name)) }
+                    fileOrDirectory.listDirectoryEntries().forEach { file -> file.copyTo(tempDir.resolve(file.name)) }
                     tempDir
                 }
 
-                fileOrDirectory.isFile -> {
-                    val tempFile = createTempFile(fileOrDirectory.name)
+                fileOrDirectory.isRegularFile() -> {
+                    val tempFile = createTempFile(fileOrDirectory.name, null)
                     tempFile.deleteOnExitRecursively()
-                    fileOrDirectory.copyTo(tempFile)
+                    fileOrDirectory.copyTo(tempFile, overwrite = true)
                     tempFile
                 }
 
-                fileOrDirectory.exists -> throw ZipException("Non-existing file or directory in KLIB archive: $fileOrDirectory")
+                fileOrDirectory.exists() -> throw ZipException("Non-existing file or directory in KLIB archive: $fileOrDirectory")
 
                 else -> throw ZipException("Unsupported type of the file system object in KLIB archive: $fileOrDirectory")
             }
         }
+    }
+
+    companion object {
+        private fun Path.deleteOnExitRecursively() {
+            if (!exists()) return
+
+            Files.walkFileTree(this, object : SimpleFileVisitor<Path>() {
+                override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                    file.toFile().deleteOnExit()
+                    return FileVisitResult.CONTINUE
+                }
+
+                override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
+                    dir.toFile().deleteOnExit()
+                    return FileVisitResult.CONTINUE
+                }
+            })
+        }
+
     }
 }
 
@@ -94,10 +123,10 @@ sealed class KlibLayoutReader<KCL : KlibComponentLayout> {
  * The factory that allows creating instances of [KlibLayoutReader] for specific [KlibComponent]s.
  */
 class KlibLayoutReaderFactory(
-    private val klibFile: KlibFile,
+    private val klibFile: Path,
     private val zipFileSystemAccessor: ZipFileSystemAccessor,
 ) {
-    fun <KCL : KlibComponentLayout> createLayoutReader(layoutBuilder: (KlibFile) -> KCL): KlibLayoutReader<KCL> {
+    fun <KCL : KlibComponentLayout> createLayoutReader(layoutBuilder: (Path) -> KCL): KlibLayoutReader<KCL> {
         return when (KlibFormat.guessBy(klibFile)) {
             KlibFormat.ZipArchive -> KlibLayoutReader.FromZipArchive(
                 klibArchive = klibFile,

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KlibSizeInfo.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KlibSizeInfo.kt
@@ -20,7 +20,12 @@ import org.jetbrains.kotlin.library.components.KlibIrConstants.KLIB_IR_STRINGS_F
 import org.jetbrains.kotlin.library.components.KlibIrConstants.KLIB_IR_TYPES_FILE_NAME
 import org.jetbrains.kotlin.library.components.KlibMetadataConstants.KLIB_METADATA_FOLDER_NAME
 import org.jetbrains.kotlin.library.components.KlibNativeConstants.KLIB_TARGETS_FOLDER_NAME
-import org.jetbrains.kotlin.konan.file.File as KFile
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
 
 /**
  * [size] is always in bytes.
@@ -55,41 +60,39 @@ class KlibElementWithSize private constructor(
     fun flatten(): List<Pair<String, Long>> = listOf(fullName to size) + children.flatMap { it.flatten() }
 }
 
-fun loadSizeInfo(klibFile: KFile): KlibElementWithSize? {
-    val libraryFile = klibFile.absoluteFile
-
+fun loadSizeInfo(klibPath: Path): KlibElementWithSize? {
     return when {
-        libraryFile.isFile -> KlibElementWithSize(
+        klibPath.isRegularFile() -> KlibElementWithSize(
             "KLIB file cumulative size",
-            libraryFile.withZipFileSystem { fs -> fs.file("/").collectTopLevelElements() }
+            klibPath.withZipFileSystem { fs -> fs.file("/").collectTopLevelElements() }
         )
 
-        !libraryFile.isDirectory -> null
+        !klibPath.isDirectory() -> null
 
         else -> KlibElementWithSize(
             "KLIB directory cumulative size",
-            libraryFile.collectTopLevelElements()
+            klibPath.collectTopLevelElements()
         )
     }
 }
 
-private fun KFile.collectTopLevelElements(): List<KlibElementWithSize> {
-    var defaultEntry: KFile? = null
-    val otherTopLevelEntries = ArrayList<KFile>()
+private fun Path.collectTopLevelElements(): List<KlibElementWithSize> {
+    var defaultEntry: Path? = null
+    val otherTopLevelEntries = ArrayList<Path>()
 
-    for (entry in entries) {
+    for (entry: Path in entries) {
         // Expand the contents of the "default" directory, don't show the directory itself.
-        if (entry.name.normalizeEntryName() == "default" && entry.isDirectory) {
+        if (entry.name.normalizeEntryName() == "default" && entry.isDirectory()) {
             defaultEntry = entry
         } else {
-            otherTopLevelEntries += entry
+            otherTopLevelEntries.add(entry)
         }
     }
 
     // The contents of the "default" entry go the first, then everything else.
-    val topLevelEntries = buildList<KFile> {
-        this += defaultEntry?.entries?.sortedBy(KFile::name).orEmpty()
-        this += otherTopLevelEntries.sortedBy(KFile::name)
+    val topLevelEntries = buildList<Path> {
+        this += defaultEntry?.entries?.sortedBy(Path::name).orEmpty()
+        this += otherTopLevelEntries.sortedBy(Path::name)
     }
 
     return topLevelEntries.map { topLevelEntry ->
@@ -107,19 +110,19 @@ private fun KFile.collectTopLevelElements(): List<KlibElementWithSize> {
     }
 }
 
-private val KFile.entries: List<KFile> get() = listFiles
+private val Path.entries: List<Path> get() = listDirectoryEntries()
 
-private fun KFile.cumulativeSize(): Long = when {
-    isFile -> size
-    isDirectory -> entries.sumOf { it.cumulativeSize() }
+private fun Path.cumulativeSize(): Long = when {
+    isRegularFile() -> Files.size(this)
+    isDirectory() -> entries.sumOf { it.cumulativeSize() }
     else -> 0L
 }
 
-private fun buildElement(name: String, entry: KFile): KlibElementWithSize {
+private fun buildElement(name: String, entry: Path): KlibElementWithSize {
     return KlibElementWithSize(name, entry.cumulativeSize())
 }
 
-private fun buildIrElement(name: String, entry: KFile): KlibElementWithSize {
+private fun buildIrElement(name: String, entry: Path): KlibElementWithSize {
     val nestedElements = ArrayList<KlibElementWithSize>()
 
     entry.entries.mapTo(nestedElements) { childEntry ->
@@ -142,8 +145,7 @@ private fun buildIrElement(name: String, entry: KFile): KlibElementWithSize {
     return KlibElementWithSize(name, nestedElements.sortedBy { it.name })
 }
 
-// On Windows, entry names start with an uppercase character and end with '/' that is not trimmed by `File.name` since the separator is `\`
-private fun String.normalizeEntryName() = if (isWindows) replaceFirstChar { it.lowercase() }.trimEnd('/') else this
-
-private val isWindows: Boolean
-    get() = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+// Entry names start with an uppercase character and end with '/'.
+private fun String.normalizeEntryName(): String {
+    return replaceFirstChar { it.lowercase() }.trimEnd('/')
+}

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/components/KlibIrComponent.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/components/KlibIrComponent.kt
@@ -21,7 +21,8 @@ import org.jetbrains.kotlin.library.components.KlibIrConstants.KLIB_IR_STRINGS_F
 import org.jetbrains.kotlin.library.components.KlibIrConstants.KLIB_IR_FILES_FILE_NAME
 import org.jetbrains.kotlin.library.components.KlibIrConstants.KLIB_IR_FILE_ENTRIES_FILE_NAME
 import org.jetbrains.kotlin.library.impl.KlibIrComponentImpl
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.exists
 
 /**
  * This component that provides read access to Klib IR. It can be used for two purposes:
@@ -49,15 +50,15 @@ interface KlibIrComponent : KlibComponent {
 
     sealed class Kind : KlibComponent.Kind<KlibIrComponent, KlibIrComponentLayout> {
         object Main : Kind() {
-            override fun createLayout(root: KlibFile) = KlibIrComponentLayout.createForMainIr(root)
+            override fun createLayout(root: Path) = KlibIrComponentLayout.createForMainIr(root)
         }
 
         object InlinableFunctions : Kind() {
-            override fun createLayout(root: KlibFile) = KlibIrComponentLayout.createForInlinableFunctionsIr(root)
+            override fun createLayout(root: Path) = KlibIrComponentLayout.createForInlinableFunctionsIr(root)
         }
 
         override fun createComponentIfDataInKlibIsAvailable(layoutReader: KlibLayoutReader<KlibIrComponentLayout>): KlibIrComponent? =
-            if (layoutReader.readInPlaceOrFallback(false) { it.irDir.exists }) KlibIrComponentImpl(layoutReader) else null
+            if (layoutReader.readInPlaceOrFallback(false) { it.irDir.exists() }) KlibIrComponentImpl(layoutReader) else null
     }
 }
 
@@ -87,18 +88,18 @@ inline val Klib.irOrFail: KlibIrComponent
 inline val Klib.inlinableFunctionsIr: KlibIrComponent?
     get() = getComponent(KlibIrComponent.Kind.InlinableFunctions)
 
-class KlibIrComponentLayout private constructor(root: KlibFile, private val irFolderName: String) : KlibComponentLayout(root) {
+class KlibIrComponentLayout private constructor(root: Path, private val irFolderName: String) : KlibComponentLayout(root) {
     /** The IR "home" directory. */
-    val irDir: KlibFile
-        get() = root.child(KLIB_DEFAULT_COMPONENT_NAME).child(irFolderName)
+    val irDir: Path
+        get() = root.resolve(KLIB_DEFAULT_COMPONENT_NAME).resolve(irFolderName)
 
     /** The file with "IR files". */
-    val irFilesFile: KlibFile
-        get() = irDir.child(KLIB_IR_FILES_FILE_NAME)
+    val irFilesFile: Path
+        get() = irDir.resolve(KLIB_IR_FILES_FILE_NAME)
 
     /** The file with "IR file entries". */
-    val irFileEntriesFile: KlibFile
-        get() = irDir.child(KLIB_IR_FILE_ENTRIES_FILE_NAME)
+    val irFileEntriesFile: Path
+        get() = irDir.resolve(KLIB_IR_FILE_ENTRIES_FILE_NAME)
 
     /**
      * The file with all IR declarations.
@@ -108,34 +109,34 @@ class KlibIrComponentLayout private constructor(root: KlibFile, private val irFo
      *   load declarations without bodies when the compiler does not need them.
      * - Local declarations are stored together with functions bodies in [bodiesFile].
      */
-    val declarationsFile: KlibFile
-        get() = irDir.child(KLIB_IR_DECLARATIONS_FILE_NAME)
+    val declarationsFile: Path
+        get() = irDir.resolve(KLIB_IR_DECLARATIONS_FILE_NAME)
 
     /** The file with function bodies. */
-    val bodiesFile: KlibFile
-        get() = irDir.child(KLIB_IR_BODIES_FILE_NAME)
+    val bodiesFile: Path
+        get() = irDir.resolve(KLIB_IR_BODIES_FILE_NAME)
 
     /** The file with IR types. */
-    val typesFile: KlibFile
-        get() = irDir.child(KLIB_IR_TYPES_FILE_NAME)
+    val typesFile: Path
+        get() = irDir.resolve(KLIB_IR_TYPES_FILE_NAME)
 
     /** The file with IR signatures. */
-    val signaturesFile: KlibFile
-        get() = irDir.child(KLIB_IR_SIGNATURES_FILE_NAME)
+    val signaturesFile: Path
+        get() = irDir.resolve(KLIB_IR_SIGNATURES_FILE_NAME)
 
     /** The file with the supplementary (debug) information about IR signatures. */
-    val signaturesDebugInfoFile: KlibFile
-        get() = irDir.child(KLIB_IR_DEBUG_INFO_FILE_NAME)
+    val signaturesDebugInfoFile: Path
+        get() = irDir.resolve(KLIB_IR_DEBUG_INFO_FILE_NAME)
 
     /** The file with string literals. */
-    val stringLiteralsFile: KlibFile
-        get() = irDir.child(KLIB_IR_STRINGS_FILE_NAME)
+    val stringLiteralsFile: Path
+        get() = irDir.resolve(KLIB_IR_STRINGS_FILE_NAME)
 
     companion object {
-        fun createForMainIr(root: KlibFile): KlibIrComponentLayout =
+        fun createForMainIr(root: Path): KlibIrComponentLayout =
             KlibIrComponentLayout(root, KLIB_IR_FOLDER_NAME)
 
-        fun createForInlinableFunctionsIr(root: KlibFile): KlibIrComponentLayout =
+        fun createForInlinableFunctionsIr(root: Path): KlibIrComponentLayout =
             KlibIrComponentLayout(root, KLIB_IR_INLINABLE_FUNCTIONS_FOLDER_NAME)
     }
 }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/components/KlibMetadataComponent.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/components/KlibMetadataComponent.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.library.components
 
-import org.jetbrains.kotlin.konan.file.File as KlibFile
 import org.jetbrains.kotlin.library.Klib
 import org.jetbrains.kotlin.library.KlibComponent
 import org.jetbrains.kotlin.library.KlibComponentLayout
@@ -19,6 +18,7 @@ import org.jetbrains.kotlin.library.components.KlibMetadataConstants.KLIB_ROOT_P
 import org.jetbrains.kotlin.library.impl.KlibMetadataComponentImpl
 import org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf
 import org.jetbrains.kotlin.metadata.ProtoBuf
+import java.nio.file.Path
 
 /**
  * This component provides read access to Klib metadata.
@@ -34,7 +34,7 @@ interface KlibMetadataComponent : KlibComponent {
     fun getPackageFragment(packageFqName: String, fragmentName: String): ByteArray
 
     companion object Kind : KlibComponent.Kind<KlibMetadataComponent, KlibMetadataComponentLayout> {
-        override fun createLayout(root: KlibFile) = KlibMetadataComponentLayout(root)
+        override fun createLayout(root: Path) = KlibMetadataComponentLayout(root)
 
         /**
          * Note: It is expected that every correct Klib has metadata files.
@@ -54,24 +54,22 @@ interface KlibMetadataComponent : KlibComponent {
 inline val Klib.metadata: KlibMetadataComponent
     get() = getComponent(KlibMetadataComponent.Kind)!!
 
-class KlibMetadataComponentLayout(root: KlibFile) : KlibComponentLayout(root) {
-    constructor(root: String) : this(KlibFile(root))
-
+class KlibMetadataComponentLayout(root: Path) : KlibComponentLayout(root) {
     /** The metadata directory. */
-    val metadataDir: KlibFile
-        get() = root.child(KLIB_DEFAULT_COMPONENT_NAME).child(KLIB_METADATA_FOLDER_NAME)
+    val metadataDir: Path
+        get() = root.resolve(KLIB_DEFAULT_COMPONENT_NAME).resolve(KLIB_METADATA_FOLDER_NAME)
 
     /** The metadata header file. */
-    val moduleHeaderFile: KlibFile
-        get() = metadataDir.child(KLIB_MODULE_METADATA_FILE_NAME)
+    val moduleHeaderFile: Path
+        get() = metadataDir.resolve(KLIB_MODULE_METADATA_FILE_NAME)
 
     /** The directory where package fragments with the fully qualified package name [packageFqName] are located. */
-    fun getPackageFragmentsDir(packageFqName: String): KlibFile =
-        metadataDir.child(if (packageFqName == "") KLIB_ROOT_PACKAGE_FRAGMENT_FOLDER_NAME else "$KLIB_NONROOT_PACKAGE_FRAGMENT_FOLDER_PREFIX$packageFqName")
+    fun getPackageFragmentsDir(packageFqName: String): Path =
+        metadataDir.resolve(if (packageFqName == "") KLIB_ROOT_PACKAGE_FRAGMENT_FOLDER_NAME else "$KLIB_NONROOT_PACKAGE_FRAGMENT_FOLDER_PREFIX$packageFqName")
 
     /** The concrete package fragment file with the name [partName] for the fully qualified package name [packageFqName]. */
-    fun getPackageFragmentFile(packageFqName: String, partName: String): KlibFile =
-        getPackageFragmentsDir(packageFqName).child("$partName.$KLIB_METADATA_FILE_EXTENSION")
+    fun getPackageFragmentFile(packageFqName: String, partName: String): Path =
+        getPackageFragmentsDir(packageFqName).resolve("$partName.$KLIB_METADATA_FILE_EXTENSION")
 }
 
 object KlibMetadataConstants {

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibImpl.kt
@@ -36,7 +36,7 @@ internal class KlibImpl(
 
     init {
         val layoutReaderFactory = KlibLayoutReaderFactory(
-            klibFile = KlibFile(path),
+            klibFile = path,
             zipFileSystemAccessor = zipFileSystemAccessor
         )
 
@@ -64,7 +64,7 @@ internal class KlibImpl(
     ).joinToString("\n")
 }
 
-internal class KlibManifestComponentLayout(root: KlibFile) : KlibComponentLayout(root) {
-    val manifestFile: KlibFile
-        get() = root.child(KLIB_DEFAULT_COMPONENT_NAME).child(KLIB_MANIFEST_FILE_NAME)
+internal class KlibManifestComponentLayout(root: Path) : KlibComponentLayout(root) {
+    val manifestFile: Path
+        get() = root.resolve(KLIB_DEFAULT_COMPONENT_NAME).resolve(KLIB_MANIFEST_FILE_NAME)
 }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibIrComponentImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibIrComponentImpl.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.library.impl
 import org.jetbrains.kotlin.library.KlibLayoutReader
 import org.jetbrains.kotlin.library.components.KlibIrComponent
 import org.jetbrains.kotlin.library.components.KlibIrComponentLayout
+import kotlin.io.path.exists
 
 /**
  * The default implementation of [KlibIrComponent].
@@ -21,7 +22,7 @@ internal class KlibIrComponentImpl(
     }
 
     private val irFileEntries: IrMultiArrayReader? by lazy {
-        if (layoutReader.readInPlace { it.irFileEntriesFile.exists })
+        if (layoutReader.readInPlace { it.irFileEntriesFile.exists() })
             IrMultiArrayReader(layoutReader, KlibIrComponentLayout::irFileEntriesFile)
         else
             null
@@ -44,7 +45,7 @@ internal class KlibIrComponentImpl(
     }
 
     private val signatureDebugInfos: IrMultiArrayReader? by lazy {
-        if (layoutReader.readInPlace { it.signaturesDebugInfoFile.exists })
+        if (layoutReader.readInPlace { it.signaturesDebugInfoFile.exists() })
             IrMultiArrayReader(layoutReader, KlibIrComponentLayout::signaturesDebugInfoFile)
         else
             null

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibIrComponentWriterImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibIrComponentWriterImpl.kt
@@ -8,14 +8,16 @@ package org.jetbrains.kotlin.library.impl
 import org.jetbrains.kotlin.library.SerializedIrFile
 import org.jetbrains.kotlin.library.components.KlibIrComponentLayout
 import org.jetbrains.kotlin.library.writer.KlibComponentWriter
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
 
 /**
  * An implementation of [KlibComponentWriter] that writes IR to the constructed Klib library.
  */
 internal sealed class KlibIrComponentWriterImpl : KlibComponentWriter {
     class ForMainIr(private val irFiles: Collection<SerializedIrFile>) : KlibIrComponentWriterImpl() {
-        override fun writeTo(root: KlibFile) {
+        override fun writeTo(root: Path) {
             writeIrFiles(
                 irFiles = irFiles,
                 layout = KlibIrComponentLayout.createForMainIr(root)
@@ -24,7 +26,7 @@ internal sealed class KlibIrComponentWriterImpl : KlibComponentWriter {
     }
 
     class ForInlinableFunctionsIr(private val inlinableFunctionsFile: SerializedIrFile) : KlibIrComponentWriterImpl() {
-        override fun writeTo(root: KlibFile) {
+        override fun writeTo(root: Path) {
             writeIrFiles(
                 irFiles = listOf(inlinableFunctionsFile),
                 layout = KlibIrComponentLayout.createForInlinableFunctionsIr(root)
@@ -33,7 +35,7 @@ internal sealed class KlibIrComponentWriterImpl : KlibComponentWriter {
     }
 
     protected fun writeIrFiles(irFiles: Collection<SerializedIrFile>, layout: KlibIrComponentLayout) {
-        layout.irDir.mkdirs()
+        layout.irDir.createDirectories()
 
         with(irFiles.sortedBy { it.path }) {
             serializeNonNullableEntities(SerializedIrFile::fileData, layout::irFilesFile)
@@ -49,12 +51,12 @@ internal sealed class KlibIrComponentWriterImpl : KlibComponentWriter {
 
     private inline fun List<SerializedIrFile>.serializeNonNullableEntities(
         accessor: (SerializedIrFile) -> ByteArray,
-        destination: () -> KlibFile,
-    ): Unit = IrArrayWriter(map { accessor(it) }, false).writeIntoFile(destination().absolutePath)
+        destination: () -> Path,
+    ): Unit = IrArrayWriter(map { accessor(it) }, false).writeIntoFile(destination().absolutePathString())
 
     private inline fun List<SerializedIrFile>.serializeNullableEntries(
         accessor: (SerializedIrFile) -> ByteArray?,
-        destination: () -> KlibFile,
+        destination: () -> Path,
     ) {
         val nonNullEntries: List<ByteArray> = mapNotNull(accessor)
         if (nonNullEntries.isEmpty()) {
@@ -69,6 +71,6 @@ internal sealed class KlibIrComponentWriterImpl : KlibComponentWriter {
                     "\nOnly ${nonNullEntries.size} out of $size serialized IR files have non-nullable values."
         }
 
-        IrArrayWriter(nonNullEntries, false).writeIntoFile(destination().absolutePath)
+        IrArrayWriter(nonNullEntries, false).writeIntoFile(destination().absolutePathString())
     }
 }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibManifestComponentWriterImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibManifestComponentWriterImpl.kt
@@ -18,9 +18,10 @@ import org.jetbrains.kotlin.library.KotlinLibraryVersioning
 import org.jetbrains.kotlin.library.writeKonanLibraryVersioning
 import org.jetbrains.kotlin.library.writer.KlibManifestWriterSpec
 import org.jetbrains.kotlin.library.writer.KlibComponentWriter
+import java.nio.file.Path
 import java.util.Properties
 import kotlin.collections.plusAssign
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import kotlin.io.path.createDirectories
 
 /**
  * An implementation of [KlibComponentWriter] that writes manifest properties to the constructed Klib library.
@@ -32,11 +33,11 @@ internal class KlibManifestComponentWriterImpl(
     val targetNames: List<String>,
     val customProperties: Properties,
 ) : KlibComponentWriter {
-    override fun writeTo(root: KlibFile) {
+    override fun writeTo(root: Path) {
         val properties = assembleProperties()
 
         val layout = KlibManifestComponentLayout(root)
-        layout.manifestFile.parentFile.mkdirs()
+        layout.manifestFile.parent.createDirectories()
         properties.saveToFile(layout.manifestFile)
     }
 

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibMetadataComponentImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibMetadataComponentImpl.kt
@@ -9,6 +9,9 @@ import org.jetbrains.kotlin.library.KlibLayoutReader
 import org.jetbrains.kotlin.library.components.KlibMetadataComponent
 import org.jetbrains.kotlin.library.components.KlibMetadataComponentLayout
 import org.jetbrains.kotlin.library.components.KlibMetadataConstants.KLIB_METADATA_FILE_EXTENSION_WITH_DOT
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.readBytes
 
 /**
  * The default implementation of [KlibMetadataComponent].
@@ -20,7 +23,7 @@ internal class KlibMetadataComponentImpl(
     override val moduleHeaderData get() = layoutReader.readInPlace { it.moduleHeaderFile.readBytes() }
 
     override fun getPackageFragmentNames(packageFqName: String) = layoutReader.readInPlace { layout ->
-        val fileList: List<String> = layout.getPackageFragmentsDir(packageFqName).listFiles.mapNotNull { file ->
+        val fileList: List<String> = layout.getPackageFragmentsDir(packageFqName).listDirectoryEntries().mapNotNull { file ->
             file.name
                 .substringBeforeLast(KLIB_METADATA_FILE_EXTENSION_WITH_DOT, missingDelimiterValue = "")
                 .takeIf { it.isNotEmpty() }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibMetadataComponentWriterImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibMetadataComponentWriterImpl.kt
@@ -14,7 +14,9 @@ import org.jetbrains.kotlin.library.writer.KlibWrittenMetadataPackageFragmentTra
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.nameWithoutExtension
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.writeBytes
 
 /**
  * An implementation of [KlibComponentWriter] that writes [SerializedMetadata] to the constructed Klib library.
@@ -23,15 +25,15 @@ internal class KlibMetadataComponentWriterImpl(
     private val metadata: SerializedMetadata,
     private val fragmentTracker: KlibWrittenMetadataPackageFragmentTracker?,
 ) : KlibComponentWriter {
-    override fun writeTo(root: KlibFile) {
+    override fun writeTo(root: Path) {
         val layout = KlibMetadataComponentLayout(root)
-        layout.metadataDir.mkdirs()
+        layout.metadataDir.createDirectories()
 
         layout.moduleHeaderFile.writeBytes(metadata.module)
 
         metadata.fragmentNames.forEachIndexed { index, packageFqName ->
-            val packageFragmentDir: KlibFile = layout.getPackageFragmentsDir(packageFqName)
-            packageFragmentDir.mkdirs()
+            val packageFragmentDir: Path = layout.getPackageFragmentsDir(packageFqName)
+            packageFragmentDir.createDirectories()
 
             val shortPackageName: String = packageFqName.substringAfterLast(".")
             val (packageFragmentWithSourceParts, packageFragmentWithoutSourceParts) =
@@ -62,9 +64,9 @@ internal class KlibMetadataComponentWriterImpl(
         sourceFile: Path?,
     ) {
         val packageFragmentFile = getPackageFragmentFile(packageFqName = packageFqName, partName = partName)
-        check(packageFragmentFile.exists.not()) { "Duplicate package fragment name '${packageFragmentFile.path}'" }
+        check(!packageFragmentFile.exists()) { "Duplicate package fragment name '$packageFragmentFile'" }
         packageFragmentFile.writeBytes(content)
 
-        fragmentTracker?.recordSourceFile(sourceFile, packageFragmentFile.javaPath())
+        fragmentTracker?.recordSourceFile(sourceFile, packageFragmentFile)
     }
 }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibResourcesComponentWriterImpl.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/KlibResourcesComponentWriterImpl.kt
@@ -9,18 +9,19 @@ import org.jetbrains.kotlin.library.KlibComponentLayout
 import org.jetbrains.kotlin.library.KlibConstants.KLIB_DEFAULT_COMPONENT_NAME
 import org.jetbrains.kotlin.library.KlibConstants.KLIB_RESOURCES_FOLDER_NAME
 import org.jetbrains.kotlin.library.writer.KlibComponentWriter
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
 
 /**
  * This is the workaround to create an empty 'resources' directory that is expected inside a KLIB.
  */
 internal object KlibResourcesComponentWriterImpl : KlibComponentWriter {
-    override fun writeTo(root: KlibFile) {
-        KlibResourcesComponentLayout(root).resourcesDir.mkdirs()
+    override fun writeTo(root: Path) {
+        KlibResourcesComponentLayout(root).resourcesDir.createDirectories()
     }
 }
 
-private class KlibResourcesComponentLayout(root: KlibFile) : KlibComponentLayout(root) {
-    val resourcesDir: KlibFile
-        get() = root.child(KLIB_DEFAULT_COMPONENT_NAME).child(KLIB_RESOURCES_FOLDER_NAME)
+private class KlibResourcesComponentLayout(root: Path) : KlibComponentLayout(root) {
+    val resourcesDir: Path
+        get() = root.resolve(KLIB_DEFAULT_COMPONENT_NAME).resolve(KLIB_RESOURCES_FOLDER_NAME)
 }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/lowLevelReaders.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/impl/lowLevelReaders.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.library.KlibComponentLayout
 import org.jetbrains.kotlin.library.KlibLayoutReader
 import org.jetbrains.kotlin.utils.readUnsignedLeb128
 import java.nio.ByteBuffer
+import java.nio.file.Path
+import kotlin.io.path.readBytes
 
 /******************************************************************************/
 /** [ByteArray] readers                                                       */
@@ -24,7 +26,7 @@ fun IrArrayReader(loadBytes: () -> ByteArray): IrArrayReader = IrArrayReader(Rea
 /** On-demand read from a file (potentially inside a KLIB archive file). */
 inline fun <KCL : KlibComponentLayout> IrArrayReader(
     layoutReader: KlibLayoutReader<KCL>,
-    crossinline getFile: KCL.() -> File,
+    crossinline getFile: KCL.() -> Path,
 ): IrArrayReader = IrArrayReader { layoutReader.readInPlace { it.getFile().readBytes() } }
 
 class IrArrayReader(private val buffer: ReadByteBufferProvider) {
@@ -43,7 +45,7 @@ fun IrMultiArrayReader(loadBytes: () -> ByteArray): IrMultiArrayReader = IrMulti
 /** On-demand read from a file (potentially inside a KLIB archive file). */
 inline fun <KCL : KlibComponentLayout> IrMultiArrayReader(
     layoutReader: KlibLayoutReader<KCL>,
-    crossinline getFile: KCL.() -> File,
+    crossinline getFile: KCL.() -> Path,
 ): IrMultiArrayReader = IrMultiArrayReader { layoutReader.readInPlace { it.getFile().readBytes() } }
 
 class IrMultiArrayReader(private val buffer: ReadByteBufferProvider) {
@@ -89,7 +91,7 @@ fun DeclarationIdMultiTableReader(loadBytes: () -> ByteArray): DeclarationIdMult
 /** On-demand read from a file (potentially inside a KLIB archive file). */
 inline fun <KCL : KlibComponentLayout> DeclarationIdMultiTableReader(
     layoutReader: KlibLayoutReader<KCL>,
-    crossinline getFile: KCL.() -> File,
+    crossinline getFile: KCL.() -> Path,
 ): DeclarationIdMultiTableReader = DeclarationIdMultiTableReader { layoutReader.readInPlace { it.getFile().readBytes() } }
 
 class DeclarationIdMultiTableReader(private val buffer: ReadByteBufferProvider) {

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/writer/KlibComponentWriter.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/writer/KlibComponentWriter.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.library.writer
 
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
 
 /**
  * A "writer" of a specific component of the constructed Klib library.
@@ -15,5 +15,5 @@ import org.jetbrains.kotlin.konan.file.File as KlibFile
  * and is responsible for writing all the necessary files to the library.
  */
 interface KlibComponentWriter {
-    fun writeTo(root: KlibFile)
+    fun writeTo(root: Path)
 }

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/writer/KlibWriter.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/writer/KlibWriter.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.library.writer
 
-import org.jetbrains.kotlin.konan.file.createTempDir
 import org.jetbrains.kotlin.konan.file.zipDirAs
 import org.jetbrains.kotlin.library.KlibFormat
 import org.jetbrains.kotlin.library.KotlinLibrary
@@ -15,8 +14,15 @@ import org.jetbrains.kotlin.library.impl.KlibManifestComponentWriterImpl
 import org.jetbrains.kotlin.library.impl.KlibManifestComponentWriterImpl.Companion.NON_CUSTOMIZED_PROPERTY_NAMES
 import org.jetbrains.kotlin.library.impl.KlibManifestComponentWriterImpl.Companion.getPropertyNameForListOfTargetNames
 import org.jetbrains.kotlin.library.impl.KlibResourcesComponentWriterImpl
+import java.nio.file.Files.createTempDirectory
+import java.nio.file.Path
 import java.util.*
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.exists
 
 /**
  * The [KlibWriter] component is the unified endpoint for writing [KotlinLibrary] artifacts to the file system.
@@ -86,7 +92,8 @@ class KlibWriter(init: KlibWriterSpec.() -> Unit) {
         }.init()
     }
 
-    fun writeTo(destinationPath: String) {
+    @OptIn(ExperimentalPathApi::class)
+    fun writeTo(destinationPath: Path) {
         check(!allowIncrementalOverwriting || format != KlibFormat.ZipArchive) {
             "Writing a KLIB in ZIP format if `allowIncrementalOverwriting` is set to `true` is not supported."
         }
@@ -101,28 +108,35 @@ class KlibWriter(init: KlibWriterSpec.() -> Unit) {
             this += KlibResourcesComponentWriterImpl
         }
 
-        val destination = KlibFile(destinationPath).absoluteFile
-
         when {
-            !destination.exists -> {
-                destination.parentFile.mkdirs()
+            !destinationPath.exists() -> {
+                // We need to compute absolute path for the generated KLIB artifact
+                // in order to be able to create all containing directories beforehand.
+                //
+                // Illustrative example:
+                //   Path(".").parent == null
+                //   Path(".").absolute().parent != null
+                destinationPath.absolute().parent.createDirectories()
             }
             !allowIncrementalOverwriting -> {
-                destination.deleteRecursively()
+                destinationPath.deleteRecursively()
             }
         }
 
         when (format) {
-            KlibFormat.Directory -> writeComponents(allComponentWriters, root = destination)
+            KlibFormat.Directory -> writeComponents(allComponentWriters, root = destinationPath)
 
             KlibFormat.ZipArchive -> {
-                val temporaryDir = createTempDir("klib")
+                val temporaryDir = createTempDirectory("klib")
                 writeComponents(allComponentWriters, root = temporaryDir)
-                temporaryDir.zipDirAs(destination)
+                temporaryDir.zipDirAs(destinationPath)
                 temporaryDir.deleteRecursively()
             }
         }
+
     }
+
+    fun writeTo(destinationPath: String) = writeTo(Path(destinationPath))
 
     private fun validateManifestPropertiesAndCreateComponentWriter(): KlibManifestComponentWriterImpl {
         val moduleName = checkNotNull(moduleName) {
@@ -159,7 +173,7 @@ class KlibWriter(init: KlibWriterSpec.() -> Unit) {
     }
 
     companion object {
-        private fun writeComponents(allComponentWriters: List<KlibComponentWriter>, root: KlibFile) {
+        private fun writeComponents(allComponentWriters: List<KlibComponentWriter>, root: Path) {
             for (componentWriter in allComponentWriters) {
                 componentWriter.writeTo(root)
             }

--- a/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibLayoutReaderTest.kt
+++ b/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibLayoutReaderTest.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.library
 
 import org.jetbrains.kotlin.konan.file.ZipFileSystemInPlaceAccessor
-import org.jetbrains.kotlin.konan.file.createTempDir
 import org.jetbrains.kotlin.konan.file.zipDirAs
 import org.jetbrains.kotlin.library.TestComponentConstants.MANDATORY_COMPONENT_BASE_FOLDER_NAME
 import org.jetbrains.kotlin.library.TestComponentConstants.MANDATORY_COMPONENT_INT_VALUE_FILE_NAME
@@ -22,18 +21,31 @@ import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
 import java.io.IOException
+import java.nio.file.Files.createTempDirectory
+import java.nio.file.Path
 import java.util.Collections.rotate
 import java.util.UUID
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.readBytes
+import kotlin.io.path.writeText
 import kotlin.random.Random
-import org.jetbrains.kotlin.konan.file.File as KlibFile
 
+@OptIn(ExperimentalPathApi::class)
 class KlibLayoutReaderTest {
-    private lateinit var tmpDir: KlibFile
+    private lateinit var tmpDir: Path
     private val random = Random(System.nanoTime())
 
     @BeforeEach
     fun setup(info: TestInfo) {
-        tmpDir = createTempDir(info.testClass.get().simpleName + "-" + info.testMethod.get().name)
+        tmpDir = createTempDirectory(info.testClass.get().simpleName + "-" + info.testMethod.get().name)
     }
 
     @AfterEach
@@ -55,11 +67,11 @@ class KlibLayoutReaderTest {
 
                 assertEquals(color, optionalComponent.stringValue)
 
-                val someUsefulFiles = optionalComponent.pathsOfExtractedFiles.map { KlibFile(it) }
+                val someUsefulFiles = optionalComponent.pathsOfExtractedFiles.map { Path(it) }
                 assertEquals(furnitureItems, someUsefulFiles.mapTo(hashSetOf()) { it.name })
 
                 someUsefulFiles.forEach { file ->
-                    val fileWasExtracted = !file.absolutePath.startsWith(lib.location.absolutePath)
+                    val fileWasExtracted = !file.absolutePathString().startsWith(lib.location.absolutePathString())
                     assertEquals(isFileExtractionExpected, fileWasExtracted)
                     assertEquals("$color ${file.name}", file.readText())
                 }
@@ -103,32 +115,32 @@ class KlibLayoutReaderTest {
         assertEquals(null, klibDir.compress().toTestLib().optionalComponent)
     }
 
-    private fun generateNewPlainKlib(intValue: Int, stringValue: String, fileNames: Collection<String>): KlibFile {
-        val klibDir = tmpDir.child(UUID.randomUUID().toString())
+    private fun generateNewPlainKlib(intValue: Int, stringValue: String, fileNames: Collection<String>): Path {
+        val klibDir = tmpDir.resolve(UUID.randomUUID().toString())
 
         val mandatoryComponentLayout = TestMandatoryComponentLayout(klibDir)
-        mandatoryComponentLayout.baseDir.mkdirs()
+        mandatoryComponentLayout.baseDir.createDirectories()
         mandatoryComponentLayout.intValueFile.writeText("$intValue")
 
         val optionalComponentLayout = TestOptionalComponentLayout(klibDir)
-        optionalComponentLayout.baseDir.mkdirs()
+        optionalComponentLayout.baseDir.createDirectories()
         optionalComponentLayout.stringValueFile.writeText(stringValue)
-        optionalComponentLayout.extractedFilesDir.mkdirs()
+        optionalComponentLayout.extractedFilesDir.createDirectories()
         for (fileName in fileNames) {
-            optionalComponentLayout.extractedFilesDir.child(fileName).writeText("$stringValue $fileName")
+            optionalComponentLayout.extractedFilesDir.resolve(fileName).writeText("$stringValue $fileName")
         }
 
         return klibDir
     }
 
-    private fun KlibFile.compress(): KlibFile {
-        val klibFile = KlibFile("$absolutePath.klib")
-        if (klibFile.exists) klibFile.delete()
+    private fun Path.compress(): Path {
+        val klibFile = Path("${absolutePathString()}.klib")
+        klibFile.deleteIfExists()
         zipDirAs(klibFile)
         return klibFile
     }
 
-    private fun KlibFile.toTestLib(): TestLib = TestLib(this)
+    private fun Path.toTestLib(): TestLib = TestLib(this)
 
     private fun getRandomColor(): String = COLORS.random(random)
 
@@ -145,7 +157,7 @@ class KlibLayoutReaderTest {
     }
 }
 
-private class TestLib(val location: KlibFile) {
+private class TestLib(val location: Path) {
     private val layoutReaderFactory = KlibLayoutReaderFactory(location, ZipFileSystemInPlaceAccessor)
     private val components = KlibComponentsCache(layoutReaderFactory)
 
@@ -156,7 +168,7 @@ private class TestLib(val location: KlibFile) {
     val optionalComponent: TestOptionalComponent?
         get() = components.getComponent(TestOptionalComponent.Kind)
 
-    override fun toString() = location.absolutePath
+    override fun toString() = location.absolutePathString()
 }
 
 /**
@@ -169,10 +181,10 @@ private interface TestOptionalComponent : KlibComponent {
     val pathsOfExtractedFiles: Collection<String>
 
     companion object Kind : KlibComponent.Kind<TestOptionalComponent, TestOptionalComponentLayout> {
-        override fun createLayout(root: KlibFile) = TestOptionalComponentLayout(root)
+        override fun createLayout(root: Path) = TestOptionalComponentLayout(root)
 
         override fun createComponentIfDataInKlibIsAvailable(layoutReader: KlibLayoutReader<TestOptionalComponentLayout>) =
-            if (layoutReader.readInPlaceOrFallback(false) { it.baseDir.exists }) TestOptionalComponentImpl(layoutReader) else null
+            if (layoutReader.readInPlaceOrFallback(false) { it.baseDir.exists() }) TestOptionalComponentImpl(layoutReader) else null
     }
 }
 
@@ -182,14 +194,14 @@ private class TestOptionalComponentImpl(private val layoutReader: KlibLayoutRead
     }
 
     override val pathsOfExtractedFiles: Collection<String> by lazy {
-        layoutReader.readExtractingToTemp { it.extractedFilesDir }.listFiles.map(KlibFile::absolutePath)
+        layoutReader.readExtractingToTemp { it.extractedFilesDir }.listDirectoryEntries().map(Path::absolutePathString)
     }
 }
 
-private class TestOptionalComponentLayout(root: KlibFile) : KlibComponentLayout(root) {
-    val baseDir: KlibFile get() = root.child(OPTIONAL_COMPONENT_BASE_FOLDER_NAME)
-    val stringValueFile: KlibFile get() = baseDir.child(OPTIONAL_COMPONENT_STRING_VALUE_FILE_NAME)
-    val extractedFilesDir: KlibFile get() = baseDir.child(OPTIONAL_COMPONENT_EXTRACTED_FILES_FOLDER_NAME)
+private class TestOptionalComponentLayout(root: Path) : KlibComponentLayout(root) {
+    val baseDir: Path get() = root.resolve(OPTIONAL_COMPONENT_BASE_FOLDER_NAME)
+    val stringValueFile: Path get() = baseDir.resolve(OPTIONAL_COMPONENT_STRING_VALUE_FILE_NAME)
+    val extractedFilesDir: Path get() = baseDir.resolve(OPTIONAL_COMPONENT_EXTRACTED_FILES_FOLDER_NAME)
 }
 
 /**
@@ -202,7 +214,7 @@ private interface TestMandatoryComponent : KlibComponent {
     val intValue: Int
 
     companion object Kind : KlibComponent.Kind<TestMandatoryComponent, TestMandatoryComponentLayout> {
-        override fun createLayout(root: KlibFile) = TestMandatoryComponentLayout(root)
+        override fun createLayout(root: Path) = TestMandatoryComponentLayout(root)
 
         override fun createComponentIfDataInKlibIsAvailable(layoutReader: KlibLayoutReader<TestMandatoryComponentLayout>) =
             TestMandatoryComponentImpl(layoutReader)
@@ -215,9 +227,9 @@ private class TestMandatoryComponentImpl(private val layoutReader: KlibLayoutRea
     }
 }
 
-private class TestMandatoryComponentLayout(root: KlibFile) : KlibComponentLayout(root) {
-    val baseDir: KlibFile get() = root.child(MANDATORY_COMPONENT_BASE_FOLDER_NAME)
-    val intValueFile: KlibFile get() = baseDir.child(MANDATORY_COMPONENT_INT_VALUE_FILE_NAME)
+private class TestMandatoryComponentLayout(root: Path) : KlibComponentLayout(root) {
+    val baseDir: Path get() = root.resolve(MANDATORY_COMPONENT_BASE_FOLDER_NAME)
+    val intValueFile: Path get() = baseDir.resolve(MANDATORY_COMPONENT_INT_VALUE_FILE_NAME)
 }
 
 
@@ -232,4 +244,4 @@ private object TestComponentConstants {
     const val MANDATORY_COMPONENT_INT_VALUE_FILE_NAME = "int.txt"
 }
 
-private fun KlibFile.readText(): String = readBytes().toString(Charsets.UTF_8).trimEnd()
+private fun Path.readText(): String = readBytes().toString(Charsets.UTF_8).trimEnd()

--- a/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibWriterTest.kt
+++ b/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibWriterTest.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.library
 import org.jetbrains.kotlin.library.KlibWriterTest.NewKlibWriterParameters
 import org.jetbrains.kotlin.library.components.KlibMetadataComponentLayout
 import org.jetbrains.kotlin.library.impl.BuiltInsPlatform
-import org.jetbrains.kotlin.library.impl.javaPath
 import org.jetbrains.kotlin.library.writer.KlibWriter
 import org.jetbrains.kotlin.library.writer.KlibWrittenMetadataPackageFragmentTracker
 import org.jetbrains.kotlin.library.writer.includeIr
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.assertThrows
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
-import org.jetbrains.kotlin.konan.file.File as KlibFile
 
 /**
  * This is the test for the redesigned (new) KLIB writer API (as the opposite of the test for the legacy one: [LegacyKlibWriterTest]).
@@ -231,11 +229,11 @@ class KlibWriterTest : AbstractKlibWriterTest<NewKlibWriterParameters>(::NewKlib
             }
         )
 
-        val layout = KlibMetadataComponentLayout(KlibFile(klibDir.path))
+        val layout = KlibMetadataComponentLayout(Path(klibDir.path))
         val expectedMappings = listOf(
-            null to layout.getPackageFragmentFile(packageFqName = "", partName = "0_").javaPath(),
-            Path("/src/a.kt") to layout.getPackageFragmentFile(packageFqName = "", partName = "a").javaPath(),
-            null to layout.getPackageFragmentFile(packageFqName = "foo.bar", partName = "0_bar").javaPath(),
+            null to layout.getPackageFragmentFile(packageFqName = "", partName = "0_"),
+            Path("/src/a.kt") to layout.getPackageFragmentFile(packageFqName = "", partName = "a"),
+            null to layout.getPackageFragmentFile(packageFqName = "foo.bar", partName = "0_bar"),
         )
 
         assertEquals(

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/KlibMockDSL.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/KlibMockDSL.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.library.impl.KlibMetadataComponentWriterImpl
 import org.jetbrains.kotlin.library.writer.KlibWrittenMetadataPackageFragmentTracker
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
 import java.io.File
+import kotlin.io.path.Path
 import kotlin.random.Random
 import org.jetbrains.kotlin.konan.file.File as KlibFile
 
@@ -161,7 +162,7 @@ fun KlibMockDSL.resources(init: KlibMockDSL.() -> Unit = {}): Unit = dir(KLIB_RE
 fun KlibMockDSL.metadata(init: KlibMockDSL.() -> Unit = {}): Unit = dir(KLIB_METADATA_FOLDER_NAME, init)
 
 fun KlibMockDSL.metadata(metadata: SerializedMetadata, fragmentTracker: KlibWrittenMetadataPackageFragmentTracker?) {
-    KlibMetadataComponentWriterImpl(metadata, fragmentTracker).writeTo(KlibFile(rootDir.path))
+    KlibMetadataComponentWriterImpl(metadata, fragmentTracker).writeTo(Path(rootDir.path))
 }
 
 fun KlibMockDSL.ir(init: KlibMockDSL.() -> Unit = {}): Unit = dir(KLIB_IR_FOLDER_NAME, init)
@@ -169,7 +170,7 @@ fun KlibMockDSL.ir(init: KlibMockDSL.() -> Unit = {}): Unit = dir(KLIB_IR_FOLDER
 fun KlibMockDSL.irInlinableFunctions(init: KlibMockDSL.() -> Unit = {}): Unit = dir(KLIB_IR_INLINABLE_FUNCTIONS_FOLDER_NAME, init)
 
 fun KlibMockDSL.irModule(serializedIrModule: SerializedIrModule) {
-    val output = KlibFile(rootDir.path)
+    val output = Path(rootDir.path)
 
     KlibIrComponentWriterImpl.ForMainIr(serializedIrModule.files).writeTo(output)
     serializedIrModule.fileWithPreparedInlinableFunctions?.let { KlibIrComponentWriterImpl.ForInlinableFunctionsIr(it).writeTo(output) }

--- a/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolCommands.kt
+++ b/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolCommands.kt
@@ -121,7 +121,7 @@ internal class Info(output: KlibToolOutput, args: KlibToolArguments) : KlibToolC
         manifestProperties.entries.forEach { [key, value] ->
             output.appendLine("  $key=$value")
         }
-        loadSizeInfo(library.libraryFile)?.renderTo(output)
+        loadSizeInfo(library.path)?.renderTo(output)
     }
 
     companion object {

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/KT59030WorkaroundTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/KT59030WorkaroundTest.kt
@@ -38,9 +38,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.io.File
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.moveTo
 import org.jetbrains.kotlin.konan.file.File as KFile
 
 // See KT-59030.
+@OptIn(ExperimentalPathApi::class)
 @Tag("partial-linkage")
 @EnforcedHostTarget
 @UsePartialLinkage(UsePartialLinkage.Mode.ERROR)
@@ -104,12 +109,12 @@ class KT59030WorkaroundTest : AbstractNativeSimpleTest() {
         originalLibraryFile.unzipTo(originalLibraryTmpDir)
 
         // Drop the metadata from the original library.
-        val originalLibraryMetadataDir = KlibMetadataComponentLayout(originalLibraryTmpDir.path).metadataDir
+        val originalLibraryMetadataDir = KlibMetadataComponentLayout(Path(originalLibraryTmpDir.path)).metadataDir
         originalLibraryMetadataDir.deleteRecursively()
 
         // Copy the metadata from the patched library.
-        val patchedLibraryMetadataDir = KlibMetadataComponentLayout(patchedLibraryTmpDir.path).metadataDir
-        patchedLibraryMetadataDir.renameTo(originalLibraryMetadataDir)
+        val patchedLibraryMetadataDir = KlibMetadataComponentLayout(Path(patchedLibraryTmpDir.path)).metadataDir
+        patchedLibraryMetadataDir.moveTo(originalLibraryMetadataDir)
 
         // Zip the resulting library.
         originalLibraryTmpDir.zipDirAs(patchedLibraryFile)

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/components/KlibBitcodeComponent.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/components/KlibBitcodeComponent.kt
@@ -14,28 +14,29 @@ import org.jetbrains.kotlin.library.KlibComponent
 import org.jetbrains.kotlin.library.KlibComponentLayout
 import org.jetbrains.kotlin.library.KlibConstants.KLIB_DEFAULT_COMPONENT_NAME
 import org.jetbrains.kotlin.library.KlibLayoutReader
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.exists
 
 interface KlibBitcodeComponent : KlibComponent {
     val bitcodeFilePaths: List<String>
 
     data class Kind(val target: KonanTarget) : KlibComponent.Kind<KlibBitcodeComponent, KlibBitcodeComponentLayout> {
-        override fun createLayout(root: KlibFile) = KlibBitcodeComponentLayout(target, root)
+        override fun createLayout(root: Path) = KlibBitcodeComponentLayout(target, root)
 
         override fun createComponentIfDataInKlibIsAvailable(layoutReader: KlibLayoutReader<KlibBitcodeComponentLayout>): KlibBitcodeComponent? =
-            if (layoutReader.readInPlaceOrFallback(false) { it.bitcodeDir.exists }) KlibBitcodeComponentImpl(layoutReader) else null
+            if (layoutReader.readInPlaceOrFallback(false) { it.bitcodeDir.exists() }) KlibBitcodeComponentImpl(layoutReader) else null
     }
 }
 
 fun Klib.bitcode(target: KonanTarget): KlibBitcodeComponent? =
     getComponent(KlibBitcodeComponent.Kind(target))
 
-class KlibBitcodeComponentLayout(val target: KonanTarget, root: KlibFile) : KlibComponentLayout(root) {
-    val bitcodeDir: KlibFile
-        get() = root.child(KLIB_DEFAULT_COMPONENT_NAME)
-            .child(KLIB_TARGETS_FOLDER_NAME)
-            .child(target.visibleName)
-            .child(KLIB_BITCODE_FOLDER_NAME)
+class KlibBitcodeComponentLayout(val target: KonanTarget, root: Path) : KlibComponentLayout(root) {
+    val bitcodeDir: Path
+        get() = root.resolve(KLIB_DEFAULT_COMPONENT_NAME)
+            .resolve(KLIB_TARGETS_FOLDER_NAME)
+            .resolve(target.visibleName)
+            .resolve(KLIB_BITCODE_FOLDER_NAME)
 }
 
 /** Constants for bitcode files stored in Native Klibs. */

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/components/KlibNativeIncludedBinariesComponent.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/components/KlibNativeIncludedBinariesComponent.kt
@@ -14,16 +14,17 @@ import org.jetbrains.kotlin.library.KlibComponent
 import org.jetbrains.kotlin.library.KlibComponentLayout
 import org.jetbrains.kotlin.library.KlibConstants.KLIB_DEFAULT_COMPONENT_NAME
 import org.jetbrains.kotlin.library.KlibLayoutReader
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.exists
 
 interface KlibNativeIncludedBinariesComponent : KlibComponent {
     val nativeIncludedBinaryFilePaths: List<String>
 
     data class Kind(val target: KonanTarget) : KlibComponent.Kind<KlibNativeIncludedBinariesComponent, KlibNativeIncludedBinariesComponentLayout> {
-        override fun createLayout(root: KlibFile) = KlibNativeIncludedBinariesComponentLayout(target, root)
+        override fun createLayout(root: Path) = KlibNativeIncludedBinariesComponentLayout(target, root)
 
         override fun createComponentIfDataInKlibIsAvailable(layoutReader: KlibLayoutReader<KlibNativeIncludedBinariesComponentLayout>): KlibNativeIncludedBinariesComponent? {
-            return if (layoutReader.readInPlaceOrFallback(false) { it.nativeIncludedBinariesDir.exists }) KlibNativeIncludedBinariesComponentImpl(layoutReader) else null
+            return if (layoutReader.readInPlaceOrFallback(false) { it.nativeIncludedBinariesDir.exists() }) KlibNativeIncludedBinariesComponentImpl(layoutReader) else null
         }
     }
 }
@@ -31,12 +32,12 @@ interface KlibNativeIncludedBinariesComponent : KlibComponent {
 fun Klib.nativeIncludedBinaries(target: KonanTarget): KlibNativeIncludedBinariesComponent? =
     getComponent(KlibNativeIncludedBinariesComponent.Kind(target))
 
-class KlibNativeIncludedBinariesComponentLayout(val target: KonanTarget, root: KlibFile) : KlibComponentLayout(root) {
-    val nativeIncludedBinariesDir: KlibFile
-        get() = root.child(KLIB_DEFAULT_COMPONENT_NAME)
-            .child(KLIB_TARGETS_FOLDER_NAME)
-            .child(target.visibleName)
-            .child(KLIB_NATIVE_INCLUDED_BINARIES_FOLDER_NAME)
+class KlibNativeIncludedBinariesComponentLayout(val target: KonanTarget, root: Path) : KlibComponentLayout(root) {
+    val nativeIncludedBinariesDir: Path
+        get() = root.resolve(KLIB_DEFAULT_COMPONENT_NAME)
+            .resolve(KLIB_TARGETS_FOLDER_NAME)
+            .resolve(target.visibleName)
+            .resolve(KLIB_NATIVE_INCLUDED_BINARIES_FOLDER_NAME)
 }
 
 /** Constants for included Native binary files stored in Klibs. */

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibBitcodeComponentImpl.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibBitcodeComponentImpl.kt
@@ -8,12 +8,16 @@ package org.jetbrains.kotlin.konan.library.impl
 import org.jetbrains.kotlin.konan.library.components.KlibBitcodeComponent
 import org.jetbrains.kotlin.konan.library.components.KlibBitcodeComponentLayout
 import org.jetbrains.kotlin.library.KlibLayoutReader
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.listDirectoryEntries
 
 internal class KlibBitcodeComponentImpl(
     private val layoutReader: KlibLayoutReader<KlibBitcodeComponentLayout>
 ) : KlibBitcodeComponent {
     override val bitcodeFilePaths: List<String> by lazy {
-        layoutReader.readExtractingToTemp(KlibBitcodeComponentLayout::bitcodeDir).listFiles.map(KlibFile::absolutePath)
+        layoutReader.readExtractingToTemp(KlibBitcodeComponentLayout::bitcodeDir)
+            .listDirectoryEntries()
+            .map(Path::absolutePathString)
     }
 }

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibBitcodeComponentWriterImpl.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibBitcodeComponentWriterImpl.kt
@@ -8,19 +8,23 @@ package org.jetbrains.kotlin.konan.library.impl
 import org.jetbrains.kotlin.konan.library.components.KlibBitcodeComponentLayout
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.library.writer.KlibComponentWriter
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import kotlin.io.path.Path
+import java.nio.file.Path
+import kotlin.io.path.copyTo
+import kotlin.io.path.createDirectories
+import kotlin.io.path.name
 
 internal class KlibBitcodeComponentWriterImpl(
     private val target: KonanTarget,
     private val bitcodeFilePaths: Collection<String>,
 ) : KlibComponentWriter {
-    override fun writeTo(root: KlibFile) {
+    override fun writeTo(root: Path) {
         val layout = KlibBitcodeComponentLayout(target, root)
-        layout.bitcodeDir.mkdirs()
+        layout.bitcodeDir.createDirectories()
 
         for (filePath in bitcodeFilePaths) {
-            val file = KlibFile(filePath)
-            file.copyTo(layout.bitcodeDir.child(file.name))
+            val file = Path(filePath)
+            file.copyTo(layout.bitcodeDir.resolve(file.name), overwrite = true)
         }
     }
 }

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibNativeIncludedBinariesComponentImpl.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibNativeIncludedBinariesComponentImpl.kt
@@ -8,12 +8,16 @@ package org.jetbrains.kotlin.konan.library.impl
 import org.jetbrains.kotlin.konan.library.components.KlibNativeIncludedBinariesComponent
 import org.jetbrains.kotlin.konan.library.components.KlibNativeIncludedBinariesComponentLayout
 import org.jetbrains.kotlin.library.KlibLayoutReader
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.listDirectoryEntries
 
 internal class KlibNativeIncludedBinariesComponentImpl(
     private val layoutReader: KlibLayoutReader<KlibNativeIncludedBinariesComponentLayout>
 ) : KlibNativeIncludedBinariesComponent {
     override val nativeIncludedBinaryFilePaths: List<String> by lazy {
-        layoutReader.readExtractingToTemp(KlibNativeIncludedBinariesComponentLayout::nativeIncludedBinariesDir).listFiles.map(KlibFile::absolutePath)
+        layoutReader.readExtractingToTemp(KlibNativeIncludedBinariesComponentLayout::nativeIncludedBinariesDir)
+            .listDirectoryEntries()
+            .map(Path::absolutePathString)
     }
 }

--- a/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibNativeIncludedBinariesComponentWriterImpl.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/library/impl/KlibNativeIncludedBinariesComponentWriterImpl.kt
@@ -8,19 +8,23 @@ package org.jetbrains.kotlin.konan.library.impl
 import org.jetbrains.kotlin.konan.library.components.KlibNativeIncludedBinariesComponentLayout
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.library.writer.KlibComponentWriter
-import org.jetbrains.kotlin.konan.file.File as KlibFile
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.copyTo
+import kotlin.io.path.createDirectories
+import kotlin.io.path.name
 
 internal class KlibNativeIncludedBinariesComponentWriterImpl(
     private val target: KonanTarget,
     private val nativeIncludedBinaryFilePaths: Collection<String>,
 ) : KlibComponentWriter {
-    override fun writeTo(root: KlibFile) {
+    override fun writeTo(root: Path) {
         val layout = KlibNativeIncludedBinariesComponentLayout(target, root)
-        layout.nativeIncludedBinariesDir.mkdirs()
+        layout.nativeIncludedBinariesDir.createDirectories()
 
         for (filePath in nativeIncludedBinaryFilePaths) {
-            val file = KlibFile(filePath)
-            file.copyTo(layout.nativeIncludedBinariesDir.child(file.name))
+            val file = Path(filePath)
+            file.copyTo(layout.nativeIncludedBinariesDir.resolve(file.name), overwrite = true)
         }
     }
 }


### PR DESCRIPTION
The `org.jetbrains.kotlin.konan.file.File` class (aka "konan-File") is going to become a compiler's implementation detail. It should not be exposed through KLIB API.

^KT-87104