### PR TITLE
[Swift Export] KT-87340: fix objc erroneously inheriting swift class

### DIFF
--- a/kotlin-native/runtime/src/main/cpp/ObjCExport.mm
+++ b/kotlin-native/runtime/src/main/cpp/ObjCExport.mm
@@ -1009,7 +1009,7 @@ static void addVirtualAdapters(Class clazz, const ObjCTypeAdapter* typeAdapter) 
   }
 }
 
-static Class createClass(const TypeInfo* typeInfo, Class superClass) {
+static Class createClass(const TypeInfo* typeInfo, Class superClass, const TypeInfo* objCSuperType) {
   // NOTE: in swift export, the generated class isn't used for direct instantiation, but rather serves the purpose of marker type
   // - for kotlin existentials (_KotlinExistential, KotlinRuntimeSupport.swift). This relies on generated class conformance to
   // - objc protocol counterparsts bound trough kotlin interface TypeInfo's
@@ -1039,8 +1039,8 @@ static Class createClass(const TypeInfo* typeInfo, Class superClass) {
   }
 
   std::unordered_set<const TypeInfo*> superImplementedInterfaces(
-          typeInfo->superType_->implementedInterfaces_,
-          typeInfo->superType_->implementedInterfaces_ + typeInfo->superType_->implementedInterfacesCount_
+          objCSuperType->implementedInterfaces_,
+          objCSuperType->implementedInterfaces_ + objCSuperType->implementedInterfacesCount_
   );
 
   for (int i = 0; i < typeInfo->implementedInterfacesCount_; ++i) {
@@ -1088,13 +1088,17 @@ static Class getOrCreateClass(const TypeInfo* typeInfo) {
     result = objc_getClass(typeAdapter->objCName);
     setClassEnsureInitialized(typeInfo, result);
   } else {
-    Class superClass = getOrCreateClass(typeInfo->superType_);
+    // Swift Export only: make sure a synthesized marker never inherits from a Swift class
+    const bool detachFromSwiftSuper = compiler::swiftExport() && getTypeAdapter(typeInfo->superType_) != nullptr;
+
+    const TypeInfo* objCSuperType = detachFromSwiftSuper ? theAnyTypeInfo : typeInfo->superType_;
+    Class superClass = getOrCreateClass(objCSuperType);
 
     std::lock_guard lockGuard(classCreationMutex); // Note: non-recursive
 
     result = objCExport(typeInfo).objCClass; // double-checking.
     if (result == nullptr) {
-        result = createClass(typeInfo, superClass);
+        result = createClass(typeInfo, superClass, objCSuperType);
         // Don't have to be a release store –
         // the operations above are synchronized and thus might not be reordered after this store.
         setClassEnsureInitialized(typeInfo, result);

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/protocols/protocols.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/protocols/protocols.kt
@@ -97,3 +97,25 @@ fun interface FunctionalInterface {
 }
 
 fun testFunctionalInterface(arg: FunctionalInterface): Int = arg.getNumber()
+
+// FILE: existentialInheritance.kt
+
+interface InhFoo
+
+open class InhBar
+
+internal class InhBaz : InhBar(), InhFoo
+
+fun returnInhFoo(): InhFoo = InhBaz()
+
+interface InhIface {
+    fun ping(): Int
+}
+
+open class InhBarWithIface : InhIface {
+    override fun ping(): Int = 42
+}
+
+internal class InhBaz2 : InhBarWithIface()
+
+fun returnInhIface(): InhIface = InhBaz2()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/protocols/protocols.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/protocols/protocols.swift
@@ -121,3 +121,16 @@ func testSAMConverterShouldBridge() throws {
     let actual = testFunctionalInterface(arg: value)
     #expect(actual == expected)
 }
+
+@Test
+func testExistentialWithExportedSuperclass() throws {
+    let x: any InhFoo = returnInhFoo()
+    #expect(x is InhFoo)
+    #expect((x as? InhBar) == nil)
+}
+
+@Test
+func testExistentialInheritsExportedSuperInterface() throws {
+    let x: any InhIface = returnInhIface()
+    #expect(x.ping() == 42)
+}


### PR DESCRIPTION
Our swift-export-generated bound wrapper classes and existential marker objc classes live in the same TypeInfo field in the same hierarchy. Before this MR, when an internal (non-exported) class had public (exported, swift wrapper is bound) parent different from KotlinBase, its generated objc marker class (used for _KotlinExistential) accidentally inherited parent's swift wrapper class - which is not allowed. Unfortunately, neither objc nor swift runtimes offer guardrails against this and just let it crash during realization of specialized generic type metadata for _KotlinExistential.