### PR TITLE
[BTA] Add conversion tests for JS/Wasm/Klib/Metadata arguments

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestArgumentProviders.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.buildtools.tests.compilation.scenario.jvmScenario
 import org.jetbrains.kotlin.buildtools.tests.compilation.scenario.wasmScenario
 import org.jetbrains.kotlin.buildtools.tests.compilation.util.btaClassloader
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import org.jetbrains.kotlin.tooling.core.toKotlinVersion
 import org.junit.jupiter.api.Named
 import org.junit.jupiter.api.Named.named
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -221,6 +222,6 @@ typealias ProjectAction = AbstractProject<out BaseCompilationOperation, out Base
 typealias ScenarioCreator = BaseCompilationTest.(ScenarioAction) -> Unit
 typealias ScenarioAction = Scenario<out BaseCompilationOperation.Builder, out BaseIncrementalCompilationConfiguration.Builder>.() -> Unit
 
-fun KotlinToolchains.supportsJs() = KotlinToolingVersion(getCompilerVersion()) >= KotlinToolingVersion(2, 4, 20, null)
-fun KotlinToolchains.supportsWasm() = KotlinToolingVersion(getCompilerVersion()) >= KotlinToolingVersion(2, 4, 20, null)
-fun KotlinToolchains.supportsMetadata() = KotlinToolingVersion(getCompilerVersion()) >= KotlinToolingVersion(2, 4, 20, null)
+fun KotlinToolchains.supportsJs() = KotlinToolingVersion(getCompilerVersion()).toKotlinVersion() >= KotlinVersion(2, 4, 20)
+fun KotlinToolchains.supportsWasm() = KotlinToolingVersion(getCompilerVersion()).toKotlinVersion() >= KotlinVersion(2, 4, 20)
+fun KotlinToolchains.supportsMetadata() = KotlinToolingVersion(getCompilerVersion()).toKotlinVersion() >= KotlinVersion(2, 4, 20)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/CommonJsAndWasmCompilerArgumentConversionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/CommonJsAndWasmCompilerArgumentConversionTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments
+
+import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation
+import org.jetbrains.kotlin.buildtools.api.CompilerArgumentsParseException
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.JS_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.JS_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.WASM_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.WASM_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.InvalidArgumentValueCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.InvalidRawValueCommonJsAndWasmCompilerArgumentsBtaV2StrategyAgnosticTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.NullableCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LinkableModule
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.Module
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.jsProject
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.wasmProject
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+
+internal class CommonJsAndWasmCompilerArgumentConversionTest : BaseCompilationTest() {
+    @AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument is converted to a raw argument")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testBtaArgumentToArgumentString() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(
+                expectedArgumentStringsFor(getValueString(value)),
+                arguments.toArgumentStrings(),
+            )
+        }
+    }
+
+    @AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument has the default value when BTA argument is not set")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testBtaArgumentNotSetByDefault() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            expectedArgumentStringsFor(getDefaultValueString()),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    @AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument can be set and retrieved")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testBtaArgumentGetWhenSet() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(value, getArgument(arguments))
+        }
+    }
+
+    @AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when not set")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testBtaArgumentGetWhenNull() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    @AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument strings are converted to BTA argument")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testRawArgumentStringsConversion() {
+        assumeArgumentSupported()
+        for (value in argumentRawValues) {
+            val arguments = buildArguments {
+                applyArgumentStrings(expectedArgumentStringsFor(value))
+            }
+
+            assertEquals(value, getValueString(getArgument(arguments)))
+        }
+    }
+
+    @AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when no raw arguments are applied")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testNoRawArgumentStrings() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            applyArgumentStrings(listOf())
+        }
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    // Kept @Disabled because the JS/Wasm SearchPathType arguments do not reject a path containing File.pathSeparator (KT-87212).
+    // The current buggy behavior is pinned by testPathSeparatorInValueCurrentlyAccepted below; once the
+    // validation is added, that test will fail - then enable this test and delete it.
+    @Disabled("KT-87212: enable once File.pathSeparator validation is added for JS/Wasm SearchPathType arguments")
+    @InvalidArgumentValueCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument with non-existent argument value fails conversion")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testInvalidArgumentConversionFails() {
+        assumeArgumentSupported()
+        for (invalidValue in invalidArgumentValues) {
+            assertThrows<CompilerArgumentsParseException> {
+                buildArguments {
+                    setArgument(this, invalidValue)
+                }
+            }
+        }
+    }
+
+    // Exact mirror of the @Disabled testInvalidArgumentConversionFails above,
+    // but asserting the current buggy behavior: the conversion does NOT reject a path containing
+    // File.pathSeparator. Runs only for the three SearchPathType arguments that have invalidArgumentValues.
+    @InvalidArgumentValueCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("KNOWN BUG (KT-87212): a path containing File.pathSeparator is silently accepted, not rejected")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T>.testPathSeparatorInvalidValuesAccepted() {
+        assumeArgumentSupported()
+        for (invalidValue in invalidArgumentValues) {
+            // BUG: once File.pathSeparator validation is added there, this will throw CompilerArgumentsParseException
+            // and this assertion will fail - the signal to delete this test and enable
+            // testInvalidArgumentConversionFails above (remove its @Disabled).
+            assertDoesNotThrow {
+                buildArguments {
+                    setArgument(this, invalidValue)
+                }
+            }
+        }
+    }
+
+    @InvalidRawValueCommonJsAndWasmCompilerArgumentsBtaV2StrategyAgnosticTest
+    @DisplayName("Raw argument with non-existent BTA argument value is rejected at compilation time")
+    fun testInvalidRawArgumentCompilationFails(config: Pair<CommonJsAndWasmArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>) {
+        val [argumentConfig, strategyConfig] = config
+        argumentConfig.assumeArgumentSupported()
+
+        when (argumentConfig.operationKind) {
+            JS_KLIB -> jsProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                argumentConfig.testInvalidRawArgumentKlibCompilationFails(module)
+            }
+            JS_LINKING -> jsProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                module.compile()
+                argumentConfig.testInvalidRawArgumentLinkingFails(module)
+            }
+            WASM_KLIB -> wasmProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                argumentConfig.testInvalidRawArgumentKlibCompilationFails(module)
+            }
+            WASM_LINKING -> wasmProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                module.compile()
+                argumentConfig.testInvalidRawArgumentLinkingFails(module)
+            }
+        }
+    }
+
+    @NullableCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument of null value is converted to raw argument")
+    fun <T> CommonJsAndWasmArgumentConfiguration<T?>.testNullBtaArgument() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            setArgument(this, null)
+        }
+
+        assertEquals(
+            expectedArgumentStringsFor(getValueString(null)),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    private fun CommonJsAndWasmArgumentConfiguration<*>.assumeArgumentSupported() {
+        assumeTrue(isPlatformSupported(), "Test requires selected platform BTA support")
+        assumeTrue(
+            kotlinToolchain.getCompilerVersion() >= availableSinceVersion.toString(),
+            "Test requires compiler version >= $availableSinceVersion"
+        )
+    }
+
+    private fun <B : BaseCompilationOperation.Builder> CommonJsAndWasmArgumentConfiguration<*>.testInvalidRawArgumentKlibCompilationFails(
+        module: Module<*, B, *>,
+    ) {
+        for (invalidValue in invalidRawValues) {
+            module.compile(compilationConfigAction = {
+                it.compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(invalidValue))
+            }) {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            }
+        }
+    }
+
+    private fun <B : BaseCompilationOperation.Builder> CommonJsAndWasmArgumentConfiguration<*>.testInvalidRawArgumentLinkingFails(
+        module: LinkableModule<*, B>,
+    ) {
+        for (invalidValue in invalidRawValues) {
+            module.link(compilationConfigAction = {
+                it.compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(invalidValue))
+            }) {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            }
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/CommonKlibCompilerArgumentConversionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/CommonKlibCompilerArgumentConversionTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments
+
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.JS_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.JS_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.WASM_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.WASM_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.InvalidRawValueCommonKlibCompilerArgumentsBtaV2StrategyAgnosticTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.NullableCommonKlibCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.jsProject
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.wasmProject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+
+internal class CommonKlibCompilerArgumentConversionTest : BaseCompilationTest() {
+    @AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument is converted to a raw argument")
+    fun <T> CommonKlibArgumentConfiguration<T>.testBtaArgumentToArgumentString() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(
+                expectedArgumentStringsFor(getValueString(value)),
+                arguments.toArgumentStrings(),
+            )
+        }
+    }
+
+    @AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument has the default value when BTA argument is not set")
+    fun <T> CommonKlibArgumentConfiguration<T>.testBtaArgumentNotSetByDefault() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            expectedArgumentStringsFor(getDefaultValueString()),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    @AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument can be set and retrieved")
+    fun <T> CommonKlibArgumentConfiguration<T>.testBtaArgumentGetWhenSet() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(value, getArgument(arguments))
+        }
+    }
+
+    @AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when not set")
+    fun <T> CommonKlibArgumentConfiguration<T>.testBtaArgumentGetWhenNull() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    @AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument strings are converted to BTA argument")
+    fun <T> CommonKlibArgumentConfiguration<T>.testRawArgumentStringsConversion() {
+        assumeArgumentSupported()
+        for (value in argumentRawValues) {
+            val arguments = buildArguments {
+                applyArgumentStrings(expectedArgumentStringsFor(value))
+            }
+
+            assertEquals(value, getValueString(getArgument(arguments)))
+        }
+    }
+
+    @AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when no raw arguments are applied")
+    fun <T> CommonKlibArgumentConfiguration<T>.testNoRawArgumentStrings() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            applyArgumentStrings(listOf())
+        }
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    @InvalidRawValueCommonKlibCompilerArgumentsBtaV2StrategyAgnosticTest
+    @DisplayName("Raw argument with non-existent BTA argument value is rejected at compilation time")
+    fun testInvalidRawArgumentCompilationFails(config: Pair<CommonKlibArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>) {
+        val [argumentConfig, strategyConfig] = config
+        argumentConfig.assumeArgumentSupported()
+
+        when (argumentConfig.operationKind) {
+            JS_KLIB -> jsProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                for (invalidValue in argumentConfig.invalidRawValues) {
+                    module.compile(compilationConfigAction = {
+                        it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                    }) {
+                        expectFail()
+                        assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                    }
+                }
+            }
+            JS_LINKING -> jsProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                module.compile()
+                for (invalidValue in argumentConfig.invalidRawValues) {
+                    module.link(compilationConfigAction = {
+                        it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                    }) {
+                        expectFail()
+                        assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                    }
+                }
+            }
+            WASM_KLIB -> wasmProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                for (invalidValue in argumentConfig.invalidRawValues) {
+                    module.compile(compilationConfigAction = {
+                        it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                    }) {
+                        expectFail()
+                        assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                    }
+                }
+            }
+            WASM_LINKING -> wasmProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                module.compile()
+                for (invalidValue in argumentConfig.invalidRawValues) {
+                    module.link(compilationConfigAction = {
+                        it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                    }) {
+                        expectFail()
+                        assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                    }
+                }
+            }
+        }
+    }
+
+    @NullableCommonKlibCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument of null value is converted to raw argument")
+    fun <T> CommonKlibArgumentConfiguration<T?>.testNullBtaArgument() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            setArgument(this, null)
+        }
+
+        assertEquals(
+            expectedArgumentStringsFor(getValueString(null)),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    private fun CommonKlibArgumentConfiguration<*>.assumeArgumentSupported() {
+        assumeTrue(isPlatformSupported(), "Test requires selected platform BTA support")
+        assumeTrue(
+            kotlinToolchain.getCompilerVersion() >= availableSinceVersion.toString(),
+            "Test requires compiler version >= $availableSinceVersion"
+        )
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/JsCompilerArgumentConversionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/JsCompilerArgumentConversionTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments
+
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.AllJsCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.InvalidRawValueJsCompilerArgumentsBtaV2StrategyAgnosticTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.NullableJsCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.jsProject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+
+internal class JsCompilerArgumentConversionTest : BaseCompilationTest() {
+    @AllJsCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument is converted to a raw argument")
+    fun <T> JsArgumentConfiguration<T>.testBtaArgumentToArgumentString() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(
+                expectedArgumentStringsFor(getValueString(value)),
+                arguments.toArgumentStrings(),
+            )
+        }
+    }
+
+    @AllJsCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument has the default value when BTA argument is not set")
+    fun <T> JsArgumentConfiguration<T>.testBtaArgumentNotSetByDefault() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            expectedArgumentStringsFor(getDefaultValueString()),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    @AllJsCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument can be set and retrieved")
+    fun <T> JsArgumentConfiguration<T>.testBtaArgumentGetWhenSet() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(value, getArgument(arguments))
+        }
+    }
+
+    @AllJsCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when not set")
+    fun <T> JsArgumentConfiguration<T>.testBtaArgumentGetWhenNull() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    @AllJsCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument strings are converted to BTA argument")
+    fun <T> JsArgumentConfiguration<T>.testRawArgumentStringsConversion() {
+        assumeArgumentSupported()
+        for (value in argumentRawValues) {
+            val arguments = buildArguments {
+                applyArgumentStrings(expectedArgumentStringsFor(value))
+            }
+
+            assertEquals(value, getValueString(getArgument(arguments)))
+        }
+    }
+
+    @AllJsCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when no raw arguments are applied")
+    fun <T> JsArgumentConfiguration<T>.testNoRawArgumentStrings() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            applyArgumentStrings(listOf())
+        }
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    @InvalidRawValueJsCompilerArgumentsBtaV2StrategyAgnosticTest
+    @DisplayName("Raw argument with non-existent BTA argument value is rejected at compilation time")
+    fun testInvalidRawArgumentCompilationFails(config: Pair<JsArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>) {
+        val [argumentConfig, strategyConfig] = config
+        argumentConfig.assumeArgumentSupported()
+
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            for (invalidValue in argumentConfig.invalidRawValues) {
+                module.link(compilationConfigAction = {
+                    it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                }) {
+                    expectFail()
+                    assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                }
+            }
+        }
+    }
+
+    @NullableJsCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument of null value is converted to raw argument")
+    fun <T> JsArgumentConfiguration<T?>.testNullBtaArgument() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            setArgument(this, null)
+        }
+
+        assertEquals(
+            expectedArgumentStringsFor(getValueString(null)),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    private fun JsArgumentConfiguration<*>.assumeArgumentSupported() {
+        assumeTrue(isPlatformSupported(), "Test requires selected platform BTA support")
+        assumeTrue(
+            kotlinToolchain.getCompilerVersion() >= availableSinceVersion.toString(),
+            "Test requires compiler version >= $availableSinceVersion"
+        )
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/MetadataCompilerArgumentConversionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/MetadataCompilerArgumentConversionTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments
+
+import org.jetbrains.kotlin.buildtools.api.CompilerArgumentsParseException
+import org.jetbrains.kotlin.buildtools.api.metadata.KotlinMetadataPlatformToolchain.Companion.metadata
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata.AllMetadataCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata.InvalidArgumentValueMetadataCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata.InvalidRawValueMetadataCompilerArgumentsBtaV2StrategyAgnosticTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata.InvalidRawValueMetadataCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata.MetadataArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata.NullableMetadataCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.metadataProject
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsMetadata
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import java.nio.file.Paths
+import kotlin.io.path.writeText
+
+internal class MetadataCompilerArgumentConversionTest : BaseCompilationTest() {
+
+    @AllMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument is converted to a raw argument")
+    fun <T> MetadataArgumentConfiguration<T>.testBtaArgumentToArgumentString() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val operation = kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments[argumentKey] = value
+            }.build()
+
+            assertEquals(
+                expectedArgumentStringsFor(getValueString(value)),
+                operation.compilerArguments.toArgumentStrings(),
+            )
+        }
+    }
+
+    @AllMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument has the default value when BTA argument is not set")
+    fun <T> MetadataArgumentConfiguration<T>.testBtaArgumentNotSetByDefault() {
+        assumeArgumentSupported()
+        val operation = kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).build()
+
+        assertEquals(
+            expectedArgumentStringsFor(getDefaultValueString()),
+            operation.compilerArguments.toArgumentStrings(),
+        )
+    }
+
+    @AllMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument can be set and retrieved")
+    fun <T> MetadataArgumentConfiguration<T>.testBtaArgumentGetWhenSet() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val operation = kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments[argumentKey] = value
+            }.build()
+
+            assertEquals(value, operation.compilerArguments[argumentKey])
+        }
+    }
+
+    @AllMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when not set")
+    fun <T> MetadataArgumentConfiguration<T>.testBtaArgumentGetWhenNull() {
+        assumeArgumentSupported()
+        val operation = kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).build()
+
+        assertEquals(
+            getDefaultValueString(), getValueString(operation.compilerArguments[argumentKey])
+        )
+    }
+
+    @AllMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument strings are converted to BTA argument")
+    fun <T> MetadataArgumentConfiguration<T>.testRawArgumentStringsConversion() {
+        assumeArgumentSupported()
+        for (value in argumentRawValues) {
+            val operation = kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(value))
+            }.build()
+
+            assertEquals(value, getValueString(operation.compilerArguments[argumentKey]))
+        }
+    }
+
+    @AllMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when no raw arguments are applied")
+    fun <T> MetadataArgumentConfiguration<T>.testNoRawArgumentStrings() {
+        assumeArgumentSupported()
+        val operation = kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+            compilerArguments.applyArgumentStrings(listOf())
+        }.build()
+
+        assertEquals(
+            getDefaultValueString(), getValueString(operation.compilerArguments[argumentKey])
+        )
+    }
+
+    // Kept @Disabled because the Metadata SearchPathType argument CLASSPATH does NOT yet reject a path containing File.pathSeparator (KT-87212).
+    // The current buggy behavior is pinned by testPathSeparatorInvalidValuesAccepted below; once the validation
+    // is added, that test will fail - then enable this test and delete it.
+    @Disabled("KT-87212: enable once File.pathSeparator validation is added for the Metadata CLASSPATH argument")
+    @InvalidArgumentValueMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument with non-existent argument value fails conversion")
+    fun <T> MetadataArgumentConfiguration<T>.testInvalidArgumentConversionFails() {
+        assumeArgumentSupported()
+        for (invalidValue in invalidArgumentValues) {
+            assertThrows<CompilerArgumentsParseException> {
+                kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                    compilerArguments[argumentKey] = invalidValue
+                }.build()
+            }
+        }
+    }
+
+    @InvalidArgumentValueMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("KNOWN BUG (KT-87212): a path containing File.pathSeparator is silently accepted, not rejected")
+    fun <T> MetadataArgumentConfiguration<T>.testPathSeparatorInvalidValuesAccepted() {
+        assumeArgumentSupported()
+        for (invalidValue in invalidArgumentValues) {
+            // BUG: once File.pathSeparator validation is added there, this will throw CompilerArgumentsParseException
+            // and this assertion will fail - the signal to delete this test and enable
+            // testInvalidArgumentConversionFails above (remove its @Disabled).
+            assertDoesNotThrow {
+                kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                    compilerArguments[argumentKey] = invalidValue
+                }.build()
+            }
+        }
+    }
+
+    // Checks the EXPECTED (deferred) behavior: an invalid enum raw value should be reported at execution
+    // (COMPILATION_ERROR), not thrown from applyArgumentStrings. Kept @Disabled because Metadata
+    // X_TARGET_PLATFORM (enum-list) currently throws eagerly (see testInvalidRawArgumentThrowsEagerly).
+    @Disabled("KT-87218: Metadata X_TARGET_PLATFORM (enum-list) throws from applyArgumentStrings instead of deferring the error to execution")
+    @InvalidRawValueMetadataCompilerArgumentsBtaV2StrategyAgnosticTest
+    @DisplayName("Raw argument with non-existent BTA argument value is rejected at compilation time")
+    fun testInvalidRawArgumentCompilationFails(config: Pair<MetadataArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>) {
+        val argumentConfig = config.first
+        val strategyConfig = config.second
+        argumentConfig.assumeArgumentSupported()
+
+        metadataProject(strategyConfig) {
+            val module = module("empty")
+            module.sourcesDirectory.resolve("box.kt").writeText("fun box(): String = \"OK\"")
+            for (invalidValue in argumentConfig.invalidRawValues) {
+                module.compile(compilationConfigAction = {
+                    it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                }) {
+                    expectFail()
+                    assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                }
+            }
+        }
+    }
+
+    @InvalidRawValueMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("KNOWN BUG (KT-87218): an invalid enum value should be deferred to execution, but applyArgumentStrings rejects it eagerly")
+    fun <T> MetadataArgumentConfiguration<T>.testInvalidRawArgumentThrowsEagerly() {
+        assumeArgumentSupported()
+        for (invalidValue in invalidRawValues) {
+            // BUG: per the BTA contract the error should be deferred to execution (like other enum arguments),
+            // but applyArgumentStrings throws eagerly. When fixed this assertThrows will fail - the signal to
+            // delete this test and enable testInvalidRawArgumentCompilationFails above.
+            assertThrows<CompilerArgumentsParseException> {
+                kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                    compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(invalidValue))
+                }.build()
+            }
+        }
+    }
+
+    @NullableMetadataCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument of null value is converted to raw argument")
+    fun <T> MetadataArgumentConfiguration<T?>.testNullBtaArgument() {
+        assumeArgumentSupported()
+        val operation = kotlinToolchain.metadata.metadataKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+            compilerArguments[argumentKey] = null
+        }.build()
+
+        assertEquals(
+            expectedArgumentStringsFor(getValueString(null)),
+            operation.compilerArguments.toArgumentStrings(),
+        )
+    }
+
+    private fun MetadataArgumentConfiguration<*>.assumeArgumentSupported() {
+        assumeTrue(kotlinToolchain.supportsMetadata(), "Test requires Metadata BTA support")
+        assumeTrue(
+            kotlinToolchain.getCompilerVersion() >= argumentKey.availableSinceVersion.toString(),
+            "Test requires compiler version >= ${argumentKey.availableSinceVersion}"
+        )
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/WasmCompilerArgumentConversionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/WasmCompilerArgumentConversionTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments
+
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.AllWasmCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.InvalidRawValueWasmCompilerArgumentsBtaV2StrategyAgnosticTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.NullableWasmCompilerArgumentsWithBtaVersionsTest
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.WasmArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.WasmArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.WasmArgumentOperationKind.LINKING
+import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.wasmProject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+
+internal class WasmCompilerArgumentConversionTest : BaseCompilationTest() {
+    @AllWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument is converted to a raw argument")
+    fun <T> WasmArgumentConfiguration<T>.testBtaArgumentToArgumentString() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(
+                expectedArgumentStringsFor(getValueString(value)),
+                arguments.toArgumentStrings(),
+            )
+        }
+    }
+
+    @AllWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument has the default value when BTA argument is not set")
+    fun <T> WasmArgumentConfiguration<T>.testBtaArgumentNotSetByDefault() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            expectedArgumentStringsFor(getDefaultValueString()),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    @AllWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument can be set and retrieved")
+    fun <T> WasmArgumentConfiguration<T>.testBtaArgumentGetWhenSet() {
+        assumeArgumentSupported()
+        for (value in argumentValues) {
+            val arguments = buildArguments {
+                setArgument(this, value)
+            }
+
+            assertEquals(value, getArgument(arguments))
+        }
+    }
+
+    @AllWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when not set")
+    fun <T> WasmArgumentConfiguration<T>.testBtaArgumentGetWhenNull() {
+        assumeArgumentSupported()
+        val arguments = buildArguments()
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    @AllWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("Raw argument strings are converted to BTA argument")
+    fun <T> WasmArgumentConfiguration<T>.testRawArgumentStringsConversion() {
+        assumeArgumentSupported()
+        for (value in argumentRawValues) {
+            val arguments = buildArguments {
+                applyArgumentStrings(expectedArgumentStringsFor(value))
+            }
+
+            assertEquals(value, getValueString(getArgument(arguments)))
+        }
+    }
+
+    @AllWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument has the default value when no raw arguments are applied")
+    fun <T> WasmArgumentConfiguration<T>.testNoRawArgumentStrings() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            applyArgumentStrings(listOf())
+        }
+
+        assertEquals(
+            getDefaultValueString(), getValueString(getArgument(arguments))
+        )
+    }
+
+    @InvalidRawValueWasmCompilerArgumentsBtaV2StrategyAgnosticTest
+    @DisplayName("Raw argument with non-existent BTA argument value is rejected at compilation time")
+    fun testInvalidRawArgumentCompilationFails(config: Pair<WasmArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>) {
+        val [argumentConfig, strategyConfig] = config
+        argumentConfig.assumeArgumentSupported()
+
+        when (argumentConfig.operationKind) {
+            KLIB -> wasmProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                for (invalidValue in argumentConfig.invalidRawValues) {
+                    module.compile(compilationConfigAction = {
+                        it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                    }) {
+                        expectFail()
+                        assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                    }
+                }
+            }
+            LINKING -> wasmProject(strategyConfig) {
+                val module = module("js-ic-basic-lib")
+                module.compile()
+                for (invalidValue in argumentConfig.invalidRawValues) {
+                    module.link(compilationConfigAction = {
+                        it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
+                    }) {
+                        expectFail()
+                        assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+                    }
+                }
+            }
+        }
+    }
+
+    @NullableWasmCompilerArgumentsWithBtaVersionsTest
+    @DisplayName("BTA argument of null value is converted to raw argument")
+    fun <T> WasmArgumentConfiguration<T?>.testNullBtaArgument() {
+        assumeArgumentSupported()
+        val arguments = buildArguments {
+            setArgument(this, null)
+        }
+
+        assertEquals(
+            expectedArgumentStringsFor(getValueString(null)),
+            arguments.toArgumentStrings(),
+        )
+    }
+
+    private fun WasmArgumentConfiguration<*>.assumeArgumentSupported() {
+        assumeTrue(isPlatformSupported(), "Test requires selected platform BTA support")
+        assumeTrue(
+            kotlinToolchain.getCompilerVersion() >= availableSinceVersion.toString(),
+            "Test requires compiler version >= $availableSinceVersion"
+        )
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/ArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/ArgumentConfiguration.kt
@@ -6,7 +6,12 @@
 package org.jetbrains.kotlin.buildtools.tests.arguments.model
 
 import org.jetbrains.kotlin.arguments.description.actualCommonCompilerArguments
+import org.jetbrains.kotlin.arguments.description.actualCommonJsAndWasmArguments
+import org.jetbrains.kotlin.arguments.description.actualCommonKlibBasedArguments
+import org.jetbrains.kotlin.arguments.description.actualJsArguments
 import org.jetbrains.kotlin.arguments.description.actualJvmCompilerArguments
+import org.jetbrains.kotlin.arguments.description.actualMetadataArguments
+import org.jetbrains.kotlin.arguments.description.actualWasmArguments
 import org.jetbrains.kotlin.arguments.dsl.base.ExperimentalArgumentApi
 import org.jetbrains.kotlin.arguments.dsl.base.KotlinCompilerArgument
 import org.jetbrains.kotlin.arguments.dsl.base.KotlinReleaseVersion
@@ -32,9 +37,17 @@ internal abstract class ArgumentConfiguration<T>(
     }
 
     fun getDefaultValueString(): String? {
-        val argument = actualJvmCompilerArguments.arguments.firstOrNull { it.name == argumentName }
-            ?: actualCommonCompilerArguments.arguments.firstOrNull { it.name == argumentName }
-            ?: error("Argument '$argumentName' not found.")
+        val argument = listOf(
+            actualJvmCompilerArguments,
+            actualCommonCompilerArguments,
+            actualJsArguments,
+            actualWasmArguments,
+            actualCommonJsAndWasmArguments,
+            actualCommonKlibBasedArguments,
+            actualMetadataArguments,
+        ).firstNotNullOfOrNull { argumentLevel ->
+            argumentLevel.arguments.firstOrNull { it.name == argumentName }
+        } ?: error("Argument '$argumentName' not found.")
 
         val kotlinToolingVersion = KotlinToolingVersion(kotlinToolchain.getCompilerVersion())
         return argument.defaultValueString(kotlinToolingVersion.toKotlinReleaseVersion())

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentConfiguration.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalBuildToolsApi::class, ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain.Companion.js
+import org.jetbrains.kotlin.buildtools.api.wasm.WasmPlatformToolchain.Companion.wasm
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.JS_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.JS_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.WASM_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.WASM_LINKING
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsJs
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsWasm
+import java.nio.file.Paths
+
+internal class CommonJsAndWasmArgumentConfiguration<T>(
+    kotlinToolchain: KotlinToolchains,
+    private val descriptor: CommonJsAndWasmArgumentTestDescriptor<T>,
+    val operationKind: CommonJsAndWasmArgumentOperationKind,
+) : ArgumentConfiguration<T>(kotlinToolchain, descriptor) {
+    val availableSinceVersion: KotlinReleaseVersion = descriptor.availableSinceVersion
+    val argumentValues: List<T> = descriptor.argumentValues
+    val argumentRawValues: List<String> = descriptor.argumentRawValues
+    val invalidArgumentValues: List<T> = descriptor.invalidArgumentValues
+    val invalidRawValues: List<String> = descriptor.invalidRawValues
+
+    fun isPlatformSupported(): Boolean = when (operationKind) {
+        JS_KLIB, JS_LINKING -> kotlinToolchain.supportsJs()
+        WASM_KLIB, WASM_LINKING -> kotlinToolchain.supportsWasm()
+    }
+
+    fun buildArguments(configure: CommonToolArguments.Builder.() -> Unit = {}): CommonToolArguments {
+        return when (operationKind) {
+            JS_KLIB -> kotlinToolchain.js.jsKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            JS_LINKING -> kotlinToolchain.js.jsLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            WASM_KLIB -> kotlinToolchain.wasm.wasmKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            WASM_LINKING -> kotlinToolchain.wasm.wasmLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+        }
+    }
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        descriptor.setArgument(arguments, value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = descriptor.getArgument(arguments)
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentOperationKind.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentOperationKind.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm
+
+internal enum class CommonJsAndWasmArgumentOperationKind(val displayName: String) {
+    JS_KLIB("JS KLIB"),
+    WASM_KLIB("Wasm KLIB"),
+    JS_LINKING("JS linking"),
+    WASM_LINKING("Wasm linking"),
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentProviders.kt
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm
+
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.IR_OUTPUT_DIR
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.LIBRARIES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_FRIEND_MODULES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.MAIN
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP_BASE_DIRS
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP_EMBED_SOURCES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP_NAMES_POLICY
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_CACHE_DIRECTORY
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_INCLUDE
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_IR_DCE_RUNTIME_DIAGNOSTIC
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsMainCallMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapEmbedSources
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapNamesPolicy
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.JS_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.JS_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.WASM_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm.CommonJsAndWasmArgumentOperationKind.WASM_LINKING
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTestArgumentProvider
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaVersionsCompilationTestArgumentProvider
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Stream
+
+internal class AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidArgumentValueCommonJsAndWasmCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsInvalidArgumentValueTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidRawValueCommonJsAndWasmCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedInvalidRawValueBtaV2ArgumentConfigurations().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class NullableCommonJsAndWasmCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsNullableTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<CommonJsAndWasmArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>>> {
+    val btaV2Strategies = BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = commonJsAndWasmCompilerArguments.filter { it.runsInvalidRawValueTest }
+
+    return btaV2Strategies.flatMap { namedStrategy ->
+        compilerArguments.flatMap { descriptor ->
+            descriptor.operationKinds.map { operationKind ->
+                named(
+                    namedStrategy.name + "[${operationKind.displayName}][${descriptor.argumentName}]",
+                    CommonJsAndWasmArgumentConfiguration(namedStrategy.payload.first, descriptor, operationKind) to namedStrategy.payload
+                )
+            }
+        }
+    }
+}
+
+private fun namedArgumentConfiguration(
+    argumentPredicate: (CommonJsAndWasmArgumentTestDescriptor<*>) -> Boolean = { true },
+): List<Named<CommonJsAndWasmArgumentConfiguration<*>>> {
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = commonJsAndWasmCompilerArguments.filter { argumentPredicate(it) }
+
+    return btaVersions.flatMap { namedKotlinToolchains ->
+        compilerArguments.flatMap { descriptor ->
+            descriptor.operationKinds.mapNotNull { operationKind ->
+                named(
+                    namedKotlinToolchains.name + "[${operationKind.displayName}][${descriptor.argumentName}]",
+                    CommonJsAndWasmArgumentConfiguration(namedKotlinToolchains.payload, descriptor, operationKind)
+                )
+            }
+        }
+    }
+}
+
+private val testBaseDir: Path = Paths.get("").toAbsolutePath()
+
+@OptIn(ExperimentalCompilerArgument::class)
+private val commonJsAndWasmCompilerArguments: List<CommonJsAndWasmArgumentTestDescriptor<*>> = listOf(
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "ir-output-dir",
+        argument = IR_OUTPUT_DIR,
+        availableSinceVersion = IR_OUTPUT_DIR.availableSinceVersion,
+        operationKinds = listOf(JS_KLIB, WASM_KLIB),
+        argumentValues = listOf(testBaseDir.resolve("path/to/output")),
+        argumentRawValues = listOf(testBaseDir.resolve("path/to/output").toFile().absolutePath),
+        runsNullableTest = true,
+        valueString = { value -> value?.toFile()?.absolutePath },
+        expectedArgumentStringsFor = { value -> listOf("-ir-output-dir", value) },
+        setArgumentValue = { value -> (this as CommonJsAndWasmArguments.Builder)[IR_OUTPUT_DIR] = value },
+        getArgumentValue = { (this as CommonJsAndWasmArguments)[IR_OUTPUT_DIR] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "libraries",
+        argument = LIBRARIES,
+        availableSinceVersion = LIBRARIES.availableSinceVersion,
+        operationKinds = listOf(JS_KLIB, WASM_KLIB),
+        argumentValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/lib1.klib"),
+                testBaseDir.resolve("path/to/lib2.klib"),
+            ),
+            listOf(testBaseDir.resolve("path/with,comma/lib3.klib")),
+        ),
+        argumentRawValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/lib1.klib"),
+                testBaseDir.resolve("path/to/lib2.klib"),
+            ).joinToString(File.pathSeparator) { it.toFile().absolutePath },
+            testBaseDir.resolve("path/with,comma/lib3.klib").toFile().absolutePath,
+        ),
+        invalidArgumentValues = listOf(listOf(testBaseDir.resolve("path/with${File.pathSeparator}separator/lib4.klib"))),
+        runsNullableTest = true,
+        valueString = { value -> value?.joinToString(File.pathSeparator) { it.toFile().absolutePath } },
+        expectedArgumentStringsFor = { value -> listOf("-libraries", value) },
+        setArgumentValue = { value -> (this as CommonJsAndWasmArguments.Builder)[LIBRARIES] = value },
+        getArgumentValue = { (this as CommonJsAndWasmArguments)[LIBRARIES] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "Xfriend-modules",
+        argument = X_FRIEND_MODULES,
+        availableSinceVersion = X_FRIEND_MODULES.availableSinceVersion,
+        operationKinds = listOf(JS_KLIB, WASM_KLIB),
+        argumentValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/friend1.klib"),
+                testBaseDir.resolve("path/to/friend2.klib"),
+            ),
+            listOf(testBaseDir.resolve("path/with,comma/lib3.klib")),
+        ),
+        argumentRawValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/friend1.klib"),
+                testBaseDir.resolve("path/to/friend2.klib"),
+            ).joinToString(File.pathSeparator) { it.toFile().absolutePath },
+            testBaseDir.resolve("path/with,comma/lib3.klib").toFile().absolutePath,
+        ),
+        invalidArgumentValues = listOf(listOf(testBaseDir.resolve("path/with${File.pathSeparator}separator.klib"))),
+        runsNullableTest = true,
+        valueString = { value -> value?.joinToString(File.pathSeparator) { it.toFile().absolutePath } },
+        expectedArgumentStringsFor = { value -> listOf("-Xfriend-modules=$value") },
+        setArgumentValue = { value -> (this as CommonJsAndWasmArguments.Builder)[X_FRIEND_MODULES] = value },
+        getArgumentValue = { (this as CommonJsAndWasmArguments)[X_FRIEND_MODULES] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "Xinclude",
+        argument = X_INCLUDE,
+        availableSinceVersion = X_INCLUDE.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = listOf(testBaseDir.resolve("path/to/included.klib")),
+        argumentRawValues = listOf(testBaseDir.resolve("path/to/included.klib").toFile().absolutePath),
+        runsNullableTest = true,
+        valueString = { value -> value?.toFile()?.absolutePath },
+        expectedArgumentStringsFor = { value -> listOf("-Xinclude=$value") },
+        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[X_INCLUDE] = value },
+        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[X_INCLUDE] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "Xcache-directory",
+        argument = X_CACHE_DIRECTORY,
+        availableSinceVersion = X_CACHE_DIRECTORY.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = listOf(testBaseDir.resolve("path/to/js-cache")),
+        argumentRawValues = listOf(testBaseDir.resolve("path/to/js-cache").toFile().absolutePath),
+        runsNullableTest = true,
+        valueString = { value -> value?.toFile()?.absolutePath },
+        expectedArgumentStringsFor = { value -> listOf("-Xcache-directory=$value") },
+        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[X_CACHE_DIRECTORY] = value },
+        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[X_CACHE_DIRECTORY] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "main",
+        argument = MAIN,
+        availableSinceVersion = MAIN.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = JsMainCallMode.entries.toList(),
+        argumentRawValues = JsMainCallMode.entries.map { it.stringValue },
+        invalidRawValues = listOf("non-existent-value"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-main", value) },
+        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[MAIN] = value },
+        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[MAIN] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "source-map-base-dirs",
+        argument = SOURCE_MAP_BASE_DIRS,
+        availableSinceVersion = SOURCE_MAP_BASE_DIRS.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/project/src/jsMain/kotlin"),
+                testBaseDir.resolve("path/to/project/build/generated"),
+            ),
+            listOf(testBaseDir.resolve("path/with,comma")),
+        ),
+        argumentRawValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/project/src/jsMain/kotlin"),
+                testBaseDir.resolve("path/to/project/build/generated"),
+            ).joinToString(File.pathSeparator) { it.toFile().absolutePath },
+            testBaseDir.resolve("path/with,comma").toFile().absolutePath,
+        ),
+        invalidArgumentValues = listOf(listOf(testBaseDir.resolve("path/with${File.pathSeparator}separator"))),
+        runsNullableTest = true,
+        valueString = { value -> value?.joinToString(File.pathSeparator) { it.toFile().absolutePath } },
+        expectedArgumentStringsFor = { value -> listOf("-source-map-base-dirs", value) },
+        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[SOURCE_MAP_BASE_DIRS] = value },
+        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[SOURCE_MAP_BASE_DIRS] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "source-map-embed-sources",
+        argument = SOURCE_MAP_EMBED_SOURCES,
+        availableSinceVersion = SOURCE_MAP_EMBED_SOURCES.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = SourceMapEmbedSources.entries.toList(),
+        argumentRawValues = SourceMapEmbedSources.entries.map { it.stringValue },
+        invalidRawValues = listOf("non-existent-value"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-source-map-embed-sources", value) },
+        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[SOURCE_MAP_EMBED_SOURCES] = value },
+        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[SOURCE_MAP_EMBED_SOURCES] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "source-map-names-policy",
+        argument = SOURCE_MAP_NAMES_POLICY,
+        availableSinceVersion = SOURCE_MAP_NAMES_POLICY.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = SourceMapNamesPolicy.entries.toList(),
+        argumentRawValues = SourceMapNamesPolicy.entries.map { it.stringValue },
+        invalidRawValues = listOf("non-existent-value"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-source-map-names-policy", value) },
+        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[SOURCE_MAP_NAMES_POLICY] = value },
+        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[SOURCE_MAP_NAMES_POLICY] },
+    ),
+    CommonJsAndWasmArgumentTestDescriptor(
+        argumentName = "Xir-dce-runtime-diagnostic",
+        argument = X_IR_DCE_RUNTIME_DIAGNOSTIC,
+        availableSinceVersion = X_IR_DCE_RUNTIME_DIAGNOSTIC.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = JsIrDiagnosticMode.entries.toList(),
+        argumentRawValues = JsIrDiagnosticMode.entries.map { it.stringValue },
+        invalidRawValues = listOf("non-existent-value"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-Xir-dce-runtime-diagnostic=$value") },
+        setArgumentValue = { value -> (this as CommonJsAndWasmCompilerLinkingArguments.Builder)[X_IR_DCE_RUNTIME_DIAGNOSTIC] = value },
+        getArgumentValue = { (this as CommonJsAndWasmCompilerLinkingArguments)[X_IR_DCE_RUNTIME_DIAGNOSTIC] },
+    ),
+)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentTestAnnotations.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentTestAnnotations.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class AllCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidArgumentValueCommonJsAndWasmCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class InvalidArgumentValueCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidRawValueCommonJsAndWasmCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider::class)
+annotation class InvalidRawValueCommonJsAndWasmCompilerArgumentsBtaV2StrategyAgnosticTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(NullableCommonJsAndWasmCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class NullableCommonJsAndWasmCompilerArgumentsWithBtaVersionsTest

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentTestDescriptor.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentTestDescriptor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonjswasm
+
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentTestDescriptor
+
+internal class CommonJsAndWasmArgumentTestDescriptor<T>(
+    override val argumentName: String,
+    override val argument: Any,
+    override val availableSinceVersion: KotlinReleaseVersion,
+    val operationKinds: List<CommonJsAndWasmArgumentOperationKind>,
+    override val argumentValues: List<T>,
+    override val argumentRawValues: List<String>,
+    override val invalidArgumentValues: List<T> = emptyList(),
+    override val invalidRawValues: List<String> = emptyList(),
+    override val runsNullableTest: Boolean = false,
+    // The whole JS/Wasm BTA toolchain is v2-only (introduced in 2.4.20), so it is not reachable through the
+    // v1 adapter; default to skipping v1 for all JS/Wasm arguments.
+    override val skipBtaV1: Boolean = true,
+    private val valueString: (T?) -> String?,
+    private val expectedArgumentStringsFor: (String) -> List<String>,
+    private val setArgumentValue: CommonToolArguments.Builder.(T) -> Unit,
+    private val getArgumentValue: CommonToolArguments.() -> T,
+) : ArgumentTestDescriptor<T> {
+    override fun getValueString(argument: T?): String? = valueString(argument)
+
+    override fun expectedArgumentStringsFor(value: String): List<String> = expectedArgumentStringsFor.invoke(value)
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        arguments.setArgumentValue(value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = arguments.getArgumentValue()
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentConfiguration.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(DeprecatedCompilerArgument::class, ExperimentalBuildToolsApi::class, ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib
+
+import org.jetbrains.kotlin.buildtools.api.DeprecatedCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain.Companion.js
+import org.jetbrains.kotlin.buildtools.api.wasm.WasmPlatformToolchain.Companion.wasm
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.JS_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.JS_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.WASM_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.WASM_LINKING
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsJs
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsWasm
+import java.nio.file.Paths
+
+internal class CommonKlibArgumentConfiguration<T>(
+    kotlinToolchain: KotlinToolchains,
+    private val descriptor: CommonKlibArgumentTestDescriptor<T>,
+    val operationKind: CommonKlibArgumentOperationKind,
+) : ArgumentConfiguration<T>(kotlinToolchain, descriptor) {
+    val availableSinceVersion: KotlinReleaseVersion = descriptor.availableSinceVersion
+    val argumentValues: List<T> = descriptor.argumentValues
+    val argumentRawValues: List<String> = descriptor.argumentRawValues
+    val invalidRawValues: List<String> = descriptor.invalidRawValues
+
+    fun isPlatformSupported(): Boolean = when (operationKind) {
+        JS_KLIB, JS_LINKING -> kotlinToolchain.supportsJs()
+        WASM_KLIB, WASM_LINKING -> kotlinToolchain.supportsWasm()
+    }
+
+    fun buildArguments(configure: CommonToolArguments.Builder.() -> Unit = {}): CommonToolArguments {
+        return when (operationKind) {
+            JS_KLIB -> kotlinToolchain.js.jsKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            JS_LINKING -> kotlinToolchain.js.jsLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            WASM_KLIB -> kotlinToolchain.wasm.wasmKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            WASM_LINKING -> kotlinToolchain.wasm.wasmLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+        }
+    }
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        descriptor.setArgument(arguments, value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = descriptor.getArgument(arguments)
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentOperationKind.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentOperationKind.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib
+
+internal enum class CommonKlibArgumentOperationKind(val displayName: String) {
+    JS_KLIB("JS KLIB"),
+    WASM_KLIB("Wasm KLIB"),
+    JS_LINKING("JS linking"),
+    WASM_LINKING("Wasm linking"),
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentProviders.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(DeprecatedCompilerArgument::class, ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib
+
+import org.jetbrains.kotlin.buildtools.api.DeprecatedCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArguments.Companion.X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsKlibArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsKlibArguments.Companion.X_KLIB_RELATIVE_PATH_BASE
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsLinkingArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsLinkingArguments.Companion.X_PARTIAL_LINKAGE
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsLinkingArguments.Companion.X_PARTIAL_LINKAGE_LOGLEVEL
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.DuplicatedUniqueNameStrategy
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageLogLevel
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageMode
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.JS_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.JS_LINKING
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.WASM_KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib.CommonKlibArgumentOperationKind.WASM_LINKING
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTestArgumentProvider
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaVersionsCompilationTestArgumentProvider
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Stream
+
+internal class AllCommonKlibCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidRawValueCommonKlibCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedInvalidRawValueBtaV2ArgumentConfigurations().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class NullableCommonKlibCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsNullableTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<CommonKlibArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>>> {
+    val btaV2Strategies = BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = commonKlibCompilerArguments.filter { it.runsInvalidRawValueTest }
+
+    return btaV2Strategies.flatMap { namedStrategy ->
+        compilerArguments.flatMap { descriptor ->
+            descriptor.operationKinds.map { operationKind ->
+                named(
+                    namedStrategy.name + "[${operationKind.displayName}][${descriptor.argumentName}]",
+                    CommonKlibArgumentConfiguration(namedStrategy.payload.first, descriptor, operationKind) to namedStrategy.payload
+                )
+            }
+        }
+    }
+}
+
+private fun namedArgumentConfiguration(
+    argumentPredicate: (CommonKlibArgumentTestDescriptor<*>) -> Boolean = { true },
+): List<Named<CommonKlibArgumentConfiguration<*>>> {
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = commonKlibCompilerArguments.filter { argumentPredicate(it) }
+
+    return btaVersions.flatMap { namedKotlinToolchains ->
+        compilerArguments.flatMap { descriptor ->
+            descriptor.operationKinds.mapNotNull { operationKind ->
+                named(
+                    namedKotlinToolchains.name + "[${operationKind.displayName}][${descriptor.argumentName}]",
+                    CommonKlibArgumentConfiguration(namedKotlinToolchains.payload, descriptor, operationKind)
+                )
+            }
+        }
+    }
+}
+
+private val testBaseDir: Path = Paths.get("").toAbsolutePath()
+
+@OptIn(ExperimentalCompilerArgument::class)
+private val commonKlibCompilerArguments: List<CommonKlibArgumentTestDescriptor<*>> = listOf(
+    CommonKlibArgumentTestDescriptor(
+        argumentName = "Xklib-relative-path-base",
+        argument = X_KLIB_RELATIVE_PATH_BASE,
+        availableSinceVersion = X_KLIB_RELATIVE_PATH_BASE.availableSinceVersion,
+        operationKinds = listOf(JS_KLIB, WASM_KLIB),
+        argumentValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/project/src/commonMain/kotlin"),
+                testBaseDir.resolve("path/to/generated/src"),
+            )
+        ),
+        argumentRawValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/project/src/commonMain/kotlin"),
+                testBaseDir.resolve("path/to/generated/src"),
+            ).joinToString(",") { it.toFile().absolutePath }
+        ),
+        valueString = { value -> value?.joinToString(",") { it.toFile().absolutePath } },
+        expectedArgumentStringsFor = { value -> listOf("-Xklib-relative-path-base=$value") },
+        setArgumentValue = { value -> (this as CommonKlibBasedArgumentsKlibArguments.Builder)[X_KLIB_RELATIVE_PATH_BASE] = value },
+        getArgumentValue = { (this as CommonKlibBasedArgumentsKlibArguments)[X_KLIB_RELATIVE_PATH_BASE] },
+    ),
+    CommonKlibArgumentTestDescriptor(
+        argumentName = "Xpartial-linkage",
+        argument = X_PARTIAL_LINKAGE,
+        availableSinceVersion = X_PARTIAL_LINKAGE.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = PartialLinkageMode.entries.toList(),
+        argumentRawValues = PartialLinkageMode.entries.map { it.stringValue },
+        invalidRawValues = listOf("disabled"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-Xpartial-linkage=$value") },
+        setArgumentValue = { value -> (this as CommonKlibBasedArgumentsLinkingArguments.Builder)[X_PARTIAL_LINKAGE] = value },
+        getArgumentValue = { (this as CommonKlibBasedArgumentsLinkingArguments)[X_PARTIAL_LINKAGE] },
+    ),
+    CommonKlibArgumentTestDescriptor(
+        argumentName = "Xpartial-linkage-loglevel",
+        argument = X_PARTIAL_LINKAGE_LOGLEVEL,
+        availableSinceVersion = X_PARTIAL_LINKAGE_LOGLEVEL.availableSinceVersion,
+        operationKinds = listOf(JS_LINKING, WASM_LINKING),
+        argumentValues = PartialLinkageLogLevel.entries.toList(),
+        argumentRawValues = PartialLinkageLogLevel.entries.map { it.stringValue },
+        invalidRawValues = listOf("warn"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-Xpartial-linkage-loglevel=$value") },
+        setArgumentValue = { value -> (this as CommonKlibBasedArgumentsLinkingArguments.Builder)[X_PARTIAL_LINKAGE_LOGLEVEL] = value },
+        getArgumentValue = { (this as CommonKlibBasedArgumentsLinkingArguments)[X_PARTIAL_LINKAGE_LOGLEVEL] },
+    ),
+    CommonKlibArgumentTestDescriptor(
+        argumentName = "Xklib-duplicated-unique-name-strategy",
+        argument = X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY,
+        availableSinceVersion = X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY.availableSinceVersion,
+        operationKinds = listOf(JS_KLIB, WASM_KLIB, JS_LINKING, WASM_LINKING),
+        argumentValues = DuplicatedUniqueNameStrategy.entries.toList(),
+        argumentRawValues = DuplicatedUniqueNameStrategy.entries.map { it.stringValue },
+        invalidRawValues = listOf("allow-second-with-warning"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-Xklib-duplicated-unique-name-strategy=$value") },
+        setArgumentValue = { value -> (this as CommonKlibBasedArguments.Builder)[X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY] = value },
+        getArgumentValue = { (this as CommonKlibBasedArguments)[X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY] },
+    ),
+)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentTestAnnotations.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentTestAnnotations.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(AllCommonKlibCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class AllCommonKlibCompilerArgumentsWithBtaVersionsTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidRawValueCommonKlibCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider::class)
+annotation class InvalidRawValueCommonKlibCompilerArgumentsBtaV2StrategyAgnosticTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(NullableCommonKlibCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class NullableCommonKlibCompilerArgumentsWithBtaVersionsTest

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentTestDescriptor.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentTestDescriptor.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.commonklib
+
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentTestDescriptor
+
+internal class CommonKlibArgumentTestDescriptor<T>(
+    override val argumentName: String,
+    override val argument: Any,
+    override val availableSinceVersion: KotlinReleaseVersion,
+    val operationKinds: List<CommonKlibArgumentOperationKind>,
+    override val argumentValues: List<T>,
+    override val argumentRawValues: List<String>,
+    override val invalidArgumentValues: List<T> = emptyList(),
+    override val invalidRawValues: List<String> = emptyList(),
+    override val runsNullableTest: Boolean = false,
+    override val skipBtaV1: Boolean = true,
+    private val valueString: (T?) -> String?,
+    private val expectedArgumentStringsFor: (String) -> List<String>,
+    private val setArgumentValue: CommonToolArguments.Builder.(T) -> Unit,
+    private val getArgumentValue: CommonToolArguments.() -> T,
+) : ArgumentTestDescriptor<T> {
+    override fun getValueString(argument: T?): String? = valueString(argument)
+
+    override fun expectedArgumentStringsFor(value: String): List<String> = expectedArgumentStringsFor.invoke(value)
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        arguments.setArgumentValue(value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = arguments.getArgumentValue()
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentConfiguration.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalBuildToolsApi::class, ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.js
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain.Companion.js
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsJs
+import java.nio.file.Paths
+
+internal class JsArgumentConfiguration<T>(
+    kotlinToolchain: KotlinToolchains,
+    private val descriptor: JsArgumentTestDescriptor<T>,
+) : ArgumentConfiguration<T>(kotlinToolchain, descriptor) {
+    val availableSinceVersion: KotlinReleaseVersion = descriptor.availableSinceVersion
+    val argumentValues: List<T> = descriptor.argumentValues
+    val argumentRawValues: List<String> = descriptor.argumentRawValues
+    val invalidRawValues: List<String> = descriptor.invalidRawValues
+
+    fun isPlatformSupported(): Boolean = kotlinToolchain.supportsJs()
+
+    fun buildArguments(configure: CommonToolArguments.Builder.() -> Unit = {}): CommonToolArguments {
+        return kotlinToolchain.js.jsLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+            compilerArguments.configure()
+        }.build().compilerArguments
+    }
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        descriptor.setArgument(arguments, value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = descriptor.getArgument(arguments)
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentProviders.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.js
+
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.MODULE_KIND
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.TARGET
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsEcmaVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTestArgumentProvider
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaVersionsCompilationTestArgumentProvider
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.stream.Stream
+
+internal class AllJsCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidRawValueJsCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedInvalidRawValueBtaV2ArgumentConfigurations().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class NullableJsCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsNullableTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<JsArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>>> {
+    val btaV2Strategies = BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = jsCompilerArguments.filter { it.runsInvalidRawValueTest }.map { named("[${it.argumentName}]", it) }
+
+    return btaV2Strategies.flatMap { namedStrategy ->
+        compilerArguments.map { namedArgumentDescriptor ->
+            named(
+                namedStrategy.name + namedArgumentDescriptor.name,
+                JsArgumentConfiguration(namedStrategy.payload.first, namedArgumentDescriptor.payload) to namedStrategy.payload
+            )
+        }
+    }
+}
+
+private fun namedArgumentConfiguration(
+    argumentPredicate: (JsArgumentTestDescriptor<*>) -> Boolean = { true },
+): List<Named<JsArgumentConfiguration<*>>> {
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = jsCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
+
+    return btaVersions.flatMap { namedKotlinToolchains ->
+        compilerArguments.map { namedArgumentDescriptor ->
+            named(
+                namedKotlinToolchains.name + namedArgumentDescriptor.name,
+                JsArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalCompilerArgument::class)
+private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
+    JsArgumentTestDescriptor(
+        argumentName = "target",
+        argument = TARGET,
+        availableSinceVersion = TARGET.availableSinceVersion,
+        argumentValues = JsEcmaVersion.entries.toList(),
+        argumentRawValues = JsEcmaVersion.entries.map { it.stringValue },
+        invalidRawValues = listOf("es15"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-target", value) },
+        setArgumentValue = { value -> (this as JsCompilerLinkingArguments.Builder)[TARGET] = value },
+        getArgumentValue = { (this as JsCompilerLinkingArguments)[TARGET] },
+    ),
+    JsArgumentTestDescriptor(
+        argumentName = "module-kind",
+        argument = MODULE_KIND,
+        availableSinceVersion = MODULE_KIND.availableSinceVersion,
+        argumentValues = JsModuleKind.entries.toList(),
+        argumentRawValues = JsModuleKind.entries.map { it.stringValue },
+        invalidRawValues = listOf("emd"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-module-kind", value) },
+        setArgumentValue = { value -> (this as JsCompilerLinkingArguments.Builder)[MODULE_KIND] = value },
+        getArgumentValue = { (this as JsCompilerLinkingArguments)[MODULE_KIND] },
+    ),
+    JsArgumentTestDescriptor(
+        argumentName = "Xir-safe-external-boolean-diagnostic",
+        argument = X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC,
+        availableSinceVersion = X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC.availableSinceVersion,
+        argumentValues = JsIrDiagnosticMode.entries.toList(),
+        argumentRawValues = JsIrDiagnosticMode.entries.map { it.stringValue },
+        invalidRawValues = listOf("error"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-Xir-safe-external-boolean-diagnostic=$value") },
+        setArgumentValue = { value -> (this as JsCompilerLinkingArguments.Builder)[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] = value },
+        getArgumentValue = { (this as JsCompilerLinkingArguments)[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] },
+    ),
+)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentTestAnnotations.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentTestAnnotations.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.js
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(AllJsCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class AllJsCompilerArgumentsWithBtaVersionsTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidRawValueJsCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider::class)
+annotation class InvalidRawValueJsCompilerArgumentsBtaV2StrategyAgnosticTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(NullableJsCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class NullableJsCompilerArgumentsWithBtaVersionsTest

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentTestDescriptor.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentTestDescriptor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.js
+
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentTestDescriptor
+
+internal class JsArgumentTestDescriptor<T>(
+    override val argumentName: String,
+    override val argument: Any,
+    override val availableSinceVersion: KotlinReleaseVersion,
+    override val argumentValues: List<T>,
+    override val argumentRawValues: List<String>,
+    override val invalidArgumentValues: List<T> = emptyList(),
+    override val invalidRawValues: List<String> = emptyList(),
+    override val runsNullableTest: Boolean = false,
+    // The whole JS BTA toolchain is v2-only (introduced in 2.4.20), so it is not reachable through the
+    // v1 adapter; default to skipping v1 for all JS arguments.
+    override val skipBtaV1: Boolean = true,
+    private val valueString: (T?) -> String?,
+    private val expectedArgumentStringsFor: (String) -> List<String>,
+    private val setArgumentValue: CommonToolArguments.Builder.(T) -> Unit,
+    private val getArgumentValue: CommonToolArguments.() -> T,
+) : ArgumentTestDescriptor<T> {
+    override fun getValueString(argument: T?): String? = valueString(argument)
+
+    override fun expectedArgumentStringsFor(value: String): List<String> = expectedArgumentStringsFor.invoke(value)
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        arguments.setArgumentValue(value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = arguments.getArgumentValue()
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentConfiguration.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata
+
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments.MetadataArgument
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentConfiguration
+
+internal class MetadataArgumentConfiguration<T>(
+    kotlinToolchain: KotlinToolchains,
+    metadataArgumentTestDescriptor: MetadataArgumentTestDescriptor<T>,
+) : ArgumentConfiguration<T>(kotlinToolchain, metadataArgumentTestDescriptor) {
+    val argumentKey: MetadataArgument<T> = metadataArgumentTestDescriptor.argument
+    val argumentValues: List<T> = metadataArgumentTestDescriptor.argumentValues
+    val argumentRawValues: List<String> = metadataArgumentTestDescriptor.argumentRawValues
+
+    val invalidArgumentValues: List<T> = metadataArgumentTestDescriptor.invalidArgumentValues
+    val invalidRawValues: List<String> = metadataArgumentTestDescriptor.invalidRawValues
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentProviders.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata
+
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments.Companion.CLASSPATH
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments.Companion.MODULE_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments.Companion.X_FRIEND_PATHS
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments.Companion.X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments.Companion.X_REFINES_PATHS
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments.Companion.X_TARGET_PLATFORM
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.MetadataTargetPlatform
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTestArgumentProvider
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaVersionsCompilationTestArgumentProvider
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Stream
+
+internal class AllMetadataCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidArgumentValueMetadataCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsInvalidArgumentValueTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class NullableMetadataCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsNullableTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidRawValueMetadataCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsInvalidRawValueTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidRawValueMetadataCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedInvalidRawValueBtaV2ArgumentConfigurations().map { Arguments.of(it) }.stream()
+    }
+}
+
+private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<MetadataArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>>> {
+    val btaV2Strategies = BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = metadataCompilerArguments.filter { it.runsInvalidRawValueTest }
+
+    return btaV2Strategies.flatMap { namedStrategy ->
+        compilerArguments.map { descriptor ->
+            named(
+                namedStrategy.name + "[${descriptor.argumentName}]",
+                MetadataArgumentConfiguration(namedStrategy.payload.first, descriptor) to namedStrategy.payload
+            )
+        }
+    }
+}
+
+private fun namedArgumentConfiguration(
+    argumentPredicate: (MetadataArgumentTestDescriptor<*>) -> Boolean = { true },
+): List<Named<MetadataArgumentConfiguration<*>>> {
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = metadataCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
+
+    return btaVersions.flatMap { namedKotlinToolchains ->
+        compilerArguments.map { namedArgumentDescriptor ->
+            named(
+                namedKotlinToolchains.name + namedArgumentDescriptor.name,
+                MetadataArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+            )
+        }
+    }
+}
+
+private val testBaseDir: Path = Paths.get("").toAbsolutePath()
+
+private val metadataCompilerArguments: List<MetadataArgumentTestDescriptor<*>> = listOf(
+    MetadataArgumentTestDescriptor(
+        argumentName = "classpath",
+        argument = CLASSPATH,
+        argumentValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/lib1.jar"),
+                testBaseDir.resolve("path/to/lib2.jar"),
+                testBaseDir.resolve("path/to/classes"),
+            ),
+            listOf(testBaseDir.resolve("path/with,comma/lib3.jar")),
+        ),
+        argumentRawValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/lib1.jar"),
+                testBaseDir.resolve("path/to/lib2.jar"),
+                testBaseDir.resolve("path/to/classes"),
+            ).joinToString(File.pathSeparator) { it.toFile().absolutePath },
+            testBaseDir.resolve("path/with,comma/lib3.jar").toFile().absolutePath,
+        ),
+        invalidArgumentValues = listOf(listOf(testBaseDir.resolve("path/with${File.pathSeparator}separator"))),
+        runsNullableTest = true,
+        valueString = { value -> value?.joinToString(File.pathSeparator) { it.toFile().absolutePath } },
+        expectedArgumentStringsFor = { value -> listOf("-classpath", value) },
+    ),
+    MetadataArgumentTestDescriptor(
+        argumentName = "Xfriend-paths",
+        argument = X_FRIEND_PATHS,
+        argumentValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/friend1"),
+                testBaseDir.resolve("path/to/friend2"),
+            )
+        ),
+        argumentRawValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/friend1"),
+                testBaseDir.resolve("path/to/friend2"),
+            ).joinToString(",") { it.toFile().absolutePath }
+        ),
+        valueString = { value -> value?.joinToString(",") { it.toFile().absolutePath } },
+        expectedArgumentStringsFor = { value -> listOf("-Xfriend-paths=$value") },
+    ),
+    MetadataArgumentTestDescriptor(
+        argumentName = "Xrefines-paths",
+        argument = X_REFINES_PATHS,
+        argumentValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/refines1"),
+                testBaseDir.resolve("path/to/refines2"),
+            )
+        ),
+        argumentRawValues = listOf(
+            listOf(
+                testBaseDir.resolve("path/to/refines1"),
+                testBaseDir.resolve("path/to/refines2"),
+            ).joinToString(",") { it.toFile().absolutePath }
+        ),
+        valueString = { value -> value?.joinToString(",") { it.toFile().absolutePath } },
+        expectedArgumentStringsFor = { value -> listOf("-Xrefines-paths=$value") },
+    ),
+    MetadataArgumentTestDescriptor(
+        argumentName = "Xtarget-platform",
+        argument = X_TARGET_PLATFORM,
+        argumentValues = listOf(MetadataTargetPlatform.entries.toList()),
+        argumentRawValues = listOf(MetadataTargetPlatform.entries.joinToString(",") { it.stringValue }),
+        invalidRawValues = listOf("WasmWas"),
+        // MetadataTargetPlatformType (EnumListType) renders an empty list as the Kotlin literal "arrayOf()"
+        // (see EnumListType.stringRepresentation in KotlinArgumentValueType.kt), which is what the model reports as this argument's default.
+        // Render the empty value the same way so the default tests compare against the model-derived default.
+        valueString = { value -> if (value.isNullOrEmpty()) "arrayOf()" else value.joinToString(",") { it.stringValue } },
+        expectedArgumentStringsFor = { value -> listOf("-Xtarget-platform=$value") },
+    ),
+    MetadataArgumentTestDescriptor(
+        argumentName = "module-name",
+        argument = MODULE_NAME,
+        argumentValues = listOf("my-metadata-module"),
+        argumentRawValues = listOf("my-metadata-module"),
+        runsNullableTest = true,
+        valueString = { value -> value },
+        expectedArgumentStringsFor = { value -> listOf("-module-name", value) },
+    ),
+    MetadataArgumentTestDescriptor(
+        argumentName = "Xklib-zip-file-accessor-cache-limit",
+        argument = X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT,
+        argumentValues = listOf(128),
+        argumentRawValues = listOf("128"),
+        valueString = { value -> value?.toString() },
+        expectedArgumentStringsFor = { value -> listOf("-Xklib-zip-file-accessor-cache-limit=$value") },
+    ),
+)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentTestAnnotations.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentTestAnnotations.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+/**
+ * Parameterized test annotation for all Metadata compiler arguments across Build Tools API versions.
+ *
+ * @see AllMetadataCompilerArgumentsWithBtaVersionsArgumentProvider
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(AllMetadataCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class AllMetadataCompilerArgumentsWithBtaVersionsTest
+
+/**
+ * Parameterized test annotation for Metadata compiler arguments that have invalid typed values
+ * (a path containing the platform path separator inside a single search-path entry).
+ *
+ * @see InvalidArgumentValueMetadataCompilerArgumentsWithBtaVersionsArgumentProvider
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidArgumentValueMetadataCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class InvalidArgumentValueMetadataCompilerArgumentsWithBtaVersionsTest
+
+/**
+ * Parameterized test annotation for nullable Metadata compiler arguments across Build Tools API versions.
+ *
+ * @see NullableMetadataCompilerArgumentsWithBtaVersionsArgumentProvider
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(NullableMetadataCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class NullableMetadataCompilerArgumentsWithBtaVersionsTest
+
+/**
+ * Parameterized test annotation for Metadata compiler arguments whose raw CLI value must be rejected
+ * (e.g. a non-existent enum entry), checked at compilation time under both BTAv2 execution strategies.
+ *
+ * @see InvalidRawValueMetadataCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider
+ */
+/**
+ * Parameterized test annotation for Metadata compiler arguments whose raw CLI value must be rejected,
+ * across Build Tools API versions (conversion-level, no compilation).
+ *
+ * @see InvalidRawValueMetadataCompilerArgumentsWithBtaVersionsArgumentProvider
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidRawValueMetadataCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class InvalidRawValueMetadataCompilerArgumentsWithBtaVersionsTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidRawValueMetadataCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider::class)
+annotation class InvalidRawValueMetadataCompilerArgumentsBtaV2StrategyAgnosticTest

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentTestDescriptor.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentTestDescriptor.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.metadata
+
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentTestDescriptor
+
+internal class MetadataArgumentTestDescriptor<T>(
+    override val argumentName: String,
+    override val argument: MetadataArguments.MetadataArgument<T>,
+    override val argumentValues: List<T>,
+    override val argumentRawValues: List<String>,
+    override val invalidArgumentValues: List<T> = emptyList(),
+    override val invalidRawValues: List<String> = emptyList(),
+    override val runsNullableTest: Boolean = false,
+    // The whole Metadata BTA toolchain is v2-only (introduced in 2.4.20), so it is not reachable through the
+    // v1 adapter; default to skipping v1 for all Metadata arguments.
+    override val skipBtaV1: Boolean = true,
+    private val valueString: (T?) -> String?,
+    private val expectedArgumentStringsFor: (String) -> List<String>,
+) : ArgumentTestDescriptor<T> {
+    override val availableSinceVersion: KotlinReleaseVersion = argument.availableSinceVersion
+
+    override fun getValueString(argument: T?): String? = valueString(argument)
+
+    override fun expectedArgumentStringsFor(value: String): List<String> = expectedArgumentStringsFor.invoke(value)
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentConfiguration.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalBuildToolsApi::class, ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm
+
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.wasm.WasmPlatformToolchain.Companion.wasm
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.WasmArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.WasmArgumentOperationKind.LINKING
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsWasm
+import java.nio.file.Paths
+
+internal class WasmArgumentConfiguration<T>(
+    kotlinToolchain: KotlinToolchains,
+    private val descriptor: WasmArgumentTestDescriptor<T>,
+) : ArgumentConfiguration<T>(kotlinToolchain, descriptor) {
+    val operationKind: WasmArgumentOperationKind = descriptor.operationKind
+    val availableSinceVersion: KotlinReleaseVersion = descriptor.availableSinceVersion
+    val argumentValues: List<T> = descriptor.argumentValues
+    val argumentRawValues: List<String> = descriptor.argumentRawValues
+    val invalidRawValues: List<String> = descriptor.invalidRawValues
+
+    fun isPlatformSupported(): Boolean = kotlinToolchain.supportsWasm()
+
+    fun buildArguments(configure: CommonToolArguments.Builder.() -> Unit = {}): CommonToolArguments {
+        return when (descriptor.operationKind) {
+            KLIB -> kotlinToolchain.wasm.wasmKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            LINKING -> kotlinToolchain.wasm.wasmLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+        }
+    }
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        descriptor.setArgument(arguments, value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = descriptor.getArgument(arguments)
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentOperationKind.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentOperationKind.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm
+
+internal enum class WasmArgumentOperationKind(val displayName: String) {
+    KLIB("KLIB"),
+    LINKING("linking"),
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentProviders.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalCompilerArgument::class)
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm
+
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerKlibArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerKlibArguments.Companion.X_WASM_TARGET
+import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerLinkingArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerLinkingArguments.Companion.X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE
+import org.jetbrains.kotlin.buildtools.api.arguments.WasmCompilerLinkingArguments.Companion.X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.WasmTarget
+import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.WasmArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm.WasmArgumentOperationKind.LINKING
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTestArgumentProvider
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaVersionsCompilationTestArgumentProvider
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Stream
+
+internal class AllWasmCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class InvalidRawValueWasmCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedInvalidRawValueBtaV2ArgumentConfigurations().map { Arguments.of(it) }.stream()
+    }
+}
+
+internal class NullableWasmCompilerArgumentsWithBtaVersionsArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+        return namedArgumentConfiguration { it.runsNullableTest }.map { Arguments.of(it) }.stream()
+    }
+}
+
+private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<WasmArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>>> {
+    val btaV2Strategies = BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = wasmCompilerArguments.filter { it.runsInvalidRawValueTest }.map {
+        named("[${it.operationKind.displayName}][${it.argumentName}]", it)
+    }
+
+    return btaV2Strategies.flatMap { namedStrategy ->
+        compilerArguments.map { namedArgumentDescriptor ->
+            named(
+                namedStrategy.name + namedArgumentDescriptor.name,
+                WasmArgumentConfiguration(namedStrategy.payload.first, namedArgumentDescriptor.payload) to namedStrategy.payload
+            )
+        }
+    }
+}
+
+private fun namedArgumentConfiguration(
+    argumentPredicate: (WasmArgumentTestDescriptor<*>) -> Boolean = { true },
+): List<Named<WasmArgumentConfiguration<*>>> {
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val compilerArguments = wasmCompilerArguments.filter { argumentPredicate(it) }.map {
+        named("[${it.operationKind.displayName}][${it.argumentName}]", it)
+    }
+
+    return btaVersions.flatMap { namedKotlinToolchains ->
+        compilerArguments.map { namedArgumentDescriptor ->
+            named(
+                namedKotlinToolchains.name + namedArgumentDescriptor.name,
+                WasmArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+            )
+        }
+    }
+}
+
+private val testBaseDir: Path = Paths.get("").toAbsolutePath()
+
+@OptIn(ExperimentalCompilerArgument::class)
+private val wasmCompilerArguments: List<WasmArgumentTestDescriptor<*>> = listOf(
+    WasmArgumentTestDescriptor(
+        argumentName = "Xwasm-target",
+        argument = X_WASM_TARGET,
+        availableSinceVersion = X_WASM_TARGET.availableSinceVersion,
+        operationKind = KLIB,
+        argumentValues = WasmTarget.entries.toList(),
+        argumentRawValues = WasmTarget.entries.map { it.stringValue },
+        invalidRawValues = listOf("wasi"),
+        runsNullableTest = true,
+        valueString = { value -> value?.stringValue },
+        expectedArgumentStringsFor = { value -> listOf("-Xwasm-target=$value") },
+        setArgumentValue = { value -> (this as WasmCompilerKlibArguments.Builder)[X_WASM_TARGET] = value },
+        getArgumentValue = { (this as WasmCompilerKlibArguments)[X_WASM_TARGET] },
+    ),
+    WasmArgumentTestDescriptor(
+        argumentName = "Xir-dce-dump-reachability-info-to-file",
+        argument = X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE,
+        availableSinceVersion = X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE.availableSinceVersion,
+        operationKind = LINKING,
+        argumentValues = listOf(testBaseDir.resolve("path/to/reachability.json")),
+        argumentRawValues = listOf(testBaseDir.resolve("path/to/reachability.json").toFile().absolutePath),
+        runsNullableTest = true,
+        valueString = { value -> value?.toFile()?.absolutePath },
+        expectedArgumentStringsFor = { value -> listOf("-Xir-dce-dump-reachability-info-to-file=$value") },
+        setArgumentValue = { value -> (this as WasmCompilerLinkingArguments.Builder)[X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE] = value },
+        getArgumentValue = { (this as WasmCompilerLinkingArguments)[X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE] },
+    ),
+    WasmArgumentTestDescriptor(
+        argumentName = "Xir-dump-declaration-ir-sizes-to-file",
+        argument = X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE,
+        availableSinceVersion = X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE.availableSinceVersion,
+        operationKind = LINKING,
+        argumentValues = listOf(testBaseDir.resolve("path/to/ir-sizes.txt")),
+        argumentRawValues = listOf(testBaseDir.resolve("path/to/ir-sizes.txt").toFile().absolutePath),
+        runsNullableTest = true,
+        valueString = { value -> value?.toFile()?.absolutePath },
+        expectedArgumentStringsFor = { value -> listOf("-Xir-dump-declaration-ir-sizes-to-file=$value") },
+        setArgumentValue = { value -> (this as WasmCompilerLinkingArguments.Builder)[X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE] = value },
+        getArgumentValue = { (this as WasmCompilerLinkingArguments)[X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE] },
+    ),
+)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentTestAnnotations.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentTestAnnotations.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(AllWasmCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class AllWasmCompilerArgumentsWithBtaVersionsTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(InvalidRawValueWasmCompilerArgumentsBtaV2StrategyAgnosticArgumentProvider::class)
+annotation class InvalidRawValueWasmCompilerArgumentsBtaV2StrategyAgnosticTest
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(NullableWasmCompilerArgumentsWithBtaVersionsArgumentProvider::class)
+annotation class NullableWasmCompilerArgumentsWithBtaVersionsTest

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentTestDescriptor.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentTestDescriptor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.wasm
+
+import org.jetbrains.kotlin.buildtools.api.KotlinReleaseVersion
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentTestDescriptor
+
+internal class WasmArgumentTestDescriptor<T>(
+    override val argumentName: String,
+    override val argument: Any,
+    override val availableSinceVersion: KotlinReleaseVersion,
+    val operationKind: WasmArgumentOperationKind,
+    override val argumentValues: List<T>,
+    override val argumentRawValues: List<String>,
+    override val invalidArgumentValues: List<T> = emptyList(),
+    override val invalidRawValues: List<String> = emptyList(),
+    override val runsNullableTest: Boolean = false,
+    // The whole Wasm BTA toolchain is v2-only (introduced in 2.4.20), so it is not reachable through the
+    // v1 adapter; default to skipping v1 for all Wasm arguments.
+    override val skipBtaV1: Boolean = true,
+    private val valueString: (T?) -> String?,
+    private val expectedArgumentStringsFor: (String) -> List<String>,
+    private val setArgumentValue: CommonToolArguments.Builder.(T) -> Unit,
+    private val getArgumentValue: CommonToolArguments.() -> T,
+) : ArgumentTestDescriptor<T> {
+    override fun getValueString(argument: T?): String? = valueString(argument)
+
+    override fun expectedArgumentStringsFor(value: String): List<String> = expectedArgumentStringsFor.invoke(value)
+
+    fun setArgument(arguments: CommonToolArguments.Builder, value: T) {
+        arguments.setArgumentValue(value)
+    }
+
+    fun getArgument(arguments: CommonToolArguments): T = arguments.getArgumentValue()
+}


### PR DESCRIPTION
Cover the type-safe JS, Wasm, common-Klib and Metadata BTA compiler arguments: BTA<->raw conversion, defaults, nullability and invalid-value handling.
Pin two known bugs with an active test plus a @Disabled check of the correct behavior, so each turns red once fixed: missing File.pathSeparator validation in search-path args (KT-87212) and the enum-list X_TARGET_PLATFORM throwing from applyArgumentStrings instead of deferring the error to execution (KT-87218).

KT-85663
KT-78224