### PR TITLE
[Swift Export] Fix `result` name conflict in reverse Kotlin bridge

### DIFF
--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/SirBridgeProviderImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/SirBridgeProviderImpl.kt
@@ -467,8 +467,8 @@ private class BridgeFunctionDescriptor(
 
             val returnBridge = returnType
             require(returnBridge is BidirectionalBridge) { "Parameter bridge must be bidirectional" }
-            add("    val __result = $swiftBridgeName($callArgs)")
-            add("    return ${returnBridge.inKotlinSources.swiftToKotlin(typeNamer, "__result")}")
+            add("    val _result = $swiftBridgeName($callArgs)")
+            add("    return ${returnBridge.inKotlinSources.swiftToKotlin(typeNamer, "_result")}")
 
             add("}")
         }

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
@@ -23,8 +23,8 @@ internal external fun kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache
 @BindReverseBridgeToMethod(kotlinx.coroutines.flow.MutableSharedFlow::class, "resetReplayCache")
 public fun kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse(self: kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = kotlinx_coroutines_flow_MutableSharedFlow_resetReplayCache__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -34,8 +34,8 @@ internal external fun kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOf
 public fun kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>, value: kotlin.Any?): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
-    val __result = kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value)
-    return __result
+    val _result = kotlinx_coroutines_flow_MutableSharedFlow_tryEmit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value)
+    return _result
 }
 
 @ImportedBridge("kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -46,8 +46,8 @@ public fun kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArgume
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __expect = if (`expect` == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(`expect`)
     val __update = if (update == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(update)
-    val __result = kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __expect, __update)
-    return __result
+    val _result = kotlinx_coroutines_flow_MutableStateFlow_compareAndSet__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __expect, __update)
+    return _result
 }
 
 @ExportedBridge("KotlinxCoroutinesCore_internal_functional_type_caller_SwiftU2EVoid__TypesOfArguments__Swift_UnsafeMutableRawPointer_Swift_Void__")

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/flow_overrides/flow_overrides.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/flow_overrides/flow_overrides.kt
@@ -22,8 +22,8 @@ internal external fun namespace_Bar_foo__reverse_swift(self: kotlin.native.inter
 @BindReverseBridgeToMethod(namespace.Bar::class, "foo")
 public fun namespace_Bar_foo__reverse(self: namespace.Bar): kotlinx.coroutines.flow.Flow<namespace.I1.I2> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_Bar_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.Flow<namespace.I1.I2>
+    val _result = namespace_Bar_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<namespace.I1.I2>
 }
 
 @ImportedBridge("namespace_Foo_foo__reverse_swift")
@@ -32,8 +32,8 @@ internal external fun namespace_Foo_foo__reverse_swift(self: kotlin.native.inter
 @BindReverseBridgeToMethod(namespace.Foo::class, "foo")
 public fun namespace_Foo_foo__reverse(self: namespace.Foo): kotlinx.coroutines.flow.Flow<namespace.I1?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_Foo_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.Flow<namespace.I1?>
+    val _result = namespace_Foo_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<namespace.I1?>
 }
 
 @ImportedBridge("namespace_MutableSharedFoo_foo__reverse_swift")
@@ -42,8 +42,8 @@ internal external fun namespace_MutableSharedFoo_foo__reverse_swift(self: kotlin
 @BindReverseBridgeToMethod(namespace.MutableSharedFoo::class, "foo")
 public fun namespace_MutableSharedFoo_foo__reverse(self: namespace.MutableSharedFoo): kotlinx.coroutines.flow.MutableSharedFlow<namespace.I1?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_MutableSharedFoo_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.MutableSharedFlow<namespace.I1?>
+    val _result = namespace_MutableSharedFoo_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.MutableSharedFlow<namespace.I1?>
 }
 
 @ImportedBridge("namespace_MutableStateFoo_foo__reverse_swift")
@@ -52,8 +52,8 @@ internal external fun namespace_MutableStateFoo_foo__reverse_swift(self: kotlin.
 @BindReverseBridgeToMethod(namespace.MutableStateFoo::class, "foo")
 public fun namespace_MutableStateFoo_foo__reverse(self: namespace.MutableStateFoo): kotlinx.coroutines.flow.MutableStateFlow<namespace.I1?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_MutableStateFoo_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.MutableStateFlow<namespace.I1?>
+    val _result = namespace_MutableStateFoo_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.MutableStateFlow<namespace.I1?>
 }
 
 @ImportedBridge("namespace_Nar_foo__reverse_swift")
@@ -62,8 +62,8 @@ internal external fun namespace_Nar_foo__reverse_swift(self: kotlin.native.inter
 @BindReverseBridgeToMethod(namespace.Nar::class, "foo")
 public fun namespace_Nar_foo__reverse(self: namespace.Nar): kotlinx.coroutines.flow.Flow<Nothing> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_Nar_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.Flow<Nothing>
+    val _result = namespace_Nar_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<Nothing>
 }
 
 @ImportedBridge("namespace_SharedFoo_foo__reverse_swift")
@@ -72,8 +72,8 @@ internal external fun namespace_SharedFoo_foo__reverse_swift(self: kotlin.native
 @BindReverseBridgeToMethod(namespace.SharedFoo::class, "foo")
 public fun namespace_SharedFoo_foo__reverse(self: namespace.SharedFoo): kotlinx.coroutines.flow.SharedFlow<namespace.I1?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_SharedFoo_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.SharedFlow<namespace.I1?>
+    val _result = namespace_SharedFoo_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.SharedFlow<namespace.I1?>
 }
 
 @ImportedBridge("namespace_StateFoo_foo__reverse_swift")
@@ -82,8 +82,8 @@ internal external fun namespace_StateFoo_foo__reverse_swift(self: kotlin.native.
 @BindReverseBridgeToMethod(namespace.StateFoo::class, "foo")
 public fun namespace_StateFoo_foo__reverse(self: namespace.StateFoo): kotlinx.coroutines.flow.StateFlow<namespace.I1?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_StateFoo_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.StateFlow<namespace.I1?>
+    val _result = namespace_StateFoo_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.StateFlow<namespace.I1?>
 }
 
 @ImportedBridge("namespace_Zar_foo__reverse_swift")
@@ -92,8 +92,8 @@ internal external fun namespace_Zar_foo__reverse_swift(self: kotlin.native.inter
 @BindReverseBridgeToMethod(namespace.Zar::class, "foo")
 public fun namespace_Zar_foo__reverse(self: namespace.Zar): kotlinx.coroutines.flow.Flow<namespace.I1.I2?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = namespace_Zar_foo__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlinx.coroutines.flow.Flow<namespace.I1.I2?>
+    val _result = namespace_Zar_foo__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlinx.coroutines.flow.Flow<namespace.I1.I2?>
 }
 
 @ExportedBridge("namespace_Bar_foo")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/annotations/golden_result/main/main.kt
@@ -54,8 +54,8 @@ internal external fun InterfaceWithDeprecatedMembers_deprecatedWarningFunction__
 @BindReverseBridgeToMethod(InterfaceWithDeprecatedMembers::class, "deprecatedWarningFunction")
 public fun InterfaceWithDeprecatedMembers_deprecatedWarningFunction__reverse(self: InterfaceWithDeprecatedMembers): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = InterfaceWithDeprecatedMembers_deprecatedWarningFunction__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = InterfaceWithDeprecatedMembers_deprecatedWarningFunction__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("InterfaceWithDeprecatedMembers_regularFunction__reverse_swift")
@@ -64,8 +64,8 @@ internal external fun InterfaceWithDeprecatedMembers_regularFunction__reverse_sw
 @BindReverseBridgeToMethod(InterfaceWithDeprecatedMembers::class, "regularFunction")
 public fun InterfaceWithDeprecatedMembers_regularFunction__reverse(self: InterfaceWithDeprecatedMembers): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = InterfaceWithDeprecatedMembers_regularFunction__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = InterfaceWithDeprecatedMembers_regularFunction__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("KotlinInterfaceC_kotlinFunD__TypesOfArguments__Swift_String____reverse_swift")
@@ -75,8 +75,8 @@ internal external fun KotlinInterfaceC_kotlinFunD__TypesOfArguments__Swift_Strin
 public fun KotlinInterfaceC_kotlinFunD__TypesOfArguments__Swift_String____reverse(self: KotlinInterfaceC, swiftParamD: kotlin.String): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __swiftParamD = swiftParamD.objcPtr()
-    val __result = KotlinInterfaceC_kotlinFunD__TypesOfArguments__Swift_String____reverse_swift(__self, __swiftParamD)
-    return run<Unit> { __result }
+    val _result = KotlinInterfaceC_kotlinFunD__TypesOfArguments__Swift_String____reverse_swift(__self, __swiftParamD)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("KotlinInterfaceC_kotlinFunE__TypesOfArguments__Swift_String____reverse_swift")
@@ -86,8 +86,8 @@ internal external fun KotlinInterfaceC_kotlinFunE__TypesOfArguments__Swift_Strin
 public fun KotlinInterfaceC_kotlinFunE__TypesOfArguments__Swift_String____reverse(self: KotlinInterfaceC, kotlinParamE: kotlin.String): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __kotlinParamE = kotlinParamE.objcPtr()
-    val __result = KotlinInterfaceC_kotlinFunE__TypesOfArguments__Swift_String____reverse_swift(__self, __kotlinParamE)
-    return run<Unit> { __result }
+    val _result = KotlinInterfaceC_kotlinFunE__TypesOfArguments__Swift_String____reverse_swift(__self, __kotlinParamE)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("NonDeprecatedInterface_bar__reverse_swift")
@@ -96,8 +96,8 @@ internal external fun NonDeprecatedInterface_bar__reverse_swift(self: kotlin.nat
 @BindReverseBridgeToMethod(NonDeprecatedInterface::class, "bar")
 public fun NonDeprecatedInterface_bar__reverse(self: NonDeprecatedInterface): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = NonDeprecatedInterface_bar__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = NonDeprecatedInterface_bar__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("PublicClassImplHiddenInterface_bar__reverse_swift")
@@ -106,8 +106,8 @@ internal external fun PublicClassImplHiddenInterface_bar__reverse_swift(self: ko
 @BindReverseBridgeToMethod(PublicClassImplHiddenInterface::class, "bar")
 public fun PublicClassImplHiddenInterface_bar__reverse(self: PublicClassImplHiddenInterface): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = PublicClassImplHiddenInterface_bar__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = PublicClassImplHiddenInterface_bar__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("PublicClassImplHiddenInterface_foo__reverse_swift")
@@ -116,8 +116,8 @@ internal external fun PublicClassImplHiddenInterface_foo__reverse_swift(self: ko
 @BindReverseBridgeToMethod(PublicClassImplHiddenInterface::class, "foo")
 public fun PublicClassImplHiddenInterface_foo__reverse(self: PublicClassImplHiddenInterface): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = PublicClassImplHiddenInterface_foo__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = PublicClassImplHiddenInterface_foo__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("SomeInterface_fooB__reverse_swift")
@@ -126,8 +126,8 @@ internal external fun SomeInterface_fooB__reverse_swift(self: kotlin.native.inte
 @BindReverseBridgeToMethod(SomeInterface::class, "fooB")
 public fun SomeInterface_fooB__reverse(self: SomeInterface): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = SomeInterface_fooB__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = SomeInterface_fooB__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ImportedBridge("deprecatedT_deprecationInheritedF__reverse_swift")
@@ -136,8 +136,8 @@ internal external fun deprecatedT_deprecationInheritedF__reverse_swift(self: kot
 @BindReverseBridgeToMethod(deprecatedT::class, "deprecationInheritedF")
 public fun deprecatedT_deprecationInheritedF__reverse(self: deprecatedT): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = deprecatedT_deprecationInheritedF__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = deprecatedT_deprecationInheritedF__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("deprecatedT_deprecationRestatedF__reverse_swift")
@@ -146,8 +146,8 @@ internal external fun deprecatedT_deprecationRestatedF__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(deprecatedT::class, "deprecationRestatedF")
 public fun deprecatedT_deprecationRestatedF__reverse(self: deprecatedT): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = deprecatedT_deprecationRestatedF__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = deprecatedT_deprecationRestatedF__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("normalT_deprecatedF__reverse_swift")
@@ -156,8 +156,8 @@ internal external fun normalT_deprecatedF__reverse_swift(self: kotlin.native.int
 @BindReverseBridgeToMethod(normalT::class, "deprecatedF")
 public fun normalT_deprecatedF__reverse(self: normalT): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = normalT_deprecatedF__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = normalT_deprecatedF__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("normalT_deprecatedInFutureF__reverse_swift")
@@ -166,8 +166,8 @@ internal external fun normalT_deprecatedInFutureF__reverse_swift(self: kotlin.na
 @BindReverseBridgeToMethod(normalT::class, "deprecatedInFutureF")
 public fun normalT_deprecatedInFutureF__reverse(self: normalT): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = normalT_deprecatedInFutureF__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = normalT_deprecatedInFutureF__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("normalT_normalF__reverse_swift")
@@ -176,8 +176,8 @@ internal external fun normalT_normalF__reverse_swift(self: kotlin.native.interna
 @BindReverseBridgeToMethod(normalT::class, "normalF")
 public fun normalT_normalF__reverse(self: normalT): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = normalT_normalF__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = normalT_normalF__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("normalT_obsoletedInFutureF__reverse_swift")
@@ -186,8 +186,8 @@ internal external fun normalT_obsoletedInFutureF__reverse_swift(self: kotlin.nat
 @BindReverseBridgeToMethod(normalT::class, "obsoletedInFutureF")
 public fun normalT_obsoletedInFutureF__reverse(self: normalT): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = normalT_obsoletedInFutureF__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = normalT_obsoletedInFutureF__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("normalT_removedInFutureF__reverse_swift")
@@ -196,8 +196,8 @@ internal external fun normalT_removedInFutureF__reverse_swift(self: kotlin.nativ
 @BindReverseBridgeToMethod(normalT::class, "removedInFutureF")
 public fun normalT_removedInFutureF__reverse(self: normalT): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = normalT_removedInFutureF__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = normalT_removedInFutureF__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ExportedBridge("ClassWithDeprecatedMembersFromInterface_deprecatedWarningFunction")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cross_language_inheritance/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cross_language_inheritance/golden_result/main/main.kt
@@ -16,8 +16,8 @@ internal external fun AbstractBase_abstractMethod__reverse_swift(self: kotlin.na
 @BindReverseBridgeToMethod(AbstractBase::class, "abstractMethod")
 public fun AbstractBase_abstractMethod__reverse(self: AbstractBase): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = AbstractBase_abstractMethod__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = AbstractBase_abstractMethod__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ImportedBridge("AbstractBase_concreteMethod__reverse_swift")
@@ -26,8 +26,8 @@ internal external fun AbstractBase_concreteMethod__reverse_swift(self: kotlin.na
 @BindReverseBridgeToMethod(AbstractBase::class, "concreteMethod")
 public fun AbstractBase_concreteMethod__reverse(self: AbstractBase): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = AbstractBase_concreteMethod__reverse_swift(__self)
-    return __result
+    val _result = AbstractBase_concreteMethod__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("Base_count__reverse_swift")
@@ -36,8 +36,8 @@ internal external fun Base_count__reverse_swift(self: kotlin.native.internal.Nat
 @BindReverseBridgeToMethod(Base::class, "count")
 public fun Base_count__reverse(self: Base): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Base_count__reverse_swift(__self)
-    return __result
+    val _result = Base_count__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("Base_greet__TypesOfArguments__Swift_String____reverse_swift")
@@ -47,8 +47,8 @@ internal external fun Base_greet__TypesOfArguments__Swift_String____reverse_swif
 public fun Base_greet__TypesOfArguments__Swift_String____reverse(self: Base, name: kotlin.String): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __name = name.objcPtr()
-    val __result = Base_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = Base_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ImportedBridge("GreeterBase_greet__TypesOfArguments__Swift_String____reverse_swift")
@@ -58,8 +58,8 @@ internal external fun GreeterBase_greet__TypesOfArguments__Swift_String____rever
 public fun GreeterBase_greet__TypesOfArguments__Swift_String____reverse(self: GreeterBase, name: kotlin.String): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __name = name.objcPtr()
-    val __result = GreeterBase_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = GreeterBase_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ImportedBridge("GreeterBase_salutation__reverse_swift")
@@ -68,8 +68,8 @@ internal external fun GreeterBase_salutation__reverse_swift(self: kotlin.native.
 @BindReverseBridgeToMethod(GreeterBase::class, "salutation")
 public fun GreeterBase_salutation__reverse(self: GreeterBase): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = GreeterBase_salutation__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = GreeterBase_salutation__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ImportedBridge("Greeter_greet__TypesOfArguments__Swift_String____reverse_swift")
@@ -79,8 +79,8 @@ internal external fun Greeter_greet__TypesOfArguments__Swift_String____reverse_s
 public fun Greeter_greet__TypesOfArguments__Swift_String____reverse(self: Greeter, name: kotlin.String): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __name = name.objcPtr()
-    val __result = Greeter_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = Greeter_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ImportedBridge("Greeter_salutation__reverse_swift")
@@ -89,8 +89,8 @@ internal external fun Greeter_salutation__reverse_swift(self: kotlin.native.inte
 @BindReverseBridgeToMethod(Greeter::class, "salutation")
 public fun Greeter_salutation__reverse(self: Greeter): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Greeter_salutation__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = Greeter_salutation__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ExportedBridge("AbstractBase_abstractMethod")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/enums/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/enums/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -16,8 +16,8 @@ internal external fun kotlin_Enum_toString__reverse_swift(self: kotlin.native.in
 @BindReverseBridgeToMethod(kotlin.Enum::class, "toString")
 public fun kotlin_Enum_toString__reverse(self: kotlin.Enum<*>): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Enum_toString__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = kotlin_Enum_toString__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ImportedBridge("kotlin_collections_Iterator_hasNext__reverse_swift")
@@ -26,8 +26,8 @@ internal external fun kotlin_collections_Iterator_hasNext__reverse_swift(self: k
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "hasNext")
 public fun kotlin_collections_Iterator_hasNext__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Iterator_next__reverse_swift")
@@ -36,8 +36,8 @@ internal external fun kotlin_collections_Iterator_next__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "next")
 public fun kotlin_collections_Iterator_next__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_next__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_Iterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ExportedBridge("kotlin_Array_get__TypesOfArguments__Swift_Int32__")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functional_type/golden_result/optional_closure/optional_closure.swift
@@ -69,7 +69,10 @@ extension optional_closure.MyInterface where Self : optional_closure.__MyInterfa
     ) -> Swift.Void {
         return { MyInterface_foo__TypesOfArguments__Swift_Optional_U2829202D_U20Swift_Void___(self.__externalRCRef(), arg.map { it in {
             let originalBlock: () -> Swift.Void = it
-            return { return { originalBlock(); return true }() }
+            return {
+                let _result = originalBlock()
+                return { _result; return true }()
+            }
         }() } ?? nil); return () }()
     }
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functions/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/functions/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -13,8 +13,8 @@ internal external fun kotlin_collections_Iterator_hasNext__reverse_swift(self: k
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "hasNext")
 public fun kotlin_collections_Iterator_hasNext__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Iterator_next__reverse_swift")
@@ -23,8 +23,8 @@ internal external fun kotlin_collections_Iterator_next__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "next")
 public fun kotlin_collections_Iterator_next__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_next__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_Iterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ExportedBridge("kotlin_collections_Iterator_hasNext")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -16,8 +16,8 @@ internal external fun kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optio
 public fun kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.Comparable<kotlin.Any?>, other: kotlin.Any?): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __other = if (other == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(other)
-    val __result = kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
-    return __result
+    val _result = kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Iterator_hasNext__reverse_swift")
@@ -26,8 +26,8 @@ internal external fun kotlin_collections_Iterator_hasNext__reverse_swift(self: k
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "hasNext")
 public fun kotlin_collections_Iterator_hasNext__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Iterator_next__reverse_swift")
@@ -36,8 +36,8 @@ internal external fun kotlin_collections_Iterator_next__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "next")
 public fun kotlin_collections_Iterator_next__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_next__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_Iterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ExportedBridge("kotlin_Array_get__TypesOfArguments__Swift_Int32__")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/f_bounded_type/f_bounded_type.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/f_bounded_type/f_bounded_type.kt
@@ -16,8 +16,8 @@ internal external fun MyComparable_compareTo__TypesOfArguments__Swift_Optional_a
 public fun MyComparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: MyComparable<kotlin.Any?>, other: kotlin.Any?): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __other = if (other == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(other)
-    val __result = MyComparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
-    return __result
+    val _result = MyComparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
+    return _result
 }
 
 @ImportedBridge("SelfReferencing_compareTo__TypesOfArguments__f_bounded_type_SelfReferencing____reverse_swift")
@@ -27,8 +27,8 @@ internal external fun SelfReferencing_compareTo__TypesOfArguments__f_bounded_typ
 public fun SelfReferencing_compareTo__TypesOfArguments__f_bounded_type_SelfReferencing____reverse(self: MyComparable<kotlin.Any?>, other: SelfReferencing<*>): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __other = kotlin.native.internal.ref.createRetainedExternalRCRef(other)
-    val __result = SelfReferencing_compareTo__TypesOfArguments__f_bounded_type_SelfReferencing____reverse_swift(__self, __other)
-    return __result
+    val _result = SelfReferencing_compareTo__TypesOfArguments__f_bounded_type_SelfReferencing____reverse_swift(__self, __other)
+    return _result
 }
 
 @ExportedBridge("MyComparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/generics/golden_result/main/main.kt
@@ -32,8 +32,8 @@ internal external fun Consumer_consume__TypesOfArguments__Swift_Optional_anyU20K
 public fun Consumer_consume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: Consumer<kotlin.Any?>, item: kotlin.Any?): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __item = if (item == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(item)
-    val __result = Consumer_consume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __item)
-    return run<Unit> { __result }
+    val _result = Consumer_consume__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __item)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Processor_process__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -43,8 +43,8 @@ internal external fun Processor_process__TypesOfArguments__Swift_Optional_anyU20
 public fun Processor_process__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: Processor<kotlin.Any?, kotlin.Any?>, input: kotlin.Any?): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __input = if (input == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(input)
-    val __result = Processor_process__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __input)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = Processor_process__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __input)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ImportedBridge("Producer_produce__reverse_swift")
@@ -53,8 +53,8 @@ internal external fun Producer_produce__reverse_swift(self: kotlin.native.intern
 @BindReverseBridgeToMethod(Producer::class, "produce")
 public fun Producer_produce__reverse(self: Producer<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Producer_produce__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = Producer_produce__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ImportedBridge("StringProducer_produce__reverse_swift")
@@ -63,8 +63,8 @@ internal external fun StringProducer_produce__reverse_swift(self: kotlin.native.
 @BindReverseBridgeToMethod(StringProducer::class, "produce")
 public fun StringProducer_produce__reverse(self: StringProducer): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = StringProducer_produce__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.String>(__result)
+    val _result = StringProducer_produce__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.String>(_result)
 }
 
 @ExportedBridge("A_foo_get")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/inheritance/golden_result/override/override.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/inheritance/golden_result/override/override.kt
@@ -16,8 +16,8 @@ internal external fun Base_g__TypesOfArguments__anyU20override_P____reverse_swif
 public fun Base_g__TypesOfArguments__anyU20override_P____reverse(self: Base, x: P): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __x = kotlin.native.internal.ref.createRetainedExternalRCRef(x)
-    val __result = Base_g__TypesOfArguments__anyU20override_P____reverse_swift(__self, __x)
-    return run<Unit> { __result }
+    val _result = Base_g__TypesOfArguments__anyU20override_P____reverse_swift(__self, __x)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("P_f__reverse_swift")
@@ -26,8 +26,8 @@ internal external fun P_f__reverse_swift(self: kotlin.native.internal.NativePtr)
 @BindReverseBridgeToMethod(P::class, "f")
 public fun P_f__reverse(self: P): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = P_f__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = P_f__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Sub_g__TypesOfArguments__anyU20override_P____reverse_swift")
@@ -37,8 +37,8 @@ internal external fun Sub_g__TypesOfArguments__anyU20override_P____reverse_swift
 public fun Sub_g__TypesOfArguments__anyU20override_P____reverse(self: Sub, x: P): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __x = kotlin.native.internal.ref.createRetainedExternalRCRef(x)
-    val __result = Sub_g__TypesOfArguments__anyU20override_P____reverse_swift(__self, __x)
-    return run<Unit> { __result }
+    val _result = Sub_g__TypesOfArguments__anyU20override_P____reverse_swift(__self, __x)
+    return run<Unit> { _result }
 }
 
 @ExportedBridge("Base_g__TypesOfArguments__anyU20override_P__")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/list/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/list/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -17,8 +17,8 @@ internal external fun kotlin_collections_Collection_contains__TypesOfArguments__
 public fun kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.Collection<kotlin.Any?>, element: kotlin.Any?): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
-    val __result = kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
-    return __result
+    val _result = kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Collection_isEmpty__reverse_swift")
@@ -27,8 +27,8 @@ internal external fun kotlin_collections_Collection_isEmpty__reverse_swift(self:
 @BindReverseBridgeToMethod(kotlin.collections.Collection::class, "isEmpty")
 public fun kotlin_collections_Collection_isEmpty__reverse(self: kotlin.collections.Collection<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Collection_isEmpty__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_Collection_isEmpty__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Collection_iterator__reverse_swift")
@@ -37,8 +37,8 @@ internal external fun kotlin_collections_Collection_iterator__reverse_swift(self
 @BindReverseBridgeToMethod(kotlin.collections.Collection::class, "iterator")
 public fun kotlin_collections_Collection_iterator__reverse(self: kotlin.collections.Collection<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Collection_iterator__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = kotlin_collections_Collection_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
 }
 
 @ImportedBridge("kotlin_collections_Iterable_iterator__reverse_swift")
@@ -47,8 +47,8 @@ internal external fun kotlin_collections_Iterable_iterator__reverse_swift(self: 
 @BindReverseBridgeToMethod(kotlin.collections.Iterable::class, "iterator")
 public fun kotlin_collections_Iterable_iterator__reverse(self: kotlin.collections.Iterable<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterable_iterator__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = kotlin_collections_Iterable_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
 }
 
 @ImportedBridge("kotlin_collections_Iterator_hasNext__reverse_swift")
@@ -57,8 +57,8 @@ internal external fun kotlin_collections_Iterator_hasNext__reverse_swift(self: k
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "hasNext")
 public fun kotlin_collections_Iterator_hasNext__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Iterator_next__reverse_swift")
@@ -67,8 +67,8 @@ internal external fun kotlin_collections_Iterator_next__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "next")
 public fun kotlin_collections_Iterator_next__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_next__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_Iterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ImportedBridge("kotlin_collections_ListIterator_hasNext__reverse_swift")
@@ -77,8 +77,8 @@ internal external fun kotlin_collections_ListIterator_hasNext__reverse_swift(sel
 @BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "hasNext")
 public fun kotlin_collections_ListIterator_hasNext__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ListIterator_hasNext__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_ListIterator_hasNext__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_ListIterator_hasPrevious__reverse_swift")
@@ -87,8 +87,8 @@ internal external fun kotlin_collections_ListIterator_hasPrevious__reverse_swift
 @BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "hasPrevious")
 public fun kotlin_collections_ListIterator_hasPrevious__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ListIterator_hasPrevious__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_ListIterator_hasPrevious__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_ListIterator_nextIndex__reverse_swift")
@@ -97,8 +97,8 @@ internal external fun kotlin_collections_ListIterator_nextIndex__reverse_swift(s
 @BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "nextIndex")
 public fun kotlin_collections_ListIterator_nextIndex__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ListIterator_nextIndex__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_ListIterator_nextIndex__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_ListIterator_next__reverse_swift")
@@ -107,8 +107,8 @@ internal external fun kotlin_collections_ListIterator_next__reverse_swift(self: 
 @BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "next")
 public fun kotlin_collections_ListIterator_next__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ListIterator_next__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_ListIterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ImportedBridge("kotlin_collections_ListIterator_previousIndex__reverse_swift")
@@ -117,8 +117,8 @@ internal external fun kotlin_collections_ListIterator_previousIndex__reverse_swi
 @BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "previousIndex")
 public fun kotlin_collections_ListIterator_previousIndex__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ListIterator_previousIndex__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_ListIterator_previousIndex__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_ListIterator_previous__reverse_swift")
@@ -127,8 +127,8 @@ internal external fun kotlin_collections_ListIterator_previous__reverse_swift(se
 @BindReverseBridgeToMethod(kotlin.collections.ListIterator::class, "previous")
 public fun kotlin_collections_ListIterator_previous__reverse(self: kotlin.collections.ListIterator<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ListIterator_previous__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_ListIterator_previous__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ImportedBridge("kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -138,8 +138,8 @@ internal external fun kotlin_collections_List_contains__TypesOfArguments__Swift_
 public fun kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.List<kotlin.Any?>, element: kotlin.Any?): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
-    val __result = kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
-    return __result
+    val _result = kotlin_collections_List_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift")
@@ -148,8 +148,8 @@ internal external fun kotlin_collections_List_get__TypesOfArguments__Swift_Int32
 @BindReverseBridgeToMethod(kotlin.collections.List::class, "get")
 public fun kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse(self: kotlin.collections.List<kotlin.Any?>, index: Int): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_List_get__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ImportedBridge("kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -159,8 +159,8 @@ internal external fun kotlin_collections_List_indexOf__TypesOfArguments__Swift_O
 public fun kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.List<kotlin.Any?>, element: kotlin.Any?): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
-    val __result = kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
-    return __result
+    val _result = kotlin_collections_List_indexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_List_isEmpty__reverse_swift")
@@ -169,8 +169,8 @@ internal external fun kotlin_collections_List_isEmpty__reverse_swift(self: kotli
 @BindReverseBridgeToMethod(kotlin.collections.List::class, "isEmpty")
 public fun kotlin_collections_List_isEmpty__reverse(self: kotlin.collections.List<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_List_isEmpty__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_List_isEmpty__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_List_iterator__reverse_swift")
@@ -179,8 +179,8 @@ internal external fun kotlin_collections_List_iterator__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(kotlin.collections.List::class, "iterator")
 public fun kotlin_collections_List_iterator__reverse(self: kotlin.collections.List<kotlin.Any?>): kotlin.collections.Iterator<kotlin.Any?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_List_iterator__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.collections.Iterator<kotlin.Any?>
+    val _result = kotlin_collections_List_iterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.Iterator<kotlin.Any?>
 }
 
 @ImportedBridge("kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -190,8 +190,8 @@ internal external fun kotlin_collections_List_lastIndexOf__TypesOfArguments__Swi
 public fun kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.collections.List<kotlin.Any?>, element: kotlin.Any?): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __element = if (element == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(element)
-    val __result = kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
-    return __result
+    val _result = kotlin_collections_List_lastIndexOf__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __element)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift")
@@ -200,8 +200,8 @@ internal external fun kotlin_collections_List_listIterator__TypesOfArguments__Sw
 @BindReverseBridgeToMethod(kotlin.collections.List::class, "listIterator")
 public fun kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse(self: kotlin.collections.List<kotlin.Any?>, index: Int): kotlin.collections.ListIterator<kotlin.Any?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = kotlin_collections_List_listIterator__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.ListIterator<kotlin.Any?>
 }
 
 @ImportedBridge("kotlin_collections_List_listIterator__reverse_swift")
@@ -210,8 +210,8 @@ internal external fun kotlin_collections_List_listIterator__reverse_swift(self: 
 @BindReverseBridgeToMethod(kotlin.collections.List::class, "listIterator")
 public fun kotlin_collections_List_listIterator__reverse(self: kotlin.collections.List<kotlin.Any?>): kotlin.collections.ListIterator<kotlin.Any?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_List_listIterator__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.collections.ListIterator<kotlin.Any?>
+    val _result = kotlin_collections_List_listIterator__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.collections.ListIterator<kotlin.Any?>
 }
 
 @ImportedBridge("kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift")
@@ -220,8 +220,8 @@ internal external fun kotlin_collections_List_subList__TypesOfArguments__Swift_I
 @BindReverseBridgeToMethod(kotlin.collections.List::class, "subList")
 public fun kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse(self: kotlin.collections.List<kotlin.Any?>, fromIndex: Int, toIndex: Int): kotlin.collections.List<kotlin.Any?> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(__self, fromIndex, toIndex)
-    return interpretObjCPointer<kotlin.collections.List<kotlin.Any?>>(__result)
+    val _result = kotlin_collections_List_subList__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(__self, fromIndex, toIndex)
+    return interpretObjCPointer<kotlin.collections.List<kotlin.Any?>>(_result)
 }
 
 @ExportedBridge("kotlin_collections_Collection_contains__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/bad_overrides/bad_overrides.kt
@@ -14,8 +14,8 @@ internal external fun weird_A_throws__reverse_swift(self: kotlin.native.internal
 @BindReverseBridgeToMethod(weird.A::class, "throws")
 public fun weird_A_throws__reverse(self: weird.A): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = weird_A_throws__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = weird_A_throws__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ExportedBridge("weird_A_bar_get")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/overrides/overrides.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/overrides/overrides.kt
@@ -18,8 +18,8 @@ internal external fun AbstractBase_abstractFun1__reverse_swift(self: kotlin.nati
 @BindReverseBridgeToMethod(AbstractBase::class, "abstractFun1")
 public fun AbstractBase_abstractFun1__reverse(self: AbstractBase): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = AbstractBase_abstractFun1__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = AbstractBase_abstractFun1__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("AbstractBase_abstractFun2__reverse_swift")
@@ -28,8 +28,8 @@ internal external fun AbstractBase_abstractFun2__reverse_swift(self: kotlin.nati
 @BindReverseBridgeToMethod(AbstractBase::class, "abstractFun2")
 public fun AbstractBase_abstractFun2__reverse(self: AbstractBase): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = AbstractBase_abstractFun2__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = AbstractBase_abstractFun2__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("AbstractDerived2_abstractFun1__reverse_swift")
@@ -38,8 +38,8 @@ internal external fun AbstractDerived2_abstractFun1__reverse_swift(self: kotlin.
 @BindReverseBridgeToMethod(AbstractDerived2::class, "abstractFun1")
 public fun AbstractDerived2_abstractFun1__reverse(self: AbstractDerived2): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = AbstractDerived2_abstractFun1__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = AbstractDerived2_abstractFun1__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Child_actuallyOverride__TypesOfArguments__Swift_Optional_Swift_Int32__overrides_Parent_Swift_Optional_overrides_Parent_____reverse_swift")
@@ -51,8 +51,8 @@ public fun Child_actuallyOverride__TypesOfArguments__Swift_Optional_Swift_Int32_
     val __nullable = if (nullable == null) kotlin.native.internal.NativePtr.NULL else nullable.objcPtr()
     val __poly = kotlin.native.internal.ref.createRetainedExternalRCRef(poly)
     val __nullablePoly = if (nullablePoly == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(nullablePoly)
-    val __result = Child_actuallyOverride__TypesOfArguments__Swift_Optional_Swift_Int32__overrides_Parent_Swift_Optional_overrides_Parent_____reverse_swift(__self, __nullable, __poly, __nullablePoly)
-    return run<Unit> { __result }
+    val _result = Child_actuallyOverride__TypesOfArguments__Swift_Optional_Swift_Int32__overrides_Parent_Swift_Optional_overrides_Parent_____reverse_swift(__self, __nullable, __poly, __nullablePoly)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Child_contains__TypesOfArguments__Swift_Int32____reverse_swift")
@@ -61,8 +61,8 @@ internal external fun Child_contains__TypesOfArguments__Swift_Int32____reverse_s
 @BindReverseBridgeToMethod(Child::class, "contains")
 public fun Child_contains__TypesOfArguments__Swift_Int32____reverse(self: Child, element: Int): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Child_contains__TypesOfArguments__Swift_Int32____reverse_swift(__self, element)
-    return __result
+    val _result = Child_contains__TypesOfArguments__Swift_Int32____reverse_swift(__self, element)
+    return _result
 }
 
 @ImportedBridge("Child_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -72,8 +72,8 @@ internal external fun Child_equals__TypesOfArguments__Swift_Optional_anyU20Kotli
 public fun Child_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: Child, to: kotlin.Any?): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __to = if (to == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(to)
-    val __result = Child_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __to)
-    return __result
+    val _result = Child_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __to)
+    return _result
 }
 
 @ImportedBridge("Child_genericReturnTypeFunc__reverse_swift")
@@ -82,8 +82,8 @@ internal external fun Child_genericReturnTypeFunc__reverse_swift(self: kotlin.na
 @BindReverseBridgeToMethod(Child::class, "genericReturnTypeFunc")
 public fun Child_genericReturnTypeFunc__reverse(self: Child): kotlin.collections.List<Child> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Child_genericReturnTypeFunc__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.collections.List<Child>>(__result)
+    val _result = Child_genericReturnTypeFunc__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.collections.List<Child>>(_result)
 }
 
 @ImportedBridge("Child_nonoverride__reverse_swift")
@@ -92,8 +92,8 @@ internal external fun Child_nonoverride__reverse_swift(self: kotlin.native.inter
 @BindReverseBridgeToMethod(Child::class, "nonoverride")
 public fun Child_nonoverride__reverse(self: Child): Nothing {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Child_nonoverride__reverse_swift(__self)
-    return run { __result; throw IllegalStateException() }
+    val _result = Child_nonoverride__reverse_swift(__self)
+    return run { _result; throw IllegalStateException() }
 }
 
 @ImportedBridge("Child_objectFunc__TypesOfArguments__overrides_Child____reverse_swift")
@@ -103,8 +103,8 @@ internal external fun Child_objectFunc__TypesOfArguments__overrides_Child____rev
 public fun Child_objectFunc__TypesOfArguments__overrides_Child____reverse(self: Child, arg: Child): Parent {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Child_objectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Parent
+    val _result = Child_objectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Parent
 }
 
 @ImportedBridge("Child_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse_swift")
@@ -114,8 +114,8 @@ internal external fun Child_objectOptionalFunc__TypesOfArguments__overrides_Chil
 public fun Child_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse(self: Child, arg: Child): Parent? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Child_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Parent
+    val _result = Child_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Parent
 }
 
 @ImportedBridge("Child_overrideChainFunc__reverse_swift")
@@ -124,8 +124,8 @@ internal external fun Child_overrideChainFunc__reverse_swift(self: kotlin.native
 @BindReverseBridgeToMethod(Child::class, "overrideChainFunc")
 public fun Child_overrideChainFunc__reverse(self: Child): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Child_overrideChainFunc__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = Child_overrideChainFunc__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Child_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift")
@@ -134,8 +134,8 @@ internal external fun Child_primitiveTypeFunc__TypesOfArguments__Swift_Int32____
 @BindReverseBridgeToMethod(Child::class, "primitiveTypeFunc")
 public fun Child_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse(self: Child, arg: Int): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Child_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift(__self, arg)
-    return __result
+    val _result = Child_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift(__self, arg)
+    return _result
 }
 
 @ImportedBridge("Child_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse_swift")
@@ -145,8 +145,8 @@ internal external fun Child_subtypeObjectFunc__TypesOfArguments__overrides_Child
 public fun Child_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse(self: Child, arg: Child): Child {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Child_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Child
+    val _result = Child_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Child
 }
 
 @ImportedBridge("Child_subtypeOptionalObjectFunc__reverse_swift")
@@ -155,8 +155,8 @@ internal external fun Child_subtypeOptionalObjectFunc__reverse_swift(self: kotli
 @BindReverseBridgeToMethod(Child::class, "subtypeOptionalObjectFunc")
 public fun Child_subtypeOptionalObjectFunc__reverse(self: Child): Child {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Child_subtypeOptionalObjectFunc__reverse_swift(__self)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Child
+    val _result = Child_subtypeOptionalObjectFunc__reverse_swift(__self)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Child
 }
 
 @ImportedBridge("Child_subtypeOptionalPrimitiveFunc__reverse_swift")
@@ -165,8 +165,8 @@ internal external fun Child_subtypeOptionalPrimitiveFunc__reverse_swift(self: ko
 @BindReverseBridgeToMethod(Child::class, "subtypeOptionalPrimitiveFunc")
 public fun Child_subtypeOptionalPrimitiveFunc__reverse(self: Child): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Child_subtypeOptionalPrimitiveFunc__reverse_swift(__self)
-    return __result
+    val _result = Child_subtypeOptionalPrimitiveFunc__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("OpenDerived1_abstractFun1__reverse_swift")
@@ -175,8 +175,8 @@ internal external fun OpenDerived1_abstractFun1__reverse_swift(self: kotlin.nati
 @BindReverseBridgeToMethod(OpenDerived1::class, "abstractFun1")
 public fun OpenDerived1_abstractFun1__reverse(self: OpenDerived1): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = OpenDerived1_abstractFun1__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = OpenDerived1_abstractFun1__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("OpenDerived1_abstractFun2__reverse_swift")
@@ -185,8 +185,8 @@ internal external fun OpenDerived1_abstractFun2__reverse_swift(self: kotlin.nati
 @BindReverseBridgeToMethod(OpenDerived1::class, "abstractFun2")
 public fun OpenDerived1_abstractFun2__reverse(self: OpenDerived1): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = OpenDerived1_abstractFun2__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = OpenDerived1_abstractFun2__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Parent_actuallyOverride__TypesOfArguments__Swift_Int32_overrides_Child_overrides_Child____reverse_swift")
@@ -197,8 +197,8 @@ public fun Parent_actuallyOverride__TypesOfArguments__Swift_Int32_overrides_Chil
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __poly = kotlin.native.internal.ref.createRetainedExternalRCRef(poly)
     val __nullablePoly = kotlin.native.internal.ref.createRetainedExternalRCRef(nullablePoly)
-    val __result = Parent_actuallyOverride__TypesOfArguments__Swift_Int32_overrides_Child_overrides_Child____reverse_swift(__self, nullable, __poly, __nullablePoly)
-    return run<Unit> { __result }
+    val _result = Parent_actuallyOverride__TypesOfArguments__Swift_Int32_overrides_Child_overrides_Child____reverse_swift(__self, nullable, __poly, __nullablePoly)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Parent_contains__TypesOfArguments__Swift_Int32____reverse_swift")
@@ -207,8 +207,8 @@ internal external fun Parent_contains__TypesOfArguments__Swift_Int32____reverse_
 @BindReverseBridgeToMethod(Parent::class, "contains")
 public fun Parent_contains__TypesOfArguments__Swift_Int32____reverse(self: Parent, element: Int): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_contains__TypesOfArguments__Swift_Int32____reverse_swift(__self, element)
-    return __result
+    val _result = Parent_contains__TypesOfArguments__Swift_Int32____reverse_swift(__self, element)
+    return _result
 }
 
 @ImportedBridge("Parent_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift")
@@ -218,8 +218,8 @@ internal external fun Parent_equals__TypesOfArguments__Swift_Optional_anyU20Kotl
 public fun Parent_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: Parent, to: kotlin.Any?): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __to = if (to == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(to)
-    val __result = Parent_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __to)
-    return __result
+    val _result = Parent_equals__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __to)
+    return _result
 }
 
 @ImportedBridge("Parent_finalOverrideFunc__reverse_swift")
@@ -228,8 +228,8 @@ internal external fun Parent_finalOverrideFunc__reverse_swift(self: kotlin.nativ
 @BindReverseBridgeToMethod(Parent::class, "finalOverrideFunc")
 public fun Parent_finalOverrideFunc__reverse(self: Parent): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_finalOverrideFunc__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = Parent_finalOverrideFunc__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Parent_finalOverrideHopFunc__reverse_swift")
@@ -238,8 +238,8 @@ internal external fun Parent_finalOverrideHopFunc__reverse_swift(self: kotlin.na
 @BindReverseBridgeToMethod(Parent::class, "finalOverrideHopFunc")
 public fun Parent_finalOverrideHopFunc__reverse(self: Parent): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_finalOverrideHopFunc__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = Parent_finalOverrideHopFunc__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Parent_genericReturnTypeFunc__reverse_swift")
@@ -248,8 +248,8 @@ internal external fun Parent_genericReturnTypeFunc__reverse_swift(self: kotlin.n
 @BindReverseBridgeToMethod(Parent::class, "genericReturnTypeFunc")
 public fun Parent_genericReturnTypeFunc__reverse(self: Parent): kotlin.collections.List<Parent> {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_genericReturnTypeFunc__reverse_swift(__self)
-    return interpretObjCPointer<kotlin.collections.List<Parent>>(__result)
+    val _result = Parent_genericReturnTypeFunc__reverse_swift(__self)
+    return interpretObjCPointer<kotlin.collections.List<Parent>>(_result)
 }
 
 @ImportedBridge("Parent_hopFunc__reverse_swift")
@@ -258,8 +258,8 @@ internal external fun Parent_hopFunc__reverse_swift(self: kotlin.native.internal
 @BindReverseBridgeToMethod(Parent::class, "hopFunc")
 public fun Parent_hopFunc__reverse(self: Parent): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_hopFunc__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = Parent_hopFunc__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Parent_nonoverride__reverse_swift")
@@ -268,8 +268,8 @@ internal external fun Parent_nonoverride__reverse_swift(self: kotlin.native.inte
 @BindReverseBridgeToMethod(Parent::class, "nonoverride")
 public fun Parent_nonoverride__reverse(self: Parent): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_nonoverride__reverse_swift(__self)
-    return __result
+    val _result = Parent_nonoverride__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("Parent_objectFunc__TypesOfArguments__overrides_Child____reverse_swift")
@@ -279,8 +279,8 @@ internal external fun Parent_objectFunc__TypesOfArguments__overrides_Child____re
 public fun Parent_objectFunc__TypesOfArguments__overrides_Child____reverse(self: Parent, arg: Child): Parent {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Parent_objectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Parent
+    val _result = Parent_objectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Parent
 }
 
 @ImportedBridge("Parent_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse_swift")
@@ -290,8 +290,8 @@ internal external fun Parent_objectOptionalFunc__TypesOfArguments__overrides_Chi
 public fun Parent_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse(self: Parent, arg: Child): Parent? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Parent_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Parent
+    val _result = Parent_objectOptionalFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Parent
 }
 
 @ImportedBridge("Parent_overrideChainFunc__reverse_swift")
@@ -300,8 +300,8 @@ internal external fun Parent_overrideChainFunc__reverse_swift(self: kotlin.nativ
 @BindReverseBridgeToMethod(Parent::class, "overrideChainFunc")
 public fun Parent_overrideChainFunc__reverse(self: Parent): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_overrideChainFunc__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = Parent_overrideChainFunc__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ImportedBridge("Parent_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift")
@@ -310,8 +310,8 @@ internal external fun Parent_primitiveTypeFunc__TypesOfArguments__Swift_Int32___
 @BindReverseBridgeToMethod(Parent::class, "primitiveTypeFunc")
 public fun Parent_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse(self: Parent, arg: Int): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift(__self, arg)
-    return __result
+    val _result = Parent_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift(__self, arg)
+    return _result
 }
 
 @ImportedBridge("Parent_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse_swift")
@@ -321,8 +321,8 @@ internal external fun Parent_subtypeObjectFunc__TypesOfArguments__overrides_Chil
 public fun Parent_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse(self: Parent, arg: Child): Parent {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Parent_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Parent
+    val _result = Parent_subtypeObjectFunc__TypesOfArguments__overrides_Child____reverse_swift(__self, __arg)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Parent
 }
 
 @ImportedBridge("Parent_subtypeOptionalObjectFunc__reverse_swift")
@@ -331,8 +331,8 @@ internal external fun Parent_subtypeOptionalObjectFunc__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(Parent::class, "subtypeOptionalObjectFunc")
 public fun Parent_subtypeOptionalObjectFunc__reverse(self: Parent): Parent? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_subtypeOptionalObjectFunc__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Parent
+    val _result = Parent_subtypeOptionalObjectFunc__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Parent
 }
 
 @ImportedBridge("Parent_subtypeOptionalPrimitiveFunc__reverse_swift")
@@ -341,8 +341,8 @@ internal external fun Parent_subtypeOptionalPrimitiveFunc__reverse_swift(self: k
 @BindReverseBridgeToMethod(Parent::class, "subtypeOptionalPrimitiveFunc")
 public fun Parent_subtypeOptionalPrimitiveFunc__reverse(self: Parent): Int? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Parent_subtypeOptionalPrimitiveFunc__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<Int>(__result)
+    val _result = Parent_subtypeOptionalPrimitiveFunc__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else interpretObjCPointer<Int>(_result)
 }
 
 @ExportedBridge("AbstractBase_abstractFun1")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/overrides_across_modules/overrides_across_modules.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/overrides/golden_result/overrides_across_modules/overrides_across_modules.kt
@@ -14,8 +14,8 @@ internal external fun Cousin_primitiveTypeFunc__TypesOfArguments__Swift_Int32___
 @BindReverseBridgeToMethod(Cousin::class, "primitiveTypeFunc")
 public fun Cousin_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse(self: Cousin, arg: Int): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = Cousin_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift(__self, arg)
-    return __result
+    val _result = Cousin_primitiveTypeFunc__TypesOfArguments__Swift_Int32____reverse_swift(__self, arg)
+    return _result
 }
 
 @ExportedBridge("Cousin_finalOverrideFunc")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.h
@@ -3,6 +3,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+_Bool Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(void * self, void * result);
+
+_Bool Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(void * self, void * result);
+
 void * conflictingTypealiases_Bar_Conflict_init_allocate();
 
 _Bool conflictingTypealiases_Bar_Conflict_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.kt
@@ -1,12 +1,34 @@
 @file:kotlin.Suppress("DEPRECATION_ERROR")
 @file:kotlin.native.internal.objc.BindClassToObjCName(conflictingTypealiases.Bar::class, "_Bar")
 @file:kotlin.native.internal.objc.BindClassToObjCName(conflictingTypealiases.Foo::class, "_Foo")
+@file:kotlin.native.internal.objc.BindClassToObjCName(Baz::class, "_Baz")
 @file:kotlin.native.internal.objc.BindClassToObjCName(conflictingTypealiases.Bar.Conflict::class, "10edge_cases59_ExportedKotlinPackages_conflictingTypealiases_Bar_ConflictC")
 @file:kotlin.native.internal.objc.BindClassToObjCName(conflictingTypealiases.Foo.Conflict::class, "10edge_cases59_ExportedKotlinPackages_conflictingTypealiases_Foo_ConflictC")
 
-import kotlin.native.internal.ExportedBridge
+import kotlin.native.internal.objc.BindReverseBridgeToMethod
+import kotlin.native.internal.ImportedBridge
 import kotlinx.cinterop.*
+import kotlin.native.internal.ExportedBridge
 import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ImportedBridge("Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+internal external fun Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(self: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean
+
+@BindReverseBridgeToMethod(Baz::class, "foo")
+public fun Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse(self: Baz, result: kotlin.Any): Unit {
+    val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
+    val __result = kotlin.native.internal.ref.createRetainedExternalRCRef(result)
+    val _result = Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(__self, __result)
+    return run<Unit> { _result }
+}
+
+@ExportedBridge("Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__")
+public fun Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(self: kotlin.native.internal.NativePtr, result: kotlin.native.internal.NativePtr): Boolean {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as Baz
+    val __result = kotlin.native.internal.ref.dereferenceExternalRCRef(result) as kotlin.Any
+    val _result = run { __self.foo(__result) }
+    return run { _result; true }
+}
 
 @ExportedBridge("conflictingTypealiases_Bar_Conflict_init_allocate")
 public fun conflictingTypealiases_Bar_Conflict_init_allocate(): kotlin.native.internal.NativePtr {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/edge_cases/edge_cases.swift
@@ -3,6 +3,16 @@
 import KotlinRuntime
 import KotlinRuntimeSupport
 
+public protocol Baz: KotlinRuntime.KotlinBase, edge_cases._Baz {
+    func foo(
+        result: any KotlinRuntimeSupport._KotlinBridgeable
+    ) -> Swift.Void
+}
+@objc(_Baz)
+public protocol _Baz {
+}
+public protocol __Baz: KotlinRuntimeSupport._KotlinBridgeable {
+}
 public final class _ExportedKotlinPackages_conflictingTypealiases_Bar_Conflict: KotlinRuntime.KotlinBase {
     public init() {
         let __kt = conflictingTypealiases_Bar_Conflict_init_allocate()
@@ -34,14 +44,27 @@ extension ExportedKotlinPackages.conflictingTypealiases.Bar where Self : Exporte
 extension ExportedKotlinPackages.conflictingTypealiases.Bar {
     typealias Conflict = edge_cases._ExportedKotlinPackages_conflictingTypealiases_Bar_Conflict
 }
+extension edge_cases.Baz where Self : edge_cases.__Baz {
+    public func foo(
+        result: any KotlinRuntimeSupport._KotlinBridgeable
+    ) -> Swift.Void {
+        return { Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable__(self.__externalRCRef(), result.__externalRCRef()); return () }()
+    }
+}
+extension edge_cases.Baz {
+}
 extension ExportedKotlinPackages.conflictingTypealiases.Foo where Self : ExportedKotlinPackages.conflictingTypealiases.__Foo {
 }
 extension ExportedKotlinPackages.conflictingTypealiases.Foo {
     typealias Conflict = edge_cases._ExportedKotlinPackages_conflictingTypealiases_Foo_Conflict
 }
+extension KotlinRuntimeSupport._KotlinExistential: edge_cases.Baz, edge_cases.__Baz where Wrapped : edge_cases._Baz {
+}
 extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.conflictingTypealiases.Foo, ExportedKotlinPackages.conflictingTypealiases.__Foo where Wrapped : ExportedKotlinPackages.conflictingTypealiases._Foo {
 }
 extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.conflictingTypealiases.Bar, ExportedKotlinPackages.conflictingTypealiases.__Bar where Wrapped : ExportedKotlinPackages.conflictingTypealiases._Bar {
+}
+extension KotlinRuntimeSupport._KotlinExistentialPenBox: edge_cases._Baz {
 }
 extension KotlinRuntimeSupport._KotlinExistentialPenBox: ExportedKotlinPackages.conflictingTypealiases._Foo {
 }
@@ -62,4 +85,10 @@ extension ExportedKotlinPackages.conflictingTypealiases {
     }
     public protocol __Foo: KotlinRuntimeSupport._KotlinBridgeable {
     }
+}
+@_cdecl("Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift")
+package func Baz_foo__TypesOfArguments__anyU20KotlinRuntimeSupport__KotlinBridgeable____reverse_swift(_ `self`: Swift.UnsafeMutableRawPointer, _ result: Swift.UnsafeMutableRawPointer) -> Swift.Bool {
+    let _self = KotlinRuntime.KotlinBase.__createProtocolWrapper(externalRCRef: `self`) as! any edge_cases.Baz
+    let _result: Swift.Void = _self.foo(result: KotlinRuntime.KotlinBase.__createBridgeable(externalRCRef: result))
+    return { _result; return true }()
 }

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/funinterface/funinterface.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/funinterface/funinterface.kt
@@ -19,8 +19,8 @@ internal external fun funinterface_FunctionalInterface_invoke__reverse_swift(sel
 @BindReverseBridgeToMethod(funinterface.FunctionalInterface::class, "invoke")
 public fun funinterface_FunctionalInterface_invoke__reverse(self: funinterface.FunctionalInterface): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = funinterface_FunctionalInterface_invoke__reverse_swift(__self)
-    return __result
+    val _result = funinterface_FunctionalInterface_invoke__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("funinterface_XMLFunctionalInterfaceWithLeadingAbbreviation_invoke__reverse_swift")
@@ -29,8 +29,8 @@ internal external fun funinterface_XMLFunctionalInterfaceWithLeadingAbbreviation
 @BindReverseBridgeToMethod(funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation::class, "invoke")
 public fun funinterface_XMLFunctionalInterfaceWithLeadingAbbreviation_invoke__reverse(self: funinterface.XMLFunctionalInterfaceWithLeadingAbbreviation): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = funinterface_XMLFunctionalInterfaceWithLeadingAbbreviation_invoke__reverse_swift(__self)
-    return __result
+    val _result = funinterface_XMLFunctionalInterfaceWithLeadingAbbreviation_invoke__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("funinterface__123FunctionalInterfaceWithLeadingNumbers_invoke__reverse_swift")
@@ -39,8 +39,8 @@ internal external fun funinterface__123FunctionalInterfaceWithLeadingNumbers_inv
 @BindReverseBridgeToMethod(funinterface._123FunctionalInterfaceWithLeadingNumbers::class, "invoke")
 public fun funinterface__123FunctionalInterfaceWithLeadingNumbers_invoke__reverse(self: funinterface._123FunctionalInterfaceWithLeadingNumbers): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = funinterface__123FunctionalInterfaceWithLeadingNumbers_invoke__reverse_swift(__self)
-    return __result
+    val _result = funinterface__123FunctionalInterfaceWithLeadingNumbers_invoke__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("funinterface__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation_invoke__reverse_swift")
@@ -49,8 +49,8 @@ internal external fun funinterface__123XMLFunctionalInterfaceWithLeadingUndersco
 @BindReverseBridgeToMethod(funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation::class, "invoke")
 public fun funinterface__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation_invoke__reverse(self: funinterface._123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = funinterface__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation_invoke__reverse_swift(__self)
-    return __result
+    val _result = funinterface__123XMLFunctionalInterfaceWithLeadingUnderscoreNumbersAndAbbreviation_invoke__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("funinterface__FunctionalInterfaceWithLeadingUnderscore_invoke__reverse_swift")
@@ -59,8 +59,8 @@ internal external fun funinterface__FunctionalInterfaceWithLeadingUnderscore_inv
 @BindReverseBridgeToMethod(funinterface._FunctionalInterfaceWithLeadingUnderscore::class, "invoke")
 public fun funinterface__FunctionalInterfaceWithLeadingUnderscore_invoke__reverse(self: funinterface._FunctionalInterfaceWithLeadingUnderscore): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = funinterface__FunctionalInterfaceWithLeadingUnderscore_invoke__reverse_swift(__self)
-    return __result
+    val _result = funinterface__FunctionalInterfaceWithLeadingUnderscore_invoke__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("funinterface_functionalInterfaceWithAlreadyLowercaseLeading_invoke__reverse_swift")
@@ -69,8 +69,8 @@ internal external fun funinterface_functionalInterfaceWithAlreadyLowercaseLeadin
 @BindReverseBridgeToMethod(funinterface.functionalInterfaceWithAlreadyLowercaseLeading::class, "invoke")
 public fun funinterface_functionalInterfaceWithAlreadyLowercaseLeading_invoke__reverse(self: funinterface.functionalInterfaceWithAlreadyLowercaseLeading): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = funinterface_functionalInterfaceWithAlreadyLowercaseLeading_invoke__reverse_swift(__self)
-    return __result
+    val _result = funinterface_functionalInterfaceWithAlreadyLowercaseLeading_invoke__reverse_swift(__self)
+    return _result
 }
 
 @ExportedBridge("funinterface_FunctionalInterface__TypesOfArguments__U2829202D_U20Swift_Int32__")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/main/main.kt
@@ -60,8 +60,8 @@ internal external fun Barable_bar__TypesOfArguments__anyU20main_Foeble____revers
 public fun Barable_bar__TypesOfArguments__anyU20main_Foeble____reverse(self: Barable, arg: Foeble): Barable {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Barable_bar__TypesOfArguments__anyU20main_Foeble____reverse_swift(__self, __arg)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Barable
+    val _result = Barable_bar__TypesOfArguments__anyU20main_Foeble____reverse_swift(__self, __arg)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Barable
 }
 
 @ImportedBridge("Foeble_bar__TypesOfArguments__anyU20main_Foeble____reverse_swift")
@@ -71,8 +71,8 @@ internal external fun Foeble_bar__TypesOfArguments__anyU20main_Foeble____reverse
 public fun Foeble_bar__TypesOfArguments__anyU20main_Foeble____reverse(self: Foeble, arg: Foeble): Foeble {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __arg = kotlin.native.internal.ref.createRetainedExternalRCRef(arg)
-    val __result = Foeble_bar__TypesOfArguments__anyU20main_Foeble____reverse_swift(__self, __arg)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as Foeble
+    val _result = Foeble_bar__TypesOfArguments__anyU20main_Foeble____reverse_swift(__self, __arg)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as Foeble
 }
 
 @ExportedBridge("Bar_bar__TypesOfArguments__anyU20main_Foeble__")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/protocols.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/protocols.kt
@@ -190,3 +190,9 @@ interface Foo {
 interface Bar: Foo {
     class Conflict
 }
+
+// FILE: special_names.kt
+
+interface Baz {
+    fun foo(result: Any)
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/ranges/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/ranges/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -14,8 +14,8 @@ internal external fun kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optio
 public fun kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlin.Comparable<kotlin.Any?>, other: kotlin.Any?): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __other = if (other == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(other)
-    val __result = kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
-    return __result
+    val _result = kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __other)
+    return _result
 }
 
 @ImportedBridge("kotlin_ranges_ClosedRange_contains__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_Comparable____reverse_swift")
@@ -25,8 +25,8 @@ internal external fun kotlin_ranges_ClosedRange_contains__TypesOfArguments__anyU
 public fun kotlin_ranges_ClosedRange_contains__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_Comparable____reverse(self: kotlin.ranges.ClosedRange<kotlin.Comparable<kotlin.Any?>>, value: kotlin.Comparable<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __value = kotlin.native.internal.ref.createRetainedExternalRCRef(value)
-    val __result = kotlin_ranges_ClosedRange_contains__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_Comparable____reverse_swift(__self, __value)
-    return __result
+    val _result = kotlin_ranges_ClosedRange_contains__TypesOfArguments__anyU20ExportedKotlinPackages_kotlin_Comparable____reverse_swift(__self, __value)
+    return _result
 }
 
 @ImportedBridge("kotlin_ranges_ClosedRange_isEmpty__reverse_swift")
@@ -35,8 +35,8 @@ internal external fun kotlin_ranges_ClosedRange_isEmpty__reverse_swift(self: kot
 @BindReverseBridgeToMethod(kotlin.ranges.ClosedRange::class, "isEmpty")
 public fun kotlin_ranges_ClosedRange_isEmpty__reverse(self: kotlin.ranges.ClosedRange<kotlin.Comparable<kotlin.Any?>>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_ranges_ClosedRange_isEmpty__reverse_swift(__self)
-    return __result
+    val _result = kotlin_ranges_ClosedRange_isEmpty__reverse_swift(__self)
+    return _result
 }
 
 @ExportedBridge("kotlin_Comparable_compareTo__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable___")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/lib/lib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/spi/golden_result/lib/lib.kt
@@ -19,8 +19,8 @@ internal external fun InternalLibInterface_bar__reverse_swift(self: kotlin.nativ
 @BindReverseBridgeToMethod(InternalLibInterface::class, "bar")
 public fun InternalLibInterface_bar__reverse(self: InternalLibInterface): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = InternalLibInterface_bar__reverse_swift(__self)
-    return run<Unit> { __result }
+    val _result = InternalLibInterface_bar__reverse_swift(__self)
+    return run<Unit> { _result }
 }
 
 @ExportedBridge("ExperimentalLibClass_bar")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/stdlibTypes/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/stdlibTypes/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -19,8 +19,8 @@ internal external fun kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____
 @BindReverseBridgeToMethod(kotlin.CharSequence::class, "get")
 public fun kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____reverse(self: kotlin.CharSequence, index: Int): Char {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
-    return __result
+    val _result = kotlin_CharSequence_get__TypesOfArguments__Swift_Int32____reverse_swift(__self, index)
+    return _result
 }
 
 @ImportedBridge("kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift")
@@ -29,8 +29,8 @@ internal external fun kotlin_CharSequence_subSequence__TypesOfArguments__Swift_I
 @BindReverseBridgeToMethod(kotlin.CharSequence::class, "subSequence")
 public fun kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse(self: kotlin.CharSequence, startIndex: Int, endIndex: Int): kotlin.CharSequence {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(__self, startIndex, endIndex)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.CharSequence
+    val _result = kotlin_CharSequence_subSequence__TypesOfArguments__Swift_Int32_Swift_Int32____reverse_swift(__self, startIndex, endIndex)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.CharSequence
 }
 
 @ImportedBridge("kotlin_collections_ByteIterator_nextByte__reverse_swift")
@@ -39,8 +39,8 @@ internal external fun kotlin_collections_ByteIterator_nextByte__reverse_swift(se
 @BindReverseBridgeToMethod(kotlin.collections.ByteIterator::class, "nextByte")
 public fun kotlin_collections_ByteIterator_nextByte__reverse(self: kotlin.collections.ByteIterator): Byte {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ByteIterator_nextByte__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_ByteIterator_nextByte__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_CharIterator_nextChar__reverse_swift")
@@ -49,8 +49,8 @@ internal external fun kotlin_collections_CharIterator_nextChar__reverse_swift(se
 @BindReverseBridgeToMethod(kotlin.collections.CharIterator::class, "nextChar")
 public fun kotlin_collections_CharIterator_nextChar__reverse(self: kotlin.collections.CharIterator): Char {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_CharIterator_nextChar__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_CharIterator_nextChar__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence__Swift_Int32_Swift_Int32____reverse_swift")
@@ -60,8 +60,8 @@ internal external fun kotlin_text_Appendable_append__TypesOfArguments__Swift_Opt
 public fun kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence__Swift_Int32_Swift_Int32____reverse(self: kotlin.text.Appendable, value: kotlin.CharSequence?, startIndex: Int, endIndex: Int): kotlin.text.Appendable {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
-    val __result = kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence__Swift_Int32_Swift_Int32____reverse_swift(__self, __value, startIndex, endIndex)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.text.Appendable
+    val _result = kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence__Swift_Int32_Swift_Int32____reverse_swift(__self, __value, startIndex, endIndex)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.text.Appendable
 }
 
 @ImportedBridge("kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence_____reverse_swift")
@@ -71,8 +71,8 @@ internal external fun kotlin_text_Appendable_append__TypesOfArguments__Swift_Opt
 public fun kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence_____reverse(self: kotlin.text.Appendable, value: kotlin.CharSequence?): kotlin.text.Appendable {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
-    val __result = kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence_____reverse_swift(__self, __value)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.text.Appendable
+    val _result = kotlin_text_Appendable_append__TypesOfArguments__Swift_Optional_anyU20ExportedKotlinPackages_kotlin_CharSequence_____reverse_swift(__self, __value)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.text.Appendable
 }
 
 @ImportedBridge("kotlin_text_Appendable_append__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift")
@@ -81,8 +81,8 @@ internal external fun kotlin_text_Appendable_append__TypesOfArguments__Swift_Uni
 @BindReverseBridgeToMethod(kotlin.text.Appendable::class, "append")
 public fun kotlin_text_Appendable_append__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse(self: kotlin.text.Appendable, value: Char): kotlin.text.Appendable {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_text_Appendable_append__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift(__self, value)
-    return kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.text.Appendable
+    val _result = kotlin_text_Appendable_append__TypesOfArguments__Swift_Unicode_UTF16_CodeUnit____reverse_swift(__self, value)
+    return kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.text.Appendable
 }
 
 @ExportedBridge("kotlin_ByteArray_get__TypesOfArguments__Swift_Int32__")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/transitiveExport/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/transitiveExport/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -16,8 +16,8 @@ internal external fun kotlin_collections_ByteIterator_nextByte__reverse_swift(se
 @BindReverseBridgeToMethod(kotlin.collections.ByteIterator::class, "nextByte")
 public fun kotlin_collections_ByteIterator_nextByte__reverse(self: kotlin.collections.ByteIterator): Byte {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_ByteIterator_nextByte__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_ByteIterator_nextByte__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Iterator_hasNext__reverse_swift")
@@ -26,8 +26,8 @@ internal external fun kotlin_collections_Iterator_hasNext__reverse_swift(self: k
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "hasNext")
 public fun kotlin_collections_Iterator_hasNext__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_Iterator_hasNext__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_Iterator_next__reverse_swift")
@@ -36,8 +36,8 @@ internal external fun kotlin_collections_Iterator_next__reverse_swift(self: kotl
 @BindReverseBridgeToMethod(kotlin.collections.Iterator::class, "next")
 public fun kotlin_collections_Iterator_next__reverse(self: kotlin.collections.Iterator<kotlin.Any?>): kotlin.Any? {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_Iterator_next__reverse_swift(__self)
-    return if (__result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(__result) as kotlin.Any
+    val _result = kotlin_collections_Iterator_next__reverse_swift(__self)
+    return if (_result == kotlin.native.internal.NativePtr.NULL) null else kotlin.native.internal.ref.dereferenceExternalRCRef(_result) as kotlin.Any
 }
 
 @ExportedBridge("kotlin_Array_get__TypesOfArguments__Swift_Int32__")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/vararg/golden_result/KotlinStdlib/KotlinStdlib.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/vararg/golden_result/KotlinStdlib/KotlinStdlib.kt
@@ -17,8 +17,8 @@ internal external fun kotlin_Number_toByte__reverse_swift(self: kotlin.native.in
 @BindReverseBridgeToMethod(kotlin.Number::class, "toByte")
 public fun kotlin_Number_toByte__reverse(self: kotlin.Number): Byte {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Number_toByte__reverse_swift(__self)
-    return __result
+    val _result = kotlin_Number_toByte__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_Number_toChar__reverse_swift")
@@ -27,8 +27,8 @@ internal external fun kotlin_Number_toChar__reverse_swift(self: kotlin.native.in
 @BindReverseBridgeToMethod(kotlin.Number::class, "toChar")
 public fun kotlin_Number_toChar__reverse(self: kotlin.Number): Char {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Number_toChar__reverse_swift(__self)
-    return __result
+    val _result = kotlin_Number_toChar__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_Number_toDouble__reverse_swift")
@@ -37,8 +37,8 @@ internal external fun kotlin_Number_toDouble__reverse_swift(self: kotlin.native.
 @BindReverseBridgeToMethod(kotlin.Number::class, "toDouble")
 public fun kotlin_Number_toDouble__reverse(self: kotlin.Number): Double {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Number_toDouble__reverse_swift(__self)
-    return __result
+    val _result = kotlin_Number_toDouble__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_Number_toFloat__reverse_swift")
@@ -47,8 +47,8 @@ internal external fun kotlin_Number_toFloat__reverse_swift(self: kotlin.native.i
 @BindReverseBridgeToMethod(kotlin.Number::class, "toFloat")
 public fun kotlin_Number_toFloat__reverse(self: kotlin.Number): Float {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Number_toFloat__reverse_swift(__self)
-    return __result
+    val _result = kotlin_Number_toFloat__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_Number_toInt__reverse_swift")
@@ -57,8 +57,8 @@ internal external fun kotlin_Number_toInt__reverse_swift(self: kotlin.native.int
 @BindReverseBridgeToMethod(kotlin.Number::class, "toInt")
 public fun kotlin_Number_toInt__reverse(self: kotlin.Number): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Number_toInt__reverse_swift(__self)
-    return __result
+    val _result = kotlin_Number_toInt__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_Number_toLong__reverse_swift")
@@ -67,8 +67,8 @@ internal external fun kotlin_Number_toLong__reverse_swift(self: kotlin.native.in
 @BindReverseBridgeToMethod(kotlin.Number::class, "toLong")
 public fun kotlin_Number_toLong__reverse(self: kotlin.Number): Long {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Number_toLong__reverse_swift(__self)
-    return __result
+    val _result = kotlin_Number_toLong__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_Number_toShort__reverse_swift")
@@ -77,8 +77,8 @@ internal external fun kotlin_Number_toShort__reverse_swift(self: kotlin.native.i
 @BindReverseBridgeToMethod(kotlin.Number::class, "toShort")
 public fun kotlin_Number_toShort__reverse(self: kotlin.Number): Short {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_Number_toShort__reverse_swift(__self)
-    return __result
+    val _result = kotlin_Number_toShort__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_BooleanIterator_nextBoolean__reverse_swift")
@@ -87,8 +87,8 @@ internal external fun kotlin_collections_BooleanIterator_nextBoolean__reverse_sw
 @BindReverseBridgeToMethod(kotlin.collections.BooleanIterator::class, "nextBoolean")
 public fun kotlin_collections_BooleanIterator_nextBoolean__reverse(self: kotlin.collections.BooleanIterator): Boolean {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_BooleanIterator_nextBoolean__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_BooleanIterator_nextBoolean__reverse_swift(__self)
+    return _result
 }
 
 @ImportedBridge("kotlin_collections_IntIterator_nextInt__reverse_swift")
@@ -97,8 +97,8 @@ internal external fun kotlin_collections_IntIterator_nextInt__reverse_swift(self
 @BindReverseBridgeToMethod(kotlin.collections.IntIterator::class, "nextInt")
 public fun kotlin_collections_IntIterator_nextInt__reverse(self: kotlin.collections.IntIterator): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    val __result = kotlin_collections_IntIterator_nextInt__reverse_swift(__self)
-    return __result
+    val _result = kotlin_collections_IntIterator_nextInt__reverse_swift(__self)
+    return _result
 }
 
 @ExportedBridge("kotlin_BooleanArray_get__TypesOfArguments__Swift_Int32__")


### PR DESCRIPTION
^KT-87150 Fixed