### PR TITLE
[Tests] [KT-88010] Prohibit empty TestClassModel consistently when generating tests

### DIFF
--- a/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/AbstractTestGenerator.kt
+++ b/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/AbstractTestGenerator.kt
@@ -12,6 +12,7 @@ abstract class AbstractTestGenerator {
         testClass: TestGroup.TestClass,
         dryRun: Boolean,
         allowGenerationOnTeamCity: Boolean,
+        tolerateEmptyModels: Boolean,
         mainClassName: String?,
     ): GenerationResult
 

--- a/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/ArgumentUtils.kt
+++ b/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/ArgumentUtils.kt
@@ -6,9 +6,13 @@
 package org.jetbrains.kotlin.generators
 
 internal fun Array<String>.allowGenerationOnTeamCity(): Boolean {
-    return any { it == "allowGenerationOnTeamCity"}
+    return any { it == "allowGenerationOnTeamCity" }
 }
 
 internal fun Array<String>.skipTestAllFilesCheck(): Boolean {
-    return any { it == "skipTestAllFilesCheck"}
+    return any { it == "skipTestAllFilesCheck" }
+}
+
+internal fun Array<String>.tolerateEmptyModels(): Boolean {
+    return any { it == "tolerateEmptyModels" }
 }

--- a/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGenerationDSLForJUnit5.kt
+++ b/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGenerationDSLForJUnit5.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.generators.allowGenerationOnTeamCity
 import org.jetbrains.kotlin.generators.dsl.TestGroupSuite
 import org.jetbrains.kotlin.generators.dsl.forEachTestClassParallel
 import org.jetbrains.kotlin.generators.skipTestAllFilesCheck
+import org.jetbrains.kotlin.generators.tolerateEmptyModels
 import org.jetbrains.kotlin.generators.util.TestGeneratorUtil
 
 fun generateTestGroupSuiteWithJUnit5(
@@ -23,6 +24,7 @@ fun generateTestGroupSuiteWithJUnit5(
         dryRun = InconsistencyChecker.hasDryRunArg(args),
         allowGenerationOnTeamCity = args.allowGenerationOnTeamCity(),
         skipTestAllFilesCheck = args.skipTestAllFilesCheck(),
+        tolerateEmptyModels = args.tolerateEmptyModels(),
         mainClassName,
         init
     )
@@ -32,6 +34,7 @@ fun generateTestGroupSuiteWithJUnit5(
     dryRun: Boolean = false,
     allowGenerationOnTeamCity: Boolean = false,
     skipTestAllFilesCheck: Boolean = false,
+    tolerateEmptyModels: Boolean = false,
     // See above
     mainClassName: String? = TestGeneratorUtil.getMainClassName(),
     init: TestGroupSuite.() -> Unit,
@@ -39,10 +42,10 @@ fun generateTestGroupSuiteWithJUnit5(
     val suite = TestGroupSuite(skipTestAllFilesCheck).apply(init)
     suite.forEachTestClassParallel { testClass ->
         (
-            val changed = newFileGenerated, val testSourceFilePath
+            val changed = newFileGenerated, val testSourceFilePath,
         ) =
             TestGeneratorForJUnit5
-                .generateAndSave(testClass, dryRun, allowGenerationOnTeamCity, mainClassName)
+                .generateAndSave(testClass, dryRun, allowGenerationOnTeamCity, tolerateEmptyModels, mainClassName)
         if (changed) {
             InconsistencyChecker.inconsistencyChecker(dryRun).add(testSourceFilePath)
         }

--- a/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGeneratorForJUnit5.kt
+++ b/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGeneratorForJUnit5.kt
@@ -287,14 +287,16 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
 
             var first = true
 
-            for (methodModel in testMethods) {
-                if (first) {
-                    first = false
-                } else {
-                    p.println()
-                }
+            if (!testClassModel.isEmpty) {
+                for (methodModel in testMethods) {
+                    if (first) {
+                        first = false
+                    } else {
+                        p.println()
+                    }
 
-                generateTestMethod(p, methodModel)
+                    generateTestMethod(p, methodModel)
+                }
             }
 
             for (innerTestClass in innerTestClasses) {

--- a/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGeneratorForJUnit5.kt
+++ b/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGeneratorForJUnit5.kt
@@ -300,7 +300,7 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
                     generateTestMethod(p, methodModel)
                 }
             } else if (!tolerateEmptyModels) {
-                throw IllegalStateException("Test class ${testClassModel.name} is empty. Please remove it")
+                throw IllegalStateException("Test class ${testClassModel.name}: ${testClassModel.testKClass} (with data at ${testClassModel.dataString}) is empty. Please remove it")
             }
 
             for (innerTestClass in innerTestClasses) {

--- a/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGeneratorForJUnit5.kt
+++ b/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/dsl/junit5/TestGeneratorForJUnit5.kt
@@ -69,6 +69,7 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
         testClass: TestGroup.TestClass,
         dryRun: Boolean,
         allowGenerationOnTeamCity: Boolean,
+        tolerateEmptyModels: Boolean,
         mainClassName: String?,
     ): GenerationResult {
         val generatorInstance = TestGeneratorInstance(
@@ -78,7 +79,7 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
             testClass.testModels,
             mainClassName,
         )
-        return generatorInstance.generateAndSave(dryRun, allowGenerationOnTeamCity)
+        return generatorInstance.generateAndSave(dryRun, allowGenerationOnTeamCity, tolerateEmptyModels)
     }
 
     private class TestGeneratorInstance(
@@ -96,8 +97,8 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
             baseDir + "/" + this.suiteClassPackage.replace(".", "/") + "/" + this.suiteClassName + ".java"
 
         @Throws(IOException::class)
-        fun generateAndSave(dryRun: Boolean, allowGenerationOnTeamCity: Boolean): GenerationResult {
-            val generatedCode = generate()
+        fun generateAndSave(dryRun: Boolean, allowGenerationOnTeamCity: Boolean, tolerateEmptyModels: Boolean): GenerationResult {
+            val generatedCode = generate(tolerateEmptyModels)
 
             val testSourceFile = File(testSourceFilePath)
             val changed = if (!dryRun) {
@@ -113,7 +114,7 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
             return GenerationResult(changed, testSourceFilePath)
         }
 
-        private fun generate(): String {
+        private fun generate(tolerateEmptyModels: Boolean): String {
             val out = StringBuilder()
             val p = Printer(out, indentUnit = Printer.TWO_SPACE_INDENT)
 
@@ -198,7 +199,7 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
                 }
             }
 
-            generateTestClass(p, model, isNested = false)
+            generateTestClass(p, model, tolerateEmptyModels, isNested = false)
             return out.toString()
         }
 
@@ -269,6 +270,7 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
         private fun generateTestClass(
             p: Printer,
             testClassModel: TestClassModel,
+            tolerateEmptyModels: Boolean,
             isNested: Boolean,
         ) {
             p.generateNestedAnnotation(isNested)
@@ -297,18 +299,18 @@ object TestGeneratorForJUnit5 : AbstractTestGenerator() {
 
                     generateTestMethod(p, methodModel)
                 }
+            } else if (!tolerateEmptyModels) {
+                throw IllegalStateException("Test class ${testClassModel.name} is empty. Please remove it")
             }
 
             for (innerTestClass in innerTestClasses) {
-                if (!innerTestClass.isEmpty) {
-                    if (first) {
-                        first = false
-                    } else {
-                        p.println()
-                    }
-
-                    generateTestClass(p, innerTestClass, true)
+                if (first) {
+                    first = false
+                } else {
+                    p.println()
                 }
+
+                generateTestClass(p, innerTestClass, tolerateEmptyModels, true)
             }
 
             p.popIndent()

--- a/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/model/SimpleTestClassModel.kt
+++ b/generators/test-generator/testFixtures/org/jetbrains/kotlin/generators/model/SimpleTestClassModel.kt
@@ -80,7 +80,7 @@ class SimpleTestClassModel(
                 testKClass,
                 isSmokeTest,
                 smokeTestLimit
-            )
+            ).takeUnless { it.isEmpty }
         }.sortedWith(BY_NAME)
     }
 

--- a/plugins/plugin-sandbox/build.gradle.kts
+++ b/plugins/plugin-sandbox/build.gradle.kts
@@ -91,7 +91,9 @@ projectTests {
         compilerPluginDependencies = listOf(sandboxPluginForTests)
     )
 
-    testGenerator("org.jetbrains.kotlin.plugin.sandbox.TestGeneratorKt", generateTestsInBuildDirectory = true)
+    testGenerator("org.jetbrains.kotlin.plugin.sandbox.TestGeneratorKt", generateTestsInBuildDirectory = true) {
+        args("tolerateEmptyModels")
+    }
 
     withJvmStdlibAndReflect()
     withScriptRuntime()

--- a/plugins/plugin-sandbox/testFixtures/org/jetbrains/kotlin/plugin/sandbox/TestGenerator.kt
+++ b/plugins/plugin-sandbox/testFixtures/org/jetbrains/kotlin/plugin/sandbox/TestGenerator.kt
@@ -9,10 +9,10 @@ import org.jetbrains.kotlin.generators.dsl.junit5.generateTestGroupSuiteWithJUni
 import org.jetbrains.kotlin.generators.model.annotation
 import org.jetbrains.kotlin.generators.tests.provider
 import org.jetbrains.kotlin.generators.tests.standalone
-import org.jetbrains.kotlin.generators.tests.standaloneNoTR
 import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeCodegenBoxTest
 import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedHostTarget
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider
+import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerTest
 import org.jetbrains.kotlin.test.utils.CUSTOM_TEST_DATA_EXTENSION_PATTERN
 import org.junit.jupiter.api.Tag
 
@@ -22,6 +22,8 @@ fun main(args: Array<String>) {
         testGroup(testsRoot, "plugins/plugin-sandbox/testData") {
             testClass<AbstractFirPsiPluginDiagnosticTest> {
                 model("diagnostics", excludedPattern = CUSTOM_TEST_DATA_EXTENSION_PATTERN)
+                model("intentionallyEmpty")
+                model("intentionallyNonExistent")
             }
 
             testClass<AbstractFirJvmLightTreePluginBlackBoxCodegenTest> {
@@ -50,6 +52,14 @@ fun main(args: Array<String>) {
 
             testClass<AbstractFirMetadataPluginSandboxTest> {
                 model("metadata")
+            }
+
+            testClass<AbstractFirMetadataPluginSandboxTest>(suiteTestClassName = "EmptyTestGenerated") {
+                model("intentionallyEmpty")
+            }
+
+            testClass<AbstractFirMetadataPluginSandboxTest>(suiteTestClassName = "NonExistentTestGenerated") {
+                model("intentionallyNonExistent")
             }
 
             testClass<AbstractNativeCodegenBoxTest>(

--- a/plugins/plugin-sandbox/testFixtures/org/jetbrains/kotlin/plugin/sandbox/TestGenerator.kt
+++ b/plugins/plugin-sandbox/testFixtures/org/jetbrains/kotlin/plugin/sandbox/TestGenerator.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.generators.tests.standalone
 import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeCodegenBoxTest
 import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedHostTarget
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider
-import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerTest
 import org.jetbrains.kotlin.test.utils.CUSTOM_TEST_DATA_EXTENSION_PATTERN
 import org.junit.jupiter.api.Tag
 

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateWasmTests.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateWasmTests.kt
@@ -26,7 +26,6 @@ fun main(args: Array<String>) {
     val k1BoxTestDir = "multiplatform/k1"
 
     val jsTranslatorTestPattern = "^([^_](.+))\\.kt$"
-    val jsTranslatorReflectionPattern = "^(findAssociatedObject(InSeparatedFile)?(Lazyness)?(AndDCE)?)\\.kt$"
     val jsTranslatorEsModulesExcludedDirs = listOf(
         // JsExport is not supported for classes
         "jsExport", "native", "export", "escapedIdentifiers",
@@ -133,7 +132,6 @@ fun main(args: Array<String>) {
                 model("native/", pattern = jsTranslatorTestPattern)
                 model("esModules/", pattern = jsTranslatorTestPattern, excludeDirs = jsTranslatorEsModulesExcludedDirs)
                 model("jsQualifier/", pattern = jsTranslatorTestPattern)
-                model("reflection/", pattern = jsTranslatorReflectionPattern)
                 model("kotlin.test/", pattern = jsTranslatorTestPattern)
             }
         }


### PR DESCRIPTION
I've added a new `tolerateEmptyModels` argument to allow such empty models.

I've added regression tests for similar situations (empty-but-existent directory, non-existent/empty directory with other `model`s).