### PR TITLE
[stdlib] Add text-specific sample for elementAtOrNull

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -40,7 +40,7 @@ public inline fun CharSequence.elementAtOrElse(index: Int, defaultValue: (Int) -
 /**
  * Returns a character at the given [index] or `null` if the [index] is out of bounds of this char sequence.
  * 
- * @sample samples.collections.Collections.Elements.elementAtOrNull
+ * @sample samples.text.Strings.elementAtOrNull
  */
 @kotlin.internal.InlineOnly
 public inline fun CharSequence.elementAtOrNull(index: Int): Char? {

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -129,6 +129,22 @@ class Strings {
     }
 
     @Sample
+    fun elementAtOrNull() {
+        val lion = "Lion"
+
+        // safe access returns char at the given index
+        assertPrints(lion.elementAtOrNull(0), "L")
+        assertPrints(lion.elementAtOrNull(lion.lastIndex), "n")
+
+        // index out of bounds returns null
+        assertPrints(lion.elementAtOrNull(-1), "null")
+        assertPrints(lion.elementAtOrNull(20), "null")
+
+        // empty string always returns null
+        assertPrints("".elementAtOrNull(0), "null")
+    }
+
+    @Sample
     fun filter() {
         val text = "a1b2c3d4e5"
 

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Elements.kt
@@ -470,6 +470,9 @@ object Elements : TemplateGroupBase() {
             inlineOnly()
             body { "return this.getOrNull(index)" }
         }
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.elementAtOrNull")
+        }
     }
 
     val f_getOrNull = fn("getOrNull(index: Int)") {


### PR DESCRIPTION
Add the `String` extension operation `elementAtOrNull` sample.

The sample demonstrates safe character access on strings, covering:
- Valid index access
- Negative and positive out-of-bounds indices
- Edge case of an empty string

All scenarios correctly return the expected character or `null`.

**Why this change ?**
- To improve the text-extension operations documentation
- Related to issue [KT-35867](https://youtrack.jetbrains.com/issue/KT-35867/kotlin.text-extension-function-samples-should-be-specialized-for-strings)