### PR TITLE
[IR] Use module fragment instead of descriptor in `createEmptyExternalPackageFragment`

### DIFF
--- a/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/declarations/impl/IrExternalPackageFragmentImpl.kt
+++ b/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/declarations/impl/IrExternalPackageFragmentImpl.kt
@@ -40,15 +40,6 @@ class IrExternalPackageFragmentImpl(
     @UnsafeDuringIrConstructionAPI
     override val declarations: MutableList<IrDeclaration> = ArrayList()
 
-    companion object {
-        @Deprecated(
-            message = "Use org.jetbrains.kotlin.ir.declarations.createEmptyExternalPackageFragment instead",
-            replaceWith = ReplaceWith("createEmptyExternalPackageFragment", "org.jetbrains.kotlin.ir.declarations.createEmptyExternalPackageFragment")
-        )
-        fun createEmptyExternalPackageFragment(module: ModuleDescriptor, fqName: FqName): IrExternalPackageFragment =
-            org.jetbrains.kotlin.ir.declarations.createEmptyExternalPackageFragment(module, fqName)
-    }
-
     init {
         symbol.bind(this)
     }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrPackageFragments.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrPackageFragments.kt
@@ -41,7 +41,14 @@ val IrPackageFragment.moduleDescriptor: ModuleDescriptor
         packageFragmentDescriptor.containingDeclaration
     }
 
+
+fun createEmptyExternalPackageFragment(module: IrModuleFragment, fqName: FqName): IrExternalPackageFragment =
+    IrExternalPackageFragmentImpl(
+        IrExternalPackageFragmentSymbolImpl(EmptyPackageFragmentDescriptor(module.descriptor, fqName)), fqName
+    )
+
 fun createEmptyExternalPackageFragment(module: ModuleDescriptor, fqName: FqName): IrExternalPackageFragment =
+    // TODO(KT-87300): Migrate all usages of this function to the one with `IrModuleFragment` instead of `ModuleDescriptor`
     IrExternalPackageFragmentImpl(
         IrExternalPackageFragmentSymbolImpl(EmptyPackageFragmentDescriptor(module, fqName)), fqName
     )

--- a/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/ImplementationConfigurator.kt
+++ b/compiler/ir/ir.tree/tree-generator/src/org/jetbrains/kotlin/ir/generator/ImplementationConfigurator.kt
@@ -167,21 +167,6 @@ object ImplementationConfigurator : AbstractIrTreeImplementationConfigurator() {
             )
             defaultWithErrorOnSet("startOffset", undefinedOffset())
             defaultWithErrorOnSet("endOffset", undefinedOffset())
-            implementation.generationCallback = {
-                println()
-                printlnMultiLine(
-                    """
-                    companion object {
-                        @Deprecated(
-                            message = "Use org.jetbrains.kotlin.ir.declarations.createEmptyExternalPackageFragment instead",
-                            replaceWith = ReplaceWith("createEmptyExternalPackageFragment", "org.jetbrains.kotlin.ir.declarations.createEmptyExternalPackageFragment")
-                        )
-                        fun createEmptyExternalPackageFragment(module: ModuleDescriptor, fqName: FqName): IrExternalPackageFragment =
-                            org.jetbrains.kotlin.ir.declarations.createEmptyExternalPackageFragment(module, fqName)
-                    }
-                    """
-                )
-            }
         }
 
         impl(file) {

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/linkage/partial/MissingDeclarationStubGenerator.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/linkage/partial/MissingDeclarationStubGenerator.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrProvider
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
 import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
@@ -35,7 +36,7 @@ internal class MissingDeclarationStubGenerator(
     private val nothingType: IrType,
 ) {
     private val commonParent by lazy {
-        createEmptyExternalPackageFragment(ErrorUtils.errorModule, FqName.ROOT)
+        createEmptyExternalPackageFragment(IrModuleFragmentImpl(ErrorUtils.errorModule), FqName.ROOT)
     }
 
     val allStubbedSymbols: Set<IrSymbol>

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicSymbols.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicSymbols.kt
@@ -93,7 +93,7 @@ abstract class AbstractAtomicSymbols(
 
     protected fun createPackage(packageName: String): IrPackageFragment =
         createEmptyExternalPackageFragment(
-            moduleFragment.descriptor,
+            moduleFragment,
             FqName(packageName)
         )
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -1264,8 +1264,7 @@ abstract class AbstractComposeLowering(
                 name = Name.special("<unsafe-coerce>")
                 origin = IrDeclarationOrigin.IR_BUILTINS_STUB
             }.apply {
-                @Suppress("DEPRECATION")
-                parent = IrExternalPackageFragmentImpl.createEmptyExternalPackageFragment(
+                parent = createEmptyExternalPackageFragment(
                     context.moduleDescriptor,
                     FqName("kotlin.jvm.internal")
                 )

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerialInfoImplJvmIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerialInfoImplJvmIrGenerator.kt
@@ -91,6 +91,7 @@ class SerialInfoImplJvmIrGenerator(
 
     private fun createPackage(packageName: String): IrPackageFragment =
         createEmptyExternalPackageFragment(
+            // TODO(KT-87315): Use `stdlib` module instead of this one.
             moduleFragment,
             FqName(packageName)
         )

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerialInfoImplJvmIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/SerialInfoImplJvmIrGenerator.kt
@@ -91,7 +91,7 @@ class SerialInfoImplJvmIrGenerator(
 
     private fun createPackage(packageName: String): IrPackageFragment =
         createEmptyExternalPackageFragment(
-            moduleFragment.descriptor,
+            moduleFragment,
             FqName(packageName)
         )
 

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
@@ -550,7 +550,7 @@ class AndroidSymbols(
 
     private fun createPackage(packageName: String): IrPackageFragment =
         createEmptyExternalPackageFragment(
-            moduleFragment.descriptor,
+            moduleFragment,
             FqName(packageName)
         )
 

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/AndroidSymbols.kt
@@ -550,6 +550,7 @@ class AndroidSymbols(
 
     private fun createPackage(packageName: String): IrPackageFragment =
         createEmptyExternalPackageFragment(
+            // TODO(KT-87315): Use `stdlib` module instead of this one.
             moduleFragment,
             FqName(packageName)
         )

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/JvmSymbolsForScripting.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/JvmSymbolsForScripting.kt
@@ -59,6 +59,7 @@ class JvmSymbolsForScripting(
 
     private fun createPackage(packageName: String): IrPackageFragment =
         createEmptyExternalPackageFragment(
+            // TODO(KT-87315): Use `stdlib` module instead of this one.
             moduleFragment,
             FqName(packageName)
         )

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/JvmSymbolsForScripting.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/JvmSymbolsForScripting.kt
@@ -59,7 +59,7 @@ class JvmSymbolsForScripting(
 
     private fun createPackage(packageName: String): IrPackageFragment =
         createEmptyExternalPackageFragment(
-            moduleFragment.descriptor,
+            moduleFragment,
             FqName(packageName)
         )
 }


### PR DESCRIPTION
And add a TODO(KT-87300) comment for remaining cases that are not so easy to migrate.

This is a preparatory step for fixing KT-87198.