### PR TITLE
JVM: Add propagated @JvmExposeBoxed annotation to constructor metadata

### DIFF
--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
@@ -377,8 +377,23 @@ class MemoizedInlineClassReplacements(
             isPrimary = constructor.isPrimary
         }.apply {
             parent = constructor.parent
-            metadata = constructor.metadata
-            constructor.metadata = null
+
+            if (constructor.metadata != null) {
+                metadata = constructor.metadata
+                constructor.metadata = null
+
+                // Propagate implicit @JvmExposeBoxed to metadata.
+                // This metadata is copied to synthetic constructor, which is not accessible from Java.
+                // Which might look contradictory, but otherwise there is no way to distinguish
+                // exposed constructor from non-exposed one if the constructor comes from another module.
+                // So, the metadata with annotation is on the synthetic constructor, but
+                // the annotation on bytecode is on the exposed constructor, which is expected to be called from Java.
+                if (!constructor.hasAnnotation(JVM_EXPOSE_BOXED_ANNOTATION_FQ_NAME)) {
+                    context.irPluginContext
+                        ?.metadataDeclarationRegistrar
+                        ?.addMetadataVisibleAnnotationsToElement(this, createJvmExposeBoxedAnnotation(this, context))
+                }
+            }
             copyFunctionSignatureFrom(constructor)
             annotations = constructor.annotations.withoutJvmExposeBoxedAnnotation()
             body = constructor.body?.patchDeclarationParents(this)
@@ -432,8 +447,15 @@ fun List<IrAnnotation>.withJvmExposeBoxedAnnotation(declaration: IrDeclaration, 
     }
     // The declaration is not annotated with @JvmExposeBoxed - the annotation is on class
     // or -Xjvm-expose-boxed is specified. Add the annotation.
+    return this + createJvmExposeBoxedAnnotation(declaration, context)
+}
+
+private fun createJvmExposeBoxedAnnotation(
+    declaration: IrDeclaration,
+    context: JvmBackendContext,
+): IrAnnotationImpl {
     val constructor = context.symbols.jvmExposeBoxedAnnotation.constructors.first()
-    return this + IrAnnotationImpl.fromSymbolOwner(
+    return IrAnnotationImpl.fromSymbolOwner(
         constructor.owner.returnType,
         constructor
     ).apply {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.declarations.buildProperty
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyDeclarationBase
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
@@ -234,6 +235,9 @@ val IrDeclaration.isStaticInlineClassReplacement: Boolean
 fun IrDeclaration.shouldBeExposedByAnnotationOrFlag(context: JvmBackendContext): Boolean {
     val isPropagatedOrImplicit = propagatedOrImplicitJvmExposeBoxed(context)
     val isExplicit = hasAnnotation(JVM_EXPOSE_BOXED_ANNOTATION_FQ_NAME)
+
+    // Do not try to propagate implicit @JvmExposeBoxed to declarations from other modules.
+    if (origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB && !isExplicit) return false
 
     if (!(isExplicit || isPropagatedOrImplicit)) return false
     if (!isFunctionWhichCanBeExposed(isPropagatedOrImplicit && !isExplicit)) return false

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/constructorOfOrdinaryMultiModule/depExposedUseExposed.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/constructorOfOrdinaryMultiModule/depExposedUseExposed.kt
@@ -1,0 +1,59 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// MODULE: lib
+// FILE: lib.kt
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmInline
+value class DepIC @JvmExposeBoxed constructor(val s: String)
+
+class DepHolder @JvmExposeBoxed constructor(val s: DepIC) {
+    fun ok(): String = s.s
+}
+
+// MODULE: main(lib)
+// FILE: usage.kt
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmInline
+value class UseIC @JvmExposeBoxed constructor(val s: String)
+
+class UseHolder @JvmExposeBoxed constructor(val s: UseIC) {
+    fun ok(): String = s.s
+}
+
+fun testFromKotlin(): String {
+    val dependency = DepHolder(DepIC("OK")).ok()
+    if (dependency != "OK") return "FAIL dependency from Kotlin: $dependency"
+
+    val usage = UseHolder(UseIC("OK")).ok()
+    if (usage != "OK") return "FAIL usage from Kotlin: $usage"
+
+    return "OK"
+}
+
+// FILE: Main.java
+public class Main {
+    public String dependency() {
+        return new DepHolder(new DepIC("OK")).ok();
+    }
+
+    public String usage() {
+        return new UseHolder(new UseIC("OK")).ok();
+    }
+}
+
+// FILE: box.kt
+fun box(): String {
+    val kotlin = testFromKotlin()
+    if (kotlin != "OK") return kotlin
+
+    val dependency = Main().dependency()
+    if (dependency != "OK") return "FAIL 1: $dependency"
+
+    val usage = Main().usage()
+    if (usage != "OK") return "FAIL 2: $usage"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/constructorOfOrdinaryMultiModule/depExposedUseNonExposed.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/constructorOfOrdinaryMultiModule/depExposedUseNonExposed.kt
@@ -1,0 +1,50 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// MODULE: lib
+// FILE: lib.kt
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmInline
+value class DepIC @JvmExposeBoxed constructor(val s: String)
+
+class DepHolder @JvmExposeBoxed constructor(val s: DepIC) {
+    fun ok(): String = s.s
+}
+
+// MODULE: main(lib)
+// FILE: usage.kt
+@JvmInline
+value class UseIC(val s: String)
+
+class UseHolder(val s: UseIC) {
+    fun ok(): String = s.s
+}
+
+fun testFromKotlin(): String {
+    val dependency = DepHolder(DepIC("OK")).ok()
+    if (dependency != "OK") return "FAIL dependency from Kotlin: $dependency"
+
+    val usage = UseHolder(UseIC("OK")).ok()
+    if (usage != "OK") return "FAIL usage from Kotlin: $usage"
+
+    return "OK"
+}
+
+// FILE: Main.java
+public class Main {
+    public String dependency() {
+        return new DepHolder(new DepIC("OK")).ok();
+    }
+}
+
+// FILE: box.kt
+fun box(): String {
+    val kotlin = testFromKotlin()
+    if (kotlin != "OK") return kotlin
+
+    val dependency = Main().dependency()
+    if (dependency != "OK") return "FAIL dependency from Java: $dependency"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/constructorOfOrdinaryMultiModule/depNonExposedUseExposed.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/constructorOfOrdinaryMultiModule/depNonExposedUseExposed.kt
@@ -1,0 +1,50 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// MODULE: lib
+// FILE: lib.kt
+@JvmInline
+value class DepIC(val s: String)
+
+class DepHolder(val s: DepIC) {
+    fun ok(): String = s.s
+}
+
+// MODULE: main(lib)
+// FILE: usage.kt
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmInline
+value class UseIC @JvmExposeBoxed constructor(val s: String)
+
+class UseHolder @JvmExposeBoxed constructor(val s: UseIC) {
+    fun ok(): String = s.s
+}
+
+fun testFromKotlin(): String {
+    val dependency = DepHolder(DepIC("OK")).ok()
+    if (dependency != "OK") return "FAIL dependency from Kotlin: $dependency"
+
+    val usage = UseHolder(UseIC("OK")).ok()
+    if (usage != "OK") return "FAIL usage from Kotlin: $usage"
+
+    return "OK"
+}
+
+// FILE: Main.java
+public class Main {
+    public String usage() {
+        return new UseHolder(new UseIC("OK")).ok();
+    }
+}
+
+// FILE: box.kt
+fun box(): String {
+    val kotlin = testFromKotlin()
+    if (kotlin != "OK") return kotlin
+
+    val usage = Main().usage()
+    if (usage != "OK") return "FAIL usage from Java: $usage"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/constructorLazy.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/constructorLazy.kt
@@ -1,0 +1,10 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+// JVM_EXPOSE_BOXED
+
+import kotlin.time.*
+
+fun box(): String {
+    TimedValue(0, Duration.ZERO)
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/depExposedUseExposed.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/depExposedUseExposed.kt
@@ -1,0 +1,57 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// MODULE: lib
+// JVM_EXPOSE_BOXED
+// FILE: lib.kt
+@JvmInline
+value class DepIC(val s: String)
+
+class DepHolder(val s: DepIC) {
+    fun ok(): String = s.s
+}
+
+// MODULE: main(lib)
+// JVM_EXPOSE_BOXED
+// FILE: usage.kt
+@JvmInline
+value class UseIC(val s: String)
+
+class UseHolder(val s: UseIC) {
+    fun ok(): String = s.s
+}
+
+fun testFromKotlin(): String {
+    val dependency = DepHolder(DepIC("OK")).ok()
+    if (dependency != "OK") return "FAIL dependency from Kotlin: $dependency"
+
+    val usage = UseHolder(UseIC("OK")).ok()
+    if (usage != "OK") return "FAIL usage from Kotlin: $usage"
+
+    return "OK"
+}
+
+// FILE: Main.java
+public class Main {
+    public String dependency() {
+        return new DepHolder(new DepIC("OK")).ok();
+    }
+
+    public String usage() {
+        return new UseHolder(new UseIC("OK")).ok();
+    }
+}
+
+// FILE: box.kt
+fun box(): String {
+    val kotlin = testFromKotlin()
+    if (kotlin != "OK") return kotlin
+
+    val dependency = Main().dependency()
+    if (dependency != "OK") return "FAIL 1: $dependency"
+
+    val usage = Main().usage()
+    if (usage != "OK") return "FAIL 2: $usage"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/depExposedUseNonExposed.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/depExposedUseNonExposed.kt
@@ -1,0 +1,49 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// MODULE: lib
+// JVM_EXPOSE_BOXED
+// FILE: lib.kt
+@JvmInline
+value class DepIC(val s: String)
+
+class DepHolder(val s: DepIC) {
+    fun ok(): String = s.s
+}
+
+// MODULE: main(lib)
+// FILE: usage.kt
+@JvmInline
+value class UseIC(val s: String)
+
+class UseHolder(val s: UseIC) {
+    fun ok(): String = s.s
+}
+
+fun testFromKotlin(): String {
+    val dependency = DepHolder(DepIC("OK")).ok()
+    if (dependency != "OK") return "FAIL dependency from Kotlin: $dependency"
+
+    val usage = UseHolder(UseIC("OK")).ok()
+    if (usage != "OK") return "FAIL usage from Kotlin: $usage"
+
+    return "OK"
+}
+
+// FILE: Main.java
+public class Main {
+    public String dependency() {
+        return new DepHolder(new DepIC("OK")).ok();
+    }
+}
+
+// FILE: box.kt
+fun box(): String {
+    val kotlin = testFromKotlin()
+    if (kotlin != "OK") return kotlin
+
+    val dependency = Main().dependency()
+    if (dependency != "OK") return "FAIL dependency from Java: $dependency"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/depNonExposedUseExposed.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/constructorOfOrdinaryMultiModule/depNonExposedUseExposed.kt
@@ -1,0 +1,49 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// MODULE: lib
+// FILE: lib.kt
+@JvmInline
+value class DepIC(val s: String)
+
+class DepHolder(val s: DepIC) {
+    fun ok(): String = s.s
+}
+
+// MODULE: main(lib)
+// JVM_EXPOSE_BOXED
+// FILE: usage.kt
+@JvmInline
+value class UseIC(val s: String)
+
+class UseHolder(val s: UseIC) {
+    fun ok(): String = s.s
+}
+
+fun testFromKotlin(): String {
+    val dependency = DepHolder(DepIC("OK")).ok()
+    if (dependency != "OK") return "FAIL dependency from Kotlin: $dependency"
+
+    val usage = UseHolder(UseIC("OK")).ok()
+    if (usage != "OK") return "FAIL usage from Kotlin: $usage"
+
+    return "OK"
+}
+
+// FILE: Main.java
+public class Main {
+    public String usage() {
+        return new UseHolder(new UseIC("OK")).ok();
+    }
+}
+
+// FILE: box.kt
+fun box(): String {
+    val kotlin = testFromKotlin()
+    if (kotlin != "OK") return kotlin
+
+    val usage = Main().usage()
+    if (usage != "OK") return "FAIL usage from Java: $usage"
+
+    return "OK"
+}


### PR DESCRIPTION
After fix of KT-86525 we started putting the metadata of exposed ordinary class constructor to synthetic constructor, which is called from Kotlin code, so it is reflected correctly in Kotlin Reflection.

However, because of this and because the synthetic constructor is being stripped of @JvmExposeBoxed annotation, there is no way to distinguish it from non-exposed constructor during lowering if the constructor is declared in a separate module.

The fix is to propagate the annotation to metadata only, keeping bytecode without one, since the metadata represents Kotlin code, so logically, the annotation should be propagated there. For other declarations, the metadata is not moved and the annotation is read from bytecode. Additionally, we expect bytecode processors/frameworks, which rely on Java reflection to inspect bytecode for @JvmExposeBoxed annotation, and putting the annotation in bytecode for synthetic constructor will add unnecessary corner case to keep in mind.

 #KT-81546 Fixed