### PR TITLE
[Wasm] Native Wasm Tail Call Support in the Kotlin/Wasm Backend

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -12990,6 +12990,51 @@
                                                 "deprecatedMessage": null
                                             },
                                             {
+                                                "name": "Xwasm-enable-tail-calls",
+                                                "shortName": null,
+                                                "deprecatedName": null,
+                                                "description": {
+                                                    "current": "Emit WebAssembly tail call instructions (return_call / return_call_indirect).",
+                                                    "valueInVersions": []
+                                                },
+                                                "delimiter": null,
+                                                "affectsCompilationOutcome": true,
+                                                "restrictedToCompilerPhase": "BACKEND_COMPILATION",
+                                                "valueType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "valueDescription": {
+                                                    "current": null,
+                                                    "valueInVersions": []
+                                                },
+                                                "releaseVersionsMetadata": {
+                                                    "introducedVersion": "2.4.20",
+                                                    "stabilizedVersion": null,
+                                                    "deprecatedVersion": null,
+                                                    "removedVersion": null
+                                                },
+                                                "argumentType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "deprecatedMessage": null
+                                            },
+                                            {
                                                 "name": "Xwasm-generate-closed-world-multimodule",
                                                 "shortName": null,
                                                 "deprecatedName": null,
@@ -15159,6 +15204,51 @@
                                                 },
                                                 "releaseVersionsMetadata": {
                                                     "introducedVersion": "2.1.20",
+                                                    "stabilizedVersion": null,
+                                                    "deprecatedVersion": null,
+                                                    "removedVersion": null
+                                                },
+                                                "argumentType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "deprecatedMessage": null
+                                            },
+                                            {
+                                                "name": "Xwasm-enable-tail-calls",
+                                                "shortName": null,
+                                                "deprecatedName": null,
+                                                "description": {
+                                                    "current": "Emit WebAssembly tail call instructions (return_call / return_call_indirect).",
+                                                    "valueInVersions": []
+                                                },
+                                                "delimiter": null,
+                                                "affectsCompilationOutcome": true,
+                                                "restrictedToCompilerPhase": "BACKEND_COMPILATION",
+                                                "valueType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "valueDescription": {
+                                                    "current": null,
+                                                    "valueInVersions": []
+                                                },
+                                                "releaseVersionsMetadata": {
+                                                    "introducedVersion": "2.4.20",
                                                     "stabilizedVersion": null,
                                                     "deprecatedVersion": null,
                                                     "removedVersion": null

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
@@ -308,4 +308,15 @@ val actualWasmArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.wa
         )
         restrictedToCompilerPhase = KotlinCompilerPhase.BACKEND_COMPILATION
     }
+
+    compilerArgument {
+        name = "Xwasm-enable-tail-calls"
+        description = "Emit WebAssembly tail call instructions (return_call / return_call_indirect).".asReleaseDependent()
+        valueType = BooleanType.defaultFalse
+
+        lifecycle(
+            introducedVersion = KotlinReleaseVersion.v2_4_20,
+        )
+        restrictedToCompilerPhase = KotlinCompilerPhase.BACKEND_COMPILATION
+    }
 }

--- a/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
+++ b/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
@@ -1120,6 +1120,7 @@ public abstract interface class org/jetbrains/kotlin/buildtools/api/arguments/Wa
 	public static final field X_WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_ENABLE_ARRAY_RANGE_CHECKS Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_ENABLE_ASSERTS Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
+	public static final field X_WASM_ENABLE_TAIL_CALLS Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_GENERATE_DWARF Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_GENERATE_WAT Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments.kt
@@ -150,6 +150,16 @@ public interface WasmCompilerLinkingArguments : WasmCompilerArguments,
         WasmCompilerLinkingArgument("X_WASM_ENABLE_ASSERTS", KotlinReleaseVersion(2, 1, 20))
 
     /**
+     * Emit WebAssembly tail call instructions (return_call / return_call_indirect).
+     *
+     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
+     */
+    @JvmField
+    @ExperimentalCompilerArgument
+    public val X_WASM_ENABLE_TAIL_CALLS: WasmCompilerLinkingArgument<Boolean> =
+        WasmCompilerLinkingArgument("X_WASM_ENABLE_TAIL_CALLS", KotlinReleaseVersion(2, 4, 20))
+
+    /**
      * Compile modules in multi-module closed-world mode using module passed in `-include` argument as main module
      *
      * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Co
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_ENABLE_ARRAY_RANGE_CHECKS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_ENABLE_ASSERTS
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_ENABLE_TAIL_CALLS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_GENERATE_DWARF
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_GENERATE_WAT
@@ -150,6 +151,7 @@ internal class WasmArgumentsImpl(
     if (X_WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION in this) { arguments.wasmDisableArrayRangeChecksSafeElimination = get(X_WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION)}
     if (X_WASM_ENABLE_ARRAY_RANGE_CHECKS in this) { arguments.wasmEnableArrayRangeChecks = get(X_WASM_ENABLE_ARRAY_RANGE_CHECKS)}
     if (X_WASM_ENABLE_ASSERTS in this) { arguments.wasmEnableAsserts = get(X_WASM_ENABLE_ASSERTS)}
+    if (X_WASM_ENABLE_TAIL_CALLS in this) { arguments.wasmEnableTailCalls = get(X_WASM_ENABLE_TAIL_CALLS)}
     if (X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE in this) { arguments.wasmGenerateClosedWorldMultimodule = get(X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE)}
     if (X_WASM_GENERATE_DWARF in this) { arguments.generateDwarf = get(X_WASM_GENERATE_DWARF)}
     if (X_WASM_GENERATE_WAT in this) { arguments.wasmGenerateWat = get(X_WASM_GENERATE_WAT)}
@@ -180,6 +182,7 @@ internal class WasmArgumentsImpl(
     try { this[X_WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION] = arguments.wasmDisableArrayRangeChecksSafeElimination } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_ENABLE_ARRAY_RANGE_CHECKS] = arguments.wasmEnableArrayRangeChecks } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_ENABLE_ASSERTS] = arguments.wasmEnableAsserts } catch (_: NoSuchMethodError) {  }
+    try { this[X_WASM_ENABLE_TAIL_CALLS] = arguments.wasmEnableTailCalls } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE] = arguments.wasmGenerateClosedWorldMultimodule } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_GENERATE_DWARF] = arguments.generateDwarf } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_GENERATE_WAT] = arguments.wasmGenerateWat } catch (_: NoSuchMethodError) {  }
@@ -208,6 +211,7 @@ internal class WasmArgumentsImpl(
     if (X_WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION in this) { arguments.wasmDisableArrayRangeChecksSafeElimination = get(X_WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION)}
     if (X_WASM_ENABLE_ARRAY_RANGE_CHECKS in this) { arguments.wasmEnableArrayRangeChecks = get(X_WASM_ENABLE_ARRAY_RANGE_CHECKS)}
     if (X_WASM_ENABLE_ASSERTS in this) { arguments.wasmEnableAsserts = get(X_WASM_ENABLE_ASSERTS)}
+    if (X_WASM_ENABLE_TAIL_CALLS in this) { arguments.wasmEnableTailCalls = get(X_WASM_ENABLE_TAIL_CALLS)}
     if (X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE in this) { arguments.wasmGenerateClosedWorldMultimodule = get(X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE)}
     if (X_WASM_GENERATE_DWARF in this) { arguments.generateDwarf = get(X_WASM_GENERATE_DWARF)}
     if (X_WASM_GENERATE_WAT in this) { arguments.wasmGenerateWat = get(X_WASM_GENERATE_WAT)}
@@ -279,6 +283,9 @@ internal class WasmArgumentsImpl(
         WasmArgument("X_WASM_ENABLE_ARRAY_RANGE_CHECKS")
 
     public val X_WASM_ENABLE_ASSERTS: WasmArgument<Boolean> = WasmArgument("X_WASM_ENABLE_ASSERTS")
+
+    public val X_WASM_ENABLE_TAIL_CALLS: WasmArgument<Boolean> =
+        WasmArgument("X_WASM_ENABLE_TAIL_CALLS")
 
     public val X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE: WasmArgument<Boolean> =
         WasmArgument("X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE")

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JSCompilerArgumentsToKotlinWasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JSCompilerArgumentsToKotlinWasmCompilerArgumentsCopyGenerated.kt
@@ -23,6 +23,7 @@ fun copyK2JSCompilerArguments(from: K2JSCompilerArguments, to: KotlinWasmCompile
     to.wasmDisableArrayRangeChecksSafeElimination = from.wasmDisableArrayRangeChecksSafeElimination
     to.wasmEnableArrayRangeChecks = from.wasmEnableArrayRangeChecks
     to.wasmEnableAsserts = from.wasmEnableAsserts
+    to.wasmEnableTailCalls = from.wasmEnableTailCalls
     to.wasmGenerateClosedWorldMultimodule = from.wasmGenerateClosedWorldMultimodule
     to.wasmGenerateWat = from.wasmGenerateWat
     to.wasmIncludedModuleOnly = from.wasmIncludedModuleOnly

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
@@ -115,6 +115,16 @@ sealed class K2WasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         }
 
     @Argument(
+        value = "-Xwasm-enable-tail-calls",
+        description = "Emit WebAssembly tail call instructions (return_call / return_call_indirect).",
+    )
+    var wasmEnableTailCalls: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xwasm-generate-closed-world-multimodule",
         description = "Compile modules in multi-module closed-world mode using module passed in `-include` argument as main module",
     )

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArgumentsCopyGenerated.kt
@@ -24,6 +24,7 @@ fun copyK2WasmCompilerArguments(from: K2WasmCompilerArguments, to: K2WasmCompile
     to.wasmDisableArrayRangeChecksSafeElimination = from.wasmDisableArrayRangeChecksSafeElimination
     to.wasmEnableArrayRangeChecks = from.wasmEnableArrayRangeChecks
     to.wasmEnableAsserts = from.wasmEnableAsserts
+    to.wasmEnableTailCalls = from.wasmEnableTailCalls
     to.wasmGenerateClosedWorldMultimodule = from.wasmGenerateClosedWorldMultimodule
     to.wasmGenerateWat = from.wasmGenerateWat
     to.wasmIncludedModuleOnly = from.wasmIncludedModuleOnly

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
@@ -116,6 +116,16 @@ class KotlinWasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         }
 
     @Argument(
+        value = "-Xwasm-enable-tail-calls",
+        description = "Emit WebAssembly tail call instructions (return_call / return_call_indirect).",
+    )
+    var wasmEnableTailCalls: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xwasm-generate-closed-world-multimodule",
         description = "Compile modules in multi-module closed-world mode using module passed in `-include` argument as main module",
     )

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArgumentsCopyGenerated.kt
@@ -23,6 +23,7 @@ fun copyKotlinWasmCompilerArguments(from: KotlinWasmCompilerArguments, to: Kotli
     to.wasmDisableArrayRangeChecksSafeElimination = from.wasmDisableArrayRangeChecksSafeElimination
     to.wasmEnableArrayRangeChecks = from.wasmEnableArrayRangeChecks
     to.wasmEnableAsserts = from.wasmEnableAsserts
+    to.wasmEnableTailCalls = from.wasmEnableTailCalls
     to.wasmGenerateClosedWorldMultimodule = from.wasmGenerateClosedWorldMultimodule
     to.wasmGenerateWat = from.wasmGenerateWat
     to.wasmIncludedModuleOnly = from.wasmIncludedModuleOnly

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmConfigurationUpdater.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmConfigurationUpdater.kt
@@ -69,6 +69,7 @@ object WasmConfigurationUpdater : ConfigurationUpdater<KotlinWasmCompilerArgumen
         )
 
         configuration.put(WasmConfigurationKeys.WASM_USE_STACK_SWITCHING_PROPOSAL, arguments.wasmUseStackSwitchingProposal)
+        configuration.put(WasmConfigurationKeys.WASM_ENABLE_TAIL_CALLS, arguments.wasmEnableTailCalls)
         configuration.put(WasmConfigurationKeys.WASM_NO_JS_TAG, arguments.wasmNoJsTag)
         configuration.put(WasmConfigurationKeys.WASM_GENERATE_DWARF, arguments.generateDwarf)
         configuration.put(WasmConfigurationKeys.WASM_FORCE_DEBUG_FRIENDLY_COMPILATION, arguments.forceDebugFriendlyCompilation)

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/WasmConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/WasmConfigurationKeysContainer.kt
@@ -32,4 +32,5 @@ object WasmConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.wasm
     val WASM_INTERNAL_LOCAL_VARIABLE_PREFIX by key<String>("Prefix for the name of internal/synthetic local variables.")
     val WASM_GENERATE_CLOSED_WORLD_MULTIMODULE by key<Boolean>("Enables multi-module closed-world mode.")
     val WASM_TEST_BOX_FUNCTION_TO_EXPORT by key<FqName>("FQ Name of the test `box` function to be exported and called by the compiler test infrastructure.")
+    val WASM_ENABLE_TAIL_CALLS by key<Boolean>("Emit native Wasm tail-call instructions (return_call / return_call_ref) for non-tailrec tail calls.")
 }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/WasmLoweringPhases.kt
@@ -264,5 +264,8 @@ val wasmLowerings: List<NamedCompilerPhase<WasmBackendContext, IrModuleFragment,
     ::WasmInlineObjectsWithPureInitializationLowering,
 
     ::WhenBranchOptimiserLowering,
+
+    ::WasmTailCallLowering,
+
     ::IrValidationAfterLoweringsSecondStagePhase,
 )

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/BodyGenerator.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/BodyGenerator.kt
@@ -55,19 +55,11 @@ class BodyGenerator(
      * Returns true if [call] should be emitted as a tail call.
      *
      * [WasmTailCallLowering] marks structurally tail-positioned calls with
-     * [WASM_TAIL_CALL] origin. This method applies additional Wasm-level eligibility
-     * filters on top of that structural check:
-     *
-     * - The callee must not be a constructor, because [visitFunctionReturn] pushes
-     *   the implicit dispatch receiver before `return`, which is incompatible with
-     *   a tail-call frame swap.
-     * - The Wasm result type of the caller must match that of the callee, because
-     *   `return_call` requires the callee's result type to equal the caller's.
+     * [WASM_TAIL_CALL] origin. On top of that, the caller's Wasm result type
+     * must match the callee's, because `return_call` requires them to be equal.
      */
     private fun isEligibleForTailCall(call: IrFunctionAccessExpression, callee: IrFunction): Boolean {
-        if (call !is IrCall) return false
         if (call.origin !== WASM_TAIL_CALL) return false
-        if (callee is IrConstructor) return false
         val caller = functionContext.irFunction ?: return false
         val callerResultType = wasmModuleTypeTransformer.transformResultType(caller.returnType)
         val calleeResultType = wasmModuleTypeTransformer.transformResultType(callee.returnType)

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/BodyGenerator.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/BodyGenerator.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.ir.util.isNullable
 import org.jetbrains.kotlin.ir.util.isSubtypeOfClass
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
+import org.jetbrains.kotlin.backend.wasm.lower.WASM_TAIL_CALL
 import org.jetbrains.kotlin.wasm.config.WasmConfigurationKeys
 import org.jetbrains.kotlin.wasm.ir.*
 import org.jetbrains.kotlin.wasm.ir.source.location.SourceLocation
@@ -49,6 +50,29 @@ class BodyGenerator(
     private val irBuiltIns: IrBuiltIns = backendContext.irBuiltIns
 
     private val unitGetInstance by lazy { backendContext.findUnitGetInstanceFunction() }
+
+    /**
+     * Returns true if [call] should be emitted as a tail call.
+     *
+     * [WasmTailCallLowering] marks structurally tail-positioned calls with
+     * [WASM_TAIL_CALL] origin. This method applies additional Wasm-level eligibility
+     * filters on top of that structural check:
+     *
+     * - The callee must not be a constructor, because [visitFunctionReturn] pushes
+     *   the implicit dispatch receiver before `return`, which is incompatible with
+     *   a tail-call frame swap.
+     * - The Wasm result type of the caller must match that of the callee, because
+     *   `return_call` requires the callee's result type to equal the caller's.
+     */
+    private fun isEligibleForTailCall(call: IrFunctionAccessExpression, callee: IrFunction): Boolean {
+        if (call !is IrCall) return false
+        if (call.origin !== WASM_TAIL_CALL) return false
+        if (callee is IrConstructor) return false
+        val caller = functionContext.irFunction ?: return false
+        val callerResultType = wasmModuleTypeTransformer.transformResultType(caller.returnType)
+        val calleeResultType = wasmModuleTypeTransformer.transformResultType(callee.returnType)
+        return callerResultType == calleeResultType
+    }
 
     fun WasmExpressionBuilder.buildGetUnit() {
         buildInstr(
@@ -853,6 +877,7 @@ class BodyGenerator(
 
         val function: IrFunction = callFunction.realOverrideTarget
         val isSuperCall = call is IrCall && call.superQualifierSymbol != null
+        val isTail = isEligibleForTailCall(call, function)
         if (function is IrSimpleFunction && function.isOverridable && !isSuperCall) {
             val originalClass = callFunction.parentAsClass
             val realOverrideTargetClass = function.parentAsClass
@@ -880,22 +905,29 @@ class BodyGenerator(
                 body.buildStructGet(typeCodegenContext.referenceGcType(klassSymbol), ANY_VTABLE_FIELD_ID, location)
                 val vTableSlotId = vfSlot + 1 //First element is always contains Special ITable
                 body.buildStructGet(vTableGcTypeReference, vTableSlotId, location)
-                body.buildInstr(WasmOp.CALL_REF, location, functionTypeReference)
+                body.buildInstr(if (isTail) WasmOp.RETURN_CALL_REF else WasmOp.CALL_REF, location, functionTypeReference)
             } else {
                 generateExpression(call.dispatchReceiver!!)
                 generateInterfaceVTableLookup(function, klassSymbol, location)
                 body.buildInstr(
-                    WasmOp.CALL_REF,
+                    if (isTail) WasmOp.RETURN_CALL_REF else WasmOp.CALL_REF,
                     location,
                     functionTypeReference
                 )
             }
         } else {
             // Static function call
-            body.buildCall(declarationCodegenContext.referenceFunction(function.symbol), location)
+            val functionReference = declarationCodegenContext.referenceFunction(function.symbol)
+            if (isTail) {
+                body.buildReturnCall(functionReference, location)
+            } else {
+                body.buildCall(functionReference, location)
+            }
         }
 
-        // Unit types don't cross function boundaries
+        // Unit types don't cross function boundaries. The trailing get_unit is unreachable after a
+        // tail call but Kotlin/Wasm's generateAsStatement still expects the value on the IR stack
+        // to drop, so we keep emitting it on both paths.
         if (function.returnType.isUnit() && function !is IrConstructor) {
             body.buildGetUnit()
         }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmTailCallLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmTailCallLowering.kt
@@ -27,7 +27,7 @@ val WASM_TAIL_CALL by IrStatementOriginImpl
  * continuation machinery, so that the structural tail-position analysis sees
  * the final IR shape. Placed at the very end of the Wasm lowering pipeline.
  */
-internal class WasmTailCallLowering(private val context: WasmBackendContext) : BodyLoweringPass {
+internal class WasmTailCallLowering(context: WasmBackendContext) : BodyLoweringPass {
     private val enabled = context.configuration.wasmEnableTailCalls
 
     override fun lower(irBody: IrBody, container: IrDeclaration) {
@@ -47,7 +47,6 @@ private fun markTailCalls(irFunction: IrFunction) {
         }
 
         override fun visitFunction(declaration: IrFunction, data: Boolean) {}
-        override fun visitClass(declaration: IrClass, data: Boolean) {}
         override fun visitTry(aTry: IrTry, data: Boolean) {}
 
         override fun visitReturn(expression: IrReturn, data: Boolean) {

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmTailCallLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmTailCallLowering.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.wasm.lower
+
+import org.jetbrains.kotlin.backend.common.BodyLoweringPass
+import org.jetbrains.kotlin.backend.wasm.WasmBackendContext
+import org.jetbrains.kotlin.builtins.StandardNames
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.types.isClassWithFqName
+import org.jetbrains.kotlin.ir.types.isUnit
+import org.jetbrains.kotlin.ir.visitors.IrVisitor
+import org.jetbrains.kotlin.wasm.config.wasmEnableTailCalls
+
+val WASM_TAIL_CALL by IrStatementOriginImpl
+
+/**
+ * Marks every [IrCall] in tail position with [WASM_TAIL_CALL] origin so that
+ * [BodyGenerator][org.jetbrains.kotlin.backend.wasm.ir2wasm.codegenGenerators.BodyGenerator]
+ * can emit `return_call` / `return_call_ref` without re-analysing the IR.
+ *
+ * Must run after all lowerings that may wrap calls in blocks, try-catch, or
+ * continuation machinery, so that the structural tail-position analysis sees
+ * the final IR shape. Placed at the very end of the Wasm lowering pipeline.
+ */
+internal class WasmTailCallLowering(private val context: WasmBackendContext) : BodyLoweringPass {
+    private val enabled = context.configuration.wasmEnableTailCalls
+
+    override fun lower(irBody: IrBody, container: IrDeclaration) {
+        if (!enabled) return
+        val irFunction = container as? IrFunction ?: return
+        if (irFunction is IrConstructor) return
+        markTailCalls(irFunction)
+    }
+}
+
+private fun markTailCalls(irFunction: IrFunction) {
+    val isUnitReturn = irFunction.returnType.isUnit()
+
+    val visitor = object : IrVisitor<Unit, Boolean>() {
+        override fun visitElement(element: IrElement, data: Boolean) {
+            element.acceptChildren(this, false)
+        }
+
+        override fun visitFunction(declaration: IrFunction, data: Boolean) {}
+        override fun visitClass(declaration: IrClass, data: Boolean) {}
+        override fun visitTry(aTry: IrTry, data: Boolean) {}
+
+        override fun visitReturn(expression: IrReturn, data: Boolean) {
+            val isTail = expression.returnTargetSymbol == irFunction.symbol
+            expression.value.accept(this, isTail)
+        }
+
+        override fun visitExpressionBody(body: IrExpressionBody, data: Boolean) =
+            body.acceptChildren(this, data)
+
+        override fun visitBlockBody(body: IrBlockBody, data: Boolean) =
+            visitStatementContainer(body, data)
+
+        override fun visitContainerExpression(expression: IrContainerExpression, data: Boolean) =
+            visitStatementContainer(expression, data)
+
+        private fun visitStatementContainer(container: IrStatementContainer, data: Boolean) {
+            container.statements.forEachIndexed { index, irStatement ->
+                val isTailStatement = if (index == container.statements.lastIndex) {
+                    data
+                } else {
+                    isUnitReturn && container.statements[index + 1].let {
+                        it is IrReturn && it.returnTargetSymbol == irFunction.symbol && it.value.isUnitRead()
+                    }
+                }
+                irStatement.accept(this, isTailStatement)
+            }
+        }
+
+        private fun IrExpression.isUnitRead(): Boolean =
+            this is IrGetObjectValue && symbol.isClassWithFqName(StandardNames.FqNames.unit)
+
+        override fun visitWhen(expression: IrWhen, data: Boolean) {
+            expression.branches.forEach {
+                it.condition.accept(this, false)
+                it.result.accept(this, data)
+            }
+        }
+
+        override fun visitCall(expression: IrCall, data: Boolean) {
+            expression.acceptChildren(this, false)
+            if (data) {
+                expression.origin = WASM_TAIL_CALL
+            }
+        }
+    }
+
+    irFunction.body?.accept(visitor, true)
+}

--- a/compiler/testData/cli/js/jsExtraHelp.out
+++ b/compiler/testData/cli/js/jsExtraHelp.out
@@ -44,6 +44,7 @@ where advanced options include:
   -Xwasm-enable-array-range-checks
                              Turn on range checks for array access functions.
   -Xwasm-enable-asserts      Turn on asserts.
+  -Xwasm-enable-tail-calls   Emit WebAssembly tail call instructions (return_call / return_call_indirect).
   -Xwasm-generate-closed-world-multimodule
                              Compile modules in multi-module closed-world mode using module passed in `-include` argument as main module
   -Xwasm-generate-dwarf      Generate DWARF debug information.

--- a/compiler/testData/cli/wasm/wasmExtraHelp.out
+++ b/compiler/testData/cli/wasm/wasmExtraHelp.out
@@ -17,6 +17,7 @@ where advanced options include:
   -Xwasm-enable-array-range-checks
                              Turn on range checks for array access functions.
   -Xwasm-enable-asserts      Turn on asserts.
+  -Xwasm-enable-tail-calls   Emit WebAssembly tail call instructions (return_call / return_call_indirect).
   -Xwasm-generate-closed-world-multimodule
                              Compile modules in multi-module closed-world mode using module passed in `-include` argument as main module
   -Xwasm-generate-dwarf      Generate DWARF debug information.

--- a/compiler/testData/codegen/box/wasm-ir-checks/wasmIrCheckForTailCalls.kt
+++ b/compiler/testData/codegen/box/wasm-ir-checks/wasmIrCheckForTailCalls.kt
@@ -1,0 +1,99 @@
+// TARGET_BACKEND: WASM
+// ENABLE_TAIL_CALLS
+
+// Direct static tail call
+// WASM_CHECK_INSTRUCTION_IN_FUNCTION: instruction=return_call inFunction=staticTailCaller
+
+// Tail call inside an IrWhen branch
+// WASM_CHECK_INSTRUCTION_IN_FUNCTION: instruction=return_call inFunction=whenTailCaller
+
+// Tail call to a Unit-returning function
+// WASM_CHECK_INSTRUCTION_IN_FUNCTION: instruction=return_call inFunction=unitTailCaller
+
+// Calls inside try-catch must NOT be emitted as tail calls
+// WASM_CHECK_INSTRUCTION_NOT_IN_FUNCTION: instruction=return_call inFunction=tryCatchCaller
+
+// `tailrec` is still lowered to a loop, so neither return_call nor a recursive call appears
+// WASM_CHECK_INSTRUCTION_NOT_IN_FUNCTION: instruction=return_call inFunction=tailrecCaller
+// WASM_CHECK_NOT_CALLED_IN_FUNCTION: shouldNotBeCalled=tailrecCaller inFunction=tailrecCaller
+
+// Virtual dispatch tail call should produce return_call_ref
+// WASM_CHECK_INSTRUCTION_IN_FUNCTION: instruction=return_call_ref inFunction=virtualTailCaller
+
+// Interface dispatch tail call should produce return_call_ref
+// WASM_CHECK_INSTRUCTION_IN_FUNCTION: instruction=return_call_ref inFunction=interfaceTailCaller
+
+
+fun staticCallee(x: Int): Int = x + 1
+
+fun staticTailCaller(x: Int): Int = staticCallee(x)
+
+
+fun whenTailCaller(x: Int): Int = when {
+    x < 0 -> staticCallee(0)
+    x > 100 -> staticCallee(100)
+    else -> staticCallee(x)
+}
+
+
+fun unitCallee() {}
+
+fun unitTailCaller() {
+    return unitCallee()
+}
+
+
+fun tryCatchCaller(x: Int): Int {
+    try {
+        return staticCallee(x)
+    } catch (e: Throwable) {
+        return -1
+    }
+}
+
+
+tailrec fun tailrecCaller(n: Int, acc: Int): Int =
+    if (n == 0) acc else tailrecCaller(n - 1, acc + 1)
+
+
+abstract class VirtualBase {
+    abstract fun action(x: Int): Int
+}
+
+class VirtualImpl : VirtualBase() {
+    override fun action(x: Int): Int = x * 2
+}
+
+fun virtualTailCaller(b: VirtualBase, x: Int): Int = b.action(x)
+
+
+interface InterfaceBase {
+    fun ping(x: Int): Int
+}
+
+class InterfaceImpl : InterfaceBase {
+    override fun ping(x: Int): Int = x + 7
+}
+
+fun interfaceTailCaller(b: InterfaceBase, x: Int): Int = b.ping(x)
+
+
+// Mutual recursion deep enough to overflow the JS host stack without tail-call lowering.
+fun even(n: Int): Boolean = if (n == 0) true else odd(n - 1)
+fun odd(n: Int): Boolean = if (n == 0) false else even(n - 1)
+
+
+fun box(): String {
+    if (staticTailCaller(41) != 42) return "fail static"
+    if (whenTailCaller(50) != 51) return "fail when"
+    unitTailCaller()
+    if (tryCatchCaller(10) != 11) return "fail try-catch"
+    if (tailrecCaller(50, 0) != 50) return "fail tailrec"
+    if (virtualTailCaller(VirtualImpl(), 21) != 42) return "fail virtual"
+    if (interfaceTailCaller(InterfaceImpl(), 35) != 42) return "fail interface"
+
+    if (!even(100_000)) return "fail mutual recursion (even)"
+    if (odd(100_000)) return "fail mutual recursion (odd)"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/wasm-ir-checks/wasmIrCheckForTailCallsDisabled.kt
+++ b/compiler/testData/codegen/box/wasm-ir-checks/wasmIrCheckForTailCallsDisabled.kt
@@ -1,0 +1,50 @@
+// TARGET_BACKEND: WASM
+
+// Without ENABLE_TAIL_CALLS (the default), calls in tail position must be emitted as
+// plain calls. Tail-call emission preserves program results, so only these
+// instruction-level checks can detect an accidentally enabled default.
+
+// Direct static tail call must stay a plain call
+// WASM_CHECK_INSTRUCTION_NOT_IN_FUNCTION: instruction=return_call inFunction=staticTailCaller
+
+// Virtual dispatch tail call must stay a plain call_ref
+// WASM_CHECK_INSTRUCTION_NOT_IN_FUNCTION: instruction=return_call_ref inFunction=virtualTailCaller
+
+// Interface dispatch tail call must stay a plain call_ref
+// WASM_CHECK_INSTRUCTION_NOT_IN_FUNCTION: instruction=return_call_ref inFunction=interfaceTailCaller
+
+
+fun staticCallee(x: Int): Int = x + 1
+
+fun staticTailCaller(x: Int): Int = staticCallee(x)
+
+
+abstract class VirtualBase {
+    abstract fun action(x: Int): Int
+}
+
+class VirtualImpl : VirtualBase() {
+    override fun action(x: Int): Int = x * 2
+}
+
+fun virtualTailCaller(b: VirtualBase, x: Int): Int = b.action(x)
+
+
+interface InterfaceBase {
+    fun ping(x: Int): Int
+}
+
+class InterfaceImpl : InterfaceBase {
+    override fun ping(x: Int): Int = x + 7
+}
+
+fun interfaceTailCaller(b: InterfaceBase, x: Int): Int = b.ping(x)
+
+
+fun box(): String {
+    if (staticTailCaller(41) != 42) return "fail static"
+    if (virtualTailCaller(VirtualImpl(), 21) != 42) return "fail virtual"
+    if (interfaceTailCaller(InterfaceImpl(), 35) != 42) return "fail interface"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/wasm-ir-checks/wasmTailCallStress.kt
+++ b/compiler/testData/codegen/box/wasm-ir-checks/wasmTailCallStress.kt
@@ -1,0 +1,70 @@
+// TARGET_BACKEND: WASM
+// ENABLE_TAIL_CALLS
+
+// Stress test for native Wasm tail call emission. Each pattern recurses at a depth that would
+// stack-overflow on the host JS engine if the calls were not lowered to `return_call` / `return_call_ref`.
+
+// Static mutual recursion. Direct top-level functions, all calls in tail position.
+fun staticEven(n: Int): Boolean = if (n == 0) true else staticOdd(n - 1)
+fun staticOdd(n: Int): Boolean = if (n == 0) false else staticEven(n - 1)
+
+
+// Virtual dispatch tail call. Two open subclasses bounce through a virtual method.
+abstract class VirtualParity {
+    var partner: VirtualParity? = null
+    abstract fun isMyKind(n: Int): Boolean
+}
+
+class VirtualEven : VirtualParity() {
+    override fun isMyKind(n: Int): Boolean = if (n == 0) true else partner!!.isMyKind(n - 1)
+}
+
+class VirtualOdd : VirtualParity() {
+    override fun isMyKind(n: Int): Boolean = if (n == 0) false else partner!!.isMyKind(n - 1)
+}
+
+
+// Interface dispatch tail call.
+interface InterfaceParity {
+    val partner: InterfaceParity?
+    fun isMyKind(n: Int): Boolean
+}
+
+class InterfaceEven(override var partner: InterfaceParity? = null) : InterfaceParity {
+    override fun isMyKind(n: Int): Boolean = if (n == 0) true else partner!!.isMyKind(n - 1)
+}
+
+class InterfaceOdd(override var partner: InterfaceParity? = null) : InterfaceParity {
+    override fun isMyKind(n: Int): Boolean = if (n == 0) false else partner!!.isMyKind(n - 1)
+}
+
+
+// Single-self recursion that is not marked `tailrec`. The backend emits `return_call` for the self call.
+fun selfSum(n: Int, acc: Long): Long = if (n == 0) acc else selfSum(n - 1, acc + n)
+
+
+fun box(): String {
+    val depth = 1_000_000
+
+    if (!staticEven(depth)) return "fail static even"
+    if (staticOdd(depth)) return "fail static odd"
+
+    val ve = VirtualEven()
+    val vo = VirtualOdd()
+    ve.partner = vo
+    vo.partner = ve
+    if (!ve.isMyKind(depth)) return "fail virtual even"
+    if (vo.isMyKind(depth)) return "fail virtual odd"
+
+    val ie = InterfaceEven()
+    val io = InterfaceOdd()
+    ie.partner = io
+    io.partner = ie
+    if (!ie.isMyKind(depth)) return "fail interface even"
+    if (io.isMyKind(depth)) return "fail interface odd"
+
+    val expectedSum = depth.toLong() * (depth + 1) / 2
+    if (selfSum(depth, 0L) != expectedSum) return "fail self sum"
+
+    return "OK"
+}

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/directives/WasmEnvironmentConfigurationDirectives.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/directives/WasmEnvironmentConfigurationDirectives.kt
@@ -30,6 +30,10 @@ object WasmEnvironmentConfigurationDirectives : SimpleDirectivesContainer() {
         description = "Use WebAssembly Stack Switching proposal for compiling Kotlin Coroutines"
     )
 
+    val ENABLE_TAIL_CALLS by directive(
+        description = "Emit WebAssembly tail call instructions (return_call / return_call_indirect)"
+    )
+
     @OptIn(SensitiveDirectiveAPI::class)
     val WASM_IGNORE_FOR by valueDirective(
         description = """

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/configuration/WasmEnvironmentConfigurator.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/configuration/WasmEnvironmentConfigurator.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.test.directives.KlibBasedCompilerTestDirectives
 import org.jetbrains.kotlin.test.directives.KlibBasedCompilerTestDirectives.KLIB_RELATIVE_PATH_BASES
 import org.jetbrains.kotlin.test.directives.WasmEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.directives.WasmEnvironmentConfigurationDirectives.DISABLE_WASM_EXCEPTION_HANDLING
+import org.jetbrains.kotlin.test.directives.WasmEnvironmentConfigurationDirectives.ENABLE_TAIL_CALLS
 import org.jetbrains.kotlin.test.directives.WasmEnvironmentConfigurationDirectives.FORCE_DEBUG_FRIENDLY_COMPILATION
 import org.jetbrains.kotlin.test.directives.WasmEnvironmentConfigurationDirectives.SOURCE_MAP_INCLUDE_MAPPINGS_FROM_UNAVAILABLE_FILES
 import org.jetbrains.kotlin.test.directives.WasmEnvironmentConfigurationDirectives.USE_NEW_EXCEPTION_HANDLING_PROPOSAL
@@ -183,6 +184,7 @@ open class WasmSecondStageEnvironmentConfigurator(
 
         configuration.put(WasmConfigurationKeys.WASM_USE_NEW_EXCEPTION_PROPOSAL, registeredDirectives.useNewExceptionHandling(wasmTarget))
         configuration.put(WasmConfigurationKeys.WASM_USE_STACK_SWITCHING_PROPOSAL, USE_STACK_SWITCHING_PROPOSAL in registeredDirectives)
+        configuration.put(WasmConfigurationKeys.WASM_ENABLE_TAIL_CALLS, ENABLE_TAIL_CALLS in registeredDirectives)
         configuration.put(WasmConfigurationKeys.WASM_NO_JS_TAG, WASM_NO_JS_TAG in registeredDirectives)
         configuration.put(
             WasmConfigurationKeys.WASM_INTERNAL_LOCAL_VARIABLE_PREFIX,

--- a/wasm/wasm.config/src/org/jetbrains/kotlin/platform/wasm/BinaryenConfig.kt
+++ b/wasm/wasm.config/src/org/jetbrains/kotlin/platform/wasm/BinaryenConfig.kt
@@ -14,6 +14,7 @@ object BinaryenConfig {
         "--enable-bulk-memory",  // For array initialization from data sections
         "--enable-stack-switching",
         "--enable-multivalue", // required for block with suspend instruction
+        "--enable-tail-call",
 
         // Other options
         "--enable-nontrapping-float-to-int",

--- a/wasm/wasm.frontend/gen/org/jetbrains/kotlin/wasm/config/WasmConfigurationKeys.kt
+++ b/wasm/wasm.frontend/gen/org/jetbrains/kotlin/wasm/config/WasmConfigurationKeys.kt
@@ -88,6 +88,10 @@ object WasmConfigurationKeys {
     @JvmField
     val WASM_TEST_BOX_FUNCTION_TO_EXPORT = CompilerConfigurationKey.create<FqName>("WASM_TEST_BOX_FUNCTION_TO_EXPORT")
 
+    // Emit native Wasm tail-call instructions (return_call / return_call_ref) for non-tailrec tail calls.
+    @JvmField
+    val WASM_ENABLE_TAIL_CALLS = CompilerConfigurationKey.create<Boolean>("WASM_ENABLE_TAIL_CALLS")
+
 }
 
 var CompilerConfiguration.wasmEnableArrayRangeChecks: Boolean
@@ -173,4 +177,8 @@ var CompilerConfiguration.wasmGenerateClosedWorldMultimodule: Boolean
 var CompilerConfiguration.wasmTestBoxFunctionToExport: FqName?
     get() = get(WasmConfigurationKeys.WASM_TEST_BOX_FUNCTION_TO_EXPORT)
     set(value) { put(WasmConfigurationKeys.WASM_TEST_BOX_FUNCTION_TO_EXPORT, requireNotNull(value) { "nullable values are not allowed" }) }
+
+var CompilerConfiguration.wasmEnableTailCalls: Boolean
+    get() = getBoolean(WasmConfigurationKeys.WASM_ENABLE_TAIL_CALLS)
+    set(value) { put(WasmConfigurationKeys.WASM_ENABLE_TAIL_CALLS, value) }
 

--- a/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/Operators.kt
+++ b/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/Operators.kt
@@ -354,6 +354,8 @@ enum class WasmOp(
     CALL("call", 0x10, FUNC_IDX),
     CALL_PURE("call", 0x10, FUNC_IDX),
     CALL_INDIRECT("call_indirect", 0x11, listOf(TYPE_IDX, TABLE_IDX)),
+    RETURN_CALL("return_call", 0x12, FUNC_IDX),
+    RETURN_CALL_INDIRECT("return_call_indirect", 0x13, listOf(TYPE_IDX, TABLE_IDX)),
     TRY("try", 0x06, BLOCK_TYPE),
     CATCH("catch", 0x07, TAG_IDX),
     CATCH_ALL("catch_all", 0x19),

--- a/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/WasmExpressionBuilder.kt
+++ b/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/WasmExpressionBuilder.kt
@@ -309,6 +309,14 @@ open class WasmExpressionBuilder(
         )
     }
 
+    fun buildReturnCall(symbol: WasmImmediate.FuncIdx, location: SourceLocation) {
+        buildInstr(WasmOp.RETURN_CALL, location, symbol)
+    }
+
+    fun buildReturnCallRef(typeRef: WasmImmediate.TypeIdx, location: SourceLocation) {
+        buildInstr(WasmOp.RETURN_CALL_REF, location, typeRef)
+    }
+
     fun buildGetLocal(local: WasmLocal, location: SourceLocation) {
         buildInstr(WasmOp.LOCAL_GET, location, WasmImmediate.LocalIdx.get(local))
     }

--- a/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/convertors/WasmIrToText.kt
+++ b/wasm/wasm.ir/src/org/jetbrains/kotlin/wasm/ir/convertors/WasmIrToText.kt
@@ -161,7 +161,7 @@ class WasmIrToText(
         )
             indent++
 
-        if (wasmInstr.operator in setOf(WasmOp.CALL_INDIRECT, WasmOp.TABLE_INIT)) {
+        if (wasmInstr.operator in setOf(WasmOp.CALL_INDIRECT, WasmOp.RETURN_CALL_INDIRECT, WasmOp.TABLE_INIT)) {
             val reversed = mutableListOf<WasmImmediate>()
             wasmInstr.forEachImmediates(reversed::add)
             reversed.reverse()


### PR DESCRIPTION
## Summary

Emit native Wasm tail call instructions (`return_call`, `return_call_ref`) for non-`tailrec` calls in tail position.

`tailrec` functions are already lowered to loops by existing infrastructure. This PR handles the general case: mutual recursion, virtual/interface dispatch, and static calls to unrelated functions. A `WasmTailCallCollector` walks the IR to identify structural tail positions (mirroring `TailRecursionCallsCollector`), then `BodyGenerator` emits `return_call` or `return_call_ref` for eligible call sites. The feature is gated behind the `-Xwasm-enable-tail-calls` flag (off by default).

Microbenchmark and real-workload results are available at https://ternbusty.github.io/posts/gsoc-wasm-tail-calls.html

## Changes

- `wasm.ir`: add `RETURN_CALL` / `RETURN_CALL_INDIRECT` operators, `buildReturnCall`, WAT text emitter, binary codec round-trip test
- `WasmTailCallCollector`: IR visitor that collects tail-position `IrCall` sites per function (`IrReturn` target, `IrWhen` branches, `IrBlock` last statement, `Unit`-returning implicit return; excludes `IrTry`)
- `BodyGenerator`: emit `return_call` / `return_call_ref` for calls that pass both the structural (collector) and semantic (result type match, non-constructor) eligibility checks
- `BinaryenConfig`: pass `--enable-tail-call` to binaryen
- `WasmConfigurationKeys`: add `WASM_ENABLE_TAIL_CALLS` configuration key
- Tests: IR-level instruction checks (`wasmIrCheckForTailCalls.kt`) and a depth-1M mutual recursion stress test across static, virtual, and interface dispatch paths (`wasmTailCallStress.kt`)