### PR TITLE
Provide Gradle DSL for return value checker

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
+++ b/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
@@ -182,6 +182,16 @@ public abstract interface class org/jetbrains/kotlin/gradle/dsl/KotlinBackwardsD
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/dsl/KotlinBaseExtension : org/jetbrains/kotlin/gradle/dsl/KotlinTopLevelExtension {
+	public abstract fun getReturnValueCheckerMode ()Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
+	public abstract fun getReturnValueCheckerModeForTests ()Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
+	public abstract fun returnValueChecker ()V
+	public abstract fun returnValueChecker (Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;)V
+	public abstract fun setReturnValueCheckerMode (Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;)V
+	public abstract fun setReturnValueCheckerModeForTests (Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;)V
+}
+
+public final class org/jetbrains/kotlin/gradle/dsl/KotlinBaseExtension$DefaultImpls {
+	public static synthetic fun returnValueChecker$default (Lorg/jetbrains/kotlin/gradle/dsl/KotlinBaseExtension;Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;ILjava/lang/Object;)V
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/dsl/KotlinCommonCompilerOptions : org/jetbrains/kotlin/gradle/dsl/KotlinCommonCompilerToolOptions {
@@ -579,6 +589,14 @@ public final class org/jetbrains/kotlin/gradle/dsl/KotlinVersion : java/lang/Enu
 public final class org/jetbrains/kotlin/gradle/dsl/KotlinVersion$Companion {
 	public final fun fromVersion (Ljava/lang/String;)Lorg/jetbrains/kotlin/gradle/dsl/KotlinVersion;
 	public final fun getDEFAULT ()Lorg/jetbrains/kotlin/gradle/dsl/KotlinVersion;
+}
+
+public final class org/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode : java/lang/Enum {
+	public static final field Check Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
+	public static final field Disabled Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
+	public static final field Full Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
+	public static fun values ()[Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/dsl/abi/AbiFilterSetSpec {

--- a/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
+++ b/libraries/tools/kotlin-gradle-plugin-api/api/kotlin-gradle-plugin-api.api
@@ -1143,11 +1143,13 @@ public abstract interface class org/jetbrains/kotlin/gradle/plugin/KotlinJvmFact
 	public abstract fun registerKotlinJvmCompileTask (Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
 	public abstract fun registerKotlinJvmCompileTask (Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
 	public abstract fun registerKotlinJvmCompileTask (Ljava/lang/String;Lorg/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions;Lorg/gradle/api/provider/Provider;)Lorg/gradle/api/tasks/TaskProvider;
+	public abstract fun registerKotlinJvmCompileTask (Ljava/lang/String;Lorg/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;)Lorg/gradle/api/tasks/TaskProvider;
 }
 
 public final class org/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory$DefaultImpls {
 	public static synthetic fun registerKaptGenerateStubsTask$default (Lorg/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory;Ljava/lang/String;Lorg/gradle/api/tasks/TaskProvider;Lorg/jetbrains/kotlin/gradle/dsl/KaptExtensionConfig;Lorg/gradle/api/provider/Provider;ILjava/lang/Object;)Lorg/gradle/api/tasks/TaskProvider;
 	public static synthetic fun registerKotlinJvmCompileTask$default (Lorg/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory;Ljava/lang/String;Lorg/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions;Lorg/gradle/api/provider/Provider;ILjava/lang/Object;)Lorg/gradle/api/tasks/TaskProvider;
+	public static synthetic fun registerKotlinJvmCompileTask$default (Lorg/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory;Ljava/lang/String;Lorg/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;ILjava/lang/Object;)Lorg/gradle/api/tasks/TaskProvider;
 }
 
 public final class org/jetbrains/kotlin/gradle/plugin/KotlinPlatformType : java/lang/Enum, java/io/Serializable, org/gradle/api/Named {

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinBaseExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinBaseExtension.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlin.gradle.dsl
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
 /**
  * A plugin DSL extension for configuring common options for the entire project.
  *
@@ -19,4 +21,49 @@ package org.jetbrains.kotlin.gradle.dsl
  */
 @Suppress("DEPRECATION")
 @KotlinGradlePluginDsl
-interface KotlinBaseExtension : KotlinTopLevelExtension
+interface KotlinBaseExtension : KotlinTopLevelExtension {
+
+    /**
+     * Configures the return value checker mode for all production compilations in the project.
+     *
+     * Unless [returnValueCheckerModeForTests] is set explicitly, this mode is also used for test compilations.
+     *
+     * Default: `null`
+     */
+    @ExperimentalKotlinGradlePluginApi
+    var returnValueCheckerMode: ReturnValueCheckerMode?
+
+    /**
+     * Configures the return value checker mode for all test compilations in the project.
+     *
+     * When `null`, test compilations use [returnValueCheckerMode].
+     *
+     * Default: `null`
+     */
+    @ExperimentalKotlinGradlePluginApi
+    var returnValueCheckerModeForTests: ReturnValueCheckerMode?
+
+    /**
+     * Enables the return value checker in [ReturnValueCheckerMode.Check] mode for both production and test compilations.
+     *
+     * Equivalent to `returnValueChecker(ReturnValueCheckerMode.Check, ReturnValueCheckerMode.Check)`. This zero-argument
+     * overload exists so the function can be called from the Groovy DSL, which cannot use Kotlin default parameter values.
+     */
+    @ExperimentalKotlinGradlePluginApi
+    fun returnValueChecker()
+
+    /**
+     * Configures the return value checker for the project.
+     *
+     * By default, the same [mode] is applied to both production and test compilations. Pass [testMode] to use a
+     * different mode for test compilations.
+     *
+     * Note: Kotlin default parameter values are not available from the Groovy DSL or Java. Non-Kotlin build scripts
+     * must pass both arguments explicitly (or use the zero-argument [returnValueChecker] overload).
+     *
+     * @param mode the mode for production compilations (and tests unless [testMode] is set). Defaults to [ReturnValueCheckerMode.Check].
+     * @param testMode the mode for test compilations. Defaults to [mode].
+     */
+    @ExperimentalKotlinGradlePluginApi
+    fun returnValueChecker(mode: ReturnValueCheckerMode = ReturnValueCheckerMode.Check, testMode: ReturnValueCheckerMode = mode)
+}

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.dsl
+
+/**
+ * Different modes that can be used to configure the level of unused return value checking for the
+ * [KotlinBaseExtension.returnValueCheckerMode] option.
+ */
+enum class ReturnValueCheckerMode {
+    /**
+     * Disables checking of unused return values.
+     */
+    Disabled,
+
+    /**
+     * Checks for unused return values of declarations that are explicitly marked as must-use.
+     */
+    Check,
+
+    /**
+     * Treats all declarations as must-use and checks for their unused return values.
+     */
+    Full;
+}

--- a/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory.kt
+++ b/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinJvmFactory.kt
@@ -10,6 +10,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs
 import org.jetbrains.kotlin.gradle.tasks.Kapt
@@ -126,6 +127,32 @@ interface KotlinJvmFactory {
         taskName: String,
         compilerOptions: KotlinJvmCompilerOptions = createCompilerJvmOptions(),
         explicitApiMode: Provider<ExplicitApiMode> = providerFactory.provider { ExplicitApiMode.Disabled },
+    ): TaskProvider<out KotlinJvmCompile>
+
+    /**
+     * Registers a new standalone Kotlin compilation task for the JVM platform.
+     *
+     * This task is not associated with any [KotlinTarget] or [KotlinCompilation].
+     * It is not executed as part of the common compilation pipeline.
+     *
+     * @param taskName the name of the task.
+     * @param compilerOptions values of this [KotlinJvmCompilerOptions] instance that are used as convention values
+     * for [KotlinJvmCompilerOptions]'s inside task.
+     * @param explicitApiMode desired [ExplicitApiMode] mode in the task.
+     * The [Provider] can have `null` value which is the same as specify [ExplicitApiMode.Disabled].
+     * By default, the value is [ExplicitApiMode.Disabled].
+     * @param returnValueCheckerMode desired [ReturnValueCheckerMode] in the task.
+     * The [Provider] can have a `null` value, which is the same as [ReturnValueCheckerMode.Disabled].
+     * By default, the value is `null`.
+     *
+     * @since 2.4.0
+     */
+    @ExperimentalKotlinGradlePluginApi
+    fun registerKotlinJvmCompileTask(
+        taskName: String,
+        compilerOptions: KotlinJvmCompilerOptions = createCompilerJvmOptions(),
+        explicitApiMode: Provider<ExplicitApiMode> = providerFactory.provider { ExplicitApiMode.Disabled },
+        returnValueCheckerMode: Provider<ReturnValueCheckerMode> = providerFactory.provider { null },
     ): TaskProvider<out KotlinJvmCompile>
 
     /**

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ReturnValueCheckerIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ReturnValueCheckerIT.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.junit.jupiter.api.DisplayName
+import kotlin.io.path.appendText
+import kotlin.io.path.writeText
+
+@JvmGradlePluginTests
+@DisplayName("Return value checker DSL")
+class ReturnValueCheckerIT : KGPBaseTest() {
+
+    private val unusedReturnValueWarning = "Unused return value"
+
+    @DisplayName("returnValueChecker() applies check mode and reports unused return values in both production and test sources")
+    @GradleTest
+    fun returnValueCheckerDefault(gradleVersion: GradleVersion) {
+        project(
+            "simpleProject",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.copy(logLevel = LogLevel.DEBUG)
+        ) {
+            addUnusedReturnValueSources()
+            // The zero-argument overload is callable from the Groovy DSL (Kotlin default parameters are not).
+            buildGradle.appendText(
+                """
+                |
+                |kotlin.returnValueChecker()
+                """.trimMargin()
+            )
+
+            build("compileKotlin", "compileTestKotlin") {
+                assertCompilerArgument(":compileKotlin", "-Xreturn-value-checker=check")
+                assertCompilerArgument(":compileTestKotlin", "-Xreturn-value-checker=check")
+                assertTaskOutputContains(":compileKotlin", unusedReturnValueWarning)
+                assertTaskOutputContains(":compileTestKotlin", unusedReturnValueWarning)
+            }
+        }
+    }
+
+    @DisplayName("returnValueChecker(Full) applies full mode and reports unused return values in both production and test sources")
+    @GradleTest
+    fun returnValueCheckerFull(gradleVersion: GradleVersion) {
+        project(
+            "simpleProject",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.copy(logLevel = LogLevel.DEBUG)
+        ) {
+            addUnusedReturnValueSources()
+            buildGradle.appendText(
+                """
+                |
+                |import org.jetbrains.kotlin.gradle.dsl.ReturnValueCheckerMode
+                |kotlin.returnValueChecker(ReturnValueCheckerMode.Full, ReturnValueCheckerMode.Full)
+                """.trimMargin()
+            )
+
+            build("compileKotlin", "compileTestKotlin") {
+                assertCompilerArgument(":compileKotlin", "-Xreturn-value-checker=full")
+                assertCompilerArgument(":compileTestKotlin", "-Xreturn-value-checker=full")
+                assertTaskOutputContains(":compileKotlin", unusedReturnValueWarning)
+                assertTaskOutputContains(":compileTestKotlin", unusedReturnValueWarning)
+            }
+        }
+    }
+
+    @DisplayName("returnValueChecker with a disabled test mode reports unused return values only in production sources")
+    @GradleTest
+    fun returnValueCheckerDisabledForTests(gradleVersion: GradleVersion) {
+        project(
+            "simpleProject",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.copy(logLevel = LogLevel.DEBUG)
+        ) {
+            addUnusedReturnValueSources()
+            buildGradle.appendText(
+                """
+                |
+                |import org.jetbrains.kotlin.gradle.dsl.ReturnValueCheckerMode
+                |kotlin.returnValueChecker(ReturnValueCheckerMode.Check, ReturnValueCheckerMode.Disabled)
+                """.trimMargin()
+            )
+
+            build("compileKotlin", "compileTestKotlin") {
+                assertCompilerArgument(":compileKotlin", "-Xreturn-value-checker=check")
+                // The production mode must not leak into tests. 'disable' equals the compiler default and is therefore
+                // omitted by the argument serializer, so no -Xreturn-value-checker argument is present at all.
+                assertNoCompilerArgument(":compileTestKotlin", "-Xreturn-value-checker=check")
+                assertNoCompilerArgument(":compileTestKotlin", "-Xreturn-value-checker=disable")
+                assertTaskOutputContains(":compileKotlin", unusedReturnValueWarning)
+                assertTaskOutputDoesNotContain(":compileTestKotlin", unusedReturnValueWarning)
+            }
+        }
+    }
+
+    @DisplayName("returnValueChecker configuration is compatible with the configuration cache")
+    @GradleTest
+    fun returnValueCheckerConfigurationCache(gradleVersion: GradleVersion) {
+        project("simpleProject", gradleVersion) {
+            buildGradle.appendText(
+                """
+                |
+                |kotlin.returnValueChecker()
+                """.trimMargin()
+            )
+
+            // Stores the configuration cache, then reruns to verify it is reused (the mode is a plain extension
+            // property captured by value at configuration time, so it must be configuration-cache compatible).
+            assertSimpleConfigurationCacheScenarioWorks(
+                ":compileKotlin",
+                buildOptions = defaultBuildOptions,
+            )
+        }
+    }
+
+    /**
+     * Adds a `@MustUseReturnValues`-annotated production declaration whose return value is ignored in both production and
+     * test sources. Such a usage is reported by the return value checker in both `check` and `full` modes, so it lets the
+     * test observe the actual `Unused return value` compiler warning.
+     */
+    private fun TestProject.addUnusedReturnValueSources() {
+        kotlinSourcesDir("main").resolve("producer.kt").writeText(
+            """
+            |@MustUseReturnValues
+            |class Producer {
+            |    fun produce(): String = "result"
+            |}
+            |
+            |fun ignoreInMain() {
+            |    Producer().produce()
+            |}
+            """.trimMargin()
+        )
+        kotlinSourcesDir("test").resolve("consumer.kt").writeText(
+            """
+            |fun ignoreInTest() {
+            |    Producer().produce()
+            |}
+            """.trimMargin()
+        )
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ReturnValueCheckerMppIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ReturnValueCheckerMppIT.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.junit.jupiter.api.DisplayName
+import kotlin.io.path.appendText
+
+@MppGradlePluginTests
+@DisplayName("Return value checker DSL in multiplatform projects")
+class ReturnValueCheckerMppIT : KGPBaseTest() {
+
+    @DisplayName("returnValueChecker reaches the JVM and JS compilations and reports unused return values end-to-end")
+    @GradleTest
+    fun returnValueCheckerReachesJvmAndJs(gradleVersion: GradleVersion) {
+        project(
+            "returnValueCheckerMpp",
+            gradleVersion,
+            // The Kotlin/JS Node.js infrastructure registers root-project tasks that are incompatible with Isolated
+            // Projects (unrelated to the return value checker), so it is disabled here while keeping the configuration cache.
+            buildOptions = defaultBuildOptions.copy(logLevel = LogLevel.DEBUG).disableIsolatedProjects()
+        ) {
+            buildGradle.appendText(
+                """
+                |
+                |kotlin.returnValueChecker()
+                """.trimMargin()
+            )
+
+            build("compileKotlinJvm", "compileKotlinJs") {
+                assertCompilerArgument(":compileKotlinJvm", "-Xreturn-value-checker=check")
+                assertCompilerArgument(":compileKotlinJs", "-Xreturn-value-checker=check")
+                // common sources are compiled with each platform, so the warning is reported in both compilations
+                assertTaskOutputContains(":compileKotlinJvm", "Unused return value")
+                assertTaskOutputContains(":compileKotlinJs", "Unused return value")
+            }
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ReturnValueCheckerTestUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ReturnValueCheckerTestUtils.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.testkit.runner.BuildResult
+import org.jetbrains.kotlin.gradle.testbase.getOutputForTask
+import org.jetbrains.kotlin.gradle.testbase.printBuildOutput
+
+/**
+ * Asserts that the output produced by the task at [taskPath] contains [expected].
+ *
+ * Unlike the whole-build `assertOutputContains`, this is scoped to a single task, which is required to attribute a
+ * compiler diagnostic (e.g. the return value checker's "Unused return value" warning) to a specific compilation.
+ */
+internal fun BuildResult.assertTaskOutputContains(taskPath: String, expected: String) {
+    val taskOutput = getOutputForTask(taskPath, LogLevel.DEBUG)
+    assert(taskOutput.contains(expected)) {
+        printBuildOutput()
+        "$taskPath output does not contain '$expected'."
+    }
+}
+
+/**
+ * Asserts that the output produced by the task at [taskPath] does not contain [unexpected].
+ */
+internal fun BuildResult.assertTaskOutputDoesNotContain(taskPath: String, unexpected: String) {
+    val taskOutput = getOutputForTask(taskPath, LogLevel.DEBUG)
+    assert(!taskOutput.contains(unexpected)) {
+        printBuildOutput()
+        "$taskPath output unexpectedly contains '$unexpected'."
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/returnValueCheckerMpp/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/returnValueCheckerMpp/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id "org.jetbrains.kotlin.multiplatform"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+kotlin {
+    jvm()
+    js {
+        nodejs()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/returnValueCheckerMpp/src/commonMain/kotlin/producer.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/returnValueCheckerMpp/src/commonMain/kotlin/producer.kt
@@ -1,0 +1,10 @@
+@MustUseReturnValues
+class Producer {
+    fun produce(): String = "result"
+}
+
+fun ignoreInCommon() {
+    // ignoring the result of a must-use declaration is reported by the return value checker;
+    // common sources are compiled together with each platform, so the warning appears in every platform compilation
+    Producer().produce()
+}

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -532,6 +532,7 @@ public abstract class org/jetbrains/kotlin/gradle/plugin/KotlinBaseApiPlugin : o
 	public fun registerKotlinJvmCompileTask (Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
 	public fun registerKotlinJvmCompileTask (Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/tasks/TaskProvider;
 	public fun registerKotlinJvmCompileTask (Ljava/lang/String;Lorg/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions;Lorg/gradle/api/provider/Provider;)Lorg/gradle/api/tasks/TaskProvider;
+	public fun registerKotlinJvmCompileTask (Ljava/lang/String;Lorg/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptions;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;)Lorg/gradle/api/tasks/TaskProvider;
 }
 
 public abstract class org/jetbrains/kotlin/gradle/plugin/KotlinBasePluginWrapper : org/jetbrains/kotlin/gradle/plugin/DefaultKotlinBasePlugin {

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -5795,6 +5795,7 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/AbstractKotlinCompile : 
 	protected fun getIncrementalProps ()Ljava/util/List;
 	protected final fun getMultiModuleICSettings ()Lorg/jetbrains/kotlin/daemon/common/MultiModuleICSettings;
 	public fun getNormalizedKotlinDaemonJvmArguments ()Lorg/gradle/api/provider/Provider;
+	public abstract fun getReturnValueCheckerMode ()Lorg/gradle/api/provider/Property;
 	protected fun makeIncrementalCompilationFeatures ()Lorg/jetbrains/kotlin/incremental/IncrementalCompilationFeatures;
 	public fun reportDiagnostic (Lorg/jetbrains/kotlin/gradle/plugin/diagnostics/ToolingDiagnostic;)V
 	public final fun setIncremental (Z)V

--- a/libraries/tools/kotlin-gradle-plugin/api/external/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/external/kotlin-gradle-plugin.api
@@ -259,13 +259,19 @@ public abstract class org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension : o
 	public final fun getExtras ()Lorg/jetbrains/kotlin/tooling/core/MutableExtras;
 	public synthetic fun getKotlinDaemonJvmArgs ()Ljava/util/List;
 	public fun getProject ()Lorg/gradle/api/Project;
+	public fun getReturnValueCheckerMode ()Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
+	public fun getReturnValueCheckerModeForTests ()Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;
 	public fun getSourceSets ()Lorg/gradle/api/NamedDomainObjectContainer;
 	public fun invokeWhenCreated (Lorg/gradle/api/NamedDomainObjectContainer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun jvmToolchain (I)V
 	public fun jvmToolchain (Lorg/gradle/api/Action;)V
+	public fun returnValueChecker ()V
+	public fun returnValueChecker (Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;)V
 	public fun setCoreLibrariesVersion (Ljava/lang/String;)V
 	public fun setExplicitApi (Lorg/jetbrains/kotlin/gradle/dsl/ExplicitApiMode;)V
 	public fun setKotlinDaemonJvmArgs (Ljava/util/List;)V
+	public fun setReturnValueCheckerMode (Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;)V
+	public fun setReturnValueCheckerModeForTests (Lorg/jetbrains/kotlin/gradle/dsl/ReturnValueCheckerMode;)V
 }
 
 public abstract interface class org/jetbrains/kotlin/gradle/dsl/KotlinTargetContainerWithJsPresetFunctions : org/jetbrains/kotlin/gradle/dsl/KotlinTargetContainerWithPresetFunctions, org/jetbrains/kotlin/gradle/plugin/KotlinJsCompilerTypeHolder {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinProjectExtension.kt
@@ -89,6 +89,15 @@ internal fun KotlinBaseExtension.explicitApiModeAsCompilerArg(): String? {
     return cliOption?.let { "-Xexplicit-api=$it" }
 }
 
+internal fun ReturnValueCheckerMode.toCompilerValue() = when (this) {
+    // "disable" is the compiler default for 'CommonCompilerArguments.returnValueChecker'. The argument serializer
+    // compares each field to a fresh default instance and omits matches, so setting this value emits no
+    // -Xreturn-value-checker flag (a silent no-op). Keep in sync if the compiler default ever changes.
+    ReturnValueCheckerMode.Disabled -> "disable"
+    ReturnValueCheckerMode.Check -> "check"
+    ReturnValueCheckerMode.Full -> "full"
+}
+
 @KotlinGradlePluginPublicDsl
 abstract class KotlinProjectExtension @Inject constructor(
     override val project: Project
@@ -154,6 +163,23 @@ abstract class KotlinProjectExtension @Inject constructor(
 
     override fun explicitApiWarning() {
         explicitApi = ExplicitApiMode.Warning
+    }
+
+    @ExperimentalKotlinGradlePluginApi
+    override var returnValueCheckerMode: ReturnValueCheckerMode? = null
+
+    @ExperimentalKotlinGradlePluginApi
+    override var returnValueCheckerModeForTests: ReturnValueCheckerMode? = null
+
+    @ExperimentalKotlinGradlePluginApi
+    override fun returnValueChecker() {
+        returnValueChecker(ReturnValueCheckerMode.Check, ReturnValueCheckerMode.Check)
+    }
+
+    @ExperimentalKotlinGradlePluginApi
+    override fun returnValueChecker(mode: ReturnValueCheckerMode, testMode: ReturnValueCheckerMode) {
+        returnValueCheckerMode = mode
+        returnValueCheckerModeForTests = testMode
     }
 
     @ExperimentalKotlinGradlePluginApi

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinBaseApiPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinBaseApiPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
@@ -105,10 +106,24 @@ abstract class KotlinBaseApiPlugin : DefaultKotlinBasePlugin(), KotlinJvmFactory
         )
     }
 
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
     override fun registerKotlinJvmCompileTask(
         taskName: String,
         compilerOptions: KotlinJvmCompilerOptions,
         explicitApiMode: Provider<ExplicitApiMode>,
+    ): TaskProvider<out KotlinJvmCompile> = registerKotlinJvmCompileTask(
+        taskName,
+        compilerOptions,
+        explicitApiMode,
+        providerFactory.provider { null },
+    )
+
+    @ExperimentalKotlinGradlePluginApi
+    override fun registerKotlinJvmCompileTask(
+        taskName: String,
+        compilerOptions: KotlinJvmCompilerOptions,
+        explicitApiMode: Provider<ExplicitApiMode>,
+        returnValueCheckerMode: Provider<ReturnValueCheckerMode>,
     ): TaskProvider<out KotlinJvmCompile> {
         val taskCompilerOptions = createCompilerJvmOptions()
         KotlinJvmCompilerOptionsHelper.syncOptionsAsConvention(compilerOptions, taskCompilerOptions)
@@ -119,6 +134,7 @@ abstract class KotlinBaseApiPlugin : DefaultKotlinBasePlugin(), KotlinJvmFactory
             KotlinCompileConfig(
                 myProject,
                 explicitApiMode,
+                returnValueCheckerMode,
             )
         )
         return registeredKotlinJvmCompileTask

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/KotlinCreateNativeCompileTasksSideEffect.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/KotlinCreateNativeCompileTasksSideEffect.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.plugin.mpp.compilationImpl
 
 import org.gradle.api.plugins.BasePlugin
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.artifacts.klibOutputDirectory
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.topLevelExtension
@@ -27,6 +28,7 @@ import org.jetbrains.kotlin.gradle.tasks.registerTask
  * Will register (and configure) the corresponding [KotlinNativeCompile] task for a given
  * [AbstractKotlinNativeCompilation] (which includes shared native metadata and 'platform compilations')
  */
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 internal val KotlinCreateNativeCompileTasksSideEffect = KotlinCompilationSideEffect<AbstractKotlinNativeCompilation> { compilation ->
     val project = compilation.project
     val extension = project.topLevelExtension
@@ -67,6 +69,19 @@ internal val KotlinCreateNativeCompileTasksSideEffect = KotlinCompilationSideEff
                     extension.explicitApi
                 } else {
                     ExplicitApiMode.Disabled
+                }
+            }
+        ).finalizeValueOnRead()
+        task.returnValueCheckerMode.value(
+            project.providers.provider {
+                // Unlike 'explicitApi', the return value checker mode applies to both production and test sources
+                // by default. The test-specific mode is used only when it was explicitly configured.
+                // Shared/intermediate native metadata compilations (e.g. 'nativeMain') are production code, not tests,
+                // so they must use the production mode like 'isMain' compilations do.
+                if (compilationInfo.isMain || isMetadataCompilation) {
+                    extension.returnValueCheckerMode
+                } else {
+                    extension.returnValueCheckerModeForTests ?: extension.returnValueCheckerMode
                 }
             }
         ).finalizeValueOnRead()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/tasks/KotlinNativeTasks.kt
@@ -155,6 +155,10 @@ abstract class AbstractKotlinNativeCompile<
     @get:Optional
     internal abstract val explicitApiMode: Property<ExplicitApiMode>
 
+    @get:Input
+    @get:Optional
+    internal abstract val returnValueCheckerMode: Property<ReturnValueCheckerMode>
+
     @get:Internal
     internal val konanTarget by providerFactory.provider {
         (compilation.tcs.compilation as AbstractKotlinNativeCompilation).konanTarget
@@ -492,6 +496,7 @@ internal constructor(
             KotlinNativeCompilerOptionsHelper.fillCompilerArguments(compilerOptions, args)
 
             explicitApiMode.orNull?.run { args.explicitApi = toCompilerValue() }
+            returnValueCheckerMode.orNull?.run { args.returnValueChecker = toCompilerValue() }
             kotlinNativeProvider.get().konanDataDir.orNull?.let {
                 args.konanDataDir = it
             }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/AbstractKotlinCompile.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/AbstractKotlinCompile.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.compilerRunner.btapi.UsesBuildSessionService
 import org.jetbrains.kotlin.compilerRunner.createGradleCompilerRunner
 import org.jetbrains.kotlin.daemon.common.MultiModuleICSettings
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.dsl.ReturnValueCheckerMode
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
 import org.jetbrains.kotlin.gradle.incremental.UsesIncrementalModuleInfoBuildService
 import org.jetbrains.kotlin.gradle.internal.UsesClassLoadersCachingBuildService
@@ -123,6 +124,10 @@ abstract class AbstractKotlinCompile<T : CommonCompilerArguments> @Inject constr
     @get:Input
     @get:Optional
     abstract val explicitApiMode: Property<ExplicitApiMode>
+
+    @get:Input
+    @get:Optional
+    abstract val returnValueCheckerMode: Property<ReturnValueCheckerMode>
 
     @get:Internal
     internal abstract val suppressKotlinOptionsFreeArgsModificationWarning: Property<Boolean>

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Kotlin2JsCompile.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/Kotlin2JsCompile.kt
@@ -178,6 +178,7 @@ abstract class Kotlin2JsCompile @Inject constructor(
             }
 
             explicitApiMode.orNull?.run { args.explicitApi = toCompilerValue() }
+            returnValueCheckerMode.orNull?.run { args.returnValueChecker = toCompilerValue() }
 
             // Overriding freeArgs from compilerOptions with enhanced one + additional one set on execution phase
             // containing additional arguments based on the js compilation configuration

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
@@ -235,6 +235,7 @@ abstract class KotlinCompile @Inject constructor(
             overrideXJvmDefaultInPresenceOfKotlinDslPlugin(args)
 
             explicitApiMode.orNull?.run { args.explicitApi = toCompilerValue() }
+            returnValueCheckerMode.orNull?.run { args.returnValueChecker = toCompilerValue() }
 
             if (useFirRunner.get()) {
                 @Suppress("DEPRECATION")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon.kt
@@ -106,6 +106,7 @@ abstract class KotlinCompileCommon @Inject constructor(
             args.destination = destinationDirectory.get().asFile.normalize().absolutePath
 
             explicitApiMode.orNull?.run { args.explicitApi = toCompilerValue() }
+            returnValueCheckerMode.orNull?.run { args.returnValueChecker = toCompilerValue() }
 
             KotlinCommonCompilerOptionsHelper.fillCompilerArguments(compilerOptions, args)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/AbstractKotlinCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/AbstractKotlinCompileConfig.kt
@@ -13,7 +13,9 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.compilerRunner.CompilerSystemPropertiesService
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.dsl.ReturnValueCheckerMode
 import org.jetbrains.kotlin.gradle.dsl.topLevelExtension
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
@@ -33,6 +35,7 @@ import org.jetbrains.kotlin.gradle.tasks.KOTLIN_BUILD_DIR_NAME
 internal abstract class AbstractKotlinCompileConfig<TASK : AbstractKotlinCompile<*>>(
     project: Project,
     val explicitApiMode: Provider<ExplicitApiMode>,
+    val returnValueCheckerMode: Provider<ReturnValueCheckerMode> = project.providers.provider<ReturnValueCheckerMode> { null },
 ) : TaskConfigAction<TASK>(project) {
 
     init {
@@ -84,6 +87,9 @@ internal abstract class AbstractKotlinCompileConfig<TASK : AbstractKotlinCompile
             task.explicitApiMode
                 .value(explicitApiMode)
                 .finalizeValueOnRead()
+            task.returnValueCheckerMode
+                .value(returnValueCheckerMode)
+                .finalizeValueOnRead()
             task.separateKmpCompilation.convention(propertiesProvider.separateKmpCompilation)
         }
     }
@@ -97,6 +103,7 @@ internal abstract class AbstractKotlinCompileConfig<TASK : AbstractKotlinCompile
     constructor(compilationInfo: KotlinCompilationInfo) : this(
         compilationInfo.project,
         compilationInfo.explicitApiMode(),
+        compilationInfo.returnValueCheckerMode(),
     ) {
         configureTask { task ->
             task.friendPaths.from({ compilationInfo.friendPaths })
@@ -139,6 +146,30 @@ private fun KotlinCompilationInfo.explicitApiMode(): Provider<ExplicitApiMode> =
         project.topLevelExtension.explicitApi
     } else {
         ExplicitApiMode.Disabled
+    }
+}
+
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
+private fun KotlinCompilationInfo.returnValueCheckerMode(): Provider<ReturnValueCheckerMode> = project.providers.provider {
+    // Unlike 'explicitApi', the return value checker mode applies to both production and test sources by default.
+    // The test-specific mode is used only when it was explicitly configured.
+    // Note: 'isCommonCompilation' here ('target is KotlinMetadataTarget') and 'isMetadataCompilation'
+    // ('compilation is KotlinMetadataCompilation') in KotlinCreateNativeCompileTasksSideEffect guard the same
+    // semantic: shared/intermediate metadata compilations are production code and must use the production mode.
+    val compilation = tcs.compilation
+    val isCommonCompilation = compilation.target is KotlinMetadataTarget
+
+    val androidCompilation = tcs.compilation as? KotlinJvmAndroidCompilation
+    val isMainAndroidCompilation = androidCompilation?.let {
+        @Suppress("DEPRECATION") val variant = it.androidVariant
+        variant != null && getTestedVariantData(variant) == null
+    } == true
+
+    val extension = project.topLevelExtension
+    if (isMain || isCommonCompilation || isMainAndroidCompilation) {
+        extension.returnValueCheckerMode
+    } else {
+        extension.returnValueCheckerModeForTests ?: extension.returnValueCheckerMode
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
@@ -14,6 +14,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.compilerRunner.btapi.BuildSessionService
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.dsl.ReturnValueCheckerMode
 import org.jetbrains.kotlin.gradle.internal.ClassLoadersCachingBuildService
 import org.jetbrains.kotlin.gradle.internal.KOTLIN_BUILD_TOOLS_API_IMPL
 import org.jetbrains.kotlin.gradle.internal.KOTLIN_MODULE_GROUP
@@ -118,9 +119,11 @@ internal open class BaseKotlinCompileConfig<TASK : KotlinCompile> : AbstractKotl
     constructor(
         project: Project,
         explicitApiMode: Provider<ExplicitApiMode>,
+        returnValueCheckerMode: Provider<ReturnValueCheckerMode> = project.providers.provider<ReturnValueCheckerMode> { null },
     ) : super(
         project,
-        explicitApiMode
+        explicitApiMode,
+        returnValueCheckerMode,
     )
 
     companion object {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinCompileApiTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinCompileApiTest.kt
@@ -7,9 +7,11 @@ package org.jetbrains.kotlin.gradle.unitTests
 
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.ReturnValueCheckerMode
 import org.jetbrains.kotlin.gradle.internal.KOTLIN_BUILD_TOOLS_API_IMPL
 import org.jetbrains.kotlin.gradle.internal.KOTLIN_MODULE_GROUP
 import org.jetbrains.kotlin.gradle.plugin.COMPILER_CLASSPATH_CONFIGURATION_NAME
@@ -160,6 +162,19 @@ class KotlinCompileApiTest {
         )
 
         assertEquals((task.get() as KotlinCompile).explicitApiMode.get(), ExplicitApiMode.Strict)
+    }
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    @Test
+    fun testCustomReturnValueCheckerMode() {
+        val task = plugin.registerKotlinJvmCompileTask(
+            "customKotlinCompile",
+            topLevelCompilerOptions,
+            project.provider { ExplicitApiMode.Disabled },
+            project.provider { ReturnValueCheckerMode.Check },
+        )
+
+        assertEquals(ReturnValueCheckerMode.Check, (task.get() as KotlinCompile).returnValueCheckerMode.get())
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ReturnValueCheckerModeTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ReturnValueCheckerModeTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.unitTests
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.compilerRunner.ArgumentUtils
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.ReturnValueCheckerMode
+import org.jetbrains.kotlin.gradle.dsl.kotlinJvmExtension
+import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerArgumentsProducer.CreateCompilerArgumentsContext.Companion.lenient
+import org.jetbrains.kotlin.gradle.util.buildProjectWithJvm
+import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+/**
+ * Configuration-phase verification of the return value checker `kotlin {}` DSL: the configured mode must end up as the
+ * `-Xreturn-value-checker` compiler argument of the corresponding compile tasks. Unlike `explicitApi`, the production
+ * mode applies to test compilations as well, unless a test-specific mode is configured. Verified by computing each
+ * task's arguments at configuration time.
+ */
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
+class ReturnValueCheckerModeTest {
+
+    @Test
+    fun returnValueCheckerNotSetByDefault() {
+        val project = buildProjectWithJvm()
+        project.evaluate()
+
+        assertFalse(
+            project.compileArguments("compileKotlin").any { it.startsWith("-Xreturn-value-checker") },
+            "the return value checker argument must not appear by default in the production compilation",
+        )
+        assertFalse(
+            project.compileArguments("compileTestKotlin").any { it.startsWith("-Xreturn-value-checker") },
+            "the return value checker argument must not appear by default in the test compilation",
+        )
+    }
+
+    @Test
+    fun returnValueCheckerAppliesToBothMainAndTest() {
+        val project = buildProjectWithJvm()
+        project.kotlinJvmExtension.returnValueChecker()
+        project.evaluate()
+
+        assertContains(project.compileArguments("compileKotlin"), "-Xreturn-value-checker=check")
+        // the return value checker mode applies to test compilations by default
+        assertContains(project.compileArguments("compileTestKotlin"), "-Xreturn-value-checker=check")
+    }
+
+    @Test
+    fun returnValueCheckerSeparateTestMode() {
+        val project = buildProjectWithJvm()
+        project.kotlinJvmExtension.returnValueChecker(ReturnValueCheckerMode.Full, ReturnValueCheckerMode.Check)
+        project.evaluate()
+
+        assertContains(project.compileArguments("compileKotlin"), "-Xreturn-value-checker=full")
+        val testArguments = project.compileArguments("compileTestKotlin")
+        assertContains(testArguments, "-Xreturn-value-checker=check")
+        assertFalse(
+            "-Xreturn-value-checker=full" in testArguments,
+            "production mode must not leak into compileTestKotlin",
+        )
+    }
+
+    @Test
+    fun returnValueCheckerDisabledForTests() {
+        val project = buildProjectWithJvm()
+        project.kotlinJvmExtension.returnValueChecker(ReturnValueCheckerMode.Check, ReturnValueCheckerMode.Disabled)
+        project.evaluate()
+
+        assertContains(project.compileArguments("compileKotlin"), "-Xreturn-value-checker=check")
+        // 'disable' equals the compiler default for 'CommonCompilerArguments.returnValueChecker', so the argument
+        // serializer omits it: setting the test mode to Disabled produces no -Xreturn-value-checker argument at all
+        // (whereas Check/Full do).
+        assertFalse(
+            project.compileArguments("compileTestKotlin").any { it.startsWith("-Xreturn-value-checker") },
+            "no return value checker argument should appear for the disabled test mode",
+        )
+    }
+
+    @Test
+    fun returnValueCheckerForTestsOnly() {
+        // Only the test mode is configured; production is left unset.
+        val project = buildProjectWithJvm()
+        project.kotlinJvmExtension.returnValueCheckerModeForTests = ReturnValueCheckerMode.Check
+        project.evaluate()
+
+        assertFalse(
+            project.compileArguments("compileKotlin").any { it.startsWith("-Xreturn-value-checker") },
+            "production compilation must not get the checker when only the test mode is configured",
+        )
+        assertContains(project.compileArguments("compileTestKotlin"), "-Xreturn-value-checker=check")
+    }
+
+    @Test
+    fun returnValueCheckerReachesAllMppTargets() {
+        val project = buildProjectWithMPP {
+            with(multiplatformExtension) {
+                jvm()
+                js()
+                // two native targets so that the shared 'nativeMain' (metadata) compilation is created
+                linuxX64()
+                linuxArm64()
+                applyDefaultHierarchyTemplate()
+                returnValueChecker()
+            }
+        }
+        project.evaluate()
+
+        // production compilations, including the shared native metadata compilation
+        val productionTasks = listOf(
+            "compileCommonMainKotlinMetadata",
+            "compileNativeMainKotlinMetadata",
+            "compileKotlinJvm",
+            "compileKotlinJs",
+            "compileKotlinLinuxX64",
+        )
+        // test compilations get the production mode by default as well
+        val testTasks = listOf("compileTestKotlinJvm", "compileTestKotlinJs", "compileTestKotlinLinuxX64")
+        for (task in productionTasks + testTasks) {
+            assertContains(project.compileArguments(task), "-Xreturn-value-checker=check", "$task is missing return value checker")
+        }
+    }
+
+    @Test
+    fun returnValueCheckerSeparateTestModeReachesAllMppTargets() {
+        val project = buildProjectWithMPP {
+            with(multiplatformExtension) {
+                jvm()
+                js()
+                // two native targets so that the shared 'nativeMain' (metadata) compilation is created
+                linuxX64()
+                linuxArm64()
+                applyDefaultHierarchyTemplate()
+                returnValueChecker(ReturnValueCheckerMode.Full, ReturnValueCheckerMode.Check)
+            }
+        }
+        project.evaluate()
+
+        // Production compilations use the production mode. 'compileNativeMainKotlinMetadata' is a shared native
+        // (metadata) compilation: it is production code, so it must use the production mode and not the test mode.
+        val productionTasks = listOf(
+            "compileCommonMainKotlinMetadata",
+            "compileNativeMainKotlinMetadata",
+            "compileKotlinJvm",
+            "compileKotlinJs",
+            "compileKotlinLinuxX64",
+        )
+        for (task in productionTasks) {
+            assertContains(project.compileArguments(task), "-Xreturn-value-checker=full", "$task must use the production mode")
+        }
+        for (task in listOf("compileTestKotlinJvm", "compileTestKotlinJs", "compileTestKotlinLinuxX64")) {
+            assertContains(project.compileArguments(task), "-Xreturn-value-checker=check", "$task must use the test mode")
+        }
+    }
+
+    private fun Project.compileArguments(taskName: String): List<String> {
+        val task = tasks.getByName(taskName) as KotlinCompilerArgumentsProducer
+        return ArgumentUtils.convertArgumentsToStringList(task.createCompilerArguments(lenient))
+    }
+}


### PR DESCRIPTION
Since this feature is stabilizing in 2.5, it needs a DSL to be configured. Note that even we have `compilerOptions` DSL for stable compiler flags, it doesn't work really well in this case because configuration a) must be applied globally for all compilations and b) may have different values for production and test sources. 
It also makes sense to add this to 2.4.20, so people would have some time trying it around, and we can stabilize DSL at the same time as the feature.
See https://youtrack.jetbrains.com/issue/KT-74808 for details. Since I'm not really familiar with the subsystem, I mainly used Claude, so please verify it all makes sense — it looks fine to me.