### PR TITLE
[K/JS] Canonicalize NaN values before computing hash codes

### DIFF
--- a/libraries/stdlib/js/runtime/bitUtils.kt
+++ b/libraries/stdlib/js/runtime/bitUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -59,11 +59,18 @@ internal fun doubleSignBit(value: Double): Int {
 
 @UsedFromCompilerGeneratedCode
 internal fun getNumberHashCode(obj: Double): Int {
+    // JS VMs don't canonicalize NaN values, so their raw bytes may differ
+    // (spec: https://tc39.es/ecma262/multipage/structured-data.html#sec-numerictorawbytes).
+    // Without user-land canonicalization, the values of the [bufInt32] elements
+    // could differ for different NaN representations (KT-86954).
+    // However, NaN hash codes should be consistent with equality semantics.
+    // To ensure this, we canonicalize NaN values in place before computing the hash code.
+    val value = if (obj.isNaN()) Double.NaN else obj
     @Suppress("DEPRECATED_IDENTITY_EQUALS")
-    if (jsBitwiseOr(obj, 0).unsafeCast<Double>() === obj) {
-        return obj.toInt()
+    if (jsBitwiseOr(value, 0).unsafeCast<Double>() === value) {
+        return value.toInt()
     }
 
-    bufFloat64[0] = obj
+    bufFloat64[0] = value
     return bufInt32[highIndex] * 31 + bufInt32[lowIndex]
 }

--- a/libraries/stdlib/js/runtime/numbers.kt
+++ b/libraries/stdlib/js/runtime/numbers.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package kotlin.js
+
+@JsName("Number")
+internal external object JsNumberObject {
+    fun isNaN(value: Number): Boolean
+    fun isFinite(value: Number): Boolean
+}

--- a/libraries/stdlib/js/src/kotlin/NumbersJs.kt
+++ b/libraries/stdlib/js/src/kotlin/NumbersJs.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -11,13 +11,13 @@ import kotlin.js.internal.boxedLong.BoxedLongApi
  * Returns `true` if the specified number is a
  * Not-a-Number (NaN) value, `false` otherwise.
  */
-public actual fun Double.isNaN(): Boolean = this != this
+public actual fun Double.isNaN(): Boolean = JsNumberObject.isNaN(this)
 
 /**
  * Returns `true` if the specified number is a
  * Not-a-Number (NaN) value, `false` otherwise.
  */
-public actual fun Float.isNaN(): Boolean = this != this
+public actual fun Float.isNaN(): Boolean = JsNumberObject.isNaN(this)
 
 /**
  * Returns `true` if this value is infinitely large in magnitude.
@@ -32,12 +32,12 @@ public actual fun Float.isInfinite(): Boolean = this == Float.POSITIVE_INFINITY 
 /**
  * Returns `true` if the argument is a finite floating-point value; returns `false` otherwise (for `NaN` and infinity arguments).
  */
-public actual fun Double.isFinite(): Boolean = !isInfinite() && !isNaN()
+public actual fun Double.isFinite(): Boolean = JsNumberObject.isFinite(this)
 
 /**
  * Returns `true` if the argument is a finite floating-point value; returns `false` otherwise (for `NaN` and infinity arguments).
  */
-public actual fun Float.isFinite(): Boolean = !isInfinite() && !isNaN()
+public actual fun Float.isFinite(): Boolean = JsNumberObject.isFinite(this)
 
 
 /**

--- a/libraries/stdlib/test/utils/HashCodeTest.kt
+++ b/libraries/stdlib/test/utils/HashCodeTest.kt
@@ -7,6 +7,7 @@ package test.utils
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class HashCodeTest {
     @Test
@@ -23,5 +24,21 @@ class HashCodeTest {
         val nullableValue: String? = value
 
         assertEquals(value.hashCode(), nullableValue.hashCode())
+    }
+
+    // KT-86954: all NaN bit patterns must produce the same hash code, matching equals() semantics.
+    @Test
+    fun hashCodeOfNaN() {
+        val canonicalDoubleNaN = Double.NaN
+        val otherDoubleNaN = Double.fromBits(canonicalDoubleNaN.toBits() or 1L)
+        assertTrue(otherDoubleNaN.isNaN())
+        assertTrue(canonicalDoubleNaN.equals(otherDoubleNaN))
+        assertEquals(canonicalDoubleNaN.hashCode(), otherDoubleNaN.hashCode())
+
+        val canonicalFloatNaN = Float.NaN
+        val otherFloatNaN = Float.fromBits(0xFFFC0000.toInt())
+        assertTrue(otherFloatNaN.isNaN())
+        assertTrue(canonicalFloatNaN.equals(otherFloatNaN))
+        assertEquals(canonicalFloatNaN.hashCode(), otherFloatNaN.hashCode())
     }
 }


### PR DESCRIPTION
JS VMs do not canonicalize NaN representations, so different NaN payloads may produce different raw bytes. This can lead to inconsistent hash codes for values that should be treated as equal.

^KT-86954 Fixed