### PR TITLE
[JKlib] Support resolving Kotlin klib dependencies during Java type resolution

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -101,7 +101,7 @@ object JKlibIrCompilationPhase :
         )
 
         val allDescriptors = dependencyDescriptorsByKlib.values + jarDepsModuleDescriptor
-        dependencyDescriptorsByKlib.values.forEach { it.setDependencies(allDescriptors) }
+        allDescriptors.forEach { it.setDependencies(allDescriptors) }
 
         val mainModule = dependencyDescriptorsByKlib.getValue(sortedDependencies.single { it.libraryFile == klib })
 
@@ -237,9 +237,6 @@ object JKlibIrCompilationPhase :
         )
         moduleClassResolver.compiledCodeResolver = dependenciesContainer.get()
 
-        dependenciesContext.setDependencies(
-            listOf(dependenciesContext.module, builtIns.builtInsModule)
-        )
         dependenciesContext.initializeModuleContents(
             CompositePackageFragmentProvider(
                 listOf(

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/JavaTypeConversion.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/JavaTypeConversion.kt
@@ -25,6 +25,8 @@ import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.utils.exceptions.errorWithAttachment
 
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+
 private fun ClassId.toConeFlexibleType(
     typeArguments: Array<out ConeTypeProjection>,
     typeArgumentsForUpper: Array<out ConeTypeProjection>,
@@ -246,8 +248,24 @@ private fun JavaClassifierType.toConeKotlinTypeForFlexibleBound(
         }
 
         null -> {
-            val classId = ClassId.topLevel(FqName(this.classifierQualifiedName))
-            classId.constructClassLikeType(isMarkedNullable = lowerBound != null, attributes = attributes)
+            var classId: ClassId? = null
+            val fqName = FqName(this.classifierQualifiedName)
+            if (!fqName.isRoot) {
+                var pkgFqn = fqName.parent()
+                var classFqn = FqName.topLevel(fqName.shortName())
+
+                while (true) {
+                    if (pkgFqn.isRoot || session.symbolProvider.hasPackage(pkgFqn)) {
+                        classId = ClassId(pkgFqn, classFqn, isLocal = false)
+                        break
+                    }
+                    classFqn = FqName(pkgFqn.shortName().asString() + "." + classFqn.asString())
+                    pkgFqn = pkgFqn.parent()
+                }
+            }
+
+            val finalClassId = classId ?: ClassId.topLevel(fqName)
+            finalClassId.constructClassLikeType(emptyArray(), isMarkedNullable = lowerBound != null, attributes)
         }
 
         else -> ConeErrorType(ConeSimpleDiagnostic("Unexpected classifier: $classifier", DiagnosticKind.Java))

--- a/compiler/jklib.tests/build.gradle.kts
+++ b/compiler/jklib.tests/build.gradle.kts
@@ -15,10 +15,18 @@ dependencies {
     testFixturesImplementation(project(":compiler:ir.serialization.jklib"))
 
     testFixturesApi("org.junit.jupiter:junit-jupiter")
+
+    testImplementation(project(":compiler:cli-jklib"))
+    testImplementation(project(":compiler:cli-jvm"))
+    testImplementation(testFixtures(project(":compiler:tests-integration")))
+    testImplementation(testFixtures(project(":compiler:tests-common")))
+    testImplementation(testFixtures(project(":compiler:tests-compiler-utils")))
+    testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 sourceSets {
     "main" { }
+    "test" { projectDefault() }
     "testFixtures" { projectDefault() }
 }
 

--- a/compiler/jklib.tests/testFixtures/org/jetbrains/kotlin/jklib/test/irText/JKlibSourceRootConfigurator.kt
+++ b/compiler/jklib.tests/testFixtures/org/jetbrains/kotlin/jklib/test/irText/JKlibSourceRootConfigurator.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.configuration.addSourcesForDependsOnClosure
 import org.jetbrains.kotlin.test.services.temporaryDirectoryManager
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import java.io.File
 
 class JKlibSourceRootConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
@@ -20,9 +21,7 @@ class JKlibSourceRootConfigurator(testServices: TestServices) : EnvironmentConfi
     override fun configureCompilerConfiguration(configuration: CompilerConfiguration, module: TestModule) {
         configuration.addSourcesForDependsOnClosure(module, testServices)
 
-        val stdlibKlib = System.getProperty("kotlin.stdlib.jklib.for.test")
-            ?: error("kotlin.stdlib.jvm.ir.klib system property is not set")
-        configuration.klibPaths += stdlibKlib
+        configuration.klibPaths += ForTestCompileRuntime.jklibStdlibForTests().path
 
         val tempDir = testServices.temporaryDirectoryManager.getOrCreateTempDirectory("klib-output")
         val outputFile = File(tempDir, "${module.name}.klib")

--- a/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibJavaInteropIntegrationTest.kt
+++ b/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibJavaInteropIntegrationTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.jklib.test
+
+import com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.cli.AbstractCliTest
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.common.disposeRootInWriteAction
+import org.jetbrains.kotlin.cli.common.messages.MessageCollectorImpl
+import org.jetbrains.kotlin.cli.jklib.K2JKlibCompiler
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.test.MockLibraryUtilExt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class JKlibJavaInteropIntegrationTest {
+
+    @Test
+    fun testJavaExtendingNestedKotlinClassFromKlib(@TempDir tempDir: File) {
+        val stdlibKlib = ForTestCompileRuntime.jklibStdlibForTests().path
+        val stdlibJar = ForTestCompileRuntime.runtimeJarForTests().path
+
+        val libADir = File(tempDir, "libA").apply { mkdirs() }
+        val outerKt = File(libADir, "Outer.kt").apply {
+            writeText(
+                """
+                package test
+
+                open class Outer {
+                    open class Inner {
+                        val prop: String = "OK"
+                        fun foo(): String = "OK"
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        val klibA = File(tempDir, "libA.klib")
+        val resA = AbstractCliTest.executeCompilerGrabOutput(
+            K2JKlibCompiler(),
+            listOf(
+                outerKt.path,
+                "-d", klibA.path,
+                "-module-name", "libA",
+                "-no-stdlib",
+                "-Xklib=$stdlibKlib"
+            )
+        )
+        assertEquals(ExitCode.OK, resA.second, "Failed to compile libA klib: ${resA.first}")
+
+        val jarA = File(tempDir, "libA.jar")
+        val resAJvm = AbstractCliTest.executeCompilerGrabOutput(
+            K2JVMCompiler(),
+            listOf(
+                outerKt.path,
+                "-d", jarA.path,
+                "-no-stdlib",
+                "-classpath", stdlibJar
+            )
+        )
+        assertEquals(ExitCode.OK, resAJvm.second, "Failed to compile libA jar: ${resAJvm.first}")
+
+        val libBDir = File(tempDir, "libB").apply { mkdirs() }
+        File(libBDir, "JavaClass.java").apply {
+            writeText(
+                """
+                package test;
+
+                public class JavaClass extends Outer.Inner {
+                }
+                """.trimIndent()
+            )
+        }
+
+        val jarB = MockLibraryUtilExt.compileJavaFilesLibraryToJar(
+            libBDir.path,
+            "libB",
+            extraClasspath = listOf(jarA.path)
+        )
+
+        val mainDir = File(tempDir, "main").apply { mkdirs() }
+        val mainKt = File(mainDir, "Main.kt").apply {
+            writeText(
+                """
+                package test
+
+                fun test() {
+                    val j = JavaClass()
+                    val x = j.prop
+                }
+                """.trimIndent()
+            )
+        }
+
+        val mainKlib = File(tempDir, "main.klib")
+        val compiler = K2JKlibCompiler()
+        val args = compiler.createArguments()
+        compiler.parseArguments(
+            arrayOf(
+                mainKt.path,
+                "-d", mainKlib.path,
+                "-module-name", "main",
+                "-no-stdlib",
+                "-classpath", jarB.path,
+                "-Xklib=$stdlibKlib${File.pathSeparator}${klibA.path}"
+            ),
+            args
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val disposable = Disposer.newDisposable()
+        try {
+            val artifact = compiler.compileKlibAndDeserializeIr(args, messageCollector, disposable)
+            if (artifact == null) {
+                error("compileKlibAndDeserializeIr returned null. Messages:\n" + messageCollector.messages.joinToString("\n"))
+            }
+        } finally {
+            disposeRootInWriteAction(disposable)
+        }
+    }
+}

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/ForTestCompileRuntime.java
@@ -214,6 +214,11 @@ public class ForTestCompileRuntime {
         return getFileFromProperty(KOTLIN_JS_STDLIB_KLIB_PATH);
     }
 
+    @NotNull
+    public static File jklibStdlibForTests() {
+        return getFileFromProperty(KOTLIN_JKLIB_STDLIB_PATH);
+    }
+
     public static File stdlibWebForTests() {
         return getFileFromProperty(KOTLIN_WEB_STDLIB_KLIB_PATH);
     }

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/codegen/forTestCompile/TestCompilePaths.kt
@@ -18,6 +18,7 @@ object TestCompilePaths {
     const val KOTLIN_ANNOTATIONS_PATH: String = "kotlin.annotations.path"
     const val KOTLIN_WEB_STDLIB_KLIB_PATH: String = "kotlin.web.stdlib.path"
     const val KOTLIN_JS_STDLIB_KLIB_PATH: String = "kotlin.js.stdlib.klib.path"
+    const val KOTLIN_JKLIB_STDLIB_PATH: String = "kotlin.stdlib.jklib.for.test"
     const val KOTLIN_WASM_STDLIB_KLIB_PATH: String = "kotlin.wasm-js.stdlib.path"
     const val KOTLIN_JS_REDUCED_STDLIB_PATH: String = "kotlin.js.reduced.stdlib.path"
     const val KOTLIN_JS_KOTLIN_TEST_KLIB_PATH: String = "kotlin.js.kotlin.test.klib.path"

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/types/JavaTypeResolver.kt
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/lazy/types/JavaTypeResolver.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.load.java.lazy.types
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMapper
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
 import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.Annotations
 import org.jetbrains.kotlin.descriptors.annotations.CompositeAnnotations
@@ -140,7 +141,26 @@ class JavaTypeResolver(
     }
 
     private fun computeTypeConstructor(javaType: JavaClassifierType, attr: JavaTypeAttributes): TypeConstructor? {
-        val classifier = javaType.classifier ?: return createNotFoundClass(javaType)
+        val classifier = javaType.classifier
+        if (classifier == null) {
+            val fqName = FqName(javaType.classifierQualifiedName)
+            if (!fqName.isRoot) {
+                var pkgFqn = fqName.parent()
+                var classFqn = FqName.topLevel(fqName.shortName())
+
+                while (true) {
+                    val candidateClassId = ClassId(pkgFqn, classFqn, isLocal = false)
+                    val classDescriptor = c.module.findClassAcrossModuleDependencies(candidateClassId)
+                    if (classDescriptor != null) {
+                        return classDescriptor.typeConstructor
+                    }
+                    if (pkgFqn.isRoot) break
+                    classFqn = FqName(pkgFqn.shortName().asString() + "." + classFqn.asString())
+                    pkgFqn = pkgFqn.parent()
+                }
+            }
+            return createNotFoundClass(javaType)
+        }
         return when (classifier) {
             is JavaClass -> {
                 val fqName = classifier.fqName.sure { "Class type should have a FQ name: $classifier" }

--- a/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/TestCompilePaths.kt
+++ b/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/TestCompilePaths.kt
@@ -16,6 +16,7 @@ object TestCompilePaths {
     const val KOTLIN_ANNOTATIONS_PATH: String = "kotlin.annotations.path"
     const val KOTLIN_WEB_STDLIB_KLIB_PATH: String = "kotlin.web.stdlib.path"
     const val KOTLIN_JS_STDLIB_KLIB_PATH: String = "kotlin.js.stdlib.klib.path"
+    const val KOTLIN_JKLIB_STDLIB_PATH: String = "kotlin.stdlib.jklib.for.test"
     const val KOTLIN_JS_REDUCED_STDLIB_PATH: String = "kotlin.js.reduced.stdlib.path"
     const val KOTLIN_JS_KOTLIN_TEST_KLIB_PATH: String = "kotlin.js.kotlin.test.klib.path"
 


### PR DESCRIPTION

This PR fixes an issue in the JKlib pipeline where Java code referencing Kotlin types compiled into .klib modules failed during Java type resolution.

Previously, when Java sources referenced Kotlin declarations from dependency klibs, `JavaTypeResolver` and `JavaTypeConversion` failed to locate class descriptors across module boundaries. We added fallback logic using `findClassAcrossModuleDependencies` to resolve class descriptors across klib module dependencies.

We also updated JKlibIrCompilationPhase so that all dependency descriptors (including jarDepsModuleDescriptor) are properly wired.

We added JKlibJavaInteropIntegrationTest to verify cross-module interop scenarios where Java classes extend nested Kotlin classes defined in pre-compiled .klib binaries.