### PR TITLE
[IR] Enable type parameters scope checking after all function inlining

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrInlineUtils.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/ir/IrInlineUtils.kt
@@ -18,7 +18,9 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnableBlockImpl
 import org.jetbrains.kotlin.ir.symbols.IrReturnTargetSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrReturnableBlockSymbolImpl
+import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.types.typeOrFail
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
@@ -128,8 +130,9 @@ fun IrInlinable.inline(target: IrDeclarationParent, arguments: List<IrValueDecla
 
         is IrInvokable -> {
             val invoke = invokable.type.getClass()!!.functions.single { it.name == OperatorNameConventions.INVOKE }
+            val returnType = (invokable.type as IrSimpleType).arguments.last().typeOrFail
             IrCallImpl(
-                UNDEFINED_OFFSET, UNDEFINED_OFFSET, invoke.returnType, invoke.symbol,
+                UNDEFINED_OFFSET, UNDEFINED_OFFSET, returnType, invoke.symbol,
                 typeArgumentsCount = 0,
             ).apply {
                 val newArguments = (listOf(invokable) + arguments).map { arg ->

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/SyntheticAccessorGenerator.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/SyntheticAccessorGenerator.kt
@@ -436,11 +436,21 @@ abstract class SyntheticAccessorGenerator<Context : LoweringContext, ScopeInfo>(
             accessorSymbol is IrConstructorSymbol -> accessorSymbol.produceCallToSyntheticConstructor(oldExpression)
             else -> accessorSymbol.produceCallToSyntheticFunction(oldExpression)
         }
-        val capturedTypeParameters = if (oldExpression is IrCall)
-            capturedTypeParametersOfSyntheticAccessor(oldExpression.symbol.owner) else listOf()
-        capturedTypeParameters.forEachIndexed { index, typeParameter ->
-            newExpression.typeArguments[index] = typeParameter.defaultType
+
+        val accessedFunction = oldExpression.symbol.owner
+        val capturedTypeParameters = if (oldExpression is IrCall) capturedTypeParametersOfSyntheticAccessor(accessedFunction) else listOf()
+        val receiverParameterClass = accessedFunction.dispatchReceiverParameter?.type?.classOrNull
+        val receiverArgumentType = oldExpression.dispatchReceiver?.type as? IrSimpleType
+        val receiverSubstitutor = if (receiverParameterClass != null && receiverArgumentType != null) {
+            AbstractIrTypeSubstitutor.forSuperClass(receiverParameterClass, receiverArgumentType)
+        } else {
+            null
         }
+        capturedTypeParameters.forEachIndexed { index, typeParameter ->
+            newExpression.typeArguments[index] =
+                receiverSubstitutor?.substitute(typeParameter.defaultType) ?: typeParameter.erasedUpperBound.defaultType
+        }
+
         newExpression.copyTypeArgumentsFrom(oldExpression, shift = capturedTypeParameters.size)
         val newExpressionArguments = if (accessorSymbol is IrConstructorSymbol) {
             oldExpression.arguments + createAccessorMarkerArgument()

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/SyntheticAccessorGenerator.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/SyntheticAccessorGenerator.kt
@@ -436,12 +436,21 @@ abstract class SyntheticAccessorGenerator<Context : LoweringContext, ScopeInfo>(
             accessorSymbol is IrConstructorSymbol -> accessorSymbol.produceCallToSyntheticConstructor(oldExpression)
             else -> accessorSymbol.produceCallToSyntheticFunction(oldExpression)
         }
-        val capturedTypeParameters = if (oldExpression is IrCall)
-            capturedTypeParametersOfSyntheticAccessor(oldExpression.symbol.owner) else listOf()
-        val receiverArguments = (oldExpression.dispatchReceiver?.type as? IrSimpleType)?.arguments
-        capturedTypeParameters.forEachIndexed { index, typeParameter ->
-            newExpression.typeArguments[index] = receiverArguments?.getOrNull(index)?.typeOrNull ?: typeParameter.defaultType
+
+        val accessedFunction = oldExpression.symbol.owner
+        val capturedTypeParameters = if (oldExpression is IrCall) capturedTypeParametersOfSyntheticAccessor(accessedFunction) else listOf()
+        val receiverParameterClass = accessedFunction.dispatchReceiverParameter?.type?.classOrNull
+        val receiverArgumentType = oldExpression.dispatchReceiver?.type as? IrSimpleType
+        val receiverSubstitutor = if (receiverParameterClass != null && receiverArgumentType != null) {
+            AbstractIrTypeSubstitutor.forSuperClass(receiverParameterClass, receiverArgumentType)
+        } else {
+            null
         }
+        capturedTypeParameters.forEachIndexed { index, typeParameter ->
+            newExpression.typeArguments[index] =
+                receiverSubstitutor?.substitute(typeParameter.defaultType) ?: typeParameter.erasedUpperBound.defaultType
+        }
+
         newExpression.copyTypeArgumentsFrom(oldExpression, shift = capturedTypeParameters.size)
         val newExpressionArguments = if (accessorSymbol is IrConstructorSymbol) {
             oldExpression.arguments + createAccessorMarkerArgument()

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/SyntheticAccessorGenerator.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/SyntheticAccessorGenerator.kt
@@ -436,21 +436,12 @@ abstract class SyntheticAccessorGenerator<Context : LoweringContext, ScopeInfo>(
             accessorSymbol is IrConstructorSymbol -> accessorSymbol.produceCallToSyntheticConstructor(oldExpression)
             else -> accessorSymbol.produceCallToSyntheticFunction(oldExpression)
         }
-
-        val accessedFunction = oldExpression.symbol.owner
-        val capturedTypeParameters = if (oldExpression is IrCall) capturedTypeParametersOfSyntheticAccessor(accessedFunction) else listOf()
-        val receiverParameterClass = accessedFunction.dispatchReceiverParameter?.type?.classOrNull
-        val receiverArgumentType = oldExpression.dispatchReceiver?.type as? IrSimpleType
-        val receiverSubstitutor = if (receiverParameterClass != null && receiverArgumentType != null) {
-            AbstractIrTypeSubstitutor.forSuperClass(receiverParameterClass, receiverArgumentType)
-        } else {
-            null
-        }
+        val capturedTypeParameters = if (oldExpression is IrCall)
+            capturedTypeParametersOfSyntheticAccessor(oldExpression.symbol.owner) else listOf()
+        val receiverArguments = (oldExpression.dispatchReceiver?.type as? IrSimpleType)?.arguments
         capturedTypeParameters.forEachIndexed { index, typeParameter ->
-            newExpression.typeArguments[index] =
-                receiverSubstitutor?.substitute(typeParameter.defaultType) ?: typeParameter.erasedUpperBound.defaultType
+            newExpression.typeArguments[index] = receiverArguments?.getOrNull(index)?.typeOrNull ?: typeParameter.defaultType
         }
-
         newExpression.copyTypeArgumentsFrom(oldExpression, shift = capturedTypeParameters.size)
         val newExpressionArguments = if (accessorSymbol is IrConstructorSymbol) {
             oldExpression.arguments + createAccessorMarkerArgument()

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/IrValidationPhase.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/IrValidationPhase.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.ir.validation.checkers.expression.IrCrossFileFieldUs
 import org.jetbrains.kotlin.ir.validation.checkers.expression.IrTypeOperatorRedundancyChecker
 import org.jetbrains.kotlin.ir.validation.checkers.expression.IrValueAccessScopeChecker
 import org.jetbrains.kotlin.ir.validation.checkers.symbol.IrVisibilityChecker
+import org.jetbrains.kotlin.ir.validation.checkers.type.IrTypeParameterScopeChecker
 import org.jetbrains.kotlin.utils.addToStdlib.applyIf
 
 abstract class IrValidationPhase<Context : LoweringContext>(val context: Context) : ModuleLoweringPass {
@@ -46,7 +47,6 @@ class KlibIrValidationBeforeLoweringPhase<Context : LoweringContext>(context: Co
                 IrExpressionBodyInFunctionChecker,
                 IrVisibilityChecker.Relaxed,
                 IrCrossFileFieldUsageChecker,
-                //IrTypeParameterScopeChecker // TODO: Re-enable checking out-of-scope type parameter usages (KT-69305)
             )
             .withVarargChecks()
             //.withTypeChecks() // TODO: Re-enable checking types (KT-68663)
@@ -101,7 +101,7 @@ class IrValidationAfterInliningAllFunctionsOnTheFirstStagePhase<Context : Loweri
 ) : IrValidationPhase<Context>(context) {
     override val defaultValidationConfig: IrValidatorConfig
         get() = IrValidatorConfig()
-            .withCheckers(IrTypeOperatorRedundancyChecker)
+            .withCheckers(IrTypeOperatorRedundancyChecker, IrTypeParameterScopeChecker)
             .withInlineFunctionCallsiteCheck(checkInlineFunctionCallSites)
             .withoutCheckersByName(context.configuration.disableIrCheckers)
 }

--- a/compiler/testData/klib/syntheticAccessors/privateMember/singleFile/leakingPrivatePropertyFromCompanionMethod.accessors.txt
+++ b/compiler/testData/klib/syntheticAccessors/privateMember/singleFile/leakingPrivatePropertyFromCompanionMethod.accessors.txt
@@ -7,8 +7,8 @@ internal class UndoManager<R : Any?>
         /* TARGET declaration */ private fun <get-capacity>(): String
     public companion object Companion
         public inline fun <reified T : Any?> getValue(value: UndoManager<T>): String
-            /* ACCESSOR use-site */ access$<get-capacity><R>($this = value)
+            /* ACCESSOR use-site */ access$<get-capacity><T>($this = value)
     /* ACCESSOR declaration */ internal companion fun <R : Any?> access$<get-capacity>($this: UndoManager<R>): String
         /* TARGET use-site */ $this.<get-capacity>()
 public fun box(): String
-    /* ACCESSOR use-site */ access$<get-capacity><R>($this = value)
+    /* ACCESSOR use-site */ access$<get-capacity><Int>($this = value)


### PR DESCRIPTION
KT-87272 Fixed
KT-69305 Fixed
KT-87274 Fixed

To test the changes please run:
`org.jetbrains.kotlin.konan.test.blackbox.NativeKlibSyntheticAccessorsBoxTestGenerated.PrivateMember.SingleFile#testLeakingPrivatePropertyFromCompanionMethod`
and: `org.jetbrains.kotlin.wasm.test.FirWasmJsCodegenBoxWithInlinedFunInKlibTestGenerated.Box.CallableReference#testInlineArrayConstructor`