### PR TITLE
[KMP] Merge JVM metadata module header across incremental builds

### DIFF
--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmSerializeCommonMetadataPipelinePhase.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmSerializeCommonMetadataPipelinePhase.kt
@@ -10,10 +10,18 @@ import org.jetbrains.kotlin.cli.pipeline.PerformanceNotifications
 import org.jetbrains.kotlin.cli.pipeline.PipelinePhase
 import org.jetbrains.kotlin.cli.pipeline.jvm.JvmFrontendPipelineArtifact
 import org.jetbrains.kotlin.cli.pipeline.metadata.MetadataFrontendPipelineArtifact
+import org.jetbrains.kotlin.cli.pipeline.metadata.MetadataInMemorySerializationArtifact
 import org.jetbrains.kotlin.cli.pipeline.metadata.MetadataKlibInMemorySerializerPhase
 import org.jetbrains.kotlin.config.commonFragmentsOutputDir
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.pipeline.AllModulesFrontendOutput
+import org.jetbrains.kotlin.library.SerializedFirMetadata
+import org.jetbrains.kotlin.library.components.KlibMetadataComponentLayout
+import org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf
+import org.jetbrains.kotlin.library.metadata.parseModuleHeader
+import java.nio.file.Path
+import kotlin.io.path.notExists
+import kotlin.io.path.readBytes
 
 internal object JvmSerializeCommonMetadataPipelinePhase : PipelinePhase<JvmFrontendPipelineArtifact, JvmFrontendPipelineArtifact>(
     name = "JvmSerializeCommonMetadataPipelinePhase",
@@ -37,11 +45,61 @@ internal object JvmSerializeCommonMetadataPipelinePhase : PipelinePhase<JvmFront
                 configuration = configuration,
                 sourceFiles = input.sourceFiles,
             )
-            val metadataInMemory = MetadataKlibInMemorySerializerPhase.executePhase(inputForPhase)
+
+            val destinationDir = outputDir.resolve(output.session.moduleData.name.asStringStripSpecialMarkers())
+
+            val metadataInMemory =
+                MetadataKlibInMemorySerializerPhase.executePhase(inputForPhase)
+                    .mergeMetadataHeader(loadPreviousMetadataHeader(destinationDir.toPath()))
+
             JvmMetadataKlibFileWriterPhase.writeToDisc(
                 metadataInMemory,
-                outputDir.resolve(output.session.moduleData.name.asStringStripSpecialMarkers())
+                destinationDir
             )
         }
+    }
+
+    private fun MetadataInMemorySerializationArtifact.mergeMetadataHeader(previousMetadataHeader: KlibMetadataProtoBuf.Header?): MetadataInMemorySerializationArtifact {
+        if (previousMetadataHeader == null) return this
+
+        (val firMetadata, val configuration) = this
+        val currentMetadataHeader = parseModuleHeader(firMetadata.module)
+
+        val header = KlibMetadataProtoBuf.Header.newBuilder().apply {
+            moduleName = currentMetadataHeader.moduleName
+            flags = currentMetadataHeader.flags
+
+            addAllPackageFragmentName(buildSet {
+                addAll(currentMetadataHeader.packageFragmentNameList)
+                addAll(previousMetadataHeader.packageFragmentNameList)
+            })
+        }.build()
+
+        return MetadataInMemorySerializationArtifact(
+            SerializedFirMetadata(header.toByteArray(), firMetadata.fragments, firMetadata.fragmentNames, firMetadata.metadataVersion),
+            configuration
+        )
+    }
+
+    /**
+     * Loads the module header produced by the previous compilation, or `null` if there is none yet.
+     *
+     * The header is read directly from the metadata output directory. This is a temporary workaround
+     * to unblock testing: the proper incremental flow should report the header output via the file
+     * mapping tracker, store it in the incremental cache, and have `IncrementalFirProvider` load the
+     * previous header from that cache instead of from the file system.
+     *
+     * TODO(KT-87249): Handle package removals and incremental tracking. The previous header is currently merged
+     *  as-is, so package fragments that are no longer produced by the compilation are kept around even when some
+     *  of them are already obsolete. Eventually this file may be removed altogether, see KT-87197.
+     */
+    private fun loadPreviousMetadataHeader(directory: Path): KlibMetadataProtoBuf.Header? {
+        val moduleHeaderFile = KlibMetadataComponentLayout(directory).moduleHeaderFile
+
+        if (moduleHeaderFile.notExists()) {
+            return null
+        }
+
+        return parseModuleHeader(moduleHeaderFile.readBytes())
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/JvmClasspathMetadataIncrementalIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/JvmClasspathMetadataIncrementalIT.kt
@@ -10,8 +10,7 @@ import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
 import org.junit.jupiter.api.DisplayName
-import kotlin.io.path.createDirectories
-import kotlin.io.path.writeText
+import kotlin.io.path.deleteExisting
 
 @MppGradlePluginTests
 @DisplayName("JVM classpath metadata incremental compilation")
@@ -65,7 +64,7 @@ class JvmClasspathMetadataIncrementalIT : KGPBaseTest() {
     }
 
     @GradleTest
-    @DisplayName("Verify that incremental compilation without JVM classpath metadata leads to correct resolution")
+    @DisplayName("Verify that incremental compilation with JVM classpath metadata leads to correct resolution")
     fun testWithJvmClasspathMetadataEnabled(gradleVersion: GradleVersion) {
         project(
             projectName = "empty", gradleVersion = gradleVersion, buildOptions = defaultBuildOptions.copy(jvmClasspathMetadata = true)
@@ -129,6 +128,121 @@ class JvmClasspathMetadataIncrementalIT : KGPBaseTest() {
                 println("KMP output: ${foo()}")
             }
             """.trimIndent()
+        }
+    }
+
+    @GradleTest
+    @DisplayName("Verify metadata header merge preserves packages of files not recompiled")
+    fun testMetadataHeaderMergePreservesUntouchedPackages(gradleVersion: GradleVersion) {
+        project(
+            projectName = "empty", gradleVersion = gradleVersion, buildOptions = defaultBuildOptions.copy(jvmClasspathMetadata = true)
+        ) {
+            setupMetadataHeaderTestProject()
+
+            build("compileKotlinJvm") {
+                assertTasksExecuted(":compileKotlinJvm")
+                assertCompiledKotlinSources(
+                    expectedSources = relativeToProject(
+                        listOf(
+                            kotlinSourcesDir("commonMain").resolve("com/example/one/bar.kt"),
+                            kotlinSourcesDir("commonMain").resolve("com/example/two/foo.kt")
+                        )
+                    ), output = output
+                )
+            }
+
+            kotlinSourcesDir("commonMain").resolve("com/example/two/foo.kt").modify { content ->
+                content.replace("fun foo() = bar(42)", "fun foo() = bar(41)")
+            }
+
+            build("compileKotlinJvm") {
+                assertTasksExecuted(":compileKotlinJvm")
+                assertCompiledKotlinSources(
+                    expectedSources = relativeToProject(listOf(kotlinSourcesDir("commonMain").resolve("com/example/two/foo.kt"))),
+                    output = output
+                )
+            }
+
+            kotlinSourcesDir("commonMain").resolve("com/example/two/foo.kt").modify { content ->
+                content.replace("fun foo() = bar(41)", "fun foo() = bar(40)")
+            }
+
+            build("compileKotlinJvm") {
+                assertTasksExecuted(":compileKotlinJvm")
+                assertCompiledKotlinSources(
+                    expectedSources = relativeToProject(listOf(kotlinSourcesDir("commonMain").resolve("com/example/two/foo.kt"))),
+                    output = output
+                )
+            }
+        }
+    }
+
+    @GradleTest
+    @DisplayName("Verify obsolete package data in metadata header does not break incremental compilation")
+    fun testObsoletePackageInMetadataHeaderDoesNotBreakIncrementalCompilation(gradleVersion: GradleVersion) {
+        project(
+            projectName = "empty", gradleVersion = gradleVersion, buildOptions = defaultBuildOptions.copy(jvmClasspathMetadata = true)
+        ) {
+            setupMetadataHeaderTestProject()
+
+            build("compileKotlinJvm") {
+                assertTasksExecuted(":compileKotlinJvm")
+                assertCompiledKotlinSources(
+                    expectedSources = relativeToProject(
+                        listOf(
+                            kotlinSourcesDir("commonMain").resolve("com/example/one/bar.kt"),
+                            kotlinSourcesDir("commonMain").resolve("com/example/two/foo.kt")
+                        )
+                    ), output = output
+                )
+            }
+
+            kotlinSourcesDir("commonMain").resolve("com/example/two/foo.kt").deleteExisting()
+
+            build("compileKotlinJvm") {
+                assertTasksExecuted(":compileKotlinJvm")
+                assertCompiledKotlinSources(
+                    expectedSources = emptyList(),
+                    output = output
+                )
+            }
+
+            kotlinSourcesDir("commonMain").resolve("com/example/one/bar.kt").modify { content ->
+                content.replace("fun bar(a: Any) = \"Any\"", "fun bar(a: Any) = \"Any!\"")
+            }
+
+            build("compileKotlinJvm") {
+                assertTasksExecuted(":compileKotlinJvm")
+                assertCompiledKotlinSources(
+                    expectedSources = relativeToProject(listOf(kotlinSourcesDir("commonMain").resolve("com/example/one/bar.kt"))),
+                    output = output
+                )
+            }
+        }
+    }
+
+    private fun TestProject.setupMetadataHeaderTestProject() {
+        addKgpToBuildScriptCompilationClasspath()
+        buildScriptInjection {
+            project.applyMultiplatform {
+                jvm()
+            }
+        }
+        kotlinSourcesDir("commonMain").apply {
+            source("com/example/one/bar.kt") {
+                """
+                    package com.example.one
+                    fun bar(a: Any) = "Any"
+                    """.trimIndent()
+            }
+
+            source("com/example/two/foo.kt") {
+                """
+                    package com.example.two
+                    import com.example.one.bar
+                    fun foo() = bar(42)
+                    """.trimIndent()
+            }
         }
     }
 }


### PR DESCRIPTION
For now the previous header is read directly from the metadata output directory, and removed packages are still kept. Both are temporary and tracked separately in KT-87249.

^KT-87248 Verification Pending