### PR TITLE
JVM: Support recursive type provided as an argument of typeOf

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/ReifiedTypeInliner.kt
@@ -135,6 +135,7 @@ class ReifiedTypeInliner(
     }
 
     private var maxStackSize = 0
+    private var maxLocals = 0
 
     private val hasReifiedParameters = parametersMapping?.hasReifiedParameters() ?: false
 
@@ -147,6 +148,7 @@ class ReifiedTypeInliner(
         if (!hasReifiedParameters) return ReifiedTypeParametersUsages()
 
         maxStackSize = 0
+        maxLocals = 0
         val result = ReifiedTypeParametersUsages()
         for (insn in node.instructions.toArray()) {
             if (isOperationReifiedMarker(insn)) {
@@ -157,7 +159,8 @@ class ReifiedTypeInliner(
             }
         }
 
-        node.maxStack = node.maxStack + maxStackSize
+        node.maxStack += maxStackSize
+        node.maxLocals += maxLocals
         return result
     }
 
@@ -189,7 +192,7 @@ class ReifiedTypeInliner(
                 OperationKind.IS -> processIs(insn, instructions, type, asmType)
                 OperationKind.JAVA_CLASS -> processJavaClass(insn, asmType)
                 OperationKind.ENUM_REIFIED -> processSpecialEnumFunction(insn, instructions, type, asmType)
-                OperationKind.TYPE_OF -> processTypeOf(insn, instructions, type)
+                OperationKind.TYPE_OF -> processTypeOf(insn, node, type)
                 OperationKind.CATCH -> processCatch(insn, node, asmType)
             }
 
@@ -272,15 +275,16 @@ class ReifiedTypeInliner(
 
     private fun processTypeOf(
         insn: MethodInsnNode,
-        instructions: InsnList,
+        node: MethodNode,
         type: IrType,
     ): Boolean = rewriteNextTypeInsn(insn, Opcodes.ACONST_NULL) { stubConstNull: AbstractInsnNode ->
         val newMethodNode = newMethodNodeWithCorrectStackSize {
-            typeSystem.generateTypeOf(it, type, intrinsicsSupport)
+            val localsUsed = typeSystem.generateTypeOf(it, type, intrinsicsSupport, node.maxLocals)
+            maxLocals = max(maxLocals, localsUsed)
         }
 
-        instructions.insert(insn, newMethodNode.instructions)
-        instructions.remove(stubConstNull)
+        node.instructions.insert(insn, newMethodNode.instructions)
+        node.instructions.remove(stubConstNull)
 
         maxStackSize = max(maxStackSize, newMethodNode.maxStack)
         return true

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/typeOf.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/typeOf.kt
@@ -6,12 +6,16 @@
 package org.jetbrains.kotlin.codegen.inline
 
 import org.jetbrains.kotlin.codegen.AsmUtil
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.ir.types.IrStarProjection
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.IrTypeProjection
+import org.jetbrains.kotlin.ir.util.arguments
 import org.jetbrains.kotlin.ir.util.isSuspendFunction
 import org.jetbrains.kotlin.resolve.jvm.AsmTypes.*
 import org.jetbrains.kotlin.types.TypeSystemCommonBackendContext
 import org.jetbrains.kotlin.types.model.KotlinTypeMarker
-import org.jetbrains.kotlin.types.model.TypeArgumentMarker
 import org.jetbrains.kotlin.types.model.TypeParameterMarker
 import org.jetbrains.kotlin.types.model.TypeVariance
 import org.jetbrains.org.objectweb.asm.Type
@@ -36,90 +40,174 @@ private inline fun InstructionAdapter.unrollArrayIfFewerThan(n: Int, limit: Int,
     return arrayOf(AsmUtil.getArrayType(type))
 }
 
+/**
+ * Returns the number of local slots used by the emitted bytecode.
+ */
 fun TypeSystemCommonBackendContext.generateTypeOf(
-    v: InstructionAdapter, type: IrType, intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport
-) {
-    generateTypeOf(v, type, intrinsicsSupport, isTypeParameterBound = false)
+    v: InstructionAdapter,
+    type: IrType,
+    intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport,
+    localsOffset: Int,
+): Int {
+    val repeatedNonReifiedTypeParameters = collectRepeatedNonReifiedTypeParameters(type)
+    val builder = TypeOfBuilder(v, repeatedNonReifiedTypeParameters, localsOffset, intrinsicsSupport, this)
+    builder.generateRepeatedNonReifiedTypeParameters()
+    builder.generateTypeOf(type, isTypeParameterBound = false)
+    return repeatedNonReifiedTypeParameters.size
 }
 
-private fun TypeSystemCommonBackendContext.generateTypeOf(
-    v: InstructionAdapter, type: IrType, intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport, isTypeParameterBound: Boolean
+private class TypeOfBuilder(
+    val v: InstructionAdapter,
+    val repeatedNonReifiedTypeParameters: List<TypeParameterMarker>,
+    val localsOffset: Int,
+    val intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport,
+    val typeSystemContext: TypeSystemCommonBackendContext,
 ) {
-    val typeParameter = type.typeConstructor().getTypeParameterClassifier()
-    val methodArguments = if (typeParameter == null) {
-        intrinsicsSupport.putClassInstance(v, type)
-        val arguments = v.unrollArrayIfFewerThan(type.argumentsCount(), 3, K_TYPE_PROJECTION) { i ->
-            generateTypeOfArgument(v, type.getArgument(i), intrinsicsSupport, isTypeParameterBound)
+    fun generateRepeatedNonReifiedTypeParameters(): Unit = with(typeSystemContext) {
+        for ([i, typeParameter] in repeatedNonReifiedTypeParameters.withIndex()) {
+            generateNonReifiedTypeParameterWithoutUpperBounds(typeParameter)
+            v.store(localsOffset + i, K_TYPE_PARAMETER)
         }
-        arrayOf(JAVA_CLASS_TYPE, *arguments)
-    } else if (!isTypeParameterBound && typeParameter.isReified()) {
-        val argument = ReificationArgument(typeParameter.getName().asString(), type.isMarkedNullable(), 0)
-        ReifiedTypeInliner.putReifiedOperationMarker(ReifiedTypeInliner.OperationKind.TYPE_OF, argument, v)
-        v.aconst(null)
-        return
-    } else if (typeReferencesParameterWithRecursiveBound(type)) {
-        intrinsicsSupport.reportNonReifiedTypeParameterWithRecursiveBoundUnsupported(typeParameter.getName())
-        v.aconst(null)
-        return
-    } else {
-        generateNonReifiedTypeParameter(v, typeParameter, intrinsicsSupport)
-        arrayOf(K_CLASSIFIER_TYPE)
+        for ([i, typeParameter] in repeatedNonReifiedTypeParameters.withIndex()) {
+            if (typeParameter.upperBoundCount() > 0) {
+                v.load(localsOffset + i, K_TYPE_PARAMETER)
+                generateSetUpperBounds(typeParameter)
+            }
+        }
     }
 
-    val methodName = if (type.isMarkedNullable()) "nullableTypeOf" else "typeOf"
-    val signature = Type.getMethodDescriptor(K_TYPE, *methodArguments)
-    v.invokestatic(REFLECTION, methodName, signature, false)
+    fun generateTypeOf(type: IrType, isTypeParameterBound: Boolean): Unit = with(typeSystemContext) {
+        val typeParameter = type.typeConstructor().getTypeParameterClassifier()
+        val methodArguments = if (typeParameter == null) {
+            intrinsicsSupport.putClassInstance(v, type)
+            val argumentsValues = type.arguments.orEmpty()
+            val arguments = v.unrollArrayIfFewerThan(argumentsValues.size, 3, K_TYPE_PROJECTION) { i ->
+                generateTypeOfArgument(argumentsValues[i], isTypeParameterBound)
+            }
+            arrayOf(JAVA_CLASS_TYPE, *arguments)
+        } else if (!isTypeParameterBound && typeParameter.isReified()) {
+            val argument = ReificationArgument(typeParameter.getName().asString(), type.isMarkedNullable(), 0)
+            ReifiedTypeInliner.putReifiedOperationMarker(ReifiedTypeInliner.OperationKind.TYPE_OF, argument, v)
+            v.aconst(null)
+            return
+        } else if (
+            !intrinsicsSupport.config.languageVersionSettings.supportsFeature(LanguageFeature.JvmSupportRecursiveTypeOf) &&
+            typeReferencesParameterWithRecursiveBound(type)
+        ) {
+            intrinsicsSupport.reportNonReifiedTypeParameterWithRecursiveBoundUnsupported(typeParameter.getName())
+            v.aconst(null)
+            return
+        } else {
+            when (val cachedIndex = repeatedNonReifiedTypeParameters.indexOf(typeParameter)) {
+                -1 -> generateNonReifiedTypeParameterWithUpperBounds(typeParameter)
+                else -> v.load(localsOffset + cachedIndex, K_TYPE_PARAMETER)
+            }
+            arrayOf(K_CLASSIFIER_TYPE)
+        }
 
-    if (type.isSuspendFunction()) {
-        intrinsicsSupport.reportSuspendTypeUnsupported()
+        val methodName = if (type.isMarkedNullable()) "nullableTypeOf" else "typeOf"
+        val signature = Type.getMethodDescriptor(K_TYPE, *methodArguments)
+        v.invokestatic(REFLECTION, methodName, signature, false)
+
+        if (type.isSuspendFunction()) {
+            intrinsicsSupport.reportSuspendTypeUnsupported()
+        }
+
+        if (intrinsicsSupport.config.stableTypeOf) {
+            if (intrinsicsSupport.isMutableCollectionType(type)) {
+                v.invokestatic(REFLECTION, "mutableCollectionType", Type.getMethodDescriptor(K_TYPE, K_TYPE), false)
+            } else if (type.typeConstructor().isNothingConstructor()) {
+                v.invokestatic(REFLECTION, "nothingType", Type.getMethodDescriptor(K_TYPE, K_TYPE), false)
+            }
+
+            if (type.isFlexible()) {
+                // If this is a flexible type, we've just generated its lower bound and have it on the stack.
+                // Let's generate the upper bound now and call the method that takes lower and upper bound and constructs a flexible KType.
+                generateTypeOf(type.upperBoundIfFlexible() as IrType, isTypeParameterBound)
+
+                v.invokestatic(REFLECTION, "platformType", Type.getMethodDescriptor(K_TYPE, K_TYPE, K_TYPE), false)
+            }
+        }
     }
 
-    if (intrinsicsSupport.config.stableTypeOf) {
-        if (intrinsicsSupport.isMutableCollectionType(type)) {
-            v.invokestatic(REFLECTION, "mutableCollectionType", Type.getMethodDescriptor(K_TYPE, K_TYPE), false)
-        } else if (type.typeConstructor().isNothingConstructor()) {
-            v.invokestatic(REFLECTION, "nothingType", Type.getMethodDescriptor(K_TYPE, K_TYPE), false)
+    fun generateTypeOfArgument(projection: IrTypeArgument, isTypeParameterBound: Boolean): Unit = with(typeSystemContext) {
+        when (projection) {
+            is IrStarProjection -> {
+                v.getstatic(K_TYPE_PROJECTION.internalName, "star", K_TYPE_PROJECTION.descriptor)
+            }
+            is IrTypeProjection -> {
+                generateTypeOf(projection.type, isTypeParameterBound)
+                val methodName = when (projection.getVariance()) {
+                    TypeVariance.INV -> "invariant"
+                    TypeVariance.IN -> "contravariant"
+                    TypeVariance.OUT -> "covariant"
+                }
+                v.invokestatic(K_TYPE_PROJECTION.internalName, methodName, Type.getMethodDescriptor(K_TYPE_PROJECTION, K_TYPE), false)
+            }
         }
+    }
 
-        if (type.isFlexible()) {
-            // If this is a flexible type, we've just generated its lower bound and have it on the stack.
-            // Let's generate the upper bound now and call the method that takes lower and upper bound and constructs a flexible KType.
-            generateTypeOf(v, type.upperBoundIfFlexible() as IrType, intrinsicsSupport, isTypeParameterBound)
-
-            v.invokestatic(REFLECTION, "platformType", Type.getMethodDescriptor(K_TYPE, K_TYPE, K_TYPE), false)
+    fun generateNonReifiedTypeParameterWithoutUpperBounds(typeParameter: TypeParameterMarker): Unit = with(typeSystemContext) {
+        intrinsicsSupport.generateTypeParameterContainer(v, typeParameter)
+        v.aconst(typeParameter.getName().asString())
+        val variance = when (typeParameter.getVariance()) {
+            TypeVariance.INV -> KVariance.INVARIANT
+            TypeVariance.IN -> KVariance.IN
+            TypeVariance.OUT -> KVariance.OUT
         }
+        v.getstatic(K_VARIANCE.internalName, variance.name, K_VARIANCE.descriptor)
+        v.iconst(if (typeParameter.isReified()) 1 else 0)
+        v.invokestatic(
+            REFLECTION, "typeParameter",
+            Type.getMethodDescriptor(K_TYPE_PARAMETER, OBJECT_TYPE, JAVA_STRING_TYPE, K_VARIANCE, Type.BOOLEAN_TYPE),
+            false,
+        )
+    }
+
+    fun generateSetUpperBounds(typeParameter: TypeParameterMarker): Unit = with(typeSystemContext) {
+        val argumentsForBounds = v.unrollArrayIfFewerThan(typeParameter.upperBoundCount(), 2, K_TYPE) { i ->
+            generateTypeOf(typeParameter.getUpperBound(i) as IrType, isTypeParameterBound = true)
+        }
+        v.invokestatic(
+            REFLECTION, "setUpperBounds", Type.getMethodDescriptor(Type.VOID_TYPE, K_TYPE_PARAMETER, *argumentsForBounds),
+            false
+        )
+    }
+
+    fun generateNonReifiedTypeParameterWithUpperBounds(typeParameter: TypeParameterMarker) {
+        generateNonReifiedTypeParameterWithoutUpperBounds(typeParameter)
+        v.dup()
+        generateSetUpperBounds(typeParameter)
     }
 }
 
-private fun TypeSystemCommonBackendContext.generateNonReifiedTypeParameter(
-    v: InstructionAdapter, typeParameter: TypeParameterMarker, intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport
-) {
-    intrinsicsSupport.generateTypeParameterContainer(v, typeParameter)
-
-    v.aconst(typeParameter.getName().asString())
-    val variance = when (typeParameter.getVariance()) {
-        TypeVariance.INV -> KVariance.INVARIANT
-        TypeVariance.IN -> KVariance.IN
-        TypeVariance.OUT -> KVariance.OUT
+private fun TypeSystemCommonBackendContext.collectRepeatedNonReifiedTypeParameters(type: IrType): List<TypeParameterMarker> {
+    fun visitTypeParameters(type: KotlinTypeMarker, isTypeParameterBound: Boolean, usages: MutableMap<TypeParameterMarker, Int>) {
+        when (val typeParameter = type.typeConstructor().getTypeParameterClassifier()) {
+            null -> {
+                for (i in 0 until type.argumentsCount()) {
+                    type.getArgument(i).getType()?.let { argumentType ->
+                        visitTypeParameters(argumentType, isTypeParameterBound, usages)
+                    }
+                }
+            }
+            else -> {
+                if (!typeParameter.isReified() || isTypeParameterBound) {
+                    val oldUsage = usages.getOrDefault(typeParameter, 0)
+                    usages[typeParameter] = oldUsage + 1
+                    if (oldUsage == 0) {
+                        for (i in 0 until typeParameter.upperBoundCount()) {
+                            visitTypeParameters(typeParameter.getUpperBound(i), true, usages)
+                        }
+                    }
+                }
+            }
+        }
     }
-    v.getstatic(K_VARIANCE.internalName, variance.name, K_VARIANCE.descriptor)
-    v.iconst(if (typeParameter.isReified()) 1 else 0)
-    v.invokestatic(
-        REFLECTION, "typeParameter",
-        Type.getMethodDescriptor(K_TYPE_PARAMETER, OBJECT_TYPE, JAVA_STRING_TYPE, K_VARIANCE, Type.BOOLEAN_TYPE),
-        false,
-    )
 
-    if (typeParameter.upperBoundCount() == 0) return
-
-    v.dup()
-    val argumentsForBounds = v.unrollArrayIfFewerThan(typeParameter.upperBoundCount(), 2, K_TYPE) { i ->
-        generateTypeOf(v, typeParameter.getUpperBound(i) as IrType, intrinsicsSupport, isTypeParameterBound = true)
-    }
-    v.invokestatic(
-        REFLECTION, "setUpperBounds", Type.getMethodDescriptor(Type.VOID_TYPE, K_TYPE_PARAMETER, *argumentsForBounds),
-        false
-    )
+    val usages = mutableMapOf<TypeParameterMarker, Int>()
+    visitTypeParameters(type, false, usages)
+    return usages.filter { it.value > 1 }.keys.toList()
 }
 
 private fun TypeSystemCommonBackendContext.typeReferencesParameterWithRecursiveBound(
@@ -140,24 +228,4 @@ private fun TypeSystemCommonBackendContext.typeReferencesParameterWithRecursiveB
         }
     }
     return false
-}
-
-private fun TypeSystemCommonBackendContext.generateTypeOfArgument(
-    v: InstructionAdapter,
-    projection: TypeArgumentMarker,
-    intrinsicsSupport: ReifiedTypeInliner.IntrinsicsSupport,
-    isTypeParameterBound: Boolean,
-) {
-    if (projection.isStarProjection()) {
-        v.getstatic(K_TYPE_PROJECTION.internalName, "star", K_TYPE_PROJECTION.descriptor)
-        return
-    }
-
-    generateTypeOf(v, projection.getType() as IrType, intrinsicsSupport, isTypeParameterBound)
-    val methodName = when (projection.getVariance()) {
-        TypeVariance.INV -> "invariant"
-        TypeVariance.IN -> "contravariant"
-        TypeVariance.OUT -> "covariant"
-    }
-    v.invokestatic(K_TYPE_PROJECTION.internalName, methodName, Type.getMethodDescriptor(K_TYPE_PROJECTION, K_TYPE), false)
 }

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/irCodegenUtils.kt
@@ -334,7 +334,7 @@ val IrClass.reifiedTypeParameters: ReifiedTypeParametersUsages
     get() {
         val tempReifiedTypeParametersUsages = ReifiedTypeParametersUsages()
         fun processTypeParameters(type: IrType) {
-            for (supertypeArgument in (type as? IrSimpleType)?.arguments ?: emptyList()) {
+            for (supertypeArgument in type.arguments.orEmpty()) {
                 if (supertypeArgument is IrTypeProjection) {
                     val typeArgument = supertypeArgument.type
                     if (typeArgument.isReifiedTypeParameter) {

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/TypeOf.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/intrinsics/TypeOf.kt
@@ -17,7 +17,7 @@ object TypeOf : IntrinsicMethod() {
     override fun invoke(expression: IrFunctionAccessExpression, codegen: ExpressionCodegen, data: BlockInfo) = with(codegen) {
         val type = expression.typeArguments[0]!!
         val support = IrInlineIntrinsicsSupport(codegen.classCodegen, expression, codegen.irFunction.fileParent)
-        typeMapper.typeSystem.generateTypeOf(mv, type, support)
+        typeMapper.typeSystem.generateTypeOf(mv, type, support, codegen.frameMap.currentSize)
         codegen.propagateChildReifiedTypeParametersUsages(codegen.typeMapper.typeSystem.extractUsedReifiedParameters(type))
         expression.onStack
     }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrTypeUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrTypeUtils.kt
@@ -251,3 +251,6 @@ fun IrClass.getAllSuperclasses(): Set<IrClass> {
 
 val IrType.isReifiedTypeParameter: Boolean
     get() = (classifierOrNull as? IrTypeParameterSymbol)?.owner?.isReified == true
+
+val IrType.arguments: List<IrTypeArgument>?
+    get() = (this as? IrSimpleType)?.arguments

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrFileSerializer.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrFileSerializer.kt
@@ -511,7 +511,7 @@ open class IrFileSerializer(
                 },
                 classifier = type.classifierOrNull,
                 nullability = (type as? IrSimpleType)?.nullability,
-                arguments = (type as? IrSimpleType)?.arguments?.map { it.toIrTypeArgumentDeduplicationKey },
+                arguments = type.arguments?.map { it.toIrTypeArgumentDeduplicationKey },
                 annotations = type.annotations,
             )
         }

--- a/compiler/testData/codegen/box/reflection/typeOf/nonReifiedTypeParameters/recursiveBoundWithInline.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/nonReifiedTypeParameters/recursiveBoundWithInline.kt
@@ -1,8 +1,9 @@
-// IGNORE_BACKEND: JVM_IR, NATIVE, JS_IR, JS_IR_ES6, WASM_JS, WASM_WASI
-// IGNORE_BACKEND_K2_MULTI_MODULE: JVM_IR, JVM_IR_SERIALIZE
+// IGNORE_BACKEND: NATIVE, JS_IR, JS_IR_ES6, WASM_JS, WASM_WASI
+// IGNORE_BACKEND_K2_MULTI_MODULE: JVM_IR_SERIALIZE
 // ^^^ This test fails during the second phase of compilation. Yet it's still used in first phase-only
 //     tests such as *IrDeserializationTest*generated.
 // KJS_WITH_FULL_RUNTIME
+// LANGUAGE: +JvmSupportRecursiveTypeOf
 
 // FILE: lib.kt
 import kotlin.reflect.typeOf

--- a/compiler/testData/codegen/box/reflection/typeOf/nonReifiedTypeParameters/recursiveBoundWithoutInline.kt
+++ b/compiler/testData/codegen/box/reflection/typeOf/nonReifiedTypeParameters/recursiveBoundWithoutInline.kt
@@ -1,8 +1,9 @@
-// IGNORE_BACKEND: JVM_IR, NATIVE, JS_IR, JS_IR_ES6, WASM_JS, WASM_WASI
+// IGNORE_BACKEND: NATIVE, JS_IR, JS_IR_ES6, WASM_JS, WASM_WASI
 // IGNORE_IR_DESERIALIZATION_TEST: NATIVE
 // ^^^ This test fails during the second phase of compilation. Yet it's still used in first phase-only
 //     tests such as *IrDeserializationTest*generated, apart from Native, where special backend checks detect forbidden IR snippet.
 // KJS_WITH_FULL_RUNTIME
+// LANGUAGE: +JvmSupportRecursiveTypeOf
 
 import kotlin.reflect.typeOf
 

--- a/compiler/testData/codegen/boxJvm/reflection/typeOf/noReflect/nonReifiedTypeParameters/recursiveBounds.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/typeOf/noReflect/nonReifiedTypeParameters/recursiveBounds.kt
@@ -1,5 +1,5 @@
 // TARGET_BACKEND: JVM
-// WITH_REFLECT
+// WITH_STDLIB
 // LANGUAGE: +JvmSupportRecursiveTypeOf
 
 package test
@@ -36,14 +36,14 @@ inline fun <reified R, T: Comparable<T>> reifiedMixedWithRecursive(): List<KType
 fun box(): String {
     run {
         val t = selfRecursive<Int>()
-        assertEquals("kotlin.Comparable<T>", t.upperBound.toString())
+        assertEquals("java.lang.Comparable<T> (Kotlin reflection is not available)", t.upperBound.toString())
         assertEquals(t, t.upperBound.argumentType.asTp)
     }
 
     run {
         val (t, u) = C<Int, Int>().makeTU()
-        assertEquals("kotlin.Comparable<U>", t.upperBound.toString())
-        assertEquals("kotlin.Comparable<T>", u.upperBound.toString())
+        assertEquals("java.lang.Comparable<U> (Kotlin reflection is not available)", t.upperBound.toString())
+        assertEquals("java.lang.Comparable<T> (Kotlin reflection is not available)", u.upperBound.toString())
         assertEquals(u, t.upperBound.argumentType.asTp)
         assertEquals(t, u.upperBound.argumentType.asTp)
     }
@@ -58,8 +58,8 @@ fun box(): String {
     run {
         val (a0, t, a1) = repeatedNonCyclic<Any, Int>()
         assertEquals(a0, a1)
-        assertEquals("kotlin.Any?", a0.upperBound.toString())
-        assertEquals("kotlin.Comparable<T>", t.upperBound.toString())
+        assertEquals("java.lang.Object? (Kotlin reflection is not available)", a0.upperBound.toString())
+        assertEquals("java.lang.Comparable<T> (Kotlin reflection is not available)", t.upperBound.toString())
         assertEquals(t, t.upperBound.argumentType.asTp)
     }
 
@@ -68,16 +68,16 @@ fun box(): String {
         assertEquals("U", u.toString())
         val t = u.upperBound.asTp
         assertEquals("T", t.toString())
-        assertEquals("kotlin.Comparable<T>", t.upperBound.toString())
+        assertEquals("java.lang.Comparable<T> (Kotlin reflection is not available)", t.upperBound.toString())
         assertEquals(t, t.upperBound.argumentType.asTp)
     }
 
     run {
         val args = reifiedMixedWithRecursive<String, Int>()
-        assertEquals("kotlin.String", args[0].toString())
-        assertEquals("kotlin.String", args[2].toString())
+        assertEquals("java.lang.String (Kotlin reflection is not available)", args[0].toString())
+        assertEquals("java.lang.String (Kotlin reflection is not available)", args[2].toString())
         val t = args[1]!!.asTp
-        assertEquals("kotlin.Comparable<T>", t.upperBound.toString())
+        assertEquals("java.lang.Comparable<T> (Kotlin reflection is not available)", t.upperBound.toString())
         assertEquals(t, t.upperBound.argumentType.asTp)
     }
 

--- a/compiler/testData/codegen/boxJvm/reflection/typeOf/nonReifiedTypeParameters/recursiveBounds.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/typeOf/nonReifiedTypeParameters/recursiveBounds.kt
@@ -1,0 +1,25 @@
+// TARGET_BACKEND: JVM
+// WITH_REFLECT
+// LANGUAGE: +JvmSupportRecursiveTypeOf
+
+package test
+
+import kotlin.reflect.typeOf
+import kotlin.reflect.KTypeParameter
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class C<T: Comparable<U>, U: Comparable<T>> {
+    fun makeTU(): List<KTypeParameter> = typeOf<Pair<T, U>>().arguments.map { it.type!!.classifier as KTypeParameter  }
+}
+
+fun box(): String {
+    val (t, u) = C<Int, Int>().makeTU()
+    val tUpper = t.upperBounds.single()
+    val uUpper = u.upperBounds.single()
+    assertEquals(tUpper.toString(), "kotlin.Comparable<U>")
+    assertEquals(uUpper.toString(), "kotlin.Comparable<T>")
+    assertEquals(tUpper.arguments.single().type!!.classifier as KTypeParameter, u)
+    assertEquals(uUpper.arguments.single().type!!.classifier as KTypeParameter, t)
+    return "OK"
+}

--- a/compiler/testData/diagnostics/tests/jvm/typeOf/nonReifiedTypeParameterWithRecursiveBoundEnabled.kt
+++ b/compiler/testData/diagnostics/tests/jvm/typeOf/nonReifiedTypeParameterWithRecursiveBoundEnabled.kt
@@ -1,11 +1,11 @@
 // RUN_PIPELINE_TILL: BACKEND
 // WITH_STDLIB
-// LANGUAGE: -JvmSupportRecursiveTypeOf
+// LANGUAGE: +JvmSupportRecursiveTypeOf
 
 import kotlin.reflect.typeOf
 
 fun <T : Comparable<T>> foo() {
-    <!TYPEOF_NON_REIFIED_TYPE_PARAMETER_WITH_RECURSIVE_BOUND!>typeOf<List<T>>()<!>
+    typeOf<List<T>>()
 }
 
 /* GENERATED_FIR_TAGS: functionDeclaration, typeConstraint, typeParameter */

--- a/core/language.version-settings/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
+++ b/core/language.version-settings/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
@@ -549,6 +549,7 @@ enum class LanguageFeature(
 
     ForbidValueClassRecursionViaTypeParameters(sinceVersion = KOTLIN_2_5, enabledInProgressiveMode = true, issue = "KT-85848"),
     IrCrossModuleInlinerBeforeKlibSerialization(KOTLIN_2_5, sinceApiVersion = ApiVersion.KOTLIN_2_3, forcesPreReleaseBinaries = true, issue = "KT-71896"),
+    JvmSupportRecursiveTypeOf(sinceVersion = KOTLIN_2_5, issue = "KT-87339"),
 
     // 2.6
 


### PR DESCRIPTION
The idea is to first create non-reified type parameters that are referenced multiple times, without upper bounds, and save them as locals. And then set up the upper bounds.

This also leads to slightly smaller bytecode when type parameters are used multiple times in general, since they are reused.

^KT-87339 Fixed