### PR TITLE
[Swift Export] Reexport cinterop klibs bundling multiple ObjC modules

### DIFF
--- a/libraries/tools/analysis-api-based-klib-reader/src/org/jetbrains/kotlin/analysis/api/klib/reader/createKaModules.kt
+++ b/libraries/tools/analysis-api-based-klib-reader/src/org/jetbrains/kotlin/analysis/api/klib/reader/createKaModules.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.platform.TargetPlatform
 /**
  * @property useSiteModule A target for creating Analysis API session via [analyze].
  * @property platformLibraries Platform libraries from the Kotlin Native distribution, if any.
- * @property cinteropReexportLibraries User cinterop klibs whose types originate from an externally-defined
+ * @property cinteropReexportLibrary User cinterop klibs whose types originate from an externally-defined
  *   ObjC module; treated as platform-like (no generated Swift module), but distinguished from distribution
  *   platform libs since they are opted in by the caller.
  */
@@ -27,7 +27,7 @@ public class KaModules<Config> internal constructor(
     public val useSiteModule: KaModule,
     private val modulesToInputs: Map<KaLibraryModule, KlibInputModule<Config>>,
     public val platformLibraries: List<KaLibraryModule>,
-    public val cinteropReexportLibraries: List<KaLibraryModule> = emptyList(),
+    public val cinteropReexportLibrary: KaLibraryModule?,
 ) {
     public val inputsToModules: Map<KlibInputModule<Config>, KaLibraryModule> = modulesToInputs.map { it.value to it.key }.toMap()
     public val mainModules: List<KaLibraryModule> = modulesToInputs.keys.toList()
@@ -43,18 +43,18 @@ public fun <Config> createKaModulesForStandaloneAnalysis(
     inputs: Collection<KlibInputModule<Config>>,
     targetPlatform: TargetPlatform,
     platformLibraries: Collection<KlibInputModule<Config>> = emptyList(),
-    cinteropReexportLibraries: Collection<KlibInputModule<Config>> = emptyList(),
+    cinteropReexportLibrary: KlibInputModule<Config>? = null,
 ): KaModules<Config> {
     lateinit var binaryModules: Map<KaLibraryModule, KlibInputModule<Config>>
     lateinit var fakeSourceModule: KaSourceModule
     var platformLibraryModules: List<KaLibraryModule> = emptyList()
-    var cinteropReexportLibraryModules: List<KaLibraryModule> = emptyList()
+    var cinteropReexportLibraryModule: KaLibraryModule? = null
     buildStandaloneAnalysisAPISession {
         buildKtModuleProvider {
             platform = targetPlatform
             binaryModules = inputs.associateBy { inputModuleIntoKaLibraryModule(it, targetPlatform) }
             platformLibraryModules = platformLibraries.map { inputModuleIntoKaLibraryModule(it, targetPlatform) }
-            cinteropReexportLibraryModules = cinteropReexportLibraries.map { inputModuleIntoKaLibraryModule(it, targetPlatform) }
+            cinteropReexportLibraryModule = cinteropReexportLibrary?.let { inputModuleIntoKaLibraryModule(it, targetPlatform) }
             // It's a pure hack: Analysis API does not properly work without root source modules.
             fakeSourceModule = addModule(
                 buildKtSourceModule {
@@ -62,12 +62,12 @@ public fun <Config> createKaModulesForStandaloneAnalysis(
                     moduleName = "fakeSourceModule"
                     binaryModules.keys.forEach(::addRegularDependency)
                     platformLibraryModules.forEach(::addRegularDependency)
-                    cinteropReexportLibraryModules.forEach(::addRegularDependency)
+                    cinteropReexportLibraryModule?.let(::addRegularDependency)
                 }
             )
         }
     }
-    return KaModules(fakeSourceModule, binaryModules, platformLibraryModules, cinteropReexportLibraryModules)
+    return KaModules(fakeSourceModule, binaryModules, platformLibraryModules, cinteropReexportLibraryModule)
 }
 
 private fun <Config> KaModuleContainerBuilder.inputModuleIntoKaLibraryModule(

--- a/native/swift/sir-printer/src/org/jetbrains/sir/printer/impl/SirAsSwiftSourcesPrinter.kt
+++ b/native/swift/sir-printer/src/org/jetbrains/sir/printer/impl/SirAsSwiftSourcesPrinter.kt
@@ -320,6 +320,9 @@ internal class SirAsSwiftSourcesPrinter private constructor(
     }
 
     private fun SirImport.print() {
+        if (conditionallyAvailable) {
+            println("#if canImport(${moduleName.swiftIdentifier})")
+        }
         print(
             when (mode) {
                 SirImport.Mode.Exported -> "@_exported "
@@ -329,6 +332,9 @@ internal class SirAsSwiftSourcesPrinter private constructor(
         )
         print(spi.render(SirTypeVariance.INVARIANT).takeUnless { it.isBlank() }?.let { "$it " } ?: "")
         println("import ${moduleName.swiftIdentifier}")
+        if (conditionallyAvailable) {
+            println("#endif")
+        }
     }
 
     private fun SirDeclarationContainer.printContainerKeyword() = print(

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirOneToOneModuleProvider.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirOneToOneModuleProvider.kt
@@ -20,18 +20,20 @@ import org.jetbrains.kotlin.sir.util.SirPlatformModule
 /**
  * A module provider implementation that generates a [SirModule] for each given [KaModule].
  *
- * [platformLibs] are Kotlin/Native distribution platform libraries, represented as [SirPlatformModule].
- * [cinteropReexportLibs] are user-provided cinterop klibs to be re-exported through an existing ObjC module,
- * represented as [SirCinteropModule]. For both, no Swift code is generated; references become `import <name>`.
+ * [platformLibs] are Kotlin/Native distribution platform libraries, represented as [SirPlatformModule]; for
+ * them no Swift code is generated and references become `import <name>`.
+ * [cinteropReexportLib] is a user-provided cinterop klib representing pre-existing ObjC modules mapped to the
+ * Clang module names stored in the cinterop klib manifest;
+ * its types are referenced bare and import those ObjC modules.
  */
 public class SirOneToOneModuleProvider(
     platformLibs: Collection<KaLibraryModule>,
-    cinteropReexportLibs: Collection<KaLibraryModule> = emptyList(),
+    cinteropReexportLib: Pair<KaLibraryModule, List<String>>? = null,
 ) : SirModuleProvider {
 
     private val moduleCache: MutableMap<KaModule, SirModule> = buildMap<KaModule, SirModule> {
         platformLibs.forEach { put(it, SirPlatformModule(it.moduleName)) }
-        cinteropReexportLibs.forEach { put(it, SirCinteropModule(it.moduleName)) }
+        cinteropReexportLib?.let { put(it.first, SirCinteropModule(it.second)) }
     }.toMutableMap()
 
     public val modules: Map<KaModule, SirModule>

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirTypeProviderImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirTypeProviderImpl.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.sir.providers.source.KotlinSource
 import org.jetbrains.kotlin.sir.providers.utils.KotlinCoroutineSupportModule
 import org.jetbrains.kotlin.sir.providers.utils.KotlinRuntimeModule
 import org.jetbrains.kotlin.sir.providers.utils.KotlinRuntimeSupportModule
+import org.jetbrains.kotlin.sir.util.SirCinteropModule
 import org.jetbrains.kotlin.sir.util.SirSwiftModule
 import org.jetbrains.kotlin.sir.util.expandedType
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
@@ -204,7 +205,15 @@ public class SirTypeProviderImpl(
                     }
                     // We're being lazy here importing all spi's preventively
                     val spi = this@extractImport.attributes.filterIsInstance<SirAttribute.SPI>()
-                    processTypeImports(listOf(SirImport(sirModule.name, spi = spi)))
+
+                    val imports = when (sirModule) {
+                        is SirCinteropModule -> sirModule.importNames.map {
+                            SirImport(it, spi = spi, conditionallyAvailable = true)
+                        }
+                        else ->
+                            listOf(SirImport(sirModule.name, spi = spi))
+                    }
+                    processTypeImports(imports)
                 }
                 is KotlinRuntimeElement -> {
                     processTypeImports(listOf(SirImport(KotlinRuntimeModule.name)))

--- a/native/swift/sir/src/org/jetbrains/kotlin/sir/SirImport.kt
+++ b/native/swift/sir/src/org/jetbrains/kotlin/sir/SirImport.kt
@@ -9,6 +9,7 @@ class SirImport(
     val moduleName: String,
     val mode: Mode = Mode.Default,
     val spi: List<SirAttribute.SPI> = emptyList(),
+    val conditionallyAvailable: Boolean = false,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -17,6 +18,7 @@ class SirImport(
         if (moduleName != other.moduleName) return false
         if (mode != other.mode) return false
         if (spi != other.spi) return false
+        if (conditionallyAvailable != other.conditionallyAvailable) return false
 
         return true
     }
@@ -25,6 +27,7 @@ class SirImport(
         var result = moduleName.hashCode()
         result = 31 * result + mode.hashCode()
         result = 31 * result + spi.hashCode()
+        result = 31 * result + conditionallyAvailable.hashCode()
         return result
     }
 

--- a/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirExtensions.kt
+++ b/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirExtensions.kt
@@ -112,9 +112,16 @@ val SirDeclaration.swiftParentNamePrefix: String?
     get() = this.parent.swiftFqNameOrNull
 
 val SirDeclarationParent.swiftFqNameOrNull: String?
-    get() = (this as? SirScopeDefiningDeclaration)?.swiftFqName
-        ?: ((this as? SirScopeDefiningElement)?.name?.swiftSanitizedName)
-        ?: ((this as? SirExtension)?.extendedType?.swiftName)
+    get() = when {
+        // Types of a cinterop re-export klib are referenced bare: every ObjC module the klib provides is
+        // imported (and a single klib may bundle several), and the klib does not record which module each
+        // type originates from. KT-82896 proposes storing the originating Clang module per declaration, which
+        // would let us emit precise modular imports / qualifiers instead of relying on bare references.
+        this is SirCinteropModule -> null
+        else -> (this as? SirScopeDefiningDeclaration)?.swiftFqName
+            ?: ((this as? SirScopeDefiningElement)?.name?.swiftSanitizedName)
+            ?: ((this as? SirExtension)?.extendedType?.swiftName)
+    }
 
 val SirScopeDefiningDeclaration.swiftFqName: String
     get() = swiftParentNamePrefix?.let { "$it.${name.swiftSanitizedName.swiftIdentifier}" } ?: name.swiftSanitizedName.swiftIdentifier

--- a/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirPlatformModule.kt
+++ b/native/swift/sir/src/org/jetbrains/kotlin/sir/util/SirPlatformModule.kt
@@ -16,4 +16,6 @@ sealed class SirPlatformLikeModule(override val name: String) : SirModule() {
 
 class SirPlatformModule(name: String) : SirPlatformLikeModule(name)
 
-class SirCinteropModule(name: String) : SirPlatformLikeModule(name)
+class SirCinteropModule(val importNames: List<String>) : SirPlatformLikeModule(SYNTHETIC_CINTEROP_MODULE_NAME)
+
+private const val SYNTHETIC_CINTEROP_MODULE_NAME = "<cinterop>"

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/cinteropReexport/cinteropReexport.kt
@@ -2,12 +2,10 @@
 // WITH_PLATFORM_LIBS
 
 // MODULE: fooKitInterop
-// SWIFT_EXPORT_CONFIG: reexportAsObjCModule=FooKit
 
 // FILE: fooKitInterop.def
 language = Objective-C
-headers = Foo.h
-headerFilter = Foo.h
+modules = FooKit
 package = foo
 
 // FILE: Foo.h

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/cinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/cinteropReexport.kt
@@ -3,12 +3,10 @@
 // APPLE_ONLY_VALIDATION
 
 // MODULE: fooKitInterop
-// SWIFT_EXPORT_CONFIG: reexportAsObjCModule=FooKit
 
 // FILE: fooKitInterop.def
 language = Objective-C
-headers = Foo.h
-headerFilter = Foo.h
+modules = FooKit BarKit
 package = foo
 
 // FILE: Foo.h
@@ -18,13 +16,25 @@ package = foo
 - (int)someValue;
 @end
 
-@protocol Bar
+@protocol Zar
 - (int)barValue;
+@end
+
+// FILE: Bar.h
+#import <Foundation/Foundation.h>
+
+@interface Bar : NSObject
+- (int)someValue;
 @end
 
 // FILE: module.modulemap
 module FooKit {
     header "Foo.h"
+    export *
+}
+
+module BarKit {
+    header "Bar.h"
     export *
 }
 
@@ -35,12 +45,15 @@ module FooKit {
 package main
 
 import foo.Foo
-import foo.BarProtocol
+import foo.Bar
+import foo.ZarProtocol
 
 fun consumesFoo(x: Foo): Int = 0
 
+fun consumesBar(x: Bar): Int = 0
+
 fun producesFoo(): Foo? = null
 
-// The cinterop names the Objective-C protocol `Bar` as the Kotlin interface `BarProtocol`; the
-// generated Swift must reference it under its original Objective-C name `FooKit.Bar`.
-fun consumesBar(x: BarProtocol): Int = 0
+// The cinterop names the Objective-C protocol `Zar` as the Kotlin interface `ZarProtocol`; the
+// generated Swift must reference it under its original Objective-C name `Zar`.
+fun consumesBar(x: ZarProtocol): Int = 0

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.h
@@ -3,9 +3,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-int32_t main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__(id x);
+int32_t main_consumesBar__TypesOfArguments__Bar__(id<NSObject> x);
 
-int32_t main_consumesFoo__TypesOfArguments__FooKit_Foo__(id<NSObject> x);
+int32_t main_consumesBar__TypesOfArguments__anyU20Zar__(id x);
+
+int32_t main_consumesFoo__TypesOfArguments__Foo__(id<NSObject> x);
 
 id<NSObject> _Nullable main_producesFoo();
 

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.kt
@@ -4,17 +4,25 @@ import kotlin.native.internal.ExportedBridge
 import kotlinx.cinterop.*
 import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
 
-@ExportedBridge("main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__")
+@ExportedBridge("main_consumesBar__TypesOfArguments__Bar__")
 @OptIn(kotlinx.cinterop.BetaInteropApi::class, kotlinx.cinterop.ExperimentalForeignApi::class)
-public fun main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__(x: kotlin.native.internal.NativePtr): Int {
-    val __x = interpretObjCPointer<foo.BarProtocol>(x)
+public fun main_consumesBar__TypesOfArguments__Bar__(x: kotlin.native.internal.NativePtr): Int {
+    val __x = interpretObjCPointer<foo.Bar>(x)
     val _result = run { main.consumesBar(__x) }
     return _result
 }
 
-@ExportedBridge("main_consumesFoo__TypesOfArguments__FooKit_Foo__")
+@ExportedBridge("main_consumesBar__TypesOfArguments__anyU20Zar__")
 @OptIn(kotlinx.cinterop.BetaInteropApi::class, kotlinx.cinterop.ExperimentalForeignApi::class)
-public fun main_consumesFoo__TypesOfArguments__FooKit_Foo__(x: kotlin.native.internal.NativePtr): Int {
+public fun main_consumesBar__TypesOfArguments__anyU20Zar__(x: kotlin.native.internal.NativePtr): Int {
+    val __x = interpretObjCPointer<foo.ZarProtocol>(x)
+    val _result = run { main.consumesBar(__x) }
+    return _result
+}
+
+@ExportedBridge("main_consumesFoo__TypesOfArguments__Foo__")
+@OptIn(kotlinx.cinterop.BetaInteropApi::class, kotlinx.cinterop.ExperimentalForeignApi::class)
+public fun main_consumesFoo__TypesOfArguments__Foo__(x: kotlin.native.internal.NativePtr): Int {
     val __x = interpretObjCPointer<foo.Foo>(x)
     val _result = run { main.consumesFoo(__x) }
     return _result

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/cinteropReexport/golden_result/CinteropReexport/CinteropReexport.swift
@@ -1,21 +1,31 @@
+#if canImport(BarKit)
+import BarKit
+#endif
 @_exported import ExportedKotlinPackages
+#if canImport(FooKit)
 import FooKit
+#endif
 @_implementationOnly import KotlinBridges_CinteropReexport
 import KotlinRuntime
 import KotlinRuntimeSupport
 
 extension ExportedKotlinPackages.main {
     public static func consumesBar(
-        x: any FooKit.Bar
+        x: any Zar
     ) -> Swift.Int32 {
-        return main_consumesBar__TypesOfArguments__anyU20FooKit_Bar__(x)
+        return main_consumesBar__TypesOfArguments__anyU20Zar__(x)
+    }
+    public static func consumesBar(
+        x: Bar
+    ) -> Swift.Int32 {
+        return main_consumesBar__TypesOfArguments__Bar__(x)
     }
     public static func consumesFoo(
-        x: FooKit.Foo
+        x: Foo
     ) -> Swift.Int32 {
-        return main_consumesFoo__TypesOfArguments__FooKit_Foo__(x)
+        return main_consumesFoo__TypesOfArguments__Foo__(x)
     }
-    public static func producesFoo() -> FooKit.Foo? {
-        return main_producesFoo().map { it in it as! FooKit.Foo }
+    public static func producesFoo() -> Foo? {
+        return main_producesFoo().map { it in it as! Foo }
     }
 }

--- a/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
@@ -46,13 +46,6 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
     var minOSVersion: String? = null
 
     /**
-     * Maps a [TestModule.Given]'s klib-file name to the name of an externally-defined ObjC module that Swift
-     * Export should treat it as — populating [SwiftModuleConfig.reexportAsObjCModule]. This is how a cinterop
-     * klib is opted into the platform-like path at test time.
-     */
-    var cinteropReexportsByKlibFileName: Map<String, String> = emptyMap()
-
-    /**
      * Additional options appended verbatim to every `swiftc` invocation made by the test harness. Tests that
      * bring their own ObjC modules need to pass `-Xcc -fmodule-map-file=<path>` here so that `import <Foo>`
      * in the generated Swift resolves through the supplied modulemap.
@@ -81,24 +74,24 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
             ?.getByName(testCaseId)!!
             .copyAndAddModules(givenModules)
 
-        // Inline cinterop modules marked with the reexportAsObjCModule directive may supply a module.modulemap
-        // that swiftc needs to resolve the generated `import <ObjCModule>` references. Discover those files
-        // automatically.
+        // Inline cinterop re-export modules may supply a module.modulemap that swiftc needs to resolve the
+        // generated `import <ObjCModule>` references. Discover those files automatically.
         val discoveredModuleMaps = originalTestCase.modules
-            .filter { it.swiftExportConfigMap()[REEXPORT_AS_OBJC_MODULE_DIRECTIVE] != null }
+            .filter { it.isCinteropReexport() }
             .flatMap { it.files }
             .map { it.location }
             .filter { it.name == "module.modulemap" }
         extraSwiftCompilerOptions = extraSwiftCompilerOptions +
             discoveredModuleMaps.flatMap { listOf("-Xcc", "-fmodule-map-file=${it.absolutePath}") }
 
-        val modulesToExport = (originalTestCase.rootModules + originalTestCase.modules + givenModules).mapToSet {
+        val inputModuleByTestModule = (originalTestCase.rootModules + originalTestCase.modules + givenModules).associateWith {
             createInputModule(
                 testModule = it,
                 originalTestCase = originalTestCase,
                 shouldBeFullyExported = it.shouldBeExportedToSwift() || originalTestCase.rootModules.contains(it)
             )
         }
+        val modulesToExport = inputModuleByTestModule.values.toSet()
 
         val config = SwiftExportConfig(
             outputPath = buildDir(testPathFull.name).resolve(testDir).toPath(),
@@ -125,11 +118,12 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
         // Inline cinterop modules flagged for reexport cannot be passed with -Xinclude to
         // binary compilation (the compiler rejects interop klibs via that flag). Expose their
         // compiled klibs as Given dependencies (-library) instead, and keep their source modules
-        // (.def/.h/.modulemap) out of the Kotlin binary compilation. We identify such modules by the
-        // reexport directive rather than by InputModule.name, because the latter is overridden with the
-        // ObjC module name and would no longer match the test module name.
-        val reexportInputs = modulesToExport.filter { it.config.moduleProvidedThroughCinterop }
-        val reexportGivens = reexportInputs.map { TestModule.Given(it.path.toFile()) }.toSet()
+        // (.def/.h/.modulemap) out of the Kotlin binary compilation.
+        val reexportGivens = inputModuleByTestModule
+            .filterKeys { it.isCinteropReexport() }
+            .values
+            .map { TestModule.Given(it.path.toFile()) }
+            .toSet()
 
         val resultingTestCase = generateSwiftExportTestCase(
             testPathFull,
@@ -139,7 +133,7 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
                 .flatMapToSet {
                     it.allRegularDependencies.filterIsInstance<TestModule.Exclusive>().toSet()
                 } - originalTestCase.rootModules)
-                .filterNot { it.swiftExportConfigMap()[REEXPORT_AS_OBJC_MODULE_DIRECTIVE] != null }
+                .filterNot { it.isCinteropReexport() }
                 .toSet(),
             dependencies = givenModules + reexportGivens
         )
@@ -152,27 +146,25 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
         shouldBeFullyExported: Boolean
     ): InputModule {
         val config = (testModule as? TestModule.Exclusive)?.swiftExportConfigMap()
-        // For cinterop re-exports the test directive (or the test-support map) supplies the desired
-        // Swift-level ObjC module name. We translate that into the standalone API: a boolean flag on
-        // SwiftModuleConfig plus the InputModule.name set to that ObjC module name.
-        val objCModuleName = when (testModule) {
-            is TestModule.Exclusive -> config?.get(REEXPORT_AS_OBJC_MODULE_DIRECTIVE)
-            is TestModule.Given -> cinteropReexportsByKlibFileName[testModule.klibFile.name]
-            else -> null
-        }
-        val input = testModule.constructSwiftInput(
+        // Whether a module is a cinterop re-export container is detected by Swift Export from the klib
+        // manifest (interop=true), so nothing has to be flagged here.
+        return testModule.constructSwiftInput(
             originalTestCase.freeCompilerArgs,
             SwiftModuleConfig(
                 rootPackage = config?.get(SwiftModuleConfig.ROOT_PACKAGE),
                 unsupportedDeclarationReporterKind = getUnsupportedDeclarationsReporterKind(config),
-                // moduleProvidedThroughCinterop implies the klib is never fully exported — it is only a container
-                // for types that may be referenced by the actually-exported modules.
-                shouldBeFullyExported = shouldBeFullyExported && objCModuleName == null,
-                moduleProvidedThroughCinterop = objCModuleName != null,
+                shouldBeFullyExported = shouldBeFullyExported,
             )
         )
-        return if (objCModuleName != null) input.copy(name = objCModuleName) else input
     }
+
+    /**
+     * A cinterop re-export test module: an inline module compiled from a `.def`. Used only for
+     * binary-compilation plumbing (such a klib is passed as `-library` rather than `-Xinclude`d).
+     * Swift Export itself detects cinterop re-export klibs from their manifest (`interop=true`).
+     */
+    private fun TestModule.isCinteropReexport(): Boolean =
+        this is TestModule.Exclusive && files.any { it.location.extension == "def" }
 
     private fun TestModule.constructSwiftInput(
         freeCompilerArgs: TestCompilerArgs,
@@ -361,14 +353,6 @@ private fun modulemapFileToSwiftCompilerOptionsIfNeeded(modulemap: File?) = modu
 private fun SwiftExportModule.resolvedDependencies(allModules: Set<SwiftExportModule>): List<SwiftExportModule> = dependencies.map { dep ->
     allModules.firstOrNull { it.name == dep.name } ?: error("Module ${this.name} requested non-existing dependency ${dep.name}")
 }
-
-/**
- * Test-fixture-only directive. Inside a `// SWIFT_EXPORT_CONFIG:` block, `reexportAsObjCModule=<Name>`
- * marks the module as a cinterop re-export and supplies the ObjC module name. The infrastructure
- * translates this into [SwiftModuleConfig.moduleProvidedThroughCinterop] plus an [InputModule.name]
- * override (the standalone API itself no longer carries the ObjC name string).
- */
-private const val REEXPORT_AS_OBJC_MODULE_DIRECTIVE: String = "reexportAsObjCModule"
 
 private fun getUnsupportedDeclarationsReporterKind(configMap: Map<String, String>?): UnsupportedDeclarationReporterKind {
     return configMap?.get(SwiftModuleConfig.UNSUPPORTED_DECLARATIONS_REPORTER_KIND)

--- a/native/swift/swift-export-standalone/build.gradle.kts
+++ b/native/swift/swift-export-standalone/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":analysis:analysis-api-standalone"))
 
     implementation(project(":libraries:tools:analysis-api-based-klib-reader"))
+    implementation(project(":kotlin-util-klib"))
     compileOnly(project(":kotlin-util-klib-metadata"))
 }
 

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.swiftexport.standalone
 
 import org.jetbrains.kotlin.analysis.api.klib.reader.createKaModulesForStandaloneAnalysis
+import org.jetbrains.kotlin.library.KLIB_PROPERTY_INTEROP
+import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.metadata.KlibInputModule
 import org.jetbrains.kotlin.sir.SirModule
 import org.jetbrains.kotlin.sir.builder.buildModule
@@ -155,7 +157,7 @@ private fun translateModules(
     config: SwiftExportConfig,
 ): List<TranslationResult> {
     val [cinteropReexportLibs, ordinaryInputs] = inputModules
-        .partition { it.config.moduleProvidedThroughCinterop }
+        .partition { it.isCinteropLibrary() }
         .let { it.first.toSet() to it.second.toSet() }
 
     val allModules = ordinaryInputs + config.stdlibInputModule
@@ -163,7 +165,7 @@ private fun translateModules(
         inputs = allModules,
         targetPlatform = config.targetPlatform,
         platformLibraries = config.platformLibsInputModule,
-        cinteropReexportLibraries = cinteropReexportLibs,
+        cinteropReexportLibrary = cinteropReexportLibs.singleOrNull(),
     )
     val explicitModulesTranslationResults = allModules
         .filter { it.config.shouldBeFullyExported }
@@ -178,6 +180,15 @@ private fun translateModules(
     val transitiveModulesTranslationResults = translateCrossReferencingModulesTransitively(transitiveExportRoots, kaModules, config)
     return explicitModulesTranslationResults + transitiveModulesTranslationResults
 }
+
+/**
+ * A cinterop klib (`interop=true` in its manifest) whose types come from pre-existing ObjC modules. Such a
+ * module is re-exported rather than translated: Swift Export imports the ObjC modules the klib declares
+ * (manifest `modules`) and references its types bare. Detected from the manifest, so callers need not flag it.
+ */
+private fun InputModule.isCinteropLibrary(): Boolean =
+    KlibLoader { libraryPaths(path.toString()) }.load().librariesStdlibFirst.singleOrNull()
+        ?.manifestProperties?.getProperty(KLIB_PROPERTY_INTEROP) == "true"
 
 private fun Collection<TranslationResult>.createModuleForPackages(config: SwiftExportConfig): SirModule = buildModule {
     name = config.moduleForPackagesName

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/builders/buildSwiftModule.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/builders/buildSwiftModule.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.klib.reader.getAllDeclarations
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibraryModule
 import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
+import org.jetbrains.kotlin.io.propertyList
+import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.sir.*
 import org.jetbrains.kotlin.sir.builder.buildModule
 import org.jetbrains.kotlin.sir.providers.SirSession
@@ -38,12 +40,24 @@ internal fun buildSirSession(
     unsupportedDeclarationReporter = moduleConfig.unsupportedDeclarationReporter,
     moduleProvider = SirOneToOneModuleProvider(
         platformLibs = kaModules.platformLibraries,
-        cinteropReexportLibs = kaModules.cinteropReexportLibraries,
+        cinteropReexportLib = kaModules.cinteropReexportLibrary?.let { it to it.reexportedObjCModuleNames() },
     ),
     targetPackageFqName = moduleConfig.targetPackageFqName,
     referencedTypeHandler = referenceHandler,
     enableCoroutinesSupport = config.enableCoroutinesSupport,
 )
+
+/**
+ * The ObjC module names a cinterop reexport klib provides, read from its manifest `modules` property
+ * (a single cinterop klib may bundle several Clang modules). Empty when the klib declares no ObjC
+ * modules to import — e.g. a header-based cinterop klib, which the reexport strategy cannot serve.
+ */
+internal fun KaLibraryModule.reexportedObjCModuleNames(): List<String> {
+    val klibPath = binaryRoots.firstOrNull() ?: return emptyList()
+    val library = KlibLoader { libraryPaths(klibPath.toString()) }.load().librariesStdlibFirst.singleOrNull()
+        ?: return emptyList()
+    return library.manifestProperties.propertyList("modules", escapeInQuotes = true)
+}
 
 /**
  * Translates the given [module] to a [SirModule].

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftModuleConfig.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftModuleConfig.kt
@@ -20,24 +20,10 @@ public data class SwiftModuleConfig(
     val unsupportedDeclarationReporterKind: UnsupportedDeclarationReporterKind = UnsupportedDeclarationReporterKind.Silent,
     val experimentalFeatures: Map<String, String> = emptyMap(),
     val shouldBeFullyExported: Boolean,
-    /**
-     * When true, the module is a user cinterop klib whose types originate from a pre-existing ObjC module.
-     * Swift Export does not generate a separate Swift module for it; references emit `import <name>`
-     * and qualify types as `<name>.Type`, where `<name>` is the module's [InputModule.name]. The caller
-     * must set [InputModule.name] to the desired Objective-C / Swift module name.
-     * Must be combined with `shouldBeFullyExported = false`.
-     */
-    val moduleProvidedThroughCinterop: Boolean = false,
 ) {
 
     val targetPackageFqName: FqName? = rootPackage?.rootPackageToFqn()
     val unsupportedDeclarationReporter: UnsupportedDeclarationReporter = unsupportedDeclarationReporterKind.toReporter()
-
-    init {
-        require(!moduleProvidedThroughCinterop || !shouldBeFullyExported) {
-            "moduleProvidedThroughCinterop is incompatible with shouldBeFullyExported = true"
-        }
-    }
 
     public companion object {
         public const val ROOT_PACKAGE: String = "packageRoot"

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportLogger
 import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportModule
 import org.jetbrains.kotlin.swiftexport.standalone.builders.KaModules
 import org.jetbrains.kotlin.swiftexport.standalone.builders.buildSirSession
+import org.jetbrains.kotlin.swiftexport.standalone.builders.reexportedObjCModuleNames
 import org.jetbrains.kotlin.swiftexport.standalone.builders.translateModule
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftExportConfig
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
@@ -182,7 +183,7 @@ private fun createTranslationResult(
 
     val knownModuleNames = setOf(KotlinRuntimeModule.name, bridgeModuleName) +
             kaModules.platformLibraries.map { it.libraryName } +
-            kaModules.cinteropReexportLibraries.map { it.libraryName }
+            kaModules.cinteropReexportLibrary?.reexportedObjCModuleNames().orEmpty()
     val referencedSwiftModules = sirModule.imports
         .filter { it.moduleName !in knownModuleNames }
         .map { SwiftExportModule.Reference(it.moduleName) }

--- a/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-standalone/swift-export-standalone.pom
+++ b/repo/artifacts-tests/src/test/resources/org/jetbrains/kotlin/swift-export-standalone/swift-export-standalone.pom
@@ -74,5 +74,11 @@
       <version>ArtifactsTest.version</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-util-klib</artifactId>
+      <version>ArtifactsTest.version</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
A cinterop klib may bundle several Clang/ObjC modules (a def with `modules = FooKit BarKit`), yet Swift Export assumed each klib maps to one ObjC module: it qualified every reexported type with that one name, emitting references like `FooKit.Bar` for a type that actually lives in `BarKit` — Swift that does not compile.

Reexport such a klib by importing every ObjC module it declares and referencing its types bare:

- The ObjC modules come from the klib manifest's `modules` property (read by `reexportedObjCModuleNames`). A reexport klib is detected from the manifest as well (`interop=true`), so callers need not flag it and `SwiftModuleConfig.moduleProvidedThroughCinterop` is removed.
- A referenced cinterop type emits one `import <module>` per declared module, each wrapped in `#if canImport(...)` since a module may be absent on some targets.
- Such types are referenced without a module prefix; their names are unique within a klib by construction (one shared Kotlin package). Precise per-module qualification is left to KT-82896.

The klib collapses into a single nameless `SirCinteropModule` holder, modelled as one cinterop module for now; widen to many if needed.

^KT-80632