### PR TITLE
[Gradle] Close test suite when Playwright-ran test times out

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
@@ -14,7 +14,11 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
 import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.Ignore
 import kotlin.test.assertContains
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.toJavaDuration
 
 @JsGradlePluginTests
 class JsBrowserTestsIT : KGPBaseTest() {
@@ -150,6 +154,64 @@ class JsBrowserTestsIT : KGPBaseTest() {
                 assertOutputContains("chromium.JsBrowserSmokeTest.assertFails[js, browser] FAILED")
                 assertOutputContains("2 tests completed, 1 failed")
                 // TODO: KT-86778 Add verification of test report
+            }
+        }
+    }
+
+    @DisplayName("KT-86958: Unclear error for js test failure on timeout")
+    @GradleTest
+    @Ignore("Currently fails due to missing infra on CI, see KTI-3326")
+    fun `prints clear error message when a test times out`(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion = gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    js {
+                        browser {
+                            @OptIn(ExperimentalJsTestDsl::class)
+                            with(test) {
+                                chromium {
+                                    it.timeout.set(1234.milliseconds.toJavaDuration())
+                                }
+                            }
+                        }
+                    }
+
+                    sourceSets.commonTest {
+                        dependencies {
+                            implementation(kotlin("test"))
+                        }
+                    }
+
+                    sourceSets.commonTest.get().compileSource(
+                        """
+                        import kotlin.test.*
+                        
+                        class JsBrowserTimeoutTest {
+                            @Test
+                            fun test() {
+                                println("hello - sleeping 10 seconds")
+                                js(""${'"'}
+                                    var end = new Date().getTime() + 10000;
+                                    while (new Date().getTime() < end) {
+                                        // busy wait
+                                    }
+                                ""${'"'})
+                                println("done sleeping")
+                            }
+                        }
+                        """.trimIndent()
+                    )
+                }
+            }
+
+            buildAndFail("jsBrowserTest") {
+                assertTasksFailed(":jsBrowserTest")
+                assertOutputContains("chromium.JsBrowserTimeoutTest.test[js, browser] FAILED")
+                assertOutputContains("com.microsoft.playwright.TimeoutError: Timeout 1234ms exceeded")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/testing/TCServiceMessagesClient.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/testing/TCServiceMessagesClient.kt
@@ -46,17 +46,14 @@ internal open class TCServiceMessagesClient(
         return result
     }
 
-    fun <T> GroupNode.suite(id: String, actions: () -> T): T {
+    fun <T> GroupNode.suite(id: String, actions: SuiteNode.() -> T): T {
         val tsStart = System.currentTimeMillis()
         val group = SuiteNode(this,id)
         open(tsStart, group)
-        val result = try {
-            actions()
-        } finally {
+        return group.actions().also {
             val tsEnd = System.currentTimeMillis()
             close(tsEnd, id)
         }
-        return result
     }
 
     override fun parseException(e: ParseException, text: String) {
@@ -563,6 +560,30 @@ internal open class TCServiceMessagesClient(
         }
 
         return null
+    }
+
+    /**
+     * Should be called in cases when a failing test brings down the entire suite (e.g. when a single JS times out which leads to the
+     * whole web page being torn down).
+     *
+     * @param failingTestCause The exception representing the original test failure. Will be attached to every [TestNode] that sits on top
+     * of the [SuiteNode] in the stack.
+     */
+    fun closeSuiteWithFailingTestCause(suiteNode: SuiteNode, ts: Long, failingTestCause: Throwable) {
+        var attachedFailureToTestNode = false
+        do {
+            val currentLeaf = leaf ?: return
+            if (currentLeaf is TestNode) {
+                currentLeaf.failure(TestFailed(currentLeaf.cleanName, failingTestCause), false)
+                attachedFailureToTestNode = true
+            }
+            close(ts, currentLeaf.localId)
+        } while (currentLeaf.localId != suiteNode.localId)
+        // If there are no TestNodes on the stack, we have to re-throw the throwable, as otherwise we'd be swallowing it and incorrectly
+        // reporting the test suite as passing.
+        if (!attachedFailureToTestNode) {
+            throw failingTestCause
+        }
     }
 
     private fun requireLeaf() = leaf ?: error("test out of group")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -74,7 +74,12 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
                     root {
                         for (runner in spec.runners) {
                             suite(id = runner.name) {
-                                executeRunner(playwright, runner, handler)
+                                try {
+                                    executeRunner(playwright, runner, handler)
+                                } catch (t: Throwable) {
+                                    val tsEnd = System.currentTimeMillis()
+                                    closeSuiteWithFailingTestCause(suiteNode = this, tsEnd, failingTestCause = t)
+                                }
                             }
                         }
                     }

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/testing/tcsmc/TCServiceMessagesClientTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/testing/tcsmc/TCServiceMessagesClientTest.kt
@@ -13,6 +13,15 @@ open class TCServiceMessagesClientTest {
     protected var treatFailedTestOutputAsStacktrace: Boolean = false
 
     internal fun assertEvents(assertion: String, produceServiceMessage: TCServiceMessagesClient.() -> Unit) {
+        assertEvents(
+            assertion = { actual ->
+                assertEquals(assertion.trimTrailingWhitespaces().trim(), actual)
+            },
+            produceServiceMessage = produceServiceMessage,
+        )
+    }
+
+    internal fun assertEvents(assertion: (actual: String) -> Unit, produceServiceMessage: TCServiceMessagesClient.() -> Unit) {
         val results = RecordingTestResultProcessor()
         val client = createClient(results)
 
@@ -20,10 +29,7 @@ open class TCServiceMessagesClientTest {
             client.produceServiceMessage()
         }
 
-        assertEquals(
-            assertion.trimTrailingWhitespaces().trim(),
-            results.output.toString().trimTrailingWhitespaces().trim()
-        )
+        assertion(results.output.toString().trimTrailingWhitespaces().trim())
     }
 
     internal open fun createClient(results: RecordingTestResultProcessor): TCServiceMessagesClient {
@@ -39,4 +45,12 @@ open class TCServiceMessagesClientTest {
 
     internal fun TCServiceMessagesClient.serviceMessage(name: String, attributes: Map<String, String>) =
         serviceMessage(ServiceMessage.parse(ServiceMessage.asString(name, attributes))!!)
+
+    internal fun runWithClient(block: TCServiceMessagesClient.() -> Unit) {
+        val results = RecordingTestResultProcessor()
+        val client = createClient(results)
+        client.root {
+            client.block()
+        }
+    }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/testing/tcsmc/TestFailureTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/testing/tcsmc/TestFailureTest.kt
@@ -10,6 +10,8 @@ import jetbrains.buildServer.messages.serviceMessages.TestStarted
 import jetbrains.buildServer.messages.serviceMessages.TestSuiteFinished
 import jetbrains.buildServer.messages.serviceMessages.TestSuiteStarted
 import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 
 class TestFailureTest : TCServiceMessagesClientTest() {
     @Test
@@ -110,6 +112,54 @@ COMPLETED FAILURE // root
             )
             serviceMessage(TestFinished("Test", 0))
             serviceMessage(TestSuiteFinished(""))
+        }
+    }
+
+    @Test
+    fun `closing failed test suite with a started test attaches failure to the test node`() {
+        assertEvents(
+            assertion = { actual ->
+                assertContains(
+                    actual,
+                    """
+                    STARTED SUITE root // root
+                      STARTED SUITE  // root/
+                        STARTED TEST displayName: Test, classDisplayName: , className: , name: Test // root//Test
+                          FAILURE java.lang.RuntimeException: Test timed out
+                    """.trimIndent()
+                )
+            }
+        ) {
+            serviceMessage(TestSuiteStarted(""))
+            serviceMessage(TestStarted("Test", false, null))
+
+            closeSuiteWithFailingTestCause(
+                suiteNode = SuiteNode(
+                    parent = RootNode(),
+                    name = "",
+                ),
+                ts = System.currentTimeMillis(),
+                failingTestCause = RuntimeException("Test timed out"),
+            )
+        }
+    }
+
+    @Test
+    fun `closing failed test suite with no started tests re-throws failure`() = runWithClient {
+        serviceMessage(TestSuiteStarted(""))
+
+        val failingTestCause = RuntimeException("Test timed out")
+        try {
+            closeSuiteWithFailingTestCause(
+                suiteNode = SuiteNode(
+                    parent = RootNode(),
+                    name = "",
+                ),
+                ts = System.currentTimeMillis(),
+                failingTestCause = failingTestCause,
+            )
+        } catch (t: Throwable) {
+            assertEquals(failingTestCause, t)
         }
     }
 }


### PR DESCRIPTION
Playwright configures browser pages with a timeout, which leads to the TimeoutError exception being thrown if the page becomes unresponsive. This is exactly what happens when a test executed by the test runner times out. Even though Mocha does report timed out tests as failures, it only happens after the test actually completes (which can be never for tests that truly hang forever), so the Playwright timeout will often take precedence.

Previously, the exception was not handled and left the executor in an inconsistent state: suite() method's finally block would attempt to close the suite, but would not close any test nodes that are part of the suite. Additionally, the exception was not reported as the cause of the suite failure.

This change adds a catch block that properly closes the suite node including the test nodes on top of it, attaching the caught exception to those test nodes. This way the failure does not affect other suites and the cause of the failure is properly reported.

^KT-86958 Verification Pending

---

Here's what the experience looks like if multiple runners are configured to run the same test that times out:


https://github.com/user-attachments/assets/cf7b5712-6f67-4983-a3ca-4145b7664c30

