### PR TITLE
[IR] Drop `lateinit` modifier from `IrFile.module` property

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/MoveBodilessDeclarationsToSeparatePlace.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/MoveBodilessDeclarationsToSeparatePlace.kt
@@ -81,7 +81,7 @@ class MoveBodilessDeclarationsToSeparatePlaceLowering(private val context: JsIrB
 
         val externalPackageFragment by lazy(LazyThreadSafetyMode.NONE) {
             context.externalPackageFragment.getOrPut(irFile.symbol) {
-                IrFileImpl(fileEntry = irFile.fileEntry, fqName = irFile.packageFqName, symbol = IrFileSymbolImpl(), module = irFile.module).also {
+                IrFileImpl(irFile.fileEntry, IrFileSymbolImpl(), irFile.packageFqName, irFile.module).also {
                     it.annotations = it.annotations memoryOptimizedPlus irFile.annotations
                 }
             }

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ModuleGenerator.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/generators/ModuleGenerator.kt
@@ -111,8 +111,8 @@ open class ModuleGenerator(override val context: GeneratorContext) : Generator {
         val fakeFile = IrFileImpl(
             fakeFileEntry,
             EmptyPackageFragmentDescriptor(context.moduleDescriptor, FqName(fakeFileEntry.name)),
+            module = IrModuleFragmentImpl(ErrorModuleDescriptor)
         )
-        fakeFile.module = IrModuleFragmentImpl(ErrorModuleDescriptor)
         val gen = SyntheticDeclarationsGenerator(context)
         gen.visitClassDescriptor(ErrorUtils.errorClass, fakeFile)
         gen.visitConstructorDescriptor(

--- a/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/declarations/impl/IrFileImpl.kt
+++ b/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/declarations/impl/IrFileImpl.kt
@@ -25,6 +25,7 @@ class IrFileImpl(
     override var fileEntry: IrFileEntry,
     override val symbol: IrFileSymbol,
     override var packageFqName: FqName,
+    override var module: IrModuleFragment,
 ) : IrFile() {
     override var startOffset: Int
         get() = 0
@@ -46,8 +47,6 @@ class IrFileImpl(
     override var annotations: List<IrAnnotation> = emptyList()
 
     override var metadata: MetadataSource? = null
-
-    override lateinit var module: IrModuleFragment
 
     init {
         symbol.bind(this)

--- a/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
+++ b/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/util/DeepCopyIrTreeWithSymbols.kt
@@ -376,10 +376,10 @@ open class DeepCopyIrTreeWithSymbols(
             packageFqName = declaration.packageFqName,
             symbol = symbolRemapper.getDeclaredFile(declaration.symbol),
             fileEntry = declaration.fileEntry,
+            module = transformedModule ?: declaration.module,
         ).apply {
             declarations.assignFrom(declaration.declarations) { it.transform() }
             annotations = declaration.annotations.memoryOptimizedMap { it.transform() }
-            module = transformedModule ?: declaration.module
             processAttributes(declaration)
         }
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrFileImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/impl/IrFileImpl.kt
@@ -14,20 +14,6 @@ import org.jetbrains.kotlin.name.FqName
 
 fun IrFileImpl(
     fileEntry: IrFileEntry,
-    symbol: IrFileSymbol,
-    fqName: FqName,
-    module: IrModuleFragment,
-) = IrFileImpl(fileEntry, symbol, fqName).apply {
-    this.module = module
-}
-
-fun IrFileImpl(
-    fileEntry: IrFileEntry,
-    packageFragmentDescriptor: PackageFragmentDescriptor,
-) = IrFileImpl(fileEntry, IrFileSymbolImpl(packageFragmentDescriptor), packageFragmentDescriptor.fqName)
-
-fun IrFileImpl(
-    fileEntry: IrFileEntry,
     packageFragmentDescriptor: PackageFragmentDescriptor,
     module: IrModuleFragment,
 ) = IrFileImpl(fileEntry, IrFileSymbolImpl(packageFragmentDescriptor), packageFragmentDescriptor.fqName, module)

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/impl/IrErrorClassImpl.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/types/impl/IrErrorClassImpl.kt
@@ -44,10 +44,9 @@ private val ErrorFile = IrFileImpl(
         override fun getLineAndColumnNumbers(offset: Int): LineAndColumn = shouldNotBeCalled()
     },
     symbol = IrFileSymbolImpl(),
-    packageFqName = FqName("<error-package>")
-).apply {
+    packageFqName = FqName("<error-package>"),
     module = IrModuleFragmentImpl(ErrorModuleDescriptor)
-}
+)
 
 val IrErrorClassImpl: IrClass = IrFactoryImpl.createClass(
     startOffset = UNDEFINED_OFFSET,

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/ImplementationConfigurator.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/ImplementationConfigurator.kt
@@ -186,11 +186,9 @@ object ImplementationConfigurator : AbstractIrTreeImplementationConfigurator() {
 
         impl(file) {
             implementation.putImplementationOptInInConstructor = false
-            implementation.constructorParameterOrderOverride = listOf("fileEntry", "symbol", "packageFqName")
+            implementation.constructorParameterOrderOverride = listOf("fileEntry", "symbol", "packageFqName", "module")
             defaultWithErrorOnSet("startOffset", "0")
             defaultWithErrorOnSet("endOffset", "maxOf(fileEntry.maxOffset, 0)")
-            isMutable("module")
-            isLateinit("module")
         }
 
         allImplOf(loop) {

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/IrTree.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/IrTree.kt
@@ -665,7 +665,7 @@ object IrTree : AbstractTreeBuilder() {
 
         +declaredSymbol(fileSymbol)
         +field("module", moduleFragment, isChild = false) {
-            deepCopyExcludeFromApply = true
+            deepCopyExcludeFromConstructor = true
         }
         +field("fileEntry", type(Packages.tree, "IrFileEntry"))
     }

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/DeepCopyIrTreeWithSymbolsPrinter.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/print/DeepCopyIrTreeWithSymbolsPrinter.kt
@@ -132,6 +132,9 @@ internal class DeepCopyIrTreeWithSymbolsPrinter(
                         copyField(element, field)
                         println(",")
                     }
+                    if (element.isSubclassOf(IrTree.file)) {
+                        println("module = transformedModule ?: ${element.visitorParameterName}.module,")
+                    }
                 }
                 val fieldsInApply = implementation.fieldsInBody.filter { !it.deepCopyExcludeFromApply && it !in constructorArguments }
                 printApply(element, fieldsInApply)
@@ -219,9 +222,6 @@ internal class DeepCopyIrTreeWithSymbolsPrinter(
             }
             if (element.isSubclassOf(IrTree.function)) {
                 println("parameters = ${element.visitorParameterName}.parameters.memoryOptimizedMap { it.transform() }")
-            }
-            if (element.isSubclassOf(IrTree.file)) {
-                println("module = transformedModule ?: ${element.visitorParameterName}.module")
             }
             if (element.isSubclassOf(IrTree.moduleFragment)) {
                 println("this@DeepCopyIrTreeWithSymbols.transformedModule = null")

--- a/compiler/ir/ir.validation/test/org/jetbrains/kotlin/ir/validation/IrValidatorTest.kt
+++ b/compiler/ir/ir.validation/test/org/jetbrains/kotlin/ir/validation/IrValidatorTest.kt
@@ -118,7 +118,7 @@ class IrValidatorTest {
         maxOffset: Int = 75,
     ): IrFile {
         val fileEntry = NaiveSourceBasedFileEntryImpl(name, lineStartOffsets = intArrayOf(0, 10, 25), maxOffset = maxOffset)
-        return IrFileImpl(fileEntry, IrFileSymbolImpl(), packageFqName).also(module::addFile)
+        return IrFileImpl(fileEntry, IrFileSymbolImpl(), packageFqName, module).also(module::addFile)
     }
 
     private fun createTrueConst() = IrConstImpl.boolean(UNDEFINED_OFFSET, UNDEFINED_OFFSET, TestIrBuiltins.booleanType, true)

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/NonLinkingIrInlineFunctionDeserializer.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/NonLinkingIrInlineFunctionDeserializer.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
+import org.jetbrains.kotlin.ir.declarations.moduleDescriptor
 import org.jetbrains.kotlin.ir.overrides.isEffectivelyPrivate
 import org.jetbrains.kotlin.ir.symbols.impl.IrFileSymbolImpl
 import org.jetbrains.kotlin.ir.util.*
@@ -26,6 +27,7 @@ import org.jetbrains.kotlin.library.components.inlinableFunctionsIr
 import org.jetbrains.kotlin.library.metadata.KlibDeserializedContainerSource
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.protobuf.ExtensionRegistryLite
+import org.jetbrains.kotlin.types.error.ErrorModuleDescriptor
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrFile as ProtoFile
@@ -76,10 +78,11 @@ class NonLinkingIrInlineFunctionDeserializer(
 
         val functionSignature: IdSignature = signatureComputer.computeSignature(function)
         // Inside the module deserializer "functionSignature" will be mapped to erased copy of inline function and this copy will be returned.
+        val originalFunctionModule = modules.getOrPut(library) { IrModuleFragmentImpl(function.module) }
         val deserializedFunction: IrSimpleFunction =
-            moduleDeserializer.deserializeInlineFunction(functionSignature, function.getPackageFragment()) ?: return null
+            moduleDeserializer.deserializeInlineFunction(functionSignature, function.getPackageFragment(), originalFunctionModule)
+                ?: return null
         deserializedFunction.originalOfPreparedInlineFunctionCopy = function
-        (deserializedFunction.parent as IrFile).module = modules.getOrPut(library) { IrModuleFragmentImpl(function.module) }
         return deserializedFunction
     }
 
@@ -103,7 +106,8 @@ class NonLinkingIrInlineFunctionDeserializer(
                 override fun getLineAndColumnNumbers(offset: Int): LineAndColumn = shouldNotBeCalled()
             },
             symbol = IrFileSymbolImpl(),
-            packageFqName = FqName("<uninitialized>")
+            packageFqName = FqName("<uninitialized>"),
+            module = IrModuleFragmentImpl(ErrorModuleDescriptor)
         ).symbol
 
         private val symbolDeserializer = IrSymbolDeserializer(
@@ -154,16 +158,22 @@ class NonLinkingIrInlineFunctionDeserializer(
 
         private val deserializedFunctionCache = mutableMapOf<IdSignature, IrSimpleFunction?>()
 
-        fun deserializeInlineFunction(signature: IdSignature, originalFunctionPackage: IrPackageFragment): IrSimpleFunction? =
+        fun deserializeInlineFunction(
+            signature: IdSignature,
+            originalFunctionPackage: IrPackageFragment,
+            originalFunctionModule: IrModuleFragment,
+        ): IrSimpleFunction? =
             deserializedFunctionCache.getOrPut(signature) {
                 val idSigIndex = reversedSignatureIndex[signature] ?: return@getOrPut null
                 val functionProto = fileReader.declaration(idSigIndex)
 
                 val fileEntry = fileEntryDeserializer.fileEntry(fileReader, functionProto.irFunction.preparedInlineFunctionFileEntryId)
+
                 val file = IrFileImpl(
                     symbol = IrFileSymbolImpl(with(originalFunctionPackage.symbol) { runIf(hasDescriptor) { descriptor } }),
                     packageFqName = originalFunctionPackage.packageFqName,
                     fileEntry = fileEntry,
+                    module = originalFunctionModule
                 )
 
                 val function = declarationDeserializer.deserializeDeclaration(functionProto, file.startOffset) as IrSimpleFunction

--- a/compiler/ir/serialization.common/testFixtures/org/jetbrains/kotlin/backend/common/serialization/IrSignatureClashTest.kt
+++ b/compiler/ir/serialization.common/testFixtures/org/jetbrains/kotlin/backend/common/serialization/IrSignatureClashTest.kt
@@ -252,7 +252,7 @@ abstract class IrSignatureClashTest {
         packageFqName: FqName = FqName("org.sample"),
     ): IrFile {
         val fileEntry = NaiveSourceBasedFileEntryImpl(name, lineStartOffsets = intArrayOf(0, 10, 25), maxOffset = 75)
-        return IrFileImpl(fileEntry, IrFileSymbolImpl(), packageFqName).also { module.files += it }
+        return IrFileImpl(fileEntry, IrFileSymbolImpl(), packageFqName, module).also { module.files += it }
     }
 
     private fun trackDeclaration(declaration: IrDeclaration): IdSignature =

--- a/compiler/ir/serialization.common/testFixtures/org/jetbrains/kotlin/backend/common/serialization/IrSignatureWithUnboundIrTest.kt
+++ b/compiler/ir/serialization.common/testFixtures/org/jetbrains/kotlin/backend/common/serialization/IrSignatureWithUnboundIrTest.kt
@@ -117,6 +117,6 @@ abstract class IrSignatureWithUnboundIrTest {
         packageFqName: FqName = FqName("org.sample"),
     ): IrFile {
         val fileEntry = NaiveSourceBasedFileEntryImpl(name, lineStartOffsets = intArrayOf(0, 10, 25), maxOffset = 75)
-        return IrFileImpl(fileEntry, IrFileSymbolImpl(), packageFqName).also { module.files += it }
+        return IrFileImpl(fileEntry, IrFileSymbolImpl(), packageFqName, module).also { module.files += it }
     }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/BackendPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/BackendPhases.kt
@@ -91,5 +91,5 @@ private fun IrModuleFragment.addFile(fileEntry: IrFileEntry, packageFqName: FqNa
         override fun getMemberScope(): MemberScope = MemberScope.Empty
     }
 
-    return IrFileImpl(fileEntry, packageFragmentDescriptor).also(this::addFile)
+    return IrFileImpl(fileEntry, packageFragmentDescriptor, this).also(this::addFile)
 }

--- a/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolCommands.kt
+++ b/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolCommands.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.backend.konan.serialization.KonanManglerIr
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl
+import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrFileSymbolImpl
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.konan.library.components.bitcode
@@ -32,6 +33,7 @@ import org.jetbrains.kotlin.library.metadata.parsePackageFragment
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi2ir.descriptors.IrBuiltInsOverDescriptors
 import org.jetbrains.kotlin.psi2ir.generators.TypeTranslatorImpl
+import org.jetbrains.kotlin.types.error.ErrorModuleDescriptor
 import org.jetbrains.kotlin.utils.Printer
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import java.io.File
@@ -221,7 +223,8 @@ internal class DumpIrInlinableFunctions(output: KlibToolOutput, args: KlibToolAr
         val dummyIrFile = IrFileImpl(
                 fileEntry = NaiveSourceBasedFileEntryImpl(name = "<unknown>"),
                 symbol = IrFileSymbolImpl(),
-                packageFqName = FqName.ROOT
+                packageFqName = FqName.ROOT,
+                module = IrModuleFragmentImpl(ErrorModuleDescriptor)
         )
 
         val dumpOptions = DumpIrTreeOptions(
@@ -230,7 +233,7 @@ internal class DumpIrInlinableFunctions(output: KlibToolOutput, args: KlibToolAr
         )
 
         val irDumps: List<String> = moduleDeserializer.reversedSignatureIndex.keys.mapNotNull { signature: IdSignature ->
-            val preprocessedFunction = moduleDeserializer.deserializeInlineFunction(signature, dummyIrFile)
+            val preprocessedFunction = moduleDeserializer.deserializeInlineFunction(signature, dummyIrFile, dummyIrFile.module)
                     ?: return@mapNotNull null
             val irDump = preprocessedFunction.dump(dumpOptions)
             val irDumpFirstLine = irDump.substringBefore(Printer.LINE_SEPARATOR)


### PR DESCRIPTION
There is no reason for late initialization, module is always available in the scope when constructing `IrFile`.

^KT-87292 Fixed