### PR TITLE
[tests] Add JsBrowserGradlePluginTests for tests with browser

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/AGENTS.md
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/AGENTS.md
@@ -8,6 +8,7 @@ Integration tests for the Kotlin Gradle Plugin using Gradle TestKit.
 # Platform-specific tests (parallel execution)
 ./gradlew :kotlin-gradle-plugin-integration-tests:kgpJvmTests
 ./gradlew :kotlin-gradle-plugin-integration-tests:kgpJsTests
+./gradlew :kotlin-gradle-plugin-integration-tests:kgpJsBrowserTests
 ./gradlew :kotlin-gradle-plugin-integration-tests:kgpMppTests
 ./gradlew :kotlin-gradle-plugin-integration-tests:kgpNativeTests
 ./gradlew :kotlin-gradle-plugin-integration-tests:kgpSwiftPMImportTests
@@ -31,6 +32,7 @@ Integration tests for the Kotlin Gradle Plugin using Gradle TestKit.
 Extend `KGPBaseTest` and annotate with appropriate tag:
 - `@JvmGradlePluginTests` - Kotlin/JVM tests
 - `@JsGradlePluginTests` - Kotlin/JS tests
+- `@JsBrowserGradlePluginTests` - Kotlin/JS tests that require running browser
 - `@MppGradlePluginTests` - Multiplatform tests
 - `@NativeGradlePluginTests` - Kotlin/Native tests
 - `@SwiftPMImportGradlePluginTests` - SwiftPM import tests

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/Readme.md
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/Readme.md
@@ -10,6 +10,7 @@ To run all tests for all Gradle plugins use `check` task.
 More fine-grained test tasks exist covering different parts of Gradle plugins:
 - `kgpJvmTests` - runs all tests for Kotlin Gradle Plugin/Jvm platform (parallel execution)
 - `kgpJsTests` - runs all tests for Kotlin Gradle Plugin/Js platform (parallel execution)
+- `kgpJsBrowserTests` - runs tests for Kotlin Gradle Plugin/Js platform that require running browser
 - `kgpAndroidTests` - runs all tests for Kotlin Gradle Plugin/Android platform (parallel execution)
 - `kgpMppTests` - run all tests for Kotlin Gradle Multiplatform plugin (parallel execution)
 - `kgpNativeTests` - run all tests for Kotlin Gradle Plugin with K/N (parallel execution)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -242,6 +242,7 @@ enum class JunitTag {
     JvmKGP,
     DaemonsKGP,
     JsKGP,
+    JsBrowserKGP,
     NativeKGP,
     MppKGP,
     AndroidKGP,
@@ -323,6 +324,11 @@ val perTagJunitTasks = JunitTag.values().map { junitTag ->
         JunitTag.JsKGP -> junitTag.taskConfiguration(
             "Run tests for Kotlin/JS part of Gradle plugin",
             "kgpJsTests",
+        )
+
+        JunitTag.JsBrowserKGP -> junitTag.taskConfiguration(
+            "Run tests for Kotlin/JS part of Gradle plugin",
+            "kgpJsBrowserTests",
         )
         JunitTag.NativeKGP -> junitTag.taskConfiguration(
             "Run tests for Kotlin/Native part of Gradle plugin",

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -29,13 +29,8 @@ import kotlin.io.path.writeText
 import kotlin.test.Ignore
 import kotlin.test.assertEquals
 
-// remove after KTI-3326 Allow kotlin teamcity agents to run playwright browsers
-@OsCondition(
-    supportedOn = [OS.MAC],
-    enabledOnCI = [OS.MAC]
-)
 @OptIn(ExperimentalJsTestDsl::class)
-@JsGradlePluginTests
+@JsBrowserGradlePluginTests
 class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
     override val defaultBuildOptions: BuildOptions
         get() = super.defaultBuildOptions.copy().disableIsolatedProjectsBecauseOfJsAndWasmKT75899()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/tagsValidator.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/tagsValidator.kt
@@ -55,6 +55,7 @@ class TagsCountValidatorInterceptor : InvocationInterceptor {
         it is JvmGradlePluginTests ||
                 it is DaemonsGradlePluginTests ||
                 it is JsGradlePluginTests ||
+                it is JsBrowserGradlePluginTests ||
                 it is NativeGradlePluginTests ||
                 it is MppGradlePluginTests ||
                 it is AndroidGradlePluginTests ||

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testTags.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testTags.kt
@@ -48,6 +48,19 @@ annotation class JvmGradlePluginTests
 annotation class JsGradlePluginTests
 
 /**
+ * Add it to tests covering Kotlin Gradle Plugin/JS platform that require to run browser.
+ *
+ * You could add tag onto test suite once, but then all tests
+ * in test suite should be for the related tag.
+ * Preferably add tag for each test.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag("JsBrowserKGP")
+@AffectedByJs
+annotation class JsBrowserGradlePluginTests
+
+/**
  * Add it to tests covering Kotlin Gradle Plugin/Native platform.
  *
  * You could add tag onto test suite once, but then all tests


### PR DESCRIPTION
For tests with browser we have a separate TC configuration that will have another environment and run nightly.

KTI-3326