### PR TITLE
[Wasm]: Turn range checks on by default.

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -12528,7 +12528,7 @@
                                                         "valueInVersions": []
                                                     },
                                                     "defaultValue": {
-                                                        "current": false,
+                                                        "current": true,
                                                         "valueInVersions": []
                                                     }
                                                 },
@@ -12549,7 +12549,7 @@
                                                         "valueInVersions": []
                                                     },
                                                     "defaultValue": {
-                                                        "current": false,
+                                                        "current": true,
                                                         "valueInVersions": []
                                                     }
                                                 },
@@ -14562,7 +14562,7 @@
                                                         "valueInVersions": []
                                                     },
                                                     "defaultValue": {
-                                                        "current": false,
+                                                        "current": true,
                                                         "valueInVersions": []
                                                     }
                                                 },
@@ -14583,7 +14583,7 @@
                                                         "valueInVersions": []
                                                     },
                                                     "defaultValue": {
-                                                        "current": false,
+                                                        "current": true,
                                                         "valueInVersions": []
                                                     }
                                                 },

--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -12529,7 +12529,13 @@
                                                     },
                                                     "defaultValue": {
                                                         "current": true,
-                                                        "valueInVersions": []
+                                                        "valueInVersions": [
+                                                            {
+                                                                "minReleaseVersion": "2.1.20",
+                                                                "maxReleaseVersion": "2.4.0",
+                                                                "value": false
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "valueDescription": {
@@ -12550,7 +12556,13 @@
                                                     },
                                                     "defaultValue": {
                                                         "current": true,
-                                                        "valueInVersions": []
+                                                        "valueInVersions": [
+                                                            {
+                                                                "minReleaseVersion": "2.1.20",
+                                                                "maxReleaseVersion": "2.4.0",
+                                                                "value": false
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "deprecatedMessage": null
@@ -14563,7 +14575,13 @@
                                                     },
                                                     "defaultValue": {
                                                         "current": true,
-                                                        "valueInVersions": []
+                                                        "valueInVersions": [
+                                                            {
+                                                                "minReleaseVersion": "2.1.20",
+                                                                "maxReleaseVersion": "2.4.0",
+                                                                "value": false
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "valueDescription": {
@@ -14584,7 +14602,13 @@
                                                     },
                                                     "defaultValue": {
                                                         "current": true,
-                                                        "valueInVersions": []
+                                                        "valueInVersions": [
+                                                            {
+                                                                "minReleaseVersion": "2.1.20",
+                                                                "maxReleaseVersion": "2.4.0",
+                                                                "value": false
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "deprecatedMessage": null

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
@@ -118,7 +118,7 @@ val actualWasmArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.wa
     compilerArgument {
         name = "Xwasm-enable-array-range-checks"
         description = "Turn on range checks for array access functions.".asReleaseDependent()
-        valueType = BooleanType.defaultFalse
+        valueType = BooleanType.defaultTrue
 
         lifecycle(
             introducedVersion = KotlinReleaseVersion.v2_1_20,

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
@@ -118,7 +118,16 @@ val actualWasmArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.wa
     compilerArgument {
         name = "Xwasm-enable-array-range-checks"
         description = "Turn on range checks for array access functions.".asReleaseDependent()
-        valueType = BooleanType.defaultTrue
+        valueType = BooleanType(
+            isNullable = ReleaseDependent(
+                true,
+                KotlinReleaseVersion.v2_1_20..KotlinReleaseVersion.v2_4_0 to false,
+            ),
+            defaultValue = ReleaseDependent(
+                true,
+                KotlinReleaseVersion.v2_1_20..KotlinReleaseVersion.v2_4_0 to false,
+            )
+        )
 
         lifecycle(
             introducedVersion = KotlinReleaseVersion.v2_1_20,

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
@@ -119,6 +119,7 @@ val actualWasmArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.wa
         name = "Xwasm-enable-array-range-checks"
         description = "Turn on range checks for array access functions.".asReleaseDependent()
         valueType = BooleanType(
+            isNullable = false.asReleaseDependent(),
             defaultValue = ReleaseDependent(
                 true,
                 KotlinReleaseVersion.v2_1_20..KotlinReleaseVersion.v2_4_0 to false,

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
@@ -119,10 +119,6 @@ val actualWasmArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.wa
         name = "Xwasm-enable-array-range-checks"
         description = "Turn on range checks for array access functions.".asReleaseDependent()
         valueType = BooleanType(
-            isNullable = ReleaseDependent(
-                true,
-                KotlinReleaseVersion.v2_1_20..KotlinReleaseVersion.v2_4_0 to false,
-            ),
             defaultValue = ReleaseDependent(
                 true,
                 KotlinReleaseVersion.v2_1_20..KotlinReleaseVersion.v2_4_0 to false,

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
@@ -88,7 +88,7 @@ sealed class K2WasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         value = "-Xwasm-enable-array-range-checks",
         description = "Turn on range checks for array access functions.",
     )
-    var wasmEnableArrayRangeChecks: Boolean = false
+    var wasmEnableArrayRangeChecks: Boolean = true
         set(value) {
             checkFrozen()
             field = value

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
@@ -89,7 +89,7 @@ class KotlinWasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         value = "-Xwasm-enable-array-range-checks",
         description = "Turn on range checks for array access functions.",
     )
-    var wasmEnableArrayRangeChecks: Boolean = false
+    var wasmEnableArrayRangeChecks: Boolean = true
         set(value) {
             checkFrozen()
             field = value


### PR DESCRIPTION
In disucssions with the team and after some benchmarks, we decided that range checks + BCE optimizations allow us to have acceptable performance in return for range checking semantics.

^KT-73452 Fixed