### PR TITLE
[IR] Correctly set return type when inlining function value

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrInlineUtils.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrInlineUtils.kt
@@ -18,7 +18,9 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnableBlockImpl
 import org.jetbrains.kotlin.ir.symbols.IrReturnTargetSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrReturnableBlockSymbolImpl
+import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.types.typeOrFail
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
@@ -128,8 +130,9 @@ fun IrInlinable.inline(target: IrDeclarationParent, arguments: List<IrValueDecla
 
         is IrInvokable -> {
             val invoke = invokable.type.getClass()!!.functions.single { it.name == OperatorNameConventions.INVOKE }
+            val returnType = (invokable.type as IrSimpleType).arguments.last().typeOrFail
             IrCallImpl(
-                UNDEFINED_OFFSET, UNDEFINED_OFFSET, invoke.returnType, invoke.symbol,
+                UNDEFINED_OFFSET, UNDEFINED_OFFSET, returnType, invoke.symbol,
                 typeArgumentsCount = 0,
             ).apply {
                 val newArguments = (listOf(invokable) + arguments).map { arg ->


### PR DESCRIPTION
When inlining a call to a function value `IrInlinable.inline` gave the synthesized `invoke` call the function's raw return type parameter instead of the concrete type.

KT-69305
^KT-87272 Fixed

To test the change please apply: 
[[TMP]_Test_setup.patch](https://github.com/user-attachments/files/29516135/TMP._Test_setup.patch)
and run `org.jetbrains.kotlin.wasm.test.FirWasmJsCodegenBoxWithInlinedFunInKlibTestGenerated.Box.CallableReference#testInlineArrayConstructors`
