### PR TITLE
[stdlib] Add text-specific sample for filterIndexed and filterIndexedTo

### DIFF
--- a/libraries/stdlib/common/src/generated/_Strings.kt
+++ b/libraries/stdlib/common/src/generated/_Strings.kt
@@ -446,7 +446,7 @@ public inline fun String.filter(predicate: (Char) -> Boolean): String {
  * @param [predicate] function that takes the index of a character and the character itself
  * and returns the result of predicate evaluation on the character.
  * 
- * @sample samples.collections.Collections.Filtering.filterIndexed
+ * @sample samples.text.Strings.filterIndexed
  */
 public inline fun CharSequence.filterIndexed(predicate: (index: Int, Char) -> Boolean): CharSequence {
     return filterIndexedTo(StringBuilder(), predicate)
@@ -457,7 +457,7 @@ public inline fun CharSequence.filterIndexed(predicate: (index: Int, Char) -> Bo
  * @param [predicate] function that takes the index of a character and the character itself
  * and returns the result of predicate evaluation on the character.
  * 
- * @sample samples.collections.Collections.Filtering.filterIndexed
+ * @sample samples.text.Strings.filterIndexed
  */
 public inline fun String.filterIndexed(predicate: (index: Int, Char) -> Boolean): String {
     return filterIndexedTo(StringBuilder(), predicate).toString()
@@ -468,7 +468,7 @@ public inline fun String.filterIndexed(predicate: (index: Int, Char) -> Boolean)
  * @param [predicate] function that takes the index of a character and the character itself
  * and returns the result of predicate evaluation on the character.
  * 
- * @sample samples.collections.Collections.Filtering.filterIndexedTo
+ * @sample samples.text.Strings.filterIndexedTo
  */
 @IgnorableReturnValue
 public inline fun <C : Appendable> CharSequence.filterIndexedTo(destination: C, predicate: (index: Int, Char) -> Boolean): C {

--- a/libraries/stdlib/samples/test/samples/text/strings.kt
+++ b/libraries/stdlib/samples/test/samples/text/strings.kt
@@ -163,6 +163,34 @@ class Strings {
     }
 
     @Sample
+    fun filterIndexed() {
+        val textWithDigits = "0K2o4t6l8i9n"
+
+        // filter by both character and index
+        assertPrints(textWithDigits.filterIndexed { index, char -> char.digitToIntOrNull() == index }, "02468")
+        // filter by character only
+        assertPrints(textWithDigits.filterIndexed { _, char -> char.isLetter() }, "Kotlin")
+        // filter by index only
+        assertPrints(textWithDigits.filterIndexed { index, _ -> index % 2 == 0 }, "024689")
+    }
+
+    @Sample
+    fun filterIndexedTo() {
+        val userInput = "0P2e4t6e8r"
+
+        val numbersOnSameIndexAsValue = StringBuilder() // Mutable destination (Appendable)
+        // append characters matching the filter (i.e. numbers on same index as character) to numbersOnSameIndexAsValue
+        userInput.filterIndexedTo(numbersOnSameIndexAsValue) { index, char -> char.digitToIntOrNull() == index }
+        assertPrints(numbersOnSameIndexAsValue, "02468")
+
+        // append characters matching the filter (i.e. letters only) to a prefixed destination (i.e. Username: )
+        assertPrints(
+            userInput.filterIndexedTo(StringBuilder("Username: ")) { _, char -> char.isLetter() },
+            "Username: Peter"
+        )
+    }
+
+    @Sample
     fun findLast() {
         val text = "a1b2c3d4e5"
 

--- a/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
+++ b/libraries/tools/kotlin-stdlib-gen/src/templates/Filtering.kt
@@ -680,6 +680,10 @@ object Filtering : TemplateGroupBase() {
                 """
             }
         }
+
+        specialFor(CharSequences, Strings) {
+            sample("samples.text.Strings.filterIndexed")
+        }
     }
 
     val f_filterIndexedTo = fn("filterIndexedTo(destination: C, predicate: (index: Int, T) -> Boolean)") {
@@ -707,6 +711,10 @@ object Filtering : TemplateGroupBase() {
             }
             return destination
             """
+        }
+
+        specialFor(CharSequences) {
+            sample("samples.text.Strings.filterIndexedTo")
         }
     }
 


### PR DESCRIPTION
Added filterIndexed() and filterIndexedTo() text-specific samples to improve `kotlin.text` extension function documentation.

filterIndexed() sample covers all filtering scenarios:
- filtering by both index and character
- filtering by index only
- filtering by character only

filterIndexedTo() sample covers appendable destination scenarios:
- appending to an empty StringBuilder
- appending to a prefixed Stringbuilder

Related: to issue KT-35867