### PR TITLE
[PSI] Support object literals in REFERENCE_BY positioning strategies

### DIFF
--- a/compiler/frontend.common-psi/src/org/jetbrains/kotlin/diagnostics/LightTreePositioningStrategies.kt
+++ b/compiler/frontend.common-psi/src/org/jetbrains/kotlin/diagnostics/LightTreePositioningStrategies.kt
@@ -798,6 +798,9 @@ object LightTreePositioningStrategies {
             }
 
             when {
+                node.tokenType == KtNodeTypes.OBJECT_LITERAL -> {
+                    return DEFAULT.mark(node, startOffset, endOffset, tree)
+                }
                 node.tokenType == KtNodeTypes.BINARY_EXPRESSION && tree.findDescendantByType(node, EQ, followFunctions = false) != null -> {
                     // Look for reference in LHS of variable assignment.
                     tree.findExpressionDeep(node)?.let {

--- a/compiler/frontend.common-psi/src/org/jetbrains/kotlin/diagnostics/PositioningStrategies.kt
+++ b/compiler/frontend.common-psi/src/org/jetbrains/kotlin/diagnostics/PositioningStrategies.kt
@@ -1216,6 +1216,9 @@ object PositioningStrategies {
      */
     class FindReferencePositioningStrategy(val locateReferencedName: Boolean) : PositioningStrategy<PsiElement>() {
         override fun mark(element: PsiElement): List<TextRange> {
+            if (element is KtObjectLiteralExpression) {
+                return DEFAULT.mark(element)
+            }
             if (element is KtBinaryExpression && element.operationToken == KtTokens.EQ) {
                 // Look for reference in LHS of variable assignment.
                 element.left?.let { return mark(it) }

--- a/compiler/testData/diagnostics/tests/crv/unusedObjectLiteral.kt
+++ b/compiler/testData/diagnostics/tests/crv/unusedObjectLiteral.kt
@@ -1,0 +1,28 @@
+// RUN_PIPELINE_TILL: BACKEND
+// WITH_STDLIB
+// ISSUE: KT-85169
+@file:MustUseReturnValues
+
+fun interface Foo {
+    fun method()
+}
+
+fun Foo(arg: () -> Unit): Foo = TODO()
+
+fun main() {
+    // Object literal with a supertype: only `object : Foo` is highlighted, not the body.
+    <!RETURN_VALUE_NOT_USED!>object : Foo<!> {
+        override fun method() {}
+    }
+
+    // Object literal without a supertype: only the `object` keyword is highlighted.
+    <!RETURN_VALUE_NOT_USED!>object<!> {
+        val x = 1
+    }
+
+    // SAM-conversion call: highlighting falls on the callee, as before.
+    <!RETURN_VALUE_NOT_USED!>Foo<!> {}
+}
+
+/* GENERATED_FIR_TAGS: annotationUseSiteTargetFile, anonymousObjectExpression, funInterface, functionDeclaration,
+functionalType, integerLiteral, interfaceDeclaration, lambdaLiteral, override, propertyDeclaration */


### PR DESCRIPTION
To be able to highlight only object literal declarations in diagnostics such as RETURN_VALUE_NOT_USED

#KT-85169 Fixed