### PR TITLE
[JVM] Don't rely on pre-lowered arrays representation when lowering loop

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/BackendSymbols.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/BackendSymbols.kt
@@ -9,13 +9,18 @@ import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.ir.*
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.getPropertyGetter
 import org.jetbrains.kotlin.ir.util.hasShape
 import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.ir.util.isPrimitiveArray
+import org.jetbrains.kotlin.ir.util.isUnsignedArray
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -118,6 +123,18 @@ abstract class BackendSymbols(irBuiltIns: IrBuiltIns) : PreSerializationSymbols.
 
     open val setWithoutBoundCheckName: Name?
         get() = null
+
+    open fun arraySizePropertyGetter(arrayType: IrType): IrSimpleFunction =
+        arrayType.getClass()!!.getPropertyGetter("size")!!.owner
+
+    open fun arrayElementGetter(arrayType: IrType, intType: IrType): IrSimpleFunction {
+        val isArray = arrayType.isArray() || arrayType.isPrimitiveArray()
+        val getFunctionName = if (isArray && getWithoutBoundCheckName != null) getWithoutBoundCheckName else OperatorNameConventions.GET
+        return arrayType.getClass()!!.functions.single {
+            it.name == getFunctionName &&
+                    it.hasShape(dispatchReceiver = true, regularParameters = 1, parameterTypes = listOf(null, intType))
+        }
+    }
 
     /**
      * Determines whether the provided function call is free of side effects.

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/handlers/IndexedGetIterationHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/handlers/IndexedGetIterationHandlers.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.isSubtypeOfClass
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
 /** Builds a [HeaderInfo] for iteration over iterables using the `get / []` operator and an index. */
@@ -84,30 +83,14 @@ internal class ArrayIterationHandler(context: CommonBackendContext) : IndexedGet
                 callee.kotlinFqName == FqName("kotlin.collections.reversed")
     }
 
-    override val IrType.sizePropertyGetter
-        get() = getClass()!!.getPropertyGetter("size")!!.owner
+    override val IrType.sizePropertyGetter: IrSimpleFunction
+        get() = context.symbols.arraySizePropertyGetter(this)
 
     private fun IrType.isArrayType() =
         isArray() || isPrimitiveArray() || (supportsUnsignedArrays && isUnsignedArray())
 
-    private val IrType.getFunctionName: Name
-        get() = context.symbols.getWithoutBoundCheckName.let {
-            if (isArrayType() && it != null) {
-                it
-            } else {
-                OperatorNameConventions.GET
-            }
-        }
-
-    override val IrType.getFunction
-        get() = getClass()!!.functions.single {
-            it.name == getFunctionName &&
-                    it.hasShape(
-                        dispatchReceiver = true,
-                        regularParameters = 1,
-                        parameterTypes = listOf(null, context.irBuiltIns.intType)
-                    )
-        }
+    override val IrType.getFunction: IrSimpleFunction
+        get() = context.symbols.arrayElementGetter(this, context.irBuiltIns.intType)
 }
 
 /**

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/handlers/IndicesHandlers.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/loops/handlers/IndicesHandlers.kt
@@ -87,7 +87,7 @@ internal class ArrayIndicesHandler(context: CommonBackendContext) : IndicesHandl
     }
 
     override val IrType.sizePropertyGetter: IrSimpleFunction
-        get() = getClass()!!.getPropertyGetter("size")!!.owner
+        get() = context.symbols.arraySizePropertyGetter(this)
 }
 
 internal class CharSequenceIndicesHandler(context: CommonBackendContext) : IndicesHandler(context) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -22,8 +22,8 @@ import org.jetbrains.kotlin.descriptors.annotations.KotlinRetention
 import org.jetbrains.kotlin.descriptors.annotations.KotlinTarget
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.declarations.*
+import org.jetbrains.kotlin.ir.classSymbolOrNull
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrRawFunctionReference
 import org.jetbrains.kotlin.ir.expressions.impl.IrAnnotationImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
@@ -41,6 +41,7 @@ import org.jetbrains.kotlin.resolve.JVM_INLINE_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.resolve.jvm.JvmClassName
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import org.jetbrains.kotlin.types.Variance
+import org.jetbrains.kotlin.util.OperatorNameConventions
 import java.lang.invoke.MethodType
 
 class JvmSymbols(
@@ -88,7 +89,7 @@ class JvmSymbols(
         classKind: ClassKind = ClassKind.CLASS,
         classModality: Modality = Modality.FINAL,
         classIsValue: Boolean = false,
-        block: (IrClass) -> Unit = {}
+        block: (IrClass) -> Unit = {},
     ): IrClassSymbol =
         irFactory.buildClass {
             name = fqName.shortName()
@@ -918,6 +919,42 @@ class JvmSymbols(
     val divideUnsignedLong: IrSimpleFunctionSymbol = javaLangLong.functionByName("divideUnsigned")
     val remainderUnsignedLong: IrSimpleFunctionSymbol = javaLangLong.functionByName("remainderUnsigned")
     val toUnsignedStringLong: IrSimpleFunctionSymbol = javaLangLong.functionByName("toUnsignedString")
+
+    private val unsignedArrayClasses: List<IrClassSymbol> =
+        StandardClassIds.elementTypeByUnsignedArrayType.keys.mapNotNull { it.classSymbolOrNull() }
+
+    private val unsignedArraySizeGetters: Map<IrClassSymbol, IrSimpleFunctionSymbol> =
+        unsignedArrayClasses.mapNotNull { arrayClass ->
+            arrayClass.owner.getPropertyGetter("size")?.let { arrayClass to it }
+        }.toMap()
+
+    private val unsignedArrayElementGetters: Map<IrClassSymbol, IrSimpleFunctionSymbol> =
+        unsignedArrayClasses.mapNotNull { arrayClass ->
+            arrayClass.owner.functions.singleOrNull {
+                it.name == OperatorNameConventions.GET &&
+                        it.hasShape(
+                            dispatchReceiver = true,
+                            regularParameters = 1,
+                            parameterTypes = listOf(null, irBuiltIns.intType)
+                        )
+            }?.let { arrayClass to it.symbol }
+        }.toMap()
+
+    override fun arraySizePropertyGetter(arrayType: IrType): IrSimpleFunction {
+        if (arrayType.isUnsignedArray()) {
+            return unsignedArraySizeGetters[arrayType.getClass()!!.symbol]?.owner
+                ?: error("size getter symbol not found for ${arrayType.getClass()}")
+        }
+        return super.arraySizePropertyGetter(arrayType)
+    }
+
+    override fun arrayElementGetter(arrayType: IrType, intType: IrType): IrSimpleFunction {
+        if (arrayType.isUnsignedArray()) {
+            return unsignedArrayElementGetters[arrayType.getClass()!!.symbol]?.owner
+                ?: error("element getter symbol not found for ${arrayType.getClass()}")
+        }
+        return super.arrayElementGetter(arrayType, intType)
+    }
 
     val intPostfixIncrDecr = createIncrDecrFun("<int-postfix-incr-decr>")
     val intPrefixIncrDecr = createIncrDecrFun("<int-prefix-incr-decr>")

--- a/compiler/testData/codegen/boxJvm/unsignedTypes/unsignedArrayForLoopDeclaredInSources.kt
+++ b/compiler/testData/codegen/boxJvm/unsignedTypes/unsignedArrayForLoopDeclaredInSources.kt
@@ -1,0 +1,133 @@
+// TARGET_BACKEND: JVM
+// WITH_STDLIB
+// PREFER_IN_TEST_OVER_STDLIB
+
+// FILE: declarations.kt
+package kotlin
+
+@kotlin.jvm.JvmInline
+value class UByteArray(val delegate: ByteArray) : Collection<UByte> {
+    override val size: Int
+        get() = delegate.size
+
+    override fun isEmpty(): Boolean = null!!
+    override fun iterator(): Iterator<UByte> = object : Iterator<UByte> {
+        private var index = 0
+        override fun hasNext(): Boolean = index < delegate.size
+        override fun next(): UByte = delegate[index++].toUByte()
+    }
+    override fun containsAll(elements: Collection<UByte>): Boolean = null!!
+    override fun contains(element: UByte): Boolean = null!!
+    operator fun get(index: Int): UByte = delegate[index].toUByte()
+    operator fun set(index: Int, value: UByte) {}
+}
+
+@kotlin.jvm.JvmInline
+value class UShortArray(val delegate: ShortArray) : Collection<UShort> {
+    override val size: Int
+        get() = delegate.size
+
+    override fun isEmpty(): Boolean = null!!
+    override fun iterator(): Iterator<UShort> = object : Iterator<UShort> {
+        private var index = 0
+        override fun hasNext(): Boolean = index < delegate.size
+        override fun next(): UShort = delegate[index++].toUShort()
+    }
+    override fun containsAll(elements: Collection<UShort>): Boolean = null!!
+    override fun contains(element: UShort): Boolean = null!!
+    operator fun get(index: Int): UShort = delegate[index].toUShort()
+    operator fun set(index: Int, value: UShort) {}
+}
+
+@kotlin.jvm.JvmInline
+value class UIntArray(val delegate: IntArray) : Collection<UInt> {
+    override val size: Int
+        get() = delegate.size
+
+    override fun isEmpty(): Boolean = null!!
+    override fun iterator(): Iterator<UInt> = object : Iterator<UInt> {
+        private var index = 0
+        override fun hasNext(): Boolean = index < delegate.size
+        override fun next(): UInt = delegate[index++].toUInt()
+    }
+    override fun containsAll(elements: Collection<UInt>): Boolean = null!!
+    override fun contains(element: UInt): Boolean = null!!
+    operator fun get(index: Int): UInt = delegate[index].toUInt()
+    operator fun set(index: Int, value: UInt) {}
+}
+
+@kotlin.jvm.JvmInline
+value class ULongArray(val delegate: LongArray) : Collection<ULong> {
+    override val size: Int
+        get() = delegate.size
+
+    override fun isEmpty(): Boolean = null!!
+    override fun iterator(): Iterator<ULong> = object : Iterator<ULong> {
+        private var index = 0
+        override fun hasNext(): Boolean = index < delegate.size
+        override fun next(): ULong = delegate[index++].toULong()
+    }
+    override fun containsAll(elements: Collection<ULong>): Boolean = null!!
+    override fun contains(element: ULong): Boolean = null!!
+    operator fun get(index: Int): ULong = delegate[index].toULong()
+    operator fun set(index: Int, value: ULong) {}
+}
+
+// FILE: test.kt
+package test
+
+import kotlin.*
+
+fun test(a: UByteArray): String {
+    for (x in a) {
+        if (x == 42.toUByte()) {
+            return "OK"
+        }
+    }
+    return "Fail"
+}
+
+fun test(a: UShortArray): String {
+    for (x in a) {
+        if (x == 42.toUShort()) {
+            return "OK"
+        }
+    }
+    return "Fail"
+}
+
+fun test(a: UIntArray): String {
+    for (x in a) {
+        if (x == 42u) {
+            return "OK"
+        }
+    }
+    return "Fail"
+}
+
+fun test(a: ULongArray): String {
+    for (x in a) {
+        if (x == 42uL) {
+            return "OK"
+        }
+    }
+    return "Fail"
+}
+
+fun testIndices(a: UIntArray): String {
+    for (i in a.indices) {
+        if (a[i] == 42u) {
+            return "OK"
+        }
+    }
+    return "Fail"
+}
+
+fun box(): String {
+    if (test(UByteArray(byteArrayOf(42.toByte()))) != "OK") return "Fail 1"
+    if (test(UShortArray(shortArrayOf(42.toShort()))) != "OK") return "Fail 2"
+    if (test(UIntArray(intArrayOf(42))) != "OK") return "Fail 3"
+    if (test(ULongArray(longArrayOf(42.toLong()))) != "OK") return "Fail 4"
+    if (testIndices(UIntArray(intArrayOf(42))) != "OK") return "Fail 5"
+    return "OK"
+}


### PR DESCRIPTION
Previously, unsigned-array loop lowering relied on unsigned array declarations remaining unchanged by `JvmPropertiesLowering`. This is not true when we compile stdlib.

Now we memoize the required properties before lowerings instead of looking them up.

NB: the stdlib compilation, however, worked because stdlib sources currently contain no loops over unsigned arrays. But we may introduce it when rewriting unsigned arrays as expected/actual.

^KT-87083: Fixed