### PR TITLE
[stdlib] Call the isSorted selectors from a single place

### DIFF
--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -5758,9 +5758,9 @@ public fun CharArray.isSorted(): Boolean {
 public inline fun <T, R : Comparable<R>> Array<out T>.isSortedBy(selector: (T) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5785,9 +5785,9 @@ public inline fun <T, R : Comparable<R>> Array<out T>.isSortedBy(selector: (T) -
 public inline fun <R : Comparable<R>> ByteArray.isSortedBy(selector: (Byte) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5812,9 +5812,9 @@ public inline fun <R : Comparable<R>> ByteArray.isSortedBy(selector: (Byte) -> R
 public inline fun <R : Comparable<R>> ShortArray.isSortedBy(selector: (Short) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5839,9 +5839,9 @@ public inline fun <R : Comparable<R>> ShortArray.isSortedBy(selector: (Short) ->
 public inline fun <R : Comparable<R>> IntArray.isSortedBy(selector: (Int) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5866,9 +5866,9 @@ public inline fun <R : Comparable<R>> IntArray.isSortedBy(selector: (Int) -> R?)
 public inline fun <R : Comparable<R>> LongArray.isSortedBy(selector: (Long) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5893,9 +5893,9 @@ public inline fun <R : Comparable<R>> LongArray.isSortedBy(selector: (Long) -> R
 public inline fun <R : Comparable<R>> FloatArray.isSortedBy(selector: (Float) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5920,9 +5920,9 @@ public inline fun <R : Comparable<R>> FloatArray.isSortedBy(selector: (Float) ->
 public inline fun <R : Comparable<R>> DoubleArray.isSortedBy(selector: (Double) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5947,9 +5947,9 @@ public inline fun <R : Comparable<R>> DoubleArray.isSortedBy(selector: (Double) 
 public inline fun <R : Comparable<R>> BooleanArray.isSortedBy(selector: (Boolean) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5974,9 +5974,9 @@ public inline fun <R : Comparable<R>> BooleanArray.isSortedBy(selector: (Boolean
 public inline fun <R : Comparable<R>> CharArray.isSortedBy(selector: (Char) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true

--- a/libraries/stdlib/common/src/generated/_Arrays.kt
+++ b/libraries/stdlib/common/src/generated/_Arrays.kt
@@ -5757,10 +5757,10 @@ public fun CharArray.isSorted(): Boolean {
 @SinceKotlin("2.4")
 public inline fun <T, R : Comparable<R>> Array<out T>.isSortedBy(selector: (T) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5784,10 +5784,10 @@ public inline fun <T, R : Comparable<R>> Array<out T>.isSortedBy(selector: (T) -
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> ByteArray.isSortedBy(selector: (Byte) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5811,10 +5811,10 @@ public inline fun <R : Comparable<R>> ByteArray.isSortedBy(selector: (Byte) -> R
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> ShortArray.isSortedBy(selector: (Short) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5838,10 +5838,10 @@ public inline fun <R : Comparable<R>> ShortArray.isSortedBy(selector: (Short) ->
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> IntArray.isSortedBy(selector: (Int) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5865,10 +5865,10 @@ public inline fun <R : Comparable<R>> IntArray.isSortedBy(selector: (Int) -> R?)
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> LongArray.isSortedBy(selector: (Long) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5892,10 +5892,10 @@ public inline fun <R : Comparable<R>> LongArray.isSortedBy(selector: (Long) -> R
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> FloatArray.isSortedBy(selector: (Float) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5919,10 +5919,10 @@ public inline fun <R : Comparable<R>> FloatArray.isSortedBy(selector: (Float) ->
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> DoubleArray.isSortedBy(selector: (Double) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5946,10 +5946,10 @@ public inline fun <R : Comparable<R>> DoubleArray.isSortedBy(selector: (Double) 
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> BooleanArray.isSortedBy(selector: (Boolean) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -5973,10 +5973,10 @@ public inline fun <R : Comparable<R>> BooleanArray.isSortedBy(selector: (Boolean
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> CharArray.isSortedBy(selector: (Char) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -6001,10 +6001,10 @@ public inline fun <R : Comparable<R>> CharArray.isSortedBy(selector: (Char) -> R
 @SinceKotlin("2.4")
 public inline fun <T, R : Comparable<R>> Array<out T>.isSortedByDescending(selector: (T) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6029,10 +6029,10 @@ public inline fun <T, R : Comparable<R>> Array<out T>.isSortedByDescending(selec
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> ByteArray.isSortedByDescending(selector: (Byte) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6057,10 +6057,10 @@ public inline fun <R : Comparable<R>> ByteArray.isSortedByDescending(selector: (
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> ShortArray.isSortedByDescending(selector: (Short) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6085,10 +6085,10 @@ public inline fun <R : Comparable<R>> ShortArray.isSortedByDescending(selector: 
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> IntArray.isSortedByDescending(selector: (Int) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6113,10 +6113,10 @@ public inline fun <R : Comparable<R>> IntArray.isSortedByDescending(selector: (I
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> LongArray.isSortedByDescending(selector: (Long) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6141,10 +6141,10 @@ public inline fun <R : Comparable<R>> LongArray.isSortedByDescending(selector: (
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> FloatArray.isSortedByDescending(selector: (Float) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6169,10 +6169,10 @@ public inline fun <R : Comparable<R>> FloatArray.isSortedByDescending(selector: 
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> DoubleArray.isSortedByDescending(selector: (Double) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6197,10 +6197,10 @@ public inline fun <R : Comparable<R>> DoubleArray.isSortedByDescending(selector:
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> BooleanArray.isSortedByDescending(selector: (Boolean) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -6225,10 +6225,10 @@ public inline fun <R : Comparable<R>> BooleanArray.isSortedByDescending(selector
 @SinceKotlin("2.4")
 public inline fun <R : Comparable<R>> CharArray.isSortedByDescending(selector: (Char) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -1031,13 +1031,17 @@ public fun <T : Comparable<T>> Iterable<T>.isSorted(): Boolean {
 public inline fun <T, R : Comparable<R>> Iterable<T>.isSortedBy(selector: (T) -> R?): Boolean {
     val iterator = iterator()
     if (!iterator.hasNext()) return true
-    val previous = iterator.next()
+    var element = iterator.next()
     if (!iterator.hasNext()) return true
-    var previousValue = selector(previous)
-    while (iterator.hasNext()) {
-        val currentValue = selector(iterator.next())
-        if (compareValues(previousValue, currentValue) > 0) return false
+    var previousValue: R? = null
+    var isFirst = true
+    while (true) {
+        val currentValue = selector(element)
+        if (!isFirst && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
+        isFirst = false
+        if (!iterator.hasNext()) break
+        element = iterator.next()
     }
     return true
 }
@@ -1067,13 +1071,17 @@ public inline fun <T, R : Comparable<R>> Iterable<T>.isSortedBy(selector: (T) ->
 public inline fun <T, R : Comparable<R>> Iterable<T>.isSortedByDescending(selector: (T) -> R?): Boolean {
     val iterator = iterator()
     if (!iterator.hasNext()) return true
-    val previous = iterator.next()
+    var element = iterator.next()
     if (!iterator.hasNext()) return true
-    var previousValue = selector(previous)
-    while (iterator.hasNext()) {
-        val currentValue = selector(iterator.next())
-        if (compareValues(previousValue, currentValue) < 0) return false
+    var previousValue: R? = null
+    var isFirst = true
+    while (true) {
+        val currentValue = selector(element)
+        if (!isFirst && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
+        isFirst = false
+        if (!iterator.hasNext()) break
+        element = iterator.next()
     }
     return true
 }

--- a/libraries/stdlib/common/src/generated/_Collections.kt
+++ b/libraries/stdlib/common/src/generated/_Collections.kt
@@ -1034,12 +1034,10 @@ public inline fun <T, R : Comparable<R>> Iterable<T>.isSortedBy(selector: (T) ->
     var element = iterator.next()
     if (!iterator.hasNext()) return true
     var previousValue: R? = null
-    var isFirst = true
     while (true) {
         val currentValue = selector(element)
-        if (!isFirst && compareValues(previousValue, currentValue) > 0) return false
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
-        isFirst = false
         if (!iterator.hasNext()) break
         element = iterator.next()
     }

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -637,13 +637,17 @@ public fun <T : Comparable<T>> Sequence<T>.isSorted(): Boolean {
 public inline fun <T, R : Comparable<R>> Sequence<T>.isSortedBy(selector: (T) -> R?): Boolean {
     val iterator = iterator()
     if (!iterator.hasNext()) return true
-    val previous = iterator.next()
+    var element = iterator.next()
     if (!iterator.hasNext()) return true
-    var previousValue = selector(previous)
-    while (iterator.hasNext()) {
-        val currentValue = selector(iterator.next())
-        if (compareValues(previousValue, currentValue) > 0) return false
+    var previousValue: R? = null
+    var isFirst = true
+    while (true) {
+        val currentValue = selector(element)
+        if (!isFirst && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
+        isFirst = false
+        if (!iterator.hasNext()) break
+        element = iterator.next()
     }
     return true
 }
@@ -675,13 +679,17 @@ public inline fun <T, R : Comparable<R>> Sequence<T>.isSortedBy(selector: (T) ->
 public inline fun <T, R : Comparable<R>> Sequence<T>.isSortedByDescending(selector: (T) -> R?): Boolean {
     val iterator = iterator()
     if (!iterator.hasNext()) return true
-    val previous = iterator.next()
+    var element = iterator.next()
     if (!iterator.hasNext()) return true
-    var previousValue = selector(previous)
-    while (iterator.hasNext()) {
-        val currentValue = selector(iterator.next())
-        if (compareValues(previousValue, currentValue) < 0) return false
+    var previousValue: R? = null
+    var isFirst = true
+    while (true) {
+        val currentValue = selector(element)
+        if (!isFirst && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
+        isFirst = false
+        if (!iterator.hasNext()) break
+        element = iterator.next()
     }
     return true
 }

--- a/libraries/stdlib/common/src/generated/_Sequences.kt
+++ b/libraries/stdlib/common/src/generated/_Sequences.kt
@@ -640,12 +640,10 @@ public inline fun <T, R : Comparable<R>> Sequence<T>.isSortedBy(selector: (T) ->
     var element = iterator.next()
     if (!iterator.hasNext()) return true
     var previousValue: R? = null
-    var isFirst = true
     while (true) {
         val currentValue = selector(element)
-        if (!isFirst && compareValues(previousValue, currentValue) > 0) return false
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
-        isFirst = false
         if (!iterator.hasNext()) break
         element = iterator.next()
     }

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -2855,10 +2855,10 @@ public fun UShortArray.isSorted(): Boolean {
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> UIntArray.isSortedBy(selector: (UInt) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -2883,10 +2883,10 @@ public inline fun <R : Comparable<R>> UIntArray.isSortedBy(selector: (UInt) -> R
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> ULongArray.isSortedBy(selector: (ULong) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -2911,10 +2911,10 @@ public inline fun <R : Comparable<R>> ULongArray.isSortedBy(selector: (ULong) ->
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> UByteArray.isSortedBy(selector: (UByte) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -2939,10 +2939,10 @@ public inline fun <R : Comparable<R>> UByteArray.isSortedBy(selector: (UByte) ->
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> UShortArray.isSortedBy(selector: (UShort) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) > 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -2968,10 +2968,10 @@ public inline fun <R : Comparable<R>> UShortArray.isSortedBy(selector: (UShort) 
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> UIntArray.isSortedByDescending(selector: (UInt) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -2997,10 +2997,10 @@ public inline fun <R : Comparable<R>> UIntArray.isSortedByDescending(selector: (
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> ULongArray.isSortedByDescending(selector: (ULong) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -3026,10 +3026,10 @@ public inline fun <R : Comparable<R>> ULongArray.isSortedByDescending(selector: 
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> UByteArray.isSortedByDescending(selector: (UByte) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true
@@ -3055,10 +3055,10 @@ public inline fun <R : Comparable<R>> UByteArray.isSortedByDescending(selector: 
 @ExperimentalUnsignedTypes
 public inline fun <R : Comparable<R>> UShortArray.isSortedByDescending(selector: (UShort) -> R?): Boolean {
     if (size < 2) return true
-    var previousValue = selector(this[0])
-    for (i in 1..lastIndex) {
+    var previousValue: R? = null
+    for (i in indices) {
         val currentValue = selector(this[i])
-        if (compareValues(previousValue, currentValue) < 0) return false
+        if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
         previousValue = currentValue
     }
     return true

--- a/libraries/stdlib/common/src/generated/_UArrays.kt
+++ b/libraries/stdlib/common/src/generated/_UArrays.kt
@@ -2856,9 +2856,9 @@ public fun UShortArray.isSorted(): Boolean {
 public inline fun <R : Comparable<R>> UIntArray.isSortedBy(selector: (UInt) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -2884,9 +2884,9 @@ public inline fun <R : Comparable<R>> UIntArray.isSortedBy(selector: (UInt) -> R
 public inline fun <R : Comparable<R>> ULongArray.isSortedBy(selector: (ULong) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -2912,9 +2912,9 @@ public inline fun <R : Comparable<R>> ULongArray.isSortedBy(selector: (ULong) ->
 public inline fun <R : Comparable<R>> UByteArray.isSortedBy(selector: (UByte) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true
@@ -2940,9 +2940,9 @@ public inline fun <R : Comparable<R>> UByteArray.isSortedBy(selector: (UByte) ->
 public inline fun <R : Comparable<R>> UShortArray.isSortedBy(selector: (UShort) -> R?): Boolean {
     if (size < 2) return true
     var previousValue: R? = null
-    for (i in indices) {
-        val currentValue = selector(this[i])
-        if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+    for (element in this) {
+        val currentValue = selector(element)
+        if (compareValues(previousValue, currentValue) > 0) return false
         previousValue = currentValue
     }
     return true

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
@@ -830,13 +830,17 @@ object Ordering : TemplateGroupBase() {
             """
             val iterator = iterator()
             if (!iterator.hasNext()) return true
-            val previous = iterator.next()
+            var element = iterator.next()
             if (!iterator.hasNext()) return true
-            var previousValue = selector(previous)
-            while (iterator.hasNext()) {
-                val currentValue = selector(iterator.next())
-                if (compareValues(previousValue, currentValue) > 0) return false
+            var previousValue: R? = null
+            var isFirst = true
+            while (true) {
+                val currentValue = selector(element)
+                if (!isFirst && compareValues(previousValue, currentValue) > 0) return false
                 previousValue = currentValue
+                isFirst = false
+                if (!iterator.hasNext()) break
+                element = iterator.next()
             }
             return true
             """
@@ -844,10 +848,10 @@ object Ordering : TemplateGroupBase() {
         body(ArraysOfObjects, ArraysOfPrimitives, ArraysOfUnsigned) {
             """
             if (size < 2) return true
-            var previousValue = selector(this[0])
-            for (i in 1..lastIndex) {
+            var previousValue: R? = null
+            for (i in indices) {
                 val currentValue = selector(this[i])
-                if (compareValues(previousValue, currentValue) > 0) return false
+                if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
                 previousValue = currentValue
             }
             return true
@@ -886,13 +890,17 @@ object Ordering : TemplateGroupBase() {
             """
             val iterator = iterator()
             if (!iterator.hasNext()) return true
-            val previous = iterator.next()
+            var element = iterator.next()
             if (!iterator.hasNext()) return true
-            var previousValue = selector(previous)
-            while (iterator.hasNext()) {
-                val currentValue = selector(iterator.next())
-                if (compareValues(previousValue, currentValue) < 0) return false
+            var previousValue: R? = null
+            var isFirst = true
+            while (true) {
+                val currentValue = selector(element)
+                if (!isFirst && compareValues(previousValue, currentValue) < 0) return false
                 previousValue = currentValue
+                isFirst = false
+                if (!iterator.hasNext()) break
+                element = iterator.next()
             }
             return true
             """
@@ -900,10 +908,10 @@ object Ordering : TemplateGroupBase() {
         body(ArraysOfObjects, ArraysOfPrimitives, ArraysOfUnsigned) {
             """
             if (size < 2) return true
-            var previousValue = selector(this[0])
-            for (i in 1..lastIndex) {
+            var previousValue: R? = null
+            for (i in indices) {
                 val currentValue = selector(this[i])
-                if (compareValues(previousValue, currentValue) < 0) return false
+                if (i > 0 && compareValues(previousValue, currentValue) < 0) return false
                 previousValue = currentValue
             }
             return true

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Ordering.kt
@@ -833,12 +833,10 @@ object Ordering : TemplateGroupBase() {
             var element = iterator.next()
             if (!iterator.hasNext()) return true
             var previousValue: R? = null
-            var isFirst = true
             while (true) {
                 val currentValue = selector(element)
-                if (!isFirst && compareValues(previousValue, currentValue) > 0) return false
+                if (compareValues(previousValue, currentValue) > 0) return false
                 previousValue = currentValue
-                isFirst = false
                 if (!iterator.hasNext()) break
                 element = iterator.next()
             }
@@ -849,9 +847,9 @@ object Ordering : TemplateGroupBase() {
             """
             if (size < 2) return true
             var previousValue: R? = null
-            for (i in indices) {
-                val currentValue = selector(this[i])
-                if (i > 0 && compareValues(previousValue, currentValue) > 0) return false
+            for (element in this) {
+                val currentValue = selector(element)
+                if (compareValues(previousValue, currentValue) > 0) return false
                 previousValue = currentValue
             }
             return true


### PR DESCRIPTION
Both functions are inline and read their selector from two places, so the compiler emitted the caller's selector twice at every call site. `allEqualBy` and `allDistinctBy` already use the single-call shape.

^KT-87173 Fixed
