### PR TITLE
[Swift Export] Translate enclosing root when an inner classifier is referenced

### DIFF
--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/dependency_inner_classifiers.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/dependency_inner_classifiers.kt
@@ -1,0 +1,22 @@
+// KIND: STANDALONE
+// MODULE: main(dependency)
+// FILE: main.kt
+import datetime.LocalDate
+
+fun today(): LocalDate = LocalDate()
+
+// MODULE: dependency
+// FILE: dependency.kt
+package datetime
+
+class LocalDate {
+    companion object {
+        fun Format(block: (DateTimeFormatBuilder.WithDate) -> Unit): DateTimeFormat = TODO()
+    }
+}
+
+interface DateTimeFormat
+
+interface DateTimeFormatBuilder {
+    interface WithDate
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
@@ -1,0 +1,2 @@
+public enum datetime {
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/dependency/dependency.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/dependency/dependency.h
@@ -1,0 +1,14 @@
+#include <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+void * datetime_LocalDate_Companion_Format__TypesOfArguments__U28anyU20dependency__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDateU29202D_U20Swift_Void__(void * self, _Bool (^block)(void *));
+
+void * datetime_LocalDate_Companion_get();
+
+void * datetime_LocalDate_init_allocate();
+
+_Bool datetime_LocalDate_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/dependency/dependency.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/dependency/dependency.kt
@@ -1,0 +1,44 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(datetime.LocalDate::class, "22ExportedKotlinPackages8datetimeO10dependencyE9LocalDateC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(datetime.LocalDate.Companion::class, "22ExportedKotlinPackages8datetimeO10dependencyE9LocalDateC9CompanionC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(datetime.DateTimeFormat::class, "_DateTimeFormat")
+@file:kotlin.native.internal.objc.BindClassToObjCName(datetime.DateTimeFormatBuilder::class, "_DateTimeFormatBuilder")
+@file:kotlin.native.internal.objc.BindClassToObjCName(datetime.DateTimeFormatBuilder.WithDate::class, "__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate")
+
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.*
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ExportedBridge("datetime_LocalDate_Companion_Format__TypesOfArguments__U28anyU20dependency__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDateU29202D_U20Swift_Void__")
+public fun datetime_LocalDate_Companion_Format__TypesOfArguments__U28anyU20dependency__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDateU29202D_U20Swift_Void__(self: kotlin.native.internal.NativePtr, block: kotlin.native.internal.NativePtr): kotlin.native.internal.NativePtr {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as datetime.LocalDate.Companion
+    val __block = run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<(kotlin.native.internal.NativePtr)->Boolean>(block);
+        { arg0: datetime.DateTimeFormatBuilder.WithDate ->
+            val _arg0 = kotlin.native.internal.ref.createRetainedExternalRCRef(arg0)
+            val _result = kotlinFun(_arg0)
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.Format(__block) }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("datetime_LocalDate_Companion_get")
+public fun datetime_LocalDate_Companion_get(): kotlin.native.internal.NativePtr {
+    val _result = run { datetime.LocalDate.Companion }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("datetime_LocalDate_init_allocate")
+public fun datetime_LocalDate_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<datetime.LocalDate>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("datetime_LocalDate_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun datetime_LocalDate_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, datetime.LocalDate()) }
+    return run { _result; true }
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/dependency/dependency.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/dependency/dependency.swift
@@ -1,0 +1,94 @@
+@_exported import ExportedKotlinPackages
+@_implementationOnly import KotlinBridges_dependency
+import KotlinRuntime
+import KotlinRuntimeSupport
+
+public protocol _ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate: KotlinRuntime.KotlinBase, dependency.__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate {
+}
+@objc(__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate)
+public protocol __ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate {
+}
+public protocol ___ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate: KotlinRuntimeSupport._KotlinBridgeable {
+}
+extension ExportedKotlinPackages.datetime.DateTimeFormat where Self : ExportedKotlinPackages.datetime.__DateTimeFormat {
+}
+extension ExportedKotlinPackages.datetime.DateTimeFormat {
+}
+extension ExportedKotlinPackages.datetime.DateTimeFormatBuilder where Self : ExportedKotlinPackages.datetime.__DateTimeFormatBuilder {
+}
+extension ExportedKotlinPackages.datetime.DateTimeFormatBuilder {
+    typealias WithDate = dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate
+}
+extension dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate where Self : dependency.___ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate {
+}
+extension dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate {
+}
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.datetime.DateTimeFormat, ExportedKotlinPackages.datetime.__DateTimeFormat where Wrapped : ExportedKotlinPackages.datetime._DateTimeFormat {
+}
+extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.datetime.DateTimeFormatBuilder, ExportedKotlinPackages.datetime.__DateTimeFormatBuilder where Wrapped : ExportedKotlinPackages.datetime._DateTimeFormatBuilder {
+}
+extension KotlinRuntimeSupport._KotlinExistential: dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate, dependency.___ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate where Wrapped : dependency.__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate {
+}
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.datetime._DateTimeFormat {
+}
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.datetime._DateTimeFormatBuilder {
+}
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: dependency.__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate {
+}
+extension ExportedKotlinPackages.datetime {
+    public protocol DateTimeFormat: KotlinRuntime.KotlinBase, ExportedKotlinPackages.datetime._DateTimeFormat {
+    }
+    public protocol DateTimeFormatBuilder: KotlinRuntime.KotlinBase, ExportedKotlinPackages.datetime._DateTimeFormatBuilder {
+    }
+    @objc(_DateTimeFormat)
+    public protocol _DateTimeFormat {
+    }
+    @objc(_DateTimeFormatBuilder)
+    public protocol _DateTimeFormatBuilder {
+    }
+    public protocol __DateTimeFormat: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public protocol __DateTimeFormatBuilder: KotlinRuntimeSupport._KotlinBridgeable {
+    }
+    public final class LocalDate: KotlinRuntime.KotlinBase {
+        public final class Companion: KotlinRuntime.KotlinBase {
+            public static var shared: ExportedKotlinPackages.datetime.LocalDate.Companion {
+                get {
+                    return ExportedKotlinPackages.datetime.LocalDate.Companion.__createClassWrapper(externalRCRef: datetime_LocalDate_Companion_get())
+                }
+            }
+            private init() {
+                fatalError()
+            }
+            package override init(
+                __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+                options: KotlinRuntime.KotlinBaseConstructionOptions
+            ) {
+                super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+            }
+            public func Format(
+                block: @escaping (any dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate) -> Swift.Void
+            ) -> any ExportedKotlinPackages.datetime.DateTimeFormat {
+                return KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: datetime_LocalDate_Companion_Format__TypesOfArguments__U28anyU20dependency__ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDateU29202D_U20Swift_Void__(self.__externalRCRef(), {
+                    let originalBlock: (any dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate) -> Swift.Void = block
+                    return { (arg0: Swift.UnsafeMutableRawPointer) in
+                        let _arg0: any dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: arg0) as! any dependency._ExportedKotlinPackages_datetime_DateTimeFormatBuilder_WithDate
+                        let _result = originalBlock(_arg0)
+                        return { _result; return true }()
+                    }
+                }())) as! any ExportedKotlinPackages.datetime.DateTimeFormat
+            }
+        }
+        public init() {
+            let __kt = datetime_LocalDate_init_allocate()
+            super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+            { datetime_LocalDate_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+        }
+        package override init(
+            __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+            options: KotlinRuntime.KotlinBaseConstructionOptions
+        ) {
+            super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+        }
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/main/main.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/main/main.h
@@ -1,0 +1,8 @@
+#include <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+void * __root___today();
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/main/main.kt
@@ -1,0 +1,11 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.*
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ExportedBridge("__root___today")
+public fun __root___today(): kotlin.native.internal.NativePtr {
+    val _result = run { today() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/dependency_inner_classifiers/golden_result/main/main.swift
@@ -1,0 +1,8 @@
+@_implementationOnly import KotlinBridges_main
+import KotlinRuntime
+import KotlinRuntimeSupport
+import dependency
+
+public func today() -> ExportedKotlinPackages.datetime.LocalDate {
+    return ExportedKotlinPackages.datetime.LocalDate.__createClassWrapper(externalRCRef: __root___today())
+}

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
@@ -48,7 +48,7 @@ internal fun translateModulePublicApi(module: InputModule, kaModules: KaModules,
             symbolContainingModule?.let { libraryName ->
                 externalTypeDeclarationReferences
                     .getOrPut(libraryName) { mutableListOf() }
-                    .addIfNotNull(symbol.classId?.asSingleFqName())
+                    .addIfNotNull(symbol.translationRootFqName)
             }
         }
         buildSirSession(module.name, kaModules, config, module.config, externalTypeReferenceHandler).withSessions {
@@ -100,7 +100,7 @@ internal fun translateCrossReferencingModulesTransitively(
         analyze(kaModules.useSiteModule) {
             val libraryName = (symbol.containingModule as? KaLibraryModule)?.libraryName
             translationStates.find { it.kaModule.libraryName == libraryName }?.let {
-                val fqName = symbol.classId?.asSingleFqName()
+                val fqName = symbol.translationRootFqName
                     ?: return@analyze
                 if (fqName !in it.processedReferences && fqName !in it.currentlyProcessing) {
                     it.unprocessedReferences += fqName
@@ -149,6 +149,9 @@ internal fun translateCrossReferencingModulesTransitively(
         }
     }
 }
+
+private val KaClassLikeSymbol.translationRootFqName: FqName?
+    get() = classId?.let { generateSequence(it) { id -> id.outerClassId }.last().asSingleFqName() }
 
 context(sir: SirSession)
 private fun createTranslationResult(


### PR DESCRIPTION


During transitive export, referenced type declarations act as roots for the translation process, and translateModule resolves them by filtering the module's top-level classifiers. An external usage, however, can reference an inner classifier (e.g. DateTimeFormatBuilder.WithDate). Its name never matches any top-level declaration, so the referenced type — and its enclosing declaration — were silently dropped from the exported Swift API.

Record the root (outermost) classifier instead of the referenced one when a new declaration reference arrives. The enclosing declaration is a top-level classifier, so it matches the filter and gets translated together with the referenced inner type. Reference de-duplication then operates on roots directly.

^KT-86463 Fixed