### PR TITLE
[Compose] Drop `ModuleDescriptor` from `StabilityInferences`

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
@@ -56,7 +56,6 @@ abstract class AbstractLiveLiteralTransformTests : AbstractIrTransformTest() {
                                 val keyVisitor = DurableKeyVisitor(builtKeys)
                                 val stabilityInferencer = StabilityInferencer(
                                     pluginContext.platform.isJvm(),
-                                    pluginContext.moduleDescriptor,
                                     emptySet()
                                 )
                                 val featureFlags = FeatureFlags()

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ClassStabilityTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ClassStabilityTransformTests.kt
@@ -1808,7 +1808,7 @@ class ClassStabilityTransformTests : AbstractIrTransformTest() {
         })
         val irClass = (irModule.files.last().declarations.last() as IrClass).apply(transform)
         val externalTypeMatchers = externalTypes.map { FqNameMatcher(it) }.toSet()
-        val stabilityInferencer = StabilityInferencer(isTargetJvm = true, irModule.descriptor, externalTypeMatchers)
+        val stabilityInferencer = StabilityInferencer(isTargetJvm = true, externalTypeMatchers)
         val classStability = stabilityInferencer.stabilityOf(irClass.defaultType as IrType, irClass.file)
 
         assertEquals(
@@ -1840,7 +1840,7 @@ class ClassStabilityTransformTests : AbstractIrTransformTest() {
         val irClass = irModule.files.last().declarations.last() as IrClass
         val externalTypeMatchers = externalTypes.map { FqNameMatcher(it) }.toSet()
         val classStability =
-            StabilityInferencer(isTargetJvm = true, irModule.descriptor, externalTypeMatchers)
+            StabilityInferencer(isTargetJvm = true, externalTypeMatchers)
                 .stabilityOf(irClass.defaultType as IrType, irClass.file)
 
         assertEquals(
@@ -1980,7 +1980,7 @@ class ClassStabilityTransformTests : AbstractIrTransformTest() {
 
         val files = listOf(SourceFile("Test.kt", testFileSource))
         val irModule = compileToIr(files, additionalPaths)
-        val stabilityInferencer = StabilityInferencer(isTargetJvm = true, irModule.descriptor, setOf())
+        val stabilityInferencer = StabilityInferencer(isTargetJvm = true, setOf())
 
         val testIrFile = irModule.files.last()
         val [aClass, bClass, cClass, dClass] = testIrFile.declarations.filterIsInstance<IrClass>()
@@ -2050,7 +2050,7 @@ class ClassStabilityTransformTests : AbstractIrTransformTest() {
         }
         val externalTypeMatchers = externalTypes.map { FqNameMatcher(it) }.toSet()
         val exprStability =
-            StabilityInferencer(isTargetJvm = true, irModule.descriptor, externalTypeMatchers).stabilityOf(irExpr, irTestFn.file)
+            StabilityInferencer(isTargetJvm = true, externalTypeMatchers).stabilityOf(irExpr, irTestFn.file)
 
         assertEquals(
             stability,

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
@@ -64,7 +64,6 @@ class ComposeIrGenerationExtension(
 
         val stabilityInferencer = StabilityInferencer(
             pluginContext.platform.isJvm(),
-            pluginContext.moduleDescriptor,
             stableTypeMatchers,
         )
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
@@ -213,7 +213,6 @@ data class SymbolForAnalysis(
 
 class StabilityInferencer(
     private val isTargetJvm: Boolean,
-    private val currentModule: ModuleDescriptor,
     externalStableTypeMatchers: Set<FqNameMatcher>,
 ) {
     private val externalTypeMatcherCollection = FqNameMatcherCollection(externalStableTypeMatchers)
@@ -412,10 +411,6 @@ class StabilityInferencer(
 
         return stability
     }
-
-    @OptIn(ObsoleteDescriptorBasedAPI::class)
-    private fun IrDeclaration.isInCurrentModule() =
-        module == currentModule
 
     private fun IrClass.isProtobufType(): Boolean {
         // Quick exit as all protos are final


### PR DESCRIPTION
It isn't used and introduces unnecessary coupling that stands in the way of fixing KT-87198.