### PR TITLE
[K/JS] Align function reference subtyping with JVM

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/BackendJsSymbols.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/BackendJsSymbols.kt
@@ -239,6 +239,8 @@ class BackendJsSymbols(
     val isArraySymbol by CallableIds.isArray.functionSymbol()
     //    val isCharSymbol = CallableIds.isChar.functionSymbol()
     val isSuspendFunctionSymbol by CallableIds.isSuspendFunction.functionSymbol()
+    val isFunctionNSymbol by CallableIds.isFunctionN.functionSymbol()
+    val isKFunctionNSymbol by CallableIds.isKFunctionN.functionSymbol()
 
     val isNumberSymbol by CallableIds.isNumber.functionSymbol()
     val isComparableSymbol by CallableIds.isComparable.functionSymbol()
@@ -621,6 +623,8 @@ private object CallableIds {
     val isArray = "isArray".jsCallableId
     //    val isChar = "isChar".jsCallableId
     val isSuspendFunction = "isSuspendFunction".jsCallableId
+    val isFunctionN = "isFunctionN".jsCallableId
+    val isKFunctionN = "isKFunctionN".jsCallableId
     val isNumber = "isNumber".jsCallableId
     val isComparable = "isComparable".jsCallableId
     val isCharSequence = "isCharSequence".jsCallableId

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/InteropCallableReferenceLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/InteropCallableReferenceLowering.kt
@@ -640,7 +640,7 @@ class InteropCallableReferenceLowering(val context: JsIrBackendContext) : BodyLo
 
         val constructedCallableReference = when {
             kFunctionImplCall != null -> {
-                val [flags, arity, id] = kFunctionImplCall.arguments
+                val [flags, arity, minimalArity, id] = kFunctionImplCall.arguments
 
                 JsIrBuilder.buildCall(constructCallableReferenceSymbol)
                     .apply {
@@ -651,14 +651,17 @@ class InteropCallableReferenceLowering(val context: JsIrBackendContext) : BodyLo
                             lambdaDeclaration.parameters.size.toIrConst(context.irBuiltIns.intType)
                         } else arity?.shallowCopy() ?: compilationException("'arity' is expected to be passed to a parent constructor", kFunctionImplCall)
 
-                        arguments[2] = flags?.shallowCopy()
+                        arguments[2] = minimalArity?.shallowCopy()
+                            ?: compilationException("'minimalArity' is expected to be passed to a parent constructor", kFunctionImplCall)
+
+                        arguments[3] = flags?.shallowCopy()
                             ?: compilationException("'flags' is expected to be passed to a parent constructor", kFunctionImplCall)
 
-                        arguments[3] = id?.deepCopyWithoutPatchingParents()
+                        arguments[4] = id?.deepCopyWithoutPatchingParents()
                             ?: compilationException("'id' is expected to be passed to a parent constructor", kFunctionImplCall)
 
-                        arguments[4] = callableName
-                        arguments[5] = if (factoryFunction.parameters.any()) {
+                        arguments[5] = callableName
+                        arguments[6] = if (factoryFunction.parameters.any()) {
                             JsIrBuilder.buildArray(
                                 factoryFunction.parameters.map { JsIrBuilder.buildGetValue(it.symbol) },
                                 context.irBuiltIns.arrayClass.typeWith(context.irBuiltIns.anyNType),
@@ -678,6 +681,7 @@ class InteropCallableReferenceLowering(val context: JsIrBackendContext) : BodyLo
                         arguments[3] = context.getVoid()
                         arguments[4] = context.getVoid()
                         arguments[5] = context.getVoid()
+                        arguments[6] = context.getVoid()
                     }
             }
 

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/JsCallableReferenceLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/JsCallableReferenceLowering.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrFail
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.hasDefaultValue
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.toIrConst
 
@@ -65,12 +66,19 @@ class JsCallableReferenceLowering(private val jsContext: JsIrBackendContext) : W
             } else if (functionReference.reflectionTargetSymbol != null) {
                 arguments[0] = functionReference.getFlags().toIrConst(context.irBuiltIns.intType)
                 arguments[1] = functionReference.getArity().toIrConst(context.irBuiltIns.intType)
-                arguments[2] = JsIrBuilder.buildCall(jsContext.symbols.signatureIdSymbol).apply {
+                arguments[2] = functionReference.getMinimalArity().toIrConst(context.irBuiltIns.intType)
+                arguments[3] = JsIrBuilder.buildCall(jsContext.symbols.signatureIdSymbol).apply {
                     arguments[0] = functionReference.getId(jsContext).toIrConst(context.irBuiltIns.stringType)
                 }
             }
         }
     }
+
+    fun IrRichFunctionReference.getMinimalArity(): Int =
+        // Here we suppose that:
+        // - Coroutine continuation is a param without a defaultValue
+        // - We can bound only parameters without defaultValue
+        (reflectionTargetSymbol?.owner?.parameters ?: invokeFunction.parameters).count { !it.hasDefaultValue() } - boundValues.size + if (invokeFunction.isSuspend) 1 else 0
 
     override fun getSuperClassType(reference: IrRichFunctionReference): IrType = when {
         reference.shouldAddContinuation -> context.symbols.coroutineImpl.owner.defaultType

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/TypeOperatorLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/TypeOperatorLowering.kt
@@ -23,6 +23,8 @@ import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
@@ -60,6 +62,8 @@ class TypeOperatorLowering(val context: JsIrBackendContext) : BodyLoweringPass {
     private val isInterfaceSymbol get() = context.symbols.isInterfaceSymbol
     private val isArraySymbol get() = context.symbols.isArraySymbol
     private val isSuspendFunctionSymbol = context.symbols.isSuspendFunctionSymbol
+    private val isFunctionNSymbol = context.symbols.isFunctionNSymbol
+    private val isKFunctionNSymbol = context.symbols.isKFunctionNSymbol
 
     //    private val isCharSymbol get() = context.symbols.isCharSymbol
 
@@ -172,7 +176,7 @@ class TypeOperatorLowering(val context: JsIrBackendContext) : BodyLoweringPass {
                         type.isDouble() ||
                         (type.isLong() && context.configuration.compileLongAsBigint) ||
                         type.isBoolean() ||
-                        type.isFunctionOrKFunction() ||
+                        type.isFunction() ||
                         type.isString()
 
             fun lowerInstanceOf(
@@ -268,7 +272,9 @@ class TypeOperatorLowering(val context: JsIrBackendContext) : BodyLoweringPass {
                     toType is IrDynamicType -> argument
                     toType.isAny() -> generateIsObjectCheck(argument)
                     toType.isNothing() -> JsIrBuilder.buildComposite(context.irBuiltIns.booleanType, listOf(argument, litFalse))
-                    toType.isSuspendFunction() -> generateSuspendFunctionCheck(argument, toType)
+                    toType.isSuspendFunction() -> generateCheckForFunctionType(isSuspendFunctionSymbol, argument, toType)
+                    toType.isNumberedFunction() -> generateCheckForFunctionType(isFunctionNSymbol, argument, toType)
+                    toType.isNumberedKFunction() -> generateCheckForFunctionType(isKFunctionNSymbol, argument, toType)
                     isTypeOfCheckingType(toType) -> generateTypeOfCheck(argument, toType)
 //                    toType.isChar() -> generateCheckForChar(argument)
                     toType.isNumber() -> generateNumberCheck(argument)
@@ -324,11 +330,15 @@ class TypeOperatorLowering(val context: JsIrBackendContext) : BodyLoweringPass {
 //            private fun generateCheckForChar(argument: IrExpression) =
 //                JsIrBuilder.buildCall(isCharSymbol).apply { dispatchReceiver = argument }
 
-            private fun generateSuspendFunctionCheck(argument: IrExpression, toType: IrType): IrExpression {
-                val arity = (toType.classifierOrFail.owner as IrClass).typeParameters.size - 1 // drop return type
+            private fun generateCheckForFunctionType(
+                predicateSymbol: IrSimpleFunctionSymbol,
+                argument: IrExpression,
+                functionalType: IrType,
+            ): IrCall {
+                val arity = (functionalType.classifierOrFail.owner as IrClass).typeParameters.size - 1 // drop return type
 
                 val irBuiltIns = context.irBuiltIns
-                return JsIrBuilder.buildCall(isSuspendFunctionSymbol, irBuiltIns.booleanType).apply {
+                return JsIrBuilder.buildCall(predicateSymbol, irBuiltIns.booleanType).apply {
                     arguments[0] = argument
                     arguments[1] = JsIrBuilder.buildInt(irBuiltIns.intType, arity)
                 }
@@ -336,7 +346,7 @@ class TypeOperatorLowering(val context: JsIrBackendContext) : BodyLoweringPass {
 
             private fun generateTypeOfCheck(argument: IrExpression, toType: IrType): IrExpression {
                 val marker = when {
-                    toType.isFunctionOrKFunction() -> functionMarker
+                    toType.isFunction() -> functionMarker
                     toType.isBoolean() -> booleanMarker
                     toType.isString() -> stringMarker
                     toType.isLong() -> bigintMarker

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIntrinsicTransformers.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsIntrinsicTransformers.kt
@@ -24,7 +24,9 @@ import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.getInlineClassBackingField
+import org.jetbrains.kotlin.ir.util.isFunction
 import org.jetbrains.kotlin.ir.util.isFunctionOrKFunction
+import org.jetbrains.kotlin.ir.util.isKFunction
 import org.jetbrains.kotlin.ir.util.isThrowable
 import org.jetbrains.kotlin.js.backend.ast.*
 import org.jetbrains.kotlin.js.backend.ast.metadata.isInlineClassBoxing
@@ -394,7 +396,7 @@ class JsIntrinsicTransformers(backendContext: JsIrBackendContext) {
                             typeArgument.isInt() ||
                             typeArgument.isFloat() ||
                             typeArgument.isDouble() -> JsNameRef("Number")
-                    typeArgument.isFunctionOrKFunction() -> JsNameRef("Function")
+                    typeArgument.isFunction() -> JsNameRef("Function")
                     else -> typeArgument.getClassRef(context.staticContext)
                 }
             }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrTypeUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrTypeUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -31,6 +31,8 @@ private val kotlinCoroutinesPackageFqn = kotlinPackageFqn.child(Name.identifier(
 fun IrType.isFunctionMarker(): Boolean = classifierOrNull?.isFunctionMarker() == true
 fun IrType.isFunction(): Boolean = classifierOrNull?.isFunction() == true
 fun IrType.isKFunction(): Boolean = classifierOrNull?.isKFunction() == true
+fun IrType.isNumberedFunction(): Boolean = classifierOrNull?.isNumberedFunction() == true
+fun IrType.isNumberedKFunction(): Boolean = classifierOrNull?.isNumberedKFunction() == true
 fun IrType.isSuspendFunction(): Boolean = classifierOrNull?.isSuspendFunction() == true
 fun IrType.isKSuspendFunction(): Boolean = classifierOrNull?.isKSuspendFunction() == true
 
@@ -43,6 +45,10 @@ fun IrClassifierSymbol.isKFunction(): Boolean = this.isClassWithNamePrefix("KFun
 fun IrClassifierSymbol.isSuspendFunction(): Boolean = this.isClassWithNamePrefix("SuspendFunction", kotlinCoroutinesPackageFqn)
 fun IrClassifierSymbol.isKSuspendFunction(): Boolean = this.isClassWithNamePrefix("KSuspendFunction", kotlinReflectionPackageFqn)
 fun IrClassifierSymbol.isFunctional(): Boolean = isFunction() || isKFunction() || isSuspendFunction() || isKSuspendFunction()
+fun IrClassifierSymbol.isNumberedFunction(): Boolean =
+    isFunction() && !isClassWithName("Function", kotlinPackageFqn)
+fun IrClassifierSymbol.isNumberedKFunction(): Boolean =
+    isKFunction() && !isClassWithName("KFunction", kotlinReflectionPackageFqn)
 
 private fun IrClassifierSymbol.isClassWithName(name: String, packageFqName: FqName): Boolean =
     checkNameAndPackage({ it == name }, { it == packageFqName.asString() })

--- a/js/js.translator/testData/box/callableReference/subtyping.kt
+++ b/js/js.translator/testData/box/callableReference/subtyping.kt
@@ -1,0 +1,260 @@
+// KT-35479
+
+package foo
+
+import kotlin.reflect.KCallable
+import kotlin.reflect.KFunction
+import kotlin.reflect.KFunction0
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KFunction2
+import kotlin.reflect.KFunction3
+import kotlin.reflect.KProperty
+
+fun topLevelFun(x: Int): Int = x + 1
+fun topLevelFunWithDefault(a: Int, b: Int = 1): Int = a + b
+
+val topLevelVal: String = "hello"
+var topLevelVar: String = "world"
+
+suspend fun suspendTopLevelFun(x: Int): Int = x + 10
+suspend fun suspendTopLevelFunWithDefault(a: Int, b: Int = 1): Int = a + b
+
+fun twoParams(x: Int, y: Int): Int = x + y
+fun threeParams(x: Int, y: Int, z: Int): Int = x + y + z
+
+class A(val memberVal: String) {
+    var memberVar: String = "mutable"
+    fun memberFun(x: Int): Int = x * 2
+}
+
+fun box(): String {
+    val lambda0 = { 42 }
+    val lambda1 = { x: Int -> x + 1 }
+    val lambda2 = { x: Int, y: Int -> x + y }
+
+    if (lambda0 !is Function<*>)         return "Fail: lambda0 should be Function"
+    if (lambda0 !is Function0<*>)        return "Fail: lambda0 should be Function0"
+    if (lambda0 is Function1<*, *>)      return "Fail: lambda0 should NOT be Function1"
+    if (lambda0 is KCallable<*>)         return "Fail: lambda0 should NOT be KCallable"
+    if (lambda0 is KFunction<*>)         return "Fail: lambda0 should NOT be KFunction"
+    if (lambda0 is KFunction0<*>)        return "Fail: lambda0 should NOT be KFunction0"
+    if (lambda0 is KProperty<*>)         return "Fail: lambda0 should NOT be KProperty"
+
+    if (lambda1 !is Function<*>)         return "Fail: lambda1 should be Function"
+    if (lambda1 !is Function1<*, *>)     return "Fail: lambda1 should be Function1"
+    if (lambda1 is Function0<*>)         return "Fail: lambda1 should NOT be Function0"
+    if (lambda1 is Function2<*, *, *>)   return "Fail: lambda1 should NOT be Function2"
+    if (lambda1 is KCallable<*>)         return "Fail: lambda1 should NOT be KCallable"
+    if (lambda1 is KFunction<*>)         return "Fail: lambda1 should NOT be KFunction"
+    if (lambda1 is KFunction1<*, *>)     return "Fail: lambda1 should NOT be KFunction1"
+    if (lambda1 is KProperty<*>)         return "Fail: lambda1 should NOT be KProperty"
+
+    if (lambda2 !is Function<*>)         return "Fail: lambda2 should be Function"
+    if (lambda2 !is Function2<*, *, *>)  return "Fail: lambda2 should be Function2"
+    if (lambda2 is Function1<*, *>)      return "Fail: lambda2 should NOT be Function1"
+    if (lambda2 is Function3<*, *, *, *>) return "Fail: lambda2 should NOT be Function3"
+    if (lambda2 is KCallable<*>)         return "Fail: lambda2 should NOT be KCallable"
+    if (lambda2 is KFunction<*>)         return "Fail: lambda2 should NOT be KFunction"
+    if (lambda2 is KFunction2<*, *, *>)  return "Fail: lambda2 should NOT be KFunction2"
+    if (lambda2 is KProperty<*>)         return "Fail: lambda2 should NOT be KProperty"
+
+    val funRef = ::topLevelFun
+
+    if (funRef !is Function<*>)          return "Fail: ::topLevelFun should be Function"
+    if (funRef !is Function1<*, *>)      return "Fail: ::topLevelFun should be Function1"
+    if (funRef is Function0<*>)          return "Fail: ::topLevelFun should NOT be Function0"
+    if (funRef is Function2<*, *, *>)    return "Fail: ::topLevelFun should NOT be Function2"
+    if (funRef !is KCallable<*>)         return "Fail: ::topLevelFun should be KCallable"
+    if (funRef !is KFunction<*>)         return "Fail: ::topLevelFun should be KFunction"
+    if (funRef !is KFunction1<*, *>)     return "Fail: ::topLevelFun should be KFunction1"
+    if (funRef is KFunction0<*>)         return "Fail: ::topLevelFun should NOT be KFunction0"
+    if (funRef is KFunction2<*, *, *>)   return "Fail: ::topLevelFun should NOT be KFunction2"
+    if (funRef is KProperty<*>)          return "Fail: ::topLevelFun should NOT be KProperty"
+    if (funRef.name != "topLevelFun")    return "Fail: expected name 'topLevelFun', got '${funRef.name}'"
+    if (funRef(1) != 2)                  return "Fail: expected topLevelFun(1) == 2"
+
+    val twoRef = ::twoParams
+
+    if (twoRef !is Function<*>)          return "Fail: ::twoParams should be Function"
+    if (twoRef !is Function2<*, *, *>)   return "Fail: ::twoParams should be Function2"
+    if (twoRef is Function1<*, *>)       return "Fail: ::twoParams should NOT be Function1"
+    if (twoRef is Function3<*, *, *, *>) return "Fail: ::twoParams should NOT be Function3"
+    if (twoRef !is KCallable<*>)         return "Fail: ::twoParams should be KCallable"
+    if (twoRef !is KFunction<*>)         return "Fail: ::twoParams should be KFunction"
+    if (twoRef !is KFunction2<*, *, *>)  return "Fail: ::twoParams should be KFunction2"
+    if (twoRef is KFunction1<*, *>)      return "Fail: ::twoParams should NOT be KFunction1"
+    if (twoRef is KFunction3<*, *, *, *>) return "Fail: ::twoParams should NOT be KFunction3"
+    if (twoRef is KProperty<*>)          return "Fail: ::twoParams should NOT be KProperty"
+    if (twoRef.name != "twoParams")      return "Fail: expected name 'twoParams', got '${twoRef.name}'"
+    if (twoRef(2, 3) != 5)               return "Fail: expected twoParams(2, 3) == 5"
+
+    val threeRef = ::threeParams
+
+    if (threeRef !is Function<*>)            return "Fail: ::threeParams should be Function"
+    if (threeRef !is Function3<*, *, *, *>)  return "Fail: ::threeParams should be Function3"
+    if (threeRef is Function2<*, *, *>)      return "Fail: ::threeParams should NOT be Function2"
+    if (threeRef !is KCallable<*>)           return "Fail: ::threeParams should be KCallable"
+    if (threeRef !is KFunction<*>)           return "Fail: ::threeParams should be KFunction"
+    if (threeRef !is KFunction3<*, *, *, *>) return "Fail: ::threeParams should be KFunction3"
+    if (threeRef is KFunction2<*, *, *>)     return "Fail: ::threeParams should NOT be KFunction2"
+    if (threeRef is KProperty<*>)            return "Fail: ::threeParams should NOT be KProperty"
+    if (threeRef.name != "threeParams")      return "Fail: expected name 'threeParams', got '${threeRef.name}'"
+    if (threeRef(1, 2, 3) != 6)              return "Fail: expected threeParams(1, 2, 3) == 6"
+
+    val valRef = ::topLevelVal
+
+    if (valRef !is Function<*>)          return "Fail: ::topLevelVal should be Function"
+    if (valRef !is Function0<*>)         return "Fail: ::topLevelVal should be Function0"
+    if (valRef is Function1<*, *>)       return "Fail: ::topLevelVal should NOT be Function1"
+    if (valRef !is KCallable<*>)         return "Fail: ::topLevelVal should be KCallable"
+    if (valRef !is KProperty<*>)         return "Fail: ::topLevelVal should be KProperty"
+    if (valRef is KFunction<*>)          return "Fail: ::topLevelVal should NOT be KFunction"
+    if (valRef is KFunction0<*>)         return "Fail: ::topLevelVal should NOT be KFunction0"
+    if (valRef.name != "topLevelVal")    return "Fail: expected name 'topLevelVal', got '${valRef.name}'"
+    if (valRef.get() != "hello")         return "Fail: expected topLevelVal == 'hello'"
+
+    val varRef = ::topLevelVar
+
+    if (varRef !is Function<*>)          return "Fail: ::topLevelVar should be Function"
+    if (varRef !is Function0<*>)         return "Fail: ::topLevelVar should be Function0"
+    if (varRef is Function1<*, *>)       return "Fail: ::topLevelVar should NOT be Function1"
+    if (varRef !is KCallable<*>)         return "Fail: ::topLevelVar should be KCallable"
+    if (varRef !is KProperty<*>)         return "Fail: ::topLevelVar should be KProperty"
+    if (varRef is KFunction<*>)          return "Fail: ::topLevelVar should NOT be KFunction"
+    if (varRef is KFunction0<*>)         return "Fail: ::topLevelVar should NOT be KFunction0"
+    if (varRef.name != "topLevelVar")    return "Fail: expected name 'topLevelVar', got '${varRef.name}'"
+
+    val memberFunRef = A::memberFun
+
+    if (memberFunRef !is Function<*>)          return "Fail: A::memberFun should be Function"
+    if (memberFunRef !is Function2<*, *, *>)   return "Fail: A::memberFun should be Function2"
+    if (memberFunRef is Function1<*, *>)       return "Fail: A::memberFun should NOT be Function1"
+    if (memberFunRef is Function3<*, *, *, *>) return "Fail: A::memberFun should NOT be Function3"
+    if (memberFunRef !is KCallable<*>)         return "Fail: A::memberFun should be KCallable"
+    if (memberFunRef !is KFunction<*>)         return "Fail: A::memberFun should be KFunction"
+    if (memberFunRef !is KFunction2<*, *, *>)  return "Fail: A::memberFun should be KFunction2"
+    if (memberFunRef is KFunction1<*, *>)      return "Fail: A::memberFun should NOT be KFunction1"
+    if (memberFunRef is KProperty<*>)          return "Fail: A::memberFun should NOT be KProperty"
+    if (memberFunRef.name != "memberFun")      return "Fail: expected name 'memberFun', got '${memberFunRef.name}'"
+
+    val a = A("test")
+    if (memberFunRef(a, 3) != 6)               return "Fail: expected A::memberFun(a, 3) == 6"
+
+    val memberValRef = A::memberVal
+
+    if (memberValRef !is Function<*>)          return "Fail: A::memberVal should be Function"
+    if (memberValRef !is Function1<*, *>)      return "Fail: A::memberVal should be Function1"
+    if (memberValRef is Function0<*>)          return "Fail: A::memberVal should NOT be Function0"
+    if (memberValRef is Function2<*, *, *>)    return "Fail: A::memberVal should NOT be Function2"
+    if (memberValRef !is KCallable<*>)         return "Fail: A::memberVal should be KCallable"
+    if (memberValRef !is KProperty<*>)         return "Fail: A::memberVal should be KProperty"
+    if (memberValRef is KFunction<*>)          return "Fail: A::memberVal should NOT be KFunction"
+    if (memberValRef is KFunction1<*, *>)      return "Fail: A::memberVal should NOT be KFunction1"
+    if (memberValRef.name != "memberVal")      return "Fail: expected name 'memberVal', got '${memberValRef.name}'"
+    if (memberValRef.get(a) != "test")         return "Fail: expected A::memberVal.get(a) == 'test'"
+
+    val memberVarRef = A::memberVar
+
+    if (memberVarRef !is Function<*>)          return "Fail: A::memberVar should be Function"
+    if (memberVarRef !is Function1<*, *>)      return "Fail: A::memberVar should be Function1"
+    if (memberVarRef is Function0<*>)          return "Fail: A::memberVar should NOT be Function0"
+    if (memberVarRef is Function2<*, *, *>)    return "Fail: A::memberVar should NOT be Function2"
+    if (memberVarRef !is KCallable<*>)         return "Fail: A::memberVar should be KCallable"
+    if (memberVarRef !is KProperty<*>)         return "Fail: A::memberVar should be KProperty"
+    if (memberVarRef is KFunction<*>)          return "Fail: A::memberVar should NOT be KFunction"
+    if (memberVarRef is KFunction1<*, *>)      return "Fail: A::memberVar should NOT be KFunction1"
+    if (memberVarRef.name != "memberVar")      return "Fail: expected name 'memberVar', got '${memberVarRef.name}'"
+    if (memberVarRef.get(a) != "mutable")      return "Fail: expected A::memberVar.get(a) == 'mutable'"
+
+    val ctorRef = ::A
+
+    if (ctorRef !is Function<*>)          return "Fail: ::A should be Function"
+    if (ctorRef !is Function1<*, *>)      return "Fail: ::A should be Function1"
+    if (ctorRef is Function0<*>)          return "Fail: ::A should NOT be Function0"
+    if (ctorRef is Function2<*, *, *>)    return "Fail: ::A should NOT be Function2"
+    if (ctorRef !is KCallable<*>)         return "Fail: ::A should be KCallable"
+    if (ctorRef !is KFunction<*>)         return "Fail: ::A should be KFunction"
+    if (ctorRef !is KFunction1<*, *>)     return "Fail: ::A should be KFunction1"
+    if (ctorRef is KFunction0<*>)         return "Fail: ::A should NOT be KFunction0"
+    if (ctorRef is KFunction2<*, *, *>)   return "Fail: ::A should NOT be KFunction2"
+    if (ctorRef is KProperty<*>)          return "Fail: ::A should NOT be KProperty"
+    if (ctorRef.name != "<init>")         return "Fail: expected ctor name '<init>', got '${ctorRef.name}'"
+
+    val constructed = ctorRef("fromCtor")
+    if (constructed.memberVal != "fromCtor") return "Fail: ctor ref produced wrong memberVal"
+
+    val defaultFunRef = ::topLevelFunWithDefault 
+
+    if (defaultFunRef !is Function<*>)             return "Fail: ::topLevelFunWithDefault should be Function"
+    if (defaultFunRef !is Function2<*, *, *>)      return "Fail: ::topLevelFunWithDefault should be Function2"
+    if (defaultFunRef is Function1<*, *>)          return "Fail: ::topLevelFunWithDefault should NOT be Function1"
+    if (defaultFunRef is Function3<*, *, *, *>)    return "Fail: ::topLevelFunWithDefault should NOT be Function3"
+    if (defaultFunRef !is KCallable<*>)            return "Fail: ::topLevelFunWithDefault should be KCallable"
+    if (defaultFunRef !is KFunction<*>)            return "Fail: ::topLevelFunWithDefault should be KFunction"
+     if (defaultFunRef !is KFunction1<*, *>)        return "Fail: ::topLevelFunWithDefault should be KFunction1"
+    if (defaultFunRef !is KFunction2<*, *, *>)     return "Fail: ::topLevelFunWithDefault should be KFunction2"
+    if (defaultFunRef is KFunction3<*, *, *, *>)   return "Fail: ::topLevelFunWithDefault should NOT be KFunction3"
+    if (defaultFunRef is KProperty<*>)             return "Fail: ::topLevelFunWithDefault should NOT be KProperty"
+    if (defaultFunRef !is ((Int, Int) -> Int))     return "Fail: ::topLevelFunWithDefault should be (Int, Int) -> Int"
+
+    val suspendLambda0: suspend () -> Int         = { 42 }
+    val suspendLambda1: suspend (Int) -> Int       = { x -> x + 1 }
+    val suspendLambda2: suspend (Int, Int) -> Int  = { x, y -> x + y }
+
+    if (suspendLambda0 !is Function<*>)            return "Fail: suspendLambda0 should be Function"
+    if (suspendLambda0 !is Function1<*, *>)        return "Fail: suspendLambda0 should be Function1"
+    if (suspendLambda0 !is (suspend () -> Int))    return "Fail: suspendLambda0 should be suspend () -> Int"
+    if (suspendLambda0 is Function0<*>)            return "Fail: suspendLambda0 should NOT be Function0"
+    if (suspendLambda0 is KCallable<*>)            return "Fail: suspendLambda0 should NOT be KCallable"
+    if (suspendLambda0 is KFunction<*>)            return "Fail: suspendLambda0 should NOT be KFunction"
+    if (suspendLambda0 is KProperty<*>)            return "Fail: suspendLambda0 should NOT be KProperty"
+
+    if (suspendLambda1 !is Function<*>)            return "Fail: suspendLambda1 should be Function"
+    if (suspendLambda1 !is (suspend (Int) -> Int)) return "Fail: suspendLambda1 should be suspend (Int) -> Int"
+    if (suspendLambda1 !is Function2<*, *, *>)     return "Fail: suspendLambda1 should NOT be Function2"
+    if (suspendLambda1 is Function1<*, *>)         return "Fail: suspendLambda1 should NOT be Function1"
+    if (suspendLambda1 is KCallable<*>)            return "Fail: suspendLambda1 should NOT be KCallable"
+    if (suspendLambda1 is KFunction<*>)            return "Fail: suspendLambda1 should NOT be KFunction"
+    if (suspendLambda1 is KProperty<*>)            return "Fail: suspendLambda1 should NOT be KProperty"
+
+    if (suspendLambda2 !is Function<*>)                    return "Fail: suspendLambda2 should be Function"
+    if (suspendLambda2 !is (suspend (Int, Int) -> Int))    return "Fail: suspendLambda2 should be suspend (Int, Int) -> Int"
+    if (suspendLambda2 !is Function3<*, *, *, *>)          return "Fail: suspendLambda2 should be Function3"
+    if (suspendLambda2 is Function2<*, *, *>)              return "Fail: suspendLambda2 should NOT be Function2"
+    if (suspendLambda2 is KCallable<*>)                    return "Fail: suspendLambda2 should NOT be KCallable"
+    if (suspendLambda2 is KFunction<*>)                    return "Fail: suspendLambda2 should NOT be KFunction"
+    if (suspendLambda2 is KProperty<*>)                    return "Fail: suspendLambda2 should NOT be KProperty"
+
+    val suspendFunRef = ::suspendTopLevelFun
+
+    if (suspendFunRef !is (suspend (Int) -> Int))          return "Fail: ::suspendTopLevelFun should be suspend (Int) -> Int"
+
+    if (suspendFunRef !is Function<*>)              return "Fail: ::suspendTopLevelFun should be Function"
+    if (suspendFunRef !is Function2<*, *, *>)          return "Fail: ::suspendTopLevelFun should be Function2"
+    if (suspendFunRef is Function0<*>)              return "Fail: ::suspendTopLevelFun should NOT be Function0"
+    if (suspendFunRef is Function1<*, *>)        return "Fail: ::suspendTopLevelFun should NOT be Function1"
+
+    if (suspendFunRef !is KCallable<*>)             return "Fail: ::suspendTopLevelFun should be KCallable"
+    if (suspendFunRef !is KFunction<*>)             return "Fail: ::suspendTopLevelFun should be KFunction"
+    if (suspendFunRef !is KFunction2<*, *, *>)      return "Fail: ::suspendTopLevelFun should be KFunction2"
+    if (suspendFunRef is KFunction0<*>)             return "Fail: ::suspendTopLevelFun should NOT be KFunction0"
+    if (suspendFunRef is KFunction1<*, *>)       return "Fail: ::suspendTopLevelFun should NOT be KFunction1"
+
+    if (suspendFunRef is KProperty<*>)              return "Fail: ::suspendTopLevelFun should NOT be KProperty"
+
+    val suspendDefaultFunRef = ::suspendTopLevelFunWithDefault
+
+    if (suspendDefaultFunRef !is Function<*>)             return "Fail: ::suspendTopLevelFunWithDefault should be Function"
+    if (suspendDefaultFunRef !is Function3<*, *, *, *>)   return "Fail: ::suspendTopLevelFunWithDefault should be Function2"
+    if (suspendDefaultFunRef is Function2<*, *, *>)          return "Fail: ::suspendTopLevelFunWithDefault should NOT be Function2"
+    if (suspendDefaultFunRef is Function1<*, *>)    return "Fail: ::suspendTopLevelFunWithDefault should NOT be Function1"
+    if (suspendDefaultFunRef !is KCallable<*>)            return "Fail: ::suspendTopLevelFunWithDefault should be KCallable"
+    if (suspendDefaultFunRef !is KFunction<*>)            return "Fail: ::suspendTopLevelFunWithDefault should be KFunction"
+    if (suspendDefaultFunRef !is KFunction2<*, *, *>)        return "Fail: ::suspendTopLevelFunWithDefault should be KFunction1"
+    if (suspendDefaultFunRef !is KFunction3<*, *, *, *>)     return "Fail: ::suspendTopLevelFunWithDefault should be KFunction2"
+    if (suspendDefaultFunRef is KFunction1<*, *>)   return "Fail: ::suspendTopLevelFunWithDefault should NOT be KFunction3"
+    if (suspendDefaultFunRef is KProperty<*>)             return "Fail: ::suspendTopLevelFunWithDefault should NOT be KProperty"
+    if (suspendDefaultFunRef !is (suspend (Int, Int) -> Int))     return "Fail: ::suspendTopLevelFunWithDefault should be (Int, Int) -> Int"
+
+    return "OK"
+}

--- a/libraries/stdlib/js/runtime/coreRuntime.kt
+++ b/libraries/stdlib/js/runtime/coreRuntime.kt
@@ -34,8 +34,6 @@ internal fun equals(obj1: dynamic, obj2: dynamic): Boolean {
         if (obj1.`$id` != obj2.`$id`) return false
         if (obj1.`$flags` != obj2.`$flags`) return false
         if (obj1.`$arity` != obj2.`$arity`) return false
-
-        if (obj1.`$bound` == null && obj2.`$bound` == null) return true
         if (obj1.`$bound` === obj2.`$bound`) return true
         if (!isJsArray(obj1.`$bound`) || !isJsArray(obj2.`$bound`)) return false
 

--- a/libraries/stdlib/js/runtime/reflectRuntime.kt
+++ b/libraries/stdlib/js/runtime/reflectRuntime.kt
@@ -7,6 +7,7 @@ package kotlin.js
 
 import kotlin.internal.UsedFromCompilerGeneratedCode
 import kotlin.internal.throwUnsupportedOperationException
+import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 
 @UsedFromCompilerGeneratedCode
@@ -21,6 +22,9 @@ internal fun getPropertyCallableRef(
     getter.get = getter
     getter.set = setter
     getter.callableName = name
+
+    // Since KProperty is not KFunction
+    getter[KFunction::class.js.asDynamic().Symbol] = false
 
     return getPropertyRefClass(
         getter,
@@ -64,19 +68,42 @@ private val propertyRefClassMetadataCache: Array<Array<dynamic>> = arrayOf<Array
     arrayOf<dynamic>(metadataObject(), metadataObject())  // 2
 )
 
+@OptIn(JsIntrinsic::class)
 @UsedFromCompilerGeneratedCode
 internal fun constructCallableReference(
     callable: dynamic,
     arity: Int,
-    flags: Int?,
+    minimalArity: Int,
+    flags: dynamic,
     signatureId: Any?,
     name: String?,
     bounds: Array<Any>?
 ): dynamic {
     callable.callableName = name
     callable.`$flags` = flags
-    callable.`$arity` = arity
     callable.`$id` = signatureId
     callable.`$bound` = bounds
+    callable.`$minimalArity` = minimalArity
+
+    // We also use `constructCallableReference` for setting $arity of suspend lambdas
+    // (while they are not implementing KFunction)
+    // So that, to not accidentally make them KFunction we check if signatureId is provided
+    val isKFunction = signatureId !== VOID
+
+    if (isKFunction) {
+        val kFunctionClass = KFunction::class.js
+        callable[kFunctionClass.asDynamic().Symbol] = true
+        js("Object.assign(callable, kFunctionClass.prototype)")
+    }
+
+    // It's either a suspend lambda or a suspend function KFunction
+    if (!isKFunction || jsBitAnd(flags, 1) === 1) {
+        // Extracting continuation from the arity
+        callable.`$arity` = arity + 1
+        callable.`$suspendArity` = arity
+    } else {
+        callable.`$arity` = arity
+    }
+
     return callable
 }

--- a/libraries/stdlib/js/runtime/typeCheckUtils.kt
+++ b/libraries/stdlib/js/runtime/typeCheckUtils.kt
@@ -7,6 +7,7 @@ package kotlin.js
 
 import kotlin.internal.UsedFromCompilerGeneratedCode
 import kotlin.js.internal.boxedLong.BoxedLongApi
+import kotlin.reflect.KFunction
 
 internal external interface Ctor {
     var Symbol: dynamic
@@ -52,7 +53,7 @@ internal fun isSuspendFunction(obj: dynamic, arity: Int): Boolean {
 
     if (objTypeOf == "function") {
         @Suppress("DEPRECATED_IDENTITY_EQUALS")
-        return obj.`$arity`.unsafeCast<Int>() === arity
+        return obj.`$suspendArity`.unsafeCast<Int>() === arity
     }
 
     val suspendArity = obj?.constructor.unsafeCast<Ctor?>()?.`$metadata$`?.suspendArity ?: return false
@@ -66,6 +67,18 @@ internal fun isSuspendFunction(obj: dynamic, arity: Int): Boolean {
         }
     }
     return result
+}
+
+@UsedFromCompilerGeneratedCode
+internal fun isKFunctionN(obj: dynamic, expectedArity: Int): Boolean {
+    return isInterface(obj, KFunction::class.js) &&
+            (expectedArity >= obj.`$minimalArity`.unsafeCast<Int>() && expectedArity <= obj.`$arity`.unsafeCast<Int>())
+}
+
+@UsedFromCompilerGeneratedCode
+internal fun isFunctionN(obj: dynamic, expectedArity: Int): Boolean {
+    val actualArity = obj.`$arity` ?: obj.length
+    return js("typeof obj === 'function'") && actualArity === expectedArity
 }
 
 internal fun isJsArray(obj: Any): Boolean {

--- a/libraries/stdlib/js/src/kotlin/reflect/KFunctionImpl.kt
+++ b/libraries/stdlib/js/src/kotlin/reflect/KFunctionImpl.kt
@@ -3,4 +3,9 @@ package kotlin.reflect.js.internal
 import kotlin.internal.UsedFromCompilerGeneratedCode
 
 @UsedFromCompilerGeneratedCode
-internal abstract class KFunctionImpl(val flags: Int, val arity: Int, val id: String)
+internal abstract class KFunctionImpl(
+    val flags: Int,
+    val arity: Int,
+    val minimalArity: Int,
+    val id: String
+)


### PR DESCRIPTION
For a long time, all function checks on the JS side were just typeof x === "function", which was misaligned with the behavior of other
 backends.

This commit introduces more precise type checks for KFunction*, Function*, and KCallable on function references and lambdas, bringing JS
 in line with the JVM backend.

^KT-35479 Fixed
^KT-87243 Fixed