### PR TITLE
[Swift Export] Fix `BidirectionalBridge` type check

### DIFF
--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
@@ -798,20 +798,36 @@ internal sealed interface Bridge {
         }
     }
 
-    class AsOptionalWrapper(
+    sealed class AsOptionalWrapper private constructor(
         val wrappedObject: Bridge,
-    ) : BidirectionalBridge {
+    ) : Bridge {
+
+        class Bidirectional(wrappedObject: BidirectionalBridge) : AsOptionalWrapper(wrappedObject), BidirectionalBridge
+        class SwiftToKotlin(wrappedObject: SwiftToKotlinBridge) : AsOptionalWrapper(wrappedObject), SwiftToKotlinBridge
+        class KotlinToSwift(wrappedObject: KotlinToSwiftBridge) : AsOptionalWrapper(wrappedObject), KotlinToSwiftBridge
+
+        companion object {
+            operator fun invoke(wrappedObject: BidirectionalBridge): Bidirectional = Bidirectional(wrappedObject)
+            operator fun invoke(wrappedObject: SwiftToKotlinBridge): SwiftToKotlin = SwiftToKotlin(wrappedObject)
+            operator fun invoke(wrappedObject: KotlinToSwiftBridge): KotlinToSwift = KotlinToSwift(wrappedObject)
+            operator fun invoke(wrappedObject: Bridge): AsOptionalWrapper = when (wrappedObject) {
+                is BidirectionalBridge -> Bidirectional(wrappedObject)
+                is SwiftToKotlinBridge -> SwiftToKotlin(wrappedObject)
+                is KotlinToSwiftBridge -> KotlinToSwift(wrappedObject)
+            }
+        }
+
         override val swiftType = wrappedObject.swiftType.optional()
-        override val kotlinType = when (wrappedObject) {
+        val kotlinType = when (wrappedObject) {
             is SwiftToKotlinBridge -> wrappedObject.kotlinType
             is KotlinToSwiftBridge -> wrappedObject.kotlinType
         }
-        override val cType = when (wrappedObject) {
+        val cType = when (wrappedObject) {
             is SwiftToKotlinBridge -> wrappedObject.cType
             is KotlinToSwiftBridge -> wrappedObject.cType
         }.nullable
 
-        override val inKotlinSources: ValueConversion
+        val inKotlinSources: ValueConversion
             get() = object : ValueConversion {
                 context(session: SirSession)
                 override fun swiftToKotlin(typeNamer: SirTypeNamer, valueExpression: String): String {
@@ -830,7 +846,7 @@ internal sealed interface Bridge {
                 }
             }
 
-        override val inSwiftSources: ValueConversion = object : ValueConversion {
+        val inSwiftSources: ValueConversion = object : ValueConversion {
             context(session: SirSession)
             override fun swiftToKotlin(typeNamer: SirTypeNamer, valueExpression: String): String {
                 require(

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/functional_type.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/functional_type.kt
@@ -48,6 +48,10 @@ fun produce_opt_closure(arg: Unit): (()->String)? = TODO()
 fun consume_producing_opt_closure(arg: (()->(()->Unit)?)?): Unit = TODO()
 fun consume_consuming_opt_closure(arg: (((()->String)?)->Unit)?): Unit = TODO()
 
+interface MyInterface {
+    fun foo(arg: (() -> Unit)?)
+}
+
 // MODULE: functional_types
 // EXPORT_TO_SWIFT
 // FILE: functional_types.kt

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.h
@@ -3,6 +3,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+_Bool MyInterface_foo__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Void___(void * self, _Bool (^_Nullable arg)(void));
+
 _Bool __root___consume_consuming_opt_closure__TypesOfArguments__Swift_Optional_U28Swift_Optional_U2829202D_U20Swift_String_U29202D_U20Swift_Void___(_Bool (^_Nullable arg)(void * _Nullable ));
 
 _Bool __root___consume_opt_closure__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Void___(_Bool (^_Nullable arg)(void));

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.kt
@@ -1,8 +1,23 @@
 @file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(MyInterface::class, "_MyInterface")
 
 import kotlin.native.internal.ExportedBridge
 import kotlinx.cinterop.*
 import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ExportedBridge("MyInterface_foo__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Void___")
+public fun MyInterface_foo__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Void___(self: kotlin.native.internal.NativePtr, arg: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as MyInterface
+    val __arg = if (arg == kotlin.native.internal.NativePtr.NULL) null else run {
+        val kotlinFun = convertBlockPtrToKotlinFunction<()->Boolean>(arg);
+        {
+            val _result = kotlinFun()
+            run<Unit> { _result }
+        }
+    }
+    val _result = run { __self.foo(__arg) }
+    return run { _result; true }
+}
 
 @ExportedBridge("__root___consume_consuming_opt_closure__TypesOfArguments__Swift_Optional_U28Swift_Optional_U2829202D_U20Swift_String_U29202D_U20Swift_Void___")
 public fun __root___consume_consuming_opt_closure__TypesOfArguments__Swift_Optional_U28Swift_Optional_U2829202D_U20Swift_String_U29202D_U20Swift_Void___(arg: kotlin.native.internal.NativePtr): Boolean {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.swift
@@ -2,6 +2,16 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
+public protocol MyInterface: KotlinRuntime.KotlinBase, optional_closure._MyInterface {
+    func foo(
+        arg: (() -> Swift.Void)?
+    ) -> Swift.Void
+}
+@objc(_MyInterface)
+public protocol _MyInterface {
+}
+public protocol __MyInterface: KotlinRuntimeSupport._KotlinBridgeable {
+}
 public func consume_consuming_opt_closure(
     arg: (((() -> Swift.String)?) -> Swift.Void)?
 ) -> Swift.Void {
@@ -39,4 +49,20 @@ public func produce_opt_closure(
         let pointerToBlock = KotlinRuntime.KotlinBase(__externalRCRefUnsafe: it, options: .asBestFittingWrapper)!
         return { return optional_closure_internal_functional_type_caller_SwiftU2EString__TypesOfArguments__Swift_UnsafeMutableRawPointer__(pointerToBlock.__externalRCRef()!) }
     }() }
+}
+extension optional_closure.MyInterface where Self : optional_closure.__MyInterface {
+    public func foo(
+        arg: (() -> Swift.Void)?
+    ) -> Swift.Void {
+        return { MyInterface_foo__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Void___(self.__externalRCRef(), arg.map { it in {
+            let originalBlock: () -> Swift.Void = it
+            return { return { originalBlock(); return true }() }
+        }() } ?? nil); return () }()
+    }
+}
+extension optional_closure.MyInterface {
+}
+extension KotlinRuntimeSupport._KotlinExistential: optional_closure.MyInterface, optional_closure.__MyInterface where Wrapped : optional_closure._MyInterface {
+}
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: optional_closure._MyInterface {
 }


### PR DESCRIPTION
`AsOptionalWrapper(AsContravariantBlock)` should not
 conform to `BidirectionalBridge`.

^KT-87144 Fixed