### PR TITLE
[IR] Fix leaking outer class type parameters in rich callable references

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSubstitutor.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/IrTypeSubstitutor.kt
@@ -55,20 +55,9 @@ abstract class AbstractIrTypeSubstitutor : TypeSubstitutorMarker {
          */
         fun forType(type: IrSimpleType): AbstractIrTypeSubstitutor {
             val clazz = type.classOrNull ?: return Empty
-            val typeParameters = clazz.owner.typeParameters.map { it.symbol }
+            val typeParameters = clazz.owner.typeConstructorParameters.map { it.symbol }.toList()
             if (typeParameters.isEmpty()) return Empty
-            /**
-             * Type may be a local class that captures type parameters of outer function, so we need to take only first
-             *   arguments, which correspond to type parameters of actual class declaration
-             */
-            val typeArgumentsForSubstitutor = type.arguments
-                .take(clazz.owner.typeParameters.size)
-
-            return IrTypeSubstitutor(
-                typeParameters,
-                typeArgumentsForSubstitutor,
-                allowEmptySubstitution = true
-            )
+            return IrTypeSubstitutor(typeParameters, type.arguments, allowEmptySubstitution = true)
         }
     }
 }

--- a/compiler/testData/codegen/box/delegation/delegationToInnerClassOfGenericClass.kt
+++ b/compiler/testData/codegen/box/delegation/delegationToInnerClassOfGenericClass.kt
@@ -1,0 +1,16 @@
+// ISSUE: KT-69305
+
+interface Mapping<T> {
+    fun map(x: String): T
+}
+
+class A<T> {
+    inner class Impl : Mapping<T> {
+        @Suppress("UNCHECKED_CAST")
+        override fun map(x: String): T = x as T
+    }
+}
+
+class B<T> : Mapping<T> by A<T>().Impl()
+
+fun box(): String = B<String>().map("OK")


### PR DESCRIPTION
When upgrading a reference to an inner-class member, only the receiver class's type arguments are remapped, so the generated adapter can reference an out-of-scope outer type parameter.

KT-69305
^KT-87138 Fixed