### PR TITLE
[Native][Tests] Support configuration of IR checkers in `NativeCompilerSecondStageFacade`

### DIFF
--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeCompilerSecondStageFacade.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeCompilerSecondStageFacade.kt
@@ -17,29 +17,23 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.AssertionsMode
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestDirectives.ASSERTIONS_MODE
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestDirectives.FILECHECK_STAGE
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestDirectives.FREE_COMPILER_ARGS
+import org.jetbrains.kotlin.konan.test.blackbox.support.group.collectToggledCheckers
 import org.jetbrains.kotlin.konan.test.blackbox.support.settings.CacheMode
 import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
 import org.jetbrains.kotlin.konan.test.blackbox.support.settings.OptimizationMode
 import org.jetbrains.kotlin.konan.test.blackbox.support.settings.withPlatformLibs
 import org.jetbrains.kotlin.konan.test.blackbox.testRunSettings
 import org.jetbrains.kotlin.test.GroupingStageInputArtifact
-import org.jetbrains.kotlin.test.TestInfrastructureException
 import org.jetbrains.kotlin.test.checkTestInfrastructure
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives
 import org.jetbrains.kotlin.test.directives.NativeEnvironmentConfigurationDirectives.WITH_PLATFORM_LIBS
 import org.jetbrains.kotlin.test.klib.CustomKlibCompilerException
 import org.jetbrains.kotlin.test.klib.CustomKlibCompilerSecondStageFacade
 import org.jetbrains.kotlin.test.model.*
-import org.jetbrains.kotlin.test.services.CompilationStage
-import org.jetbrains.kotlin.test.services.TestServices
-import org.jetbrains.kotlin.test.services.artifactsProvider
-import org.jetbrains.kotlin.test.services.assertions
-import org.jetbrains.kotlin.test.services.compilerConfigurationProvider
+import org.jetbrains.kotlin.test.services.*
 import org.jetbrains.kotlin.test.services.configuration.NativeEnvironmentConfigurator
-import org.jetbrains.kotlin.test.services.moduleStructure
-import org.jetbrains.kotlin.test.services.temporaryDirectoryManager
-import org.jetbrains.kotlin.test.services.testInfo
 import org.jetbrains.kotlin.test.testInfraError
+import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -91,7 +85,7 @@ class NativeCompilerSecondStageFacade private constructor(
                 enableAssertions = AssertionsMode.ALWAYS_DISABLE !in module.directives[ASSERTIONS_MODE],
                 withPlatformLibs = module.directives.contains(WITH_PLATFORM_LIBS),
                 customLanguageFeatures = module.directives[LanguageSettingsDirectives.LANGUAGE],
-                freeArgs = module.directives[FREE_COMPILER_ARGS] + customArgs,
+                freeArgs = module.directives[FREE_COMPILER_ARGS] + irCheckersArguments(module) + customArgs,
                 verifyIrMode = if (isCompatibilityTesting) VerifyIrMode.NONE else VerifyIrMode.ERROR,
             )
 
@@ -155,7 +149,7 @@ class NativeCompilerSecondStageFacade private constructor(
                 enableAssertions = AssertionsMode.ALWAYS_DISABLE !in someModule.directives[ASSERTIONS_MODE],
                 withPlatformLibs = someModule.directives.contains(WITH_PLATFORM_LIBS),
                 customLanguageFeatures = someModule.directives[LanguageSettingsDirectives.LANGUAGE],
-                freeArgs = freeArgs + "-Xklib-duplicated-unique-name-strategy=allow-all-with-warning",
+                freeArgs = freeArgs + irCheckersArguments(someModule) + "-Xklib-duplicated-unique-name-strategy=allow-all-with-warning",
                 verifyIrMode = VerifyIrMode.ERROR,
             )
 
@@ -276,3 +270,10 @@ internal fun TestModule.fileCheckStage(): String? {
  * Constructs file check dump path for the given executable file and stage
  */
 internal fun File.fileCheckDump(fileCheckStage: String): File = this.resolveSibling("out.$fileCheckStage.ll")
+
+fun irCheckersArguments(module: TestModule): List<String> =
+    module.directives.collectToggledCheckers().let { [additional, disabled] ->
+        val additionalArgs = additional.ifNotEmpty { "-Xadditional-ir-checkers=" + additional.joinToString(",") }
+        val disabledArgs = disabled.ifNotEmpty { "-Xdisable-ir-checkers=" + disabled.joinToString(",") }
+        listOfNotNull(additionalArgs, disabledArgs)
+    }

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeGroupingTestIsolator.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/NativeGroupingTestIsolator.kt
@@ -10,15 +10,18 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.AssertionsMode
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestDirectives
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestDirectives.FREE_COMPILER_ARGS
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestKind
+import org.jetbrains.kotlin.konan.test.blackbox.support.group.collectToggledCheckers
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.isDisabledNative
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.isIgnoredTarget
 import org.jetbrains.kotlin.konan.test.blackbox.support.testKind
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
 import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
+import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.directives.model.singleOrZeroValue
 import org.jetbrains.kotlin.test.model.GroupingTestIsolator
 import org.jetbrains.kotlin.test.services.TestModuleStructure
 import org.jetbrains.kotlin.test.services.TestServices
+import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
 class NativeGroupingTestIsolator(testServices: TestServices) : GroupingTestIsolator(testServices, affectsFileGenerators = true) {
     companion object {
@@ -52,6 +55,7 @@ class NativeGroupingTestIsolator(testServices: TestServices) : GroupingTestIsola
         val specificTokens = listOfNotNull(
             computeAssertionsModeToken(moduleStructure),
             computeFreeCompilerArgsToken(moduleStructure),
+            computeToggledCheckersToken(registeredDirectives),
         )
 
         return when (specificTokens.size) {
@@ -71,6 +75,11 @@ class NativeGroupingTestIsolator(testServices: TestServices) : GroupingTestIsola
         return FreeCompilerArgsToken(freeArgs.toSet())
     }
 
+    private fun computeToggledCheckersToken(registeredDirectives: RegisteredDirectives): ToggledCheckersToken? =
+        registeredDirectives.collectToggledCheckers().let { [additional, disabled] -> additional + disabled }
+            .ifNotEmpty { ToggledCheckersToken(this) }
+
+
     private val packageKotlinInternalRegex = Regex("package\\s${StandardNames.KOTLIN_INTERNAL_FQ_NAME}")
     private val sourceContainsCache = HashMap<Pair<TestModuleStructure, Regex>, Boolean>()
 
@@ -79,4 +88,6 @@ class NativeGroupingTestIsolator(testServices: TestServices) : GroupingTestIsola
     }
 
     private data class FreeCompilerArgsToken(val freeArgs: Set<String>) : BatchToken()
+
+    private data class ToggledCheckersToken(val toggledCheckers: Set<String>) : BatchToken()
 }

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/IgnoreDisableHelper.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/IgnoreDisableHelper.kt
@@ -18,6 +18,8 @@ import org.jetbrains.kotlin.test.TargetBackend
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.directives.model.StringDirective
+import org.jetbrains.kotlin.test.services.IrCheckersDisabledByTestDirectives
+import org.jetbrains.kotlin.test.services.IrCheckersEnabledByTestDirectives
 
 private val TARGET_FAMILY = "targetFamily"
 private val TARGET_ARCHITECTURE = "targetArchitecture"
@@ -102,3 +104,11 @@ internal fun Settings.evaluate(registeredDirectives: RegisteredDirectives, direc
     }
     return false
 }
+
+fun RegisteredDirectives.collectToggledCheckers(): Pair<Set<String>, Set<String>> {
+    val additionalCheckers = IrCheckersEnabledByTestDirectives.filter { it.key in this }.values.toSet()
+    val disabledIrCheckers = IrCheckersDisabledByTestDirectives.filter { this[it.key].containsNativeOrAny }.values.toSet()
+
+    return additionalCheckers to disabledIrCheckers
+}
+


### PR DESCRIPTION
Also, add a `toggledCheckerToken` for correct isolation.

^KT-87264 Fixed