### PR TITLE
[stdlib] Call the allEqualBy selector from a single place

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -14941,12 +14941,16 @@ public fun CharArray.allEqual(): Boolean {
 @ExperimentalStdlibApi
 public inline fun <T, K> Array<out T>.allEqualBy(selector: (T) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -14970,12 +14974,16 @@ public inline fun <T, K> Array<out T>.allEqualBy(selector: (T) -> K): Boolean {
 @ExperimentalStdlibApi
 public inline fun <K> ByteArray.allEqualBy(selector: (Byte) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -14999,12 +15007,16 @@ public inline fun <K> ByteArray.allEqualBy(selector: (Byte) -> K): Boolean {
 @ExperimentalStdlibApi
 public inline fun <K> ShortArray.allEqualBy(selector: (Short) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -15028,12 +15040,16 @@ public inline fun <K> ShortArray.allEqualBy(selector: (Short) -> K): Boolean {
 @ExperimentalStdlibApi
 public inline fun <K> IntArray.allEqualBy(selector: (Int) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -15057,12 +15073,16 @@ public inline fun <K> IntArray.allEqualBy(selector: (Int) -> K): Boolean {
 @ExperimentalStdlibApi
 public inline fun <K> LongArray.allEqualBy(selector: (Long) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -15086,12 +15106,16 @@ public inline fun <K> LongArray.allEqualBy(selector: (Long) -> K): Boolean {
 @ExperimentalStdlibApi
 public inline fun <K> FloatArray.allEqualBy(selector: (Float) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -15115,12 +15139,16 @@ public inline fun <K> FloatArray.allEqualBy(selector: (Float) -> K): Boolean {
 @ExperimentalStdlibApi
 public inline fun <K> DoubleArray.allEqualBy(selector: (Double) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -15144,12 +15172,16 @@ public inline fun <K> DoubleArray.allEqualBy(selector: (Double) -> K): Boolean {
 @ExperimentalStdlibApi
 public inline fun <K> BooleanArray.allEqualBy(selector: (Boolean) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -15173,12 +15205,16 @@ public inline fun <K> BooleanArray.allEqualBy(selector: (Boolean) -> K): Boolean
 @ExperimentalStdlibApi
 public inline fun <K> CharArray.allEqualBy(selector: (Char) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -2046,15 +2046,23 @@ public fun <T> Iterable<T>.allEqual(): Boolean {
 public inline fun <T, K> Iterable<T>.allEqualBy(selector: (T) -> K): Boolean {
     val iterator = iterator()
     if (!iterator.hasNext()) return true
-    val first = iterator.next()
+    var element = iterator.next()
     if (!iterator.hasNext()) return true
-    val firstKey = selector(first)
-    do {
-        val key = selector(iterator.next())
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
-    } while (iterator.hasNext())
+    var firstKey: K? = null
+    var isFirst = true
+    while (true) {
+        val key = selector(element)
+        if (isFirst) {
+            firstKey = key
+            isFirst = false
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
+        if (!iterator.hasNext()) break
+        element = iterator.next()
+    }
     return true
 }
 

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -1530,15 +1530,23 @@ public fun <T> Sequence<T>.allEqual(): Boolean {
 public inline fun <T, K> Sequence<T>.allEqualBy(selector: (T) -> K): Boolean {
     val iterator = iterator()
     if (!iterator.hasNext()) return true
-    val first = iterator.next()
+    var element = iterator.next()
     if (!iterator.hasNext()) return true
-    val firstKey = selector(first)
-    do {
-        val key = selector(iterator.next())
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
-    } while (iterator.hasNext())
+    var firstKey: K? = null
+    var isFirst = true
+    while (true) {
+        val key = selector(element)
+        if (isFirst) {
+            firstKey = key
+            isFirst = false
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
+        if (!iterator.hasNext()) break
+        element = iterator.next()
+    }
     return true
 }
 

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -6352,12 +6352,16 @@ public fun UShortArray.allEqual(): Boolean {
 @ExperimentalUnsignedTypes
 public inline fun <K> UIntArray.allEqualBy(selector: (UInt) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -6382,12 +6386,16 @@ public inline fun <K> UIntArray.allEqualBy(selector: (UInt) -> K): Boolean {
 @ExperimentalUnsignedTypes
 public inline fun <K> ULongArray.allEqualBy(selector: (ULong) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -6412,12 +6420,16 @@ public inline fun <K> ULongArray.allEqualBy(selector: (ULong) -> K): Boolean {
 @ExperimentalUnsignedTypes
 public inline fun <K> UByteArray.allEqualBy(selector: (UByte) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }
@@ -6442,12 +6454,16 @@ public inline fun <K> UByteArray.allEqualBy(selector: (UByte) -> K): Boolean {
 @ExperimentalUnsignedTypes
 public inline fun <K> UShortArray.allEqualBy(selector: (UShort) -> K): Boolean {
     if (size < 2) return true
-    val firstKey = selector(this[0])
-    for (i in 1..lastIndex) {
+    var firstKey: K? = null
+    for (i in indices) {
         val key = selector(this[i])
-        // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-        val equal = firstKey?.equals(key) ?: (key == null)
-        if (!equal) return false
+        if (i == 0) {
+            firstKey = key
+        } else {
+            // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+            val equal = firstKey?.equals(key) ?: (key == null)
+            if (!equal) return false
+        }
     }
     return true
 }

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Aggregates.kt
@@ -313,27 +313,39 @@ object Aggregates : TemplateGroupBase() {
             """
             val iterator = iterator()
             if (!iterator.hasNext()) return true
-            val first = iterator.next()
+            var element = iterator.next()
             if (!iterator.hasNext()) return true
-            val firstKey = selector(first)
-            do {
-                val key = selector(iterator.next())
-                // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-                val equal = firstKey?.equals(key) ?: (key == null)
-                if (!equal) return false
-            } while (iterator.hasNext())
+            var firstKey: K? = null
+            var isFirst = true
+            while (true) {
+                val key = selector(element)
+                if (isFirst) {
+                    firstKey = key
+                    isFirst = false
+                } else {
+                    // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+                    val equal = firstKey?.equals(key) ?: (key == null)
+                    if (!equal) return false
+                }
+                if (!iterator.hasNext()) break
+                element = iterator.next()
+            }
             return true
             """
         }
         body(ArraysOfObjects, ArraysOfPrimitives, ArraysOfUnsigned) {
             """
             if (size < 2) return true
-            val firstKey = selector(this[0])
-            for (i in 1..lastIndex) {
+            var firstKey: K? = null
+            for (i in indices) {
                 val key = selector(this[i])
-                // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
-                val equal = firstKey?.equals(key) ?: (key == null)
-                if (!equal) return false
+                if (i == 0) {
+                    firstKey = key
+                } else {
+                    // Workaround for KT-86678 (revert in KT-86680): `==` on boxed Double/Float is wrong for NaN on Native.
+                    val equal = firstKey?.equals(key) ?: (key == null)
+                    if (!equal) return false
+                }
             }
             return true
             """


### PR DESCRIPTION
Because selector is inlined at each textual call, the old two-call body emitted the caller's selector twice at every `allEqualBy` call site. `allDistinctBy` already uses the single-call shape.

^KT-87166 Fixed
