### PR TITLE
[K/JS] Support exporting Kotlin typealiases to TypeScript declarations

### DIFF
--- a/build-common/testFixtures/org/jetbrains/kotlin/library/metadata/DebugKlibMetadataProtoBuf.java
+++ b/build-common/testFixtures/org/jetbrains/kotlin/library/metadata/DebugKlibMetadataProtoBuf.java
@@ -8,6 +8,7 @@ public final class DebugKlibMetadataProtoBuf {
   public static void registerAllExtensions(
       org.jetbrains.kotlin.protobuf.ExtensionRegistry registry) {
     registry.add(org.jetbrains.kotlin.library.metadata.DebugKlibMetadataProtoBuf.packageFqName);
+    registry.add(org.jetbrains.kotlin.library.metadata.DebugKlibMetadataProtoBuf.typeAliasFile);
     registry.add(org.jetbrains.kotlin.library.metadata.DebugKlibMetadataProtoBuf.classAnnotation);
     registry.add(org.jetbrains.kotlin.library.metadata.DebugKlibMetadataProtoBuf.classFile);
     registry.add(org.jetbrains.kotlin.library.metadata.DebugKlibMetadataProtoBuf.classKdoc);
@@ -1006,6 +1007,17 @@ public final class DebugKlibMetadataProtoBuf {
           .newFileScopedGeneratedExtension(
         java.lang.Integer.class,
         null);
+  public static final int TYPE_ALIAS_FILE_FIELD_NUMBER = 170;
+  /**
+   * <code>extend .org.jetbrains.kotlin.metadata.TypeAlias { ... }</code>
+   */
+  public static final
+    org.jetbrains.kotlin.protobuf.GeneratedMessage.GeneratedExtension<
+      org.jetbrains.kotlin.metadata.DebugProtoBuf.TypeAlias,
+      java.lang.Integer> typeAliasFile = org.jetbrains.kotlin.protobuf.GeneratedMessage
+          .newFileScopedGeneratedExtension(
+        java.lang.Integer.class,
+        null);
   public static final int CLASS_ANNOTATION_FIELD_NUMBER = 170;
   /**
    * <code>extend .org.jetbrains.kotlin.metadata.Class { ... }</code>
@@ -1318,73 +1330,74 @@ public final class DebugKlibMetadataProtoBuf {
       "name\030\001 \002(\t\022\r\n\005flags\030\002 \001(\005\022\035\n\025package_fra" +
       "gment_name\030\007 \003(\t\022\025\n\rempty_package\030\010 \003(\t:" +
       "@\n\017package_fq_name\022&.org.jetbrains.kotli" +
-      "n.metadata.Package\030\253\001 \001(\005:j\n\020class_annot" +
-      "ation\022$.org.jetbrains.kotlin.metadata.Cl",
-      "ass\030\252\001 \003(\0132).org.jetbrains.kotlin.metada" +
-      "ta.Annotation:?\n\nclass_file\022$.org.jetbra" +
-      "ins.kotlin.metadata.Class\030\257\001 \001(\005B\004\200\265\030\001:?" +
-      "\n\nclass_kdoc\022$.org.jetbrains.kotlin.meta" +
-      "data.Class\030\260\001 \001(\tB\004\200\265\030\001:v\n\026constructor_a" +
-      "nnotation\022*.org.jetbrains.kotlin.metadat" +
-      "a.Constructor\030\252\001 \003(\0132).org.jetbrains.kot" +
-      "lin.metadata.Annotation:K\n\020constructor_k" +
-      "doc\022*.org.jetbrains.kotlin.metadata.Cons" +
-      "tructor\030\255\001 \001(\tB\004\200\265\030\001:p\n\023function_annotat",
-      "ion\022\'.org.jetbrains.kotlin.metadata.Func" +
-      "tion\030\252\001 \003(\0132).org.jetbrains.kotlin.metad" +
-      "ata.Annotation:\203\001\n&function_extension_re" +
-      "ceiver_annotation\022\'.org.jetbrains.kotlin" +
-      ".metadata.Function\030\253\001 \003(\0132).org.jetbrain" +
-      "s.kotlin.metadata.Annotation:E\n\rfunction" +
-      "_file\022\'.org.jetbrains.kotlin.metadata.Fu" +
-      "nction\030\254\001 \001(\005B\004\200\265\030\001:E\n\rfunction_kdoc\022\'.o" +
-      "rg.jetbrains.kotlin.metadata.Function\030\256\001" +
-      " \001(\tB\004\200\265\030\001:p\n\023property_annotation\022\'.org.",
-      "jetbrains.kotlin.metadata.Property\030\252\001 \003(" +
-      "\0132).org.jetbrains.kotlin.metadata.Annota" +
-      "tion:w\n\032property_getter_annotation\022\'.org" +
-      ".jetbrains.kotlin.metadata.Property\030\261\001 \003" +
-      "(\0132).org.jetbrains.kotlin.metadata.Annot" +
-      "ation:w\n\032property_setter_annotation\022\'.or" +
-      "g.jetbrains.kotlin.metadata.Property\030\262\001 " +
-      "\003(\0132).org.jetbrains.kotlin.metadata.Anno" +
-      "tation:~\n!property_backing_field_annotat" +
-      "ion\022\'.org.jetbrains.kotlin.metadata.Prop",
-      "erty\030\265\001 \003(\0132).org.jetbrains.kotlin.metad" +
-      "ata.Annotation:\200\001\n#property_delegated_fi" +
-      "eld_annotation\022\'.org.jetbrains.kotlin.me" +
-      "tadata.Property\030\266\001 \003(\0132).org.jetbrains.k" +
-      "otlin.metadata.Annotation:\203\001\n&property_e" +
-      "xtension_receiver_annotation\022\'.org.jetbr" +
-      "ains.kotlin.metadata.Property\030\267\001 \003(\0132).o" +
+      "n.metadata.Package\030\253\001 \001(\005:H\n\017type_alias_" +
+      "file\022(.org.jetbrains.kotlin.metadata.Typ",
+      "eAlias\030\252\001 \001(\005B\004\200\265\030\001:j\n\020class_annotation\022" +
+      "$.org.jetbrains.kotlin.metadata.Class\030\252\001" +
+      " \003(\0132).org.jetbrains.kotlin.metadata.Ann" +
+      "otation:?\n\nclass_file\022$.org.jetbrains.ko" +
+      "tlin.metadata.Class\030\257\001 \001(\005B\004\200\265\030\001:?\n\nclas" +
+      "s_kdoc\022$.org.jetbrains.kotlin.metadata.C" +
+      "lass\030\260\001 \001(\tB\004\200\265\030\001:v\n\026constructor_annotat" +
+      "ion\022*.org.jetbrains.kotlin.metadata.Cons" +
+      "tructor\030\252\001 \003(\0132).org.jetbrains.kotlin.me" +
+      "tadata.Annotation:K\n\020constructor_kdoc\022*.",
+      "org.jetbrains.kotlin.metadata.Constructo" +
+      "r\030\255\001 \001(\tB\004\200\265\030\001:p\n\023function_annotation\022\'." +
+      "org.jetbrains.kotlin.metadata.Function\030\252" +
+      "\001 \003(\0132).org.jetbrains.kotlin.metadata.An" +
+      "notation:\203\001\n&function_extension_receiver" +
+      "_annotation\022\'.org.jetbrains.kotlin.metad" +
+      "ata.Function\030\253\001 \003(\0132).org.jetbrains.kotl" +
+      "in.metadata.Annotation:E\n\rfunction_file\022" +
+      "\'.org.jetbrains.kotlin.metadata.Function" +
+      "\030\254\001 \001(\005B\004\200\265\030\001:E\n\rfunction_kdoc\022\'.org.jet",
+      "brains.kotlin.metadata.Function\030\256\001 \001(\tB\004" +
+      "\200\265\030\001:p\n\023property_annotation\022\'.org.jetbra" +
+      "ins.kotlin.metadata.Property\030\252\001 \003(\0132).or" +
+      "g.jetbrains.kotlin.metadata.Annotation:w" +
+      "\n\032property_getter_annotation\022\'.org.jetbr" +
+      "ains.kotlin.metadata.Property\030\261\001 \003(\0132).o" +
       "rg.jetbrains.kotlin.metadata.Annotation:" +
-      "~\n\022compile_time_value\022\'.org.jetbrains.ko" +
-      "tlin.metadata.Property\030\255\001 \001(\01328.org.jetb",
-      "rains.kotlin.metadata.Annotation.Argumen" +
-      "t.Value:E\n\rproperty_file\022\'.org.jetbrains" +
-      ".kotlin.metadata.Property\030\260\001 \001(\005B\004\200\265\030\001:E" +
-      "\n\rproperty_kdoc\022\'.org.jetbrains.kotlin.m" +
-      "etadata.Property\030\264\001 \001(\tB\004\200\265\030\001:s\n\025enum_en" +
-      "try_annotation\022(.org.jetbrains.kotlin.me" +
-      "tadata.EnumEntry\030\252\001 \003(\0132).org.jetbrains." +
-      "kotlin.metadata.Annotation:E\n\022enum_entry" +
-      "_ordinal\022(.org.jetbrains.kotlin.metadata" +
-      ".EnumEntry\030\253\001 \001(\005:w\n\024parameter_annotatio",
-      "n\022-.org.jetbrains.kotlin.metadata.ValueP" +
-      "arameter\030\252\001 \003(\0132).org.jetbrains.kotlin.m" +
-      "etadata.Annotation:h\n\017type_annotation\022#." +
-      "org.jetbrains.kotlin.metadata.Type\030\252\001 \003(" +
-      "\0132).org.jetbrains.kotlin.metadata.Annota" +
-      "tion:{\n\031type_parameter_annotation\022,.org." +
-      "jetbrains.kotlin.metadata.TypeParameter\030" +
-      "\252\001 \003(\0132).org.jetbrains.kotlin.metadata.A" +
-      "nnotation:A\n\010is_empty\022..org.jetbrains.ko" +
-      "tlin.metadata.PackageFragment\030\254\001 \001(\010:@\n\007",
-      "fq_name\022..org.jetbrains.kotlin.metadata." +
-      "PackageFragment\030\255\001 \001(\t:G\n\nclass_name\022..o" +
-      "rg.jetbrains.kotlin.metadata.PackageFrag" +
-      "ment\030\256\001 \003(\005B\002\020\001B\033B\031DebugKlibMetadataProt" +
-      "oBuf"
+      "w\n\032property_setter_annotation\022\'.org.jetb" +
+      "rains.kotlin.metadata.Property\030\262\001 \003(\0132)." +
+      "org.jetbrains.kotlin.metadata.Annotation",
+      ":~\n!property_backing_field_annotation\022\'." +
+      "org.jetbrains.kotlin.metadata.Property\030\265" +
+      "\001 \003(\0132).org.jetbrains.kotlin.metadata.An" +
+      "notation:\200\001\n#property_delegated_field_an" +
+      "notation\022\'.org.jetbrains.kotlin.metadata" +
+      ".Property\030\266\001 \003(\0132).org.jetbrains.kotlin." +
+      "metadata.Annotation:\203\001\n&property_extensi" +
+      "on_receiver_annotation\022\'.org.jetbrains.k" +
+      "otlin.metadata.Property\030\267\001 \003(\0132).org.jet" +
+      "brains.kotlin.metadata.Annotation:~\n\022com",
+      "pile_time_value\022\'.org.jetbrains.kotlin.m" +
+      "etadata.Property\030\255\001 \001(\01328.org.jetbrains." +
+      "kotlin.metadata.Annotation.Argument.Valu" +
+      "e:E\n\rproperty_file\022\'.org.jetbrains.kotli" +
+      "n.metadata.Property\030\260\001 \001(\005B\004\200\265\030\001:E\n\rprop" +
+      "erty_kdoc\022\'.org.jetbrains.kotlin.metadat" +
+      "a.Property\030\264\001 \001(\tB\004\200\265\030\001:s\n\025enum_entry_an" +
+      "notation\022(.org.jetbrains.kotlin.metadata" +
+      ".EnumEntry\030\252\001 \003(\0132).org.jetbrains.kotlin" +
+      ".metadata.Annotation:E\n\022enum_entry_ordin",
+      "al\022(.org.jetbrains.kotlin.metadata.EnumE" +
+      "ntry\030\253\001 \001(\005:w\n\024parameter_annotation\022-.or" +
+      "g.jetbrains.kotlin.metadata.ValueParamet" +
+      "er\030\252\001 \003(\0132).org.jetbrains.kotlin.metadat" +
+      "a.Annotation:h\n\017type_annotation\022#.org.je" +
+      "tbrains.kotlin.metadata.Type\030\252\001 \003(\0132).or" +
+      "g.jetbrains.kotlin.metadata.Annotation:{" +
+      "\n\031type_parameter_annotation\022,.org.jetbra" +
+      "ins.kotlin.metadata.TypeParameter\030\252\001 \003(\013" +
+      "2).org.jetbrains.kotlin.metadata.Annotat",
+      "ion:A\n\010is_empty\022..org.jetbrains.kotlin.m" +
+      "etadata.PackageFragment\030\254\001 \001(\010:@\n\007fq_nam" +
+      "e\022..org.jetbrains.kotlin.metadata.Packag" +
+      "eFragment\030\255\001 \001(\t:G\n\nclass_name\022..org.jet" +
+      "brains.kotlin.metadata.PackageFragment\030\256" +
+      "\001 \003(\005B\002\020\001B\033B\031DebugKlibMetadataProtoBuf"
     };
     org.jetbrains.kotlin.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new org.jetbrains.kotlin.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -1407,34 +1420,36 @@ public final class DebugKlibMetadataProtoBuf {
         internal_static_org_jetbrains_kotlin_library_metadata_Header_descriptor,
         new java.lang.String[] { "ModuleName", "Flags", "PackageFragmentName", "EmptyPackage", });
     packageFqName.internalInit(descriptor.getExtensions().get(0));
-    classAnnotation.internalInit(descriptor.getExtensions().get(1));
-    classFile.internalInit(descriptor.getExtensions().get(2));
-    classKdoc.internalInit(descriptor.getExtensions().get(3));
-    constructorAnnotation.internalInit(descriptor.getExtensions().get(4));
-    constructorKdoc.internalInit(descriptor.getExtensions().get(5));
-    functionAnnotation.internalInit(descriptor.getExtensions().get(6));
-    functionExtensionReceiverAnnotation.internalInit(descriptor.getExtensions().get(7));
-    functionFile.internalInit(descriptor.getExtensions().get(8));
-    functionKdoc.internalInit(descriptor.getExtensions().get(9));
-    propertyAnnotation.internalInit(descriptor.getExtensions().get(10));
-    propertyGetterAnnotation.internalInit(descriptor.getExtensions().get(11));
-    propertySetterAnnotation.internalInit(descriptor.getExtensions().get(12));
-    propertyBackingFieldAnnotation.internalInit(descriptor.getExtensions().get(13));
-    propertyDelegatedFieldAnnotation.internalInit(descriptor.getExtensions().get(14));
-    propertyExtensionReceiverAnnotation.internalInit(descriptor.getExtensions().get(15));
-    compileTimeValue.internalInit(descriptor.getExtensions().get(16));
-    propertyFile.internalInit(descriptor.getExtensions().get(17));
-    propertyKdoc.internalInit(descriptor.getExtensions().get(18));
-    enumEntryAnnotation.internalInit(descriptor.getExtensions().get(19));
-    enumEntryOrdinal.internalInit(descriptor.getExtensions().get(20));
-    parameterAnnotation.internalInit(descriptor.getExtensions().get(21));
-    typeAnnotation.internalInit(descriptor.getExtensions().get(22));
-    typeParameterAnnotation.internalInit(descriptor.getExtensions().get(23));
-    isEmpty.internalInit(descriptor.getExtensions().get(24));
-    fqName.internalInit(descriptor.getExtensions().get(25));
-    className.internalInit(descriptor.getExtensions().get(26));
+    typeAliasFile.internalInit(descriptor.getExtensions().get(1));
+    classAnnotation.internalInit(descriptor.getExtensions().get(2));
+    classFile.internalInit(descriptor.getExtensions().get(3));
+    classKdoc.internalInit(descriptor.getExtensions().get(4));
+    constructorAnnotation.internalInit(descriptor.getExtensions().get(5));
+    constructorKdoc.internalInit(descriptor.getExtensions().get(6));
+    functionAnnotation.internalInit(descriptor.getExtensions().get(7));
+    functionExtensionReceiverAnnotation.internalInit(descriptor.getExtensions().get(8));
+    functionFile.internalInit(descriptor.getExtensions().get(9));
+    functionKdoc.internalInit(descriptor.getExtensions().get(10));
+    propertyAnnotation.internalInit(descriptor.getExtensions().get(11));
+    propertyGetterAnnotation.internalInit(descriptor.getExtensions().get(12));
+    propertySetterAnnotation.internalInit(descriptor.getExtensions().get(13));
+    propertyBackingFieldAnnotation.internalInit(descriptor.getExtensions().get(14));
+    propertyDelegatedFieldAnnotation.internalInit(descriptor.getExtensions().get(15));
+    propertyExtensionReceiverAnnotation.internalInit(descriptor.getExtensions().get(16));
+    compileTimeValue.internalInit(descriptor.getExtensions().get(17));
+    propertyFile.internalInit(descriptor.getExtensions().get(18));
+    propertyKdoc.internalInit(descriptor.getExtensions().get(19));
+    enumEntryAnnotation.internalInit(descriptor.getExtensions().get(20));
+    enumEntryOrdinal.internalInit(descriptor.getExtensions().get(21));
+    parameterAnnotation.internalInit(descriptor.getExtensions().get(22));
+    typeAnnotation.internalInit(descriptor.getExtensions().get(23));
+    typeParameterAnnotation.internalInit(descriptor.getExtensions().get(24));
+    isEmpty.internalInit(descriptor.getExtensions().get(25));
+    fqName.internalInit(descriptor.getExtensions().get(26));
+    className.internalInit(descriptor.getExtensions().get(27));
     org.jetbrains.kotlin.protobuf.ExtensionRegistry registry =
         org.jetbrains.kotlin.protobuf.ExtensionRegistry.newInstance();
+    registry.add(org.jetbrains.kotlin.metadata.DebugExtOptionsProtoBuf.skipInComparison);
     registry.add(org.jetbrains.kotlin.metadata.DebugExtOptionsProtoBuf.skipInComparison);
     registry.add(org.jetbrains.kotlin.metadata.DebugExtOptionsProtoBuf.skipInComparison);
     registry.add(org.jetbrains.kotlin.metadata.DebugExtOptionsProtoBuf.skipInComparison);

--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -3869,8 +3869,7 @@
                                 "current": false,
                                 "valueInVersions": []
                             }
-                        },
-                        "deprecatedMessage": null
+                        }
                     },
                     {
                         "name": "Xexpect-actual-classes",

--- a/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/declaration/FirJsExportDeclarationChecker.kt
+++ b/compiler/fir/checkers/checkers.js/src/org/jetbrains/kotlin/fir/analysis/js/checkers/declaration/FirJsExportDeclarationChecker.kt
@@ -232,7 +232,13 @@ object FirJsExportDeclarationChecker : FirBasicDeclarationChecker(MppCheckerKind
             }
 
             is FirTypeAlias -> {
-                reportWrongExportedDeclaration("typealias")
+                if (LanguageFeature.JsAllowExportTypealiases.isEnabled()) {
+                    declaration.expandedTypeRef
+                        .takeIf { !it.coneType.isExportable() }
+                        ?.let {
+                            reporter.reportOn(it.source, FirJsErrors.NON_EXPORTABLE_TYPE, "referenced type", it.coneType)
+                        }
+                } else reportWrongExportedDeclaration("typealias")
             }
 
             else -> {

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/session/MetadataLibraryBasedSymbolProvider.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.declarations.FirTypeAlias
 import org.jetbrains.kotlin.fir.declarations.utils.klibFileAnnotations
 import org.jetbrains.kotlin.fir.declarations.utils.klibSourceFile
 import org.jetbrains.kotlin.fir.deserialization.*
@@ -211,6 +212,12 @@ abstract class MetadataLibraryBasedSymbolProvider<L>(
 
     override fun loadFunctionExtensions(packagePart: PackagePartsCacheData, proto: ProtoBuf.Function, fir: FirFunction) {
         fir.klibSourceFile = loadKlibSourceFileExtensionOrNull(packagePart, proto, KlibMetadataProtoBuf.functionFile) ?: return
+    }
+
+    override fun loadTypeAliasExtensions(
+        packagePart: PackagePartsCacheData, proto: ProtoBuf.TypeAlias, fir: FirTypeAlias,
+    ) {
+        fir.klibSourceFile = loadKlibSourceFileExtensionOrNull(packagePart, proto, KlibMetadataProtoBuf.typeAliasFile) ?: return
     }
 
     override fun loadPropertyExtensions(packagePart: PackagePartsCacheData, proto: ProtoBuf.Property, fir: FirProperty) {

--- a/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
+++ b/compiler/fir/fir-deserialization/src/org/jetbrains/kotlin/fir/deserialization/AbstractFirDeserializedSymbolProvider.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.fir.caches.getValue
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.declarations.FirTypeAlias
 import org.jetbrains.kotlin.fir.declarations.utils.klibFileAnnotations
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.declarations.utils.isExpect
@@ -267,6 +268,7 @@ abstract class AbstractFirDeserializedSymbolProvider(
             val aliasProto = part.proto.getTypeAlias(ids.single())
             val postProcessor: DeserializedTypeAliasPostProcessor = {
                 part.context.memberDeserializer.loadTypeAlias(aliasProto, classId, kotlinScopeProvider, it)
+                loadTypeAliasExtensions(part, aliasProto, it.fir)
                 if (part.fileAnnotations.isNotEmpty()) {
                     it.fir.klibFileAnnotations = part.fileAnnotations
                 }
@@ -341,6 +343,11 @@ abstract class AbstractFirDeserializedSymbolProvider(
                 fir.symbol
             }
         }
+    }
+
+    open fun loadTypeAliasExtensions(
+        packagePart: PackagePartsCacheData, proto: ProtoBuf.TypeAlias, fir: FirTypeAlias,
+    ) {
     }
 
     open fun loadFunctionExtensions(

--- a/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirKLibSerializerExtension.kt
+++ b/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirKLibSerializerExtension.kt
@@ -61,6 +61,11 @@ class FirKLibSerializerExtension(
         super.serializeConstructor(constructor, proto, childSerializer)
     }
 
+    override fun serializeTypeAlias(typeAlias: FirTypeAlias, proto: ProtoBuf.TypeAlias.Builder) {
+        typeAlias.setFileId(proto, KlibMetadataProtoBuf.typeAliasFile)
+        super.serializeTypeAlias(typeAlias, proto)
+    }
+
     override fun serializeProperty(
         property: FirProperty,
         proto: ProtoBuf.Property.Builder,

--- a/compiler/testData/diagnostics/testsWithJsStdLib/export/exportableTypeAlias.kt
+++ b/compiler/testData/diagnostics/testsWithJsStdLib/export/exportableTypeAlias.kt
@@ -1,0 +1,16 @@
+// RUN_PIPELINE_TILL: BACKEND
+// OPT_IN: kotlin.js.ExperimentalJsExport
+// LANGUAGE: +JsAllowExportTypealiases
+package foo
+
+@JsExport
+typealias ExportableTypealias = Int
+
+@JsExport.Ignore
+open class Foo
+
+@JsExport
+typealias AliasToNotExportableType = <!NON_EXPORTABLE_TYPE!>Foo<!>
+
+@JsExport
+typealias UsageOfNotExportableTypeInTypeArgs = <!NON_EXPORTABLE_TYPE!>Pair<String, Foo><!>

--- a/compiler/testData/diagnostics/testsWithJsStdLib/export/nestedTypealias.kt
+++ b/compiler/testData/diagnostics/testsWithJsStdLib/export/nestedTypealias.kt
@@ -8,7 +8,7 @@ class B
 
 @JsExport
 interface I {
-    <!WRONG_EXPORTED_DECLARATION!>typealias Foo = A<!>
-    <!WRONG_EXPORTED_DECLARATION!>typealias Bar = B<!>
-    <!WRONG_EXPORTED_DECLARATION!>typealias Baz = Int<!>
+    typealias Foo = A
+    typealias Bar = <!NON_EXPORTABLE_TYPE!>B<!>
+    typealias Baz = Int
 }

--- a/compiler/testData/diagnostics/testsWithJsStdLib/export/wrongExportedDeclaration.kt
+++ b/compiler/testData/diagnostics/testsWithJsStdLib/export/wrongExportedDeclaration.kt
@@ -102,14 +102,14 @@ external fun baz(): String<!>
 external var qux: String<!>
 
 external var quux: String
-    <!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET("getter; class, property, function, file")!>@JsExport<!>
+    <!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET("getter; class, property, function, file, typealias")!>@JsExport<!>
     get() = definedExternally
-    <!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET("setter; class, property, function, file")!>@JsExport<!>
+    <!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET("setter; class, property, function, file, typealias")!>@JsExport<!>
     set(v) = definedExternally
 
-<!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET("getter; get; class, property, function, file")!>@get:JsExport<!>
-<!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET("setter; set; class, property, function, file")!>@set:JsExport<!>
+<!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET("getter; get; class, property, function, file, typealias")!>@get:JsExport<!>
+<!NESTED_JS_EXPORT, WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET("setter; set; class, property, function, file, typealias")!>@set:JsExport<!>
 external var quuux: String
 
-<!WRONG_EXPORTED_DECLARATION("typealias")!><!WRONG_ANNOTATION_TARGET("typealias; class, property, function, file")!>@JsExport<!>
-<!WRONG_MODIFIER_TARGET("external; typealias")!>external<!> typealias ExternalTypeAlias = String<!>
+@JsExport
+<!WRONG_MODIFIER_TARGET("external; typealias")!>external<!> typealias ExternalTypeAlias = String

--- a/compiler/util-klib/src/KlibMetadataProtoBuf.proto
+++ b/compiler/util-klib/src/KlibMetadataProtoBuf.proto
@@ -53,6 +53,10 @@ extend org.jetbrains.kotlin.metadata.Package {
   optional int32 package_fq_name = 171;
 }
 
+extend org.jetbrains.kotlin.metadata.TypeAlias {
+  optional int32 type_alias_file = 170 [(org.jetbrains.kotlin.metadata.skip_in_comparison) = true];
+}
+
 extend org.jetbrains.kotlin.metadata.Class {
   repeated org.jetbrains.kotlin.metadata.Annotation class_annotation = 170;
   optional int32 class_file = 175 [(org.jetbrains.kotlin.metadata.skip_in_comparison) = true];

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/metadata/KlibMetadataProtoBuf.java
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/metadata/KlibMetadataProtoBuf.java
@@ -8,6 +8,7 @@ public final class KlibMetadataProtoBuf {
   public static void registerAllExtensions(
       org.jetbrains.kotlin.protobuf.ExtensionRegistryLite registry) {
     registry.add(org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf.packageFqName);
+    registry.add(org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf.typeAliasFile);
     registry.add(org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf.classAnnotation);
     registry.add(org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf.classFile);
     registry.add(org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf.classKdoc);
@@ -964,6 +965,22 @@ public final class KlibMetadataProtoBuf {
         null,
         null,
         171,
+        org.jetbrains.kotlin.protobuf.WireFormat.FieldType.INT32,
+        java.lang.Integer.class);
+  public static final int TYPE_ALIAS_FILE_FIELD_NUMBER = 170;
+  /**
+   * <code>extend .org.jetbrains.kotlin.metadata.TypeAlias { ... }</code>
+   */
+  public static final
+    org.jetbrains.kotlin.protobuf.GeneratedMessageLite.GeneratedExtension<
+      org.jetbrains.kotlin.metadata.ProtoBuf.TypeAlias,
+      java.lang.Integer> typeAliasFile = org.jetbrains.kotlin.protobuf.GeneratedMessageLite
+          .newSingularGeneratedExtension(
+        org.jetbrains.kotlin.metadata.ProtoBuf.TypeAlias.getDefaultInstance(),
+        0,
+        null,
+        null,
+        170,
         org.jetbrains.kotlin.protobuf.WireFormat.FieldType.INT32,
         java.lang.Integer.class);
   public static final int CLASS_ANNOTATION_FIELD_NUMBER = 170;

--- a/core/language.version-settings/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
+++ b/core/language.version-settings/src/org/jetbrains/kotlin/config/LanguageVersionSettings.kt
@@ -557,6 +557,7 @@ enum class LanguageFeature(
     ForbidValueClassRecursionViaTypeParameters(sinceVersion = KOTLIN_2_5, enabledInProgressiveMode = true, issue = "KT-85848"),
     IrCrossModuleInlinerBeforeKlibSerialization(KOTLIN_2_5, sinceApiVersion = ApiVersion.KOTLIN_2_3, forcesPreReleaseBinaries = true, issue = "KT-71896"),
     JvmSupportRecursiveTypeOf(sinceVersion = KOTLIN_2_5, issue = "KT-87339"),
+    JsAllowExportTypealiases(sinceVersion = KOTLIN_2_5, "KT-49795"),
 
     // 2.6
 

--- a/js/js.translator/testData/typescript-export/js/typealiases/tsconfig.json
+++ b/js/js.translator/testData/typescript-export/js/typealiases/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": [ "./*" ],
+  "extends": "../../common.tsconfig.json"
+}

--- a/js/js.translator/testData/typescript-export/js/typealiases/tsconfig.json
+++ b/js/js.translator/testData/typescript-export/js/typealiases/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "include": [ "./*" ],
+  "exclude": [ "./typealiases.d.ts" ],
   "extends": "../../common.tsconfig.json"
 }

--- a/js/js.translator/testData/typescript-export/js/typealiases/typealiases.aa.d.ts
+++ b/js/js.translator/testData/typescript-export/js/typealiases/typealiases.aa.d.ts
@@ -1,0 +1,463 @@
+declare namespace JS_TESTS {
+    type Nullable<T> = T | null | undefined
+    function KtSingleton<T>(): T & (abstract new() => any);
+    namespace kotlin {
+        class Pair<out A, out B> /* implements kotlin.io.Serializable */ {
+            constructor(first: A, second: B);
+            toString(): string;
+            copy(first?: A, second?: B): kotlin.Pair<A, B>;
+            equals(other: Nullable<any>): boolean;
+            hashCode(): number;
+            get first(): A;
+            get second(): B;
+        }
+        namespace Pair {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <A, B>() => Pair<A, B>;
+            }
+        }
+    }
+    namespace foo {
+        function consumeMyInt(value: foo.MyInt): foo.MyInt;
+        function consumeCallback(cb: Nullable<foo.SimpleCallback>): Nullable<void>;
+        function consumeGenericAlias(value: foo.AliasGenericClass<string>): string;
+        function acceptInnerAlias(value: foo.AliasWithInnerClass<number, string>): void;
+        class ClassUsingAlias {
+            constructor(id: foo.MyInt, name: foo.MyString);
+            get id(): foo.MyInt;
+            get name(): foo.MyString;
+        }
+        namespace ClassUsingAlias {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassUsingAlias;
+            }
+        }
+        type AliasWithVarianceInAliasedType<T> = foo.GenericClass<T>;
+        type AliasWithVarianceInsideOfAliasedType<T> = foo.GenericClassWithVariance<T>;
+        type AliasWithInnerClass<T, S> = foo.GenericClass.Inner<S, T>;
+    }
+    namespace foo {
+        class SomeClass {
+            constructor(value: string);
+            get value(): string;
+        }
+        namespace SomeClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => SomeClass;
+            }
+        }
+        class GenericClass<T> {
+            constructor(value: T);
+            get value(): T;
+            get Inner(): {
+                new<S>(): foo.GenericClass.Inner<S, T>;
+            };
+        }
+        namespace GenericClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T>() => GenericClass<T>;
+            }
+            class Inner<S, T$GenericClass> {
+                private constructor();
+            }
+            namespace Inner {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new <S, T$GenericClass>() => Inner<S, T$GenericClass>;
+                }
+            }
+        }
+        class GenericClassWithVariance<out T> {
+            constructor(value: T);
+            get value(): T;
+        }
+        namespace GenericClassWithVariance {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T>() => GenericClassWithVariance<T>;
+            }
+        }
+        class TwoGenericParamsClass<A, B> {
+            constructor(first: A, second: B);
+            get first(): A;
+            get second(): B;
+        }
+        namespace TwoGenericParamsClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <A, B>() => TwoGenericParamsClass<A, B>;
+            }
+        }
+        interface SomeInterface {
+            readonly prop: string;
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.SomeInterface": unique symbol;
+            };
+        }
+        interface SomeExternalInterface {
+        }
+        abstract class SomeEnum {
+            private constructor();
+            static get A(): foo.SomeEnum & {
+                get name(): "A";
+                get ordinal(): 0;
+            };
+            static get B(): foo.SomeEnum & {
+                get name(): "B";
+                get ordinal(): 1;
+            };
+            static get C(): foo.SomeEnum & {
+                get name(): "C";
+                get ordinal(): 2;
+            };
+            static values(): [typeof foo.SomeEnum.A, typeof foo.SomeEnum.B, typeof foo.SomeEnum.C];
+            static valueOf(value: string): foo.SomeEnum;
+            get name(): "A" | "B" | "C";
+            get ordinal(): 0 | 1 | 2;
+        }
+        namespace SomeEnum {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => SomeEnum;
+            }
+        }
+        abstract class SomeObject extends KtSingleton<SomeObject.$metadata$.constructor>() {
+            private constructor();
+        }
+        namespace SomeObject {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                abstract class constructor {
+                    get value(): string;
+                    private constructor();
+                }
+            }
+        }
+        interface Comparable<in T> {
+            compareTo(other: T): number;
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.Comparable": unique symbol;
+            };
+        }
+        class ClassWithConstraint<T extends foo.SomeClass> {
+            constructor(value: T);
+            get value(): T;
+            get InnerWithConstraints(): {
+                new<S extends foo.SomeEnum>(): foo.ClassWithConstraint.InnerWithConstraints<S, T>;
+            };
+        }
+        namespace ClassWithConstraint {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T extends foo.SomeClass>() => ClassWithConstraint<T>;
+            }
+            class InnerWithConstraints<S extends foo.SomeEnum, T$ClassWithConstraint extends foo.SomeClass> {
+                private constructor();
+            }
+            namespace InnerWithConstraints {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new <S extends foo.SomeEnum, T$ClassWithConstraint extends foo.SomeClass>() => InnerWithConstraints<S, T$ClassWithConstraint>;
+                }
+            }
+        }
+        class RecursiveBoundClass<T extends foo.Comparable<T>> {
+            constructor(value: T);
+            get value(): T;
+        }
+        namespace RecursiveBoundClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T extends foo.Comparable<T>>() => RecursiveBoundClass<T>;
+            }
+        }
+        class ClassWithNestedTypealiases {
+            constructor();
+        }
+        namespace ClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithNestedTypealiases;
+            }
+            type NestedInt = number;
+            type NestedString = string;
+            type NestedClassAlias = foo.SomeClass;
+            type NestedGenericAlias<T> = foo.GenericClass<T>;
+            type NestedConcreteGenericAlias = foo.GenericClass<string>;
+            type NestedCallback = () => void;
+            type NestedNullable = Nullable<number>;
+            type Self = foo.ClassWithNestedTypealiases;
+        }
+        class GenericClassWithNestedTypealiases<T> {
+            constructor();
+        }
+        namespace GenericClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T>() => GenericClassWithNestedTypealiases<T>;
+            }
+            type NestedAlias = number;
+            type NestedGenericAlias<T, R> = foo.TwoGenericParamsClass<T, R>;
+            type Self<T> = foo.GenericClassWithNestedTypealiases<T>;
+        }
+        interface InterfaceWithNestedTypealiases {
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.InterfaceWithNestedTypealiases": unique symbol;
+            };
+        }
+        namespace InterfaceWithNestedTypealiases {
+            type InterfaceNestedInt = number;
+            type InterfaceNestedClassAlias = foo.SomeClass;
+            type InterfaceNestedGenericAlias<T> = foo.GenericClass<T>;
+            type InterfaceNestedCallback = (p0: number) => string;
+            type Self = foo.InterfaceWithNestedTypealiases;
+        }
+        abstract class ObjectWithNestedTypealiases extends KtSingleton<ObjectWithNestedTypealiases.$metadata$.constructor>() {
+            private constructor();
+        }
+        namespace ObjectWithNestedTypealiases {
+            type ObjectNestedInt = number;
+            type ObjectNestedClassAlias = foo.SomeClass;
+            type ObjectNestedGenericAlias<T> = foo.GenericClass<T>;
+            type Self = typeof foo.ObjectWithNestedTypealiases;
+        }
+        namespace ObjectWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                abstract class constructor {
+                    private constructor();
+                }
+            }
+        }
+        class ClassWithCompanionTypealiases {
+            constructor();
+        }
+        namespace ClassWithCompanionTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithCompanionTypealiases;
+            }
+            abstract class Companion extends KtSingleton<Companion.$metadata$.constructor>() {
+                private constructor();
+            }
+            namespace Companion {
+                type CompanionNestedInt = number;
+                type CompanionNestedString = string;
+                type CompanionNestedGenericAlias<T> = foo.GenericClass<T>;
+                type Self = typeof foo.ClassWithCompanionTypealiases.Companion;
+            }
+            namespace Companion {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    abstract class constructor {
+                        private constructor();
+                    }
+                }
+            }
+        }
+        class ClassWithNamedCompanionTypealiases {
+            constructor();
+        }
+        namespace ClassWithNamedCompanionTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithNamedCompanionTypealiases;
+            }
+            abstract class Named extends KtSingleton<Named.$metadata$.constructor>() {
+                private constructor();
+            }
+            namespace Named {
+                type NamedCompanionNestedAlias = string;
+                type NamedCompanionGenericAlias<T> = foo.GenericClass<T>;
+                type Self = typeof foo.ClassWithNamedCompanionTypealiases.Named;
+            }
+            namespace Named {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    abstract class constructor {
+                        private constructor();
+                    }
+                }
+            }
+        }
+        abstract class EnumWithNestedTypealiases {
+            private constructor();
+            static get X(): foo.EnumWithNestedTypealiases & {
+                get name(): "X";
+                get ordinal(): 0;
+            };
+            static get Y(): foo.EnumWithNestedTypealiases & {
+                get name(): "Y";
+                get ordinal(): 1;
+            };
+            static get Z(): foo.EnumWithNestedTypealiases & {
+                get name(): "Z";
+                get ordinal(): 2;
+            };
+            static values(): [typeof foo.EnumWithNestedTypealiases.X, typeof foo.EnumWithNestedTypealiases.Y, typeof foo.EnumWithNestedTypealiases.Z];
+            static valueOf(value: string): foo.EnumWithNestedTypealiases;
+            get name(): "X" | "Y" | "Z";
+            get ordinal(): 0 | 1 | 2;
+        }
+        namespace EnumWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => EnumWithNestedTypealiases;
+            }
+            type EnumNestedInt = number;
+            type EnumNestedClassAlias = foo.SomeClass;
+            type Self = foo.EnumWithNestedTypealiases;
+        }
+        class OpenClassWithNestedTypealiases {
+            constructor();
+        }
+        namespace OpenClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => OpenClassWithNestedTypealiases;
+            }
+            type OpenClassNestedAlias = string;
+            type OpenClassNestedGenericAlias<T> = foo.GenericClass<T>;
+        }
+        abstract class AbstractClassWithNestedTypealiases {
+            constructor();
+        }
+        namespace AbstractClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => AbstractClassWithNestedTypealiases;
+            }
+            type AbstractNestedAlias = number;
+            type AbstractNestedClassAlias = foo.SomeClass;
+        }
+        class OuterWithNested {
+            constructor();
+        }
+        namespace OuterWithNested {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => OuterWithNested;
+            }
+            class InnerNested {
+                constructor();
+            }
+            namespace InnerNested {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new () => InnerNested;
+                }
+                type DeeplyNestedAlias = number;
+                type DeeplyNestedClassAlias = foo.SomeClass;
+            }
+            type OuterNestedAlias = string;
+        }
+        abstract class SealedClassWithNestedTypealiases {
+            private constructor();
+        }
+        namespace SealedClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => SealedClassWithNestedTypealiases;
+            }
+            class Sub extends foo.SealedClassWithNestedTypealiases.$metadata$.constructor {
+                constructor();
+            }
+            namespace Sub {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new () => Sub;
+                }
+            }
+            type SealedNestedAlias = number;
+        }
+        interface SealedInterfaceWithNestedTypealiases {
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.SealedInterfaceWithNestedTypealiases": unique symbol;
+            };
+        }
+        namespace SealedInterfaceWithNestedTypealiases {
+            class Impl implements foo.SealedInterfaceWithNestedTypealiases {
+                constructor();
+                readonly __doNotUseOrImplementIt: foo.SealedInterfaceWithNestedTypealiases["__doNotUseOrImplementIt"];
+            }
+            namespace Impl {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new () => Impl;
+                }
+            }
+            type SealedInterfaceNestedAlias = string;
+        }
+        class ClassWithIgnoredNestedTypealias {
+            constructor();
+        }
+        namespace ClassWithIgnoredNestedTypealias {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithIgnoredNestedTypealias;
+            }
+            type VisibleAlias = number;
+        }
+        type MyInt = number;
+        type MyString = string;
+        type MyBoolean = boolean;
+        type MyDouble = number;
+        type MyByte = number;
+        type MyShort = number;
+        type MyFloat = number;
+        type MyChar = any/* kotlin.Char */;
+        type MyAny = any;
+        type NullableInt = Nullable<number>;
+        type NullableString = Nullable<string>;
+        type NullableAny = Nullable<any>;
+        type MyUByte = any/* kotlin.UByte */;
+        type MyUShort = any/* kotlin.UShort */;
+        type MyUInt = any/* kotlin.UInt */;
+        type MyIntArray = Int32Array;
+        type MyBooleanArray = any /*BooleanArray*/;
+        type MyStringArray = Array<string>;
+        type MyNullableIntArray = Nullable<Int32Array>;
+        type NestedArray = Array<Array<string>>;
+        type AliasSomeClass = foo.SomeClass;
+        type AliasSomeInterface = foo.SomeInterface;
+        type AliasSomeExternalInterface = foo.SomeExternalInterface;
+        type AliasSomeEnum = foo.SomeEnum;
+        type NullableSomeClass = Nullable<foo.SomeClass>;
+        type ConcreteGenericClass = foo.GenericClass<string>;
+        type ConcreteGenericClassInt = foo.GenericClass<number>;
+        type ConcreteTwoGenericParamsClass = foo.TwoGenericParamsClass<string, number>;
+        type AliasGenericClass<T> = foo.GenericClass<T>;
+        type AliasTwoGenericParamsClass<A, B> = foo.TwoGenericParamsClass<A, B>;
+        type FlippedTwoGenericParamsClass<A, B> = foo.TwoGenericParamsClass<B, A>;
+        type PartiallySpecializedGenericClass<T> = foo.TwoGenericParamsClass<string, T>;
+        type AliasClassWithConstraint<T extends foo.SomeClass> = foo.ClassWithConstraint<T>;
+        type AliasClassWithMultipleConstraints<T extends foo.Comparable<T> & foo.SomeClass & foo.SomeEnum> = kotlin.Pair<foo.RecursiveBoundClass<T>, foo.ClassWithConstraint.InnerWithConstraints<T, T>>;
+        type AliasRecursiveBound<T extends foo.Comparable<T>> = foo.RecursiveBoundClass<T>;
+        type AliasOfConstrainedAlias<T extends foo.SomeClass> = foo.AliasClassWithConstraint<T>;
+        type NullableGenericClass<T> = Nullable<foo.GenericClass<T>>;
+        type GenericClassNullableParam<T> = foo.GenericClass<Nullable<T>>;
+        type SimpleCallback = () => void;
+        type IntToString = (p0: number) => string;
+        type BinaryOperation = (p0: number, p1: number) => number;
+        type GenericTransformer<T, R> = (p0: T) => R;
+        type NullableCallback = Nullable<() => void>;
+        type CallbackWithNullableParam = (p0: Nullable<number>) => Nullable<string>;
+        type HigherOrderFunction = (p0: (p0: number) => string) => number;
+        type CurriedFunction = (p0: number) => (p0: string) => boolean;
+        type SuspendCallback = () => Promise<void>;
+        type SuspendTransformer<T, R> = (p0: T) => Promise<R>;
+        type AliasOfMyInt = foo.MyInt;
+        type AliasOfAliasSomeClass = foo.AliasSomeClass;
+        type AliasOfGenericAlias<T> = foo.AliasGenericClass<T>;
+        type MyThrowable = Error;
+        type NullableThrowable = Nullable<Error>;
+        type MyNothing = never;
+        type MyUnit = void;
+    }
+}
+
+

--- a/js/js.translator/testData/typescript-export/js/typealiases/typealiases.d.ts
+++ b/js/js.translator/testData/typescript-export/js/typealiases/typealiases.d.ts
@@ -1,0 +1,351 @@
+declare namespace JS_TESTS {
+    type Nullable<T> = T | null | undefined
+    function KtSingleton<T>(): T & (abstract new() => any);
+    namespace kotlin.collections {
+        interface KtList<out E> /* extends kotlin.collections.Collection<E> */ {
+            asJsReadonlyArrayView(): ReadonlyArray<E>;
+            readonly __doNotUseOrImplementIt: {
+                readonly "kotlin.collections.KtList": unique symbol;
+            };
+        }
+        namespace KtList {
+            function fromJsArray<E>(array: ReadonlyArray<E>): kotlin.collections.KtList<E>;
+        }
+    }
+    namespace foo {
+        interface SomeExternalInterface {
+        }
+    }
+    namespace foo {
+        class SomeClass {
+            constructor(value: string);
+            get value(): string;
+        }
+        namespace SomeClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => SomeClass;
+            }
+        }
+        class GenericClass<T> {
+            constructor(value: T);
+            get value(): T;
+            get Inner(): {
+                new<S>(): GenericClass.Inner<S, T>;
+            };
+        }
+        namespace GenericClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T>() => GenericClass<T>;
+            }
+            class Inner<S, T$GenericClass> {
+                private constructor();
+            }
+            namespace Inner {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new <S, T$GenericClass>() => Inner<S, T$GenericClass>;
+                }
+            }
+        }
+        class GenericClassWithVariance<out T> {
+            constructor(value: T);
+            get value(): T;
+        }
+        namespace GenericClassWithVariance {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T>() => GenericClassWithVariance<T>;
+            }
+        }
+        class TwoGenericParamsClass<A, B> {
+            constructor(first: A, second: B);
+            get first(): A;
+            get second(): B;
+        }
+        namespace TwoGenericParamsClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <A, B>() => TwoGenericParamsClass<A, B>;
+            }
+        }
+        interface SomeInterface {
+            readonly prop: string;
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.SomeInterface": unique symbol;
+            };
+        }
+        abstract class SomeEnum {
+            private constructor();
+            static get A(): foo.SomeEnum & {
+                get name(): "A";
+                get ordinal(): 0;
+            };
+            static get B(): foo.SomeEnum & {
+                get name(): "B";
+                get ordinal(): 1;
+            };
+            static get C(): foo.SomeEnum & {
+                get name(): "C";
+                get ordinal(): 2;
+            };
+            static values(): [typeof foo.SomeEnum.A, typeof foo.SomeEnum.B, typeof foo.SomeEnum.C];
+            static valueOf(value: string): foo.SomeEnum;
+            get name(): "A" | "B" | "C";
+            get ordinal(): 0 | 1 | 2;
+        }
+        namespace SomeEnum {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => SomeEnum;
+            }
+        }
+        abstract class SomeObject extends KtSingleton<SomeObject.$metadata$.constructor>() {
+            private constructor();
+        }
+        namespace SomeObject {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                abstract class constructor {
+                    get value(): string;
+                    private constructor();
+                }
+            }
+        }
+        interface Comparable<in T> {
+            compareTo(other: T): number;
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.Comparable": unique symbol;
+            };
+        }
+        class ClassWithConstraint<T extends foo.SomeClass> {
+            constructor(value: T);
+            get value(): T;
+            get InnerWithConstraints(): {
+                new<S extends foo.SomeEnum>(): ClassWithConstraint.InnerWithConstraints<S, T>;
+            };
+        }
+        namespace ClassWithConstraint {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T extends foo.SomeClass>() => ClassWithConstraint<T>;
+            }
+            class InnerWithConstraints<S extends foo.SomeEnum, T$ClassWithConstraint extends foo.SomeClass> {
+                private constructor();
+            }
+            namespace InnerWithConstraints {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new <S extends foo.SomeEnum, T$ClassWithConstraint extends foo.SomeClass>() => InnerWithConstraints<S, T$ClassWithConstraint>;
+                }
+            }
+        }
+        class RecursiveBoundClass<T extends foo.Comparable<T>> {
+            constructor(value: T);
+            get value(): T;
+        }
+        namespace RecursiveBoundClass {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T extends foo.Comparable<T>>() => RecursiveBoundClass<T>;
+            }
+        }
+        class ClassWithNestedTypealiases {
+            constructor();
+        }
+        namespace ClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithNestedTypealiases;
+            }
+        }
+        class GenericClassWithNestedTypealiases<T> {
+            constructor();
+        }
+        namespace GenericClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new <T>() => GenericClassWithNestedTypealiases<T>;
+            }
+        }
+        interface InterfaceWithNestedTypealiases {
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.InterfaceWithNestedTypealiases": unique symbol;
+            };
+        }
+        abstract class ObjectWithNestedTypealiases extends KtSingleton<ObjectWithNestedTypealiases.$metadata$.constructor>() {
+            private constructor();
+        }
+        namespace ObjectWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                abstract class constructor {
+                    private constructor();
+                }
+            }
+        }
+        class ClassWithCompanionTypealiases {
+            constructor();
+        }
+        namespace ClassWithCompanionTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithCompanionTypealiases;
+            }
+            abstract class Companion extends KtSingleton<Companion.$metadata$.constructor>() {
+                private constructor();
+            }
+            namespace Companion {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    abstract class constructor {
+                        private constructor();
+                    }
+                }
+            }
+        }
+        class ClassWithNamedCompanionTypealiases {
+            constructor();
+        }
+        namespace ClassWithNamedCompanionTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithNamedCompanionTypealiases;
+            }
+            abstract class Named extends KtSingleton<Named.$metadata$.constructor>() {
+                private constructor();
+            }
+            namespace Named {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    abstract class constructor {
+                        private constructor();
+                    }
+                }
+            }
+        }
+        abstract class EnumWithNestedTypealiases {
+            private constructor();
+            static get X(): foo.EnumWithNestedTypealiases & {
+                get name(): "X";
+                get ordinal(): 0;
+            };
+            static get Y(): foo.EnumWithNestedTypealiases & {
+                get name(): "Y";
+                get ordinal(): 1;
+            };
+            static get Z(): foo.EnumWithNestedTypealiases & {
+                get name(): "Z";
+                get ordinal(): 2;
+            };
+            static values(): [typeof foo.EnumWithNestedTypealiases.X, typeof foo.EnumWithNestedTypealiases.Y, typeof foo.EnumWithNestedTypealiases.Z];
+            static valueOf(value: string): foo.EnumWithNestedTypealiases;
+            get name(): "X" | "Y" | "Z";
+            get ordinal(): 0 | 1 | 2;
+        }
+        namespace EnumWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => EnumWithNestedTypealiases;
+            }
+        }
+        class OpenClassWithNestedTypealiases {
+            constructor();
+        }
+        namespace OpenClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => OpenClassWithNestedTypealiases;
+            }
+        }
+        abstract class AbstractClassWithNestedTypealiases {
+            constructor();
+        }
+        namespace AbstractClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => AbstractClassWithNestedTypealiases;
+            }
+        }
+        class OuterWithNested {
+            constructor();
+        }
+        namespace OuterWithNested {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => OuterWithNested;
+            }
+            class InnerNested {
+                constructor();
+            }
+            namespace InnerNested {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new () => InnerNested;
+                }
+            }
+        }
+        abstract class SealedClassWithNestedTypealiases {
+            private constructor();
+        }
+        namespace SealedClassWithNestedTypealiases {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => SealedClassWithNestedTypealiases;
+            }
+            class Sub extends foo.SealedClassWithNestedTypealiases.$metadata$.constructor {
+                constructor();
+            }
+            namespace Sub {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new () => Sub;
+                }
+            }
+        }
+        interface SealedInterfaceWithNestedTypealiases {
+            readonly __doNotUseOrImplementIt: {
+                readonly "foo.SealedInterfaceWithNestedTypealiases": unique symbol;
+            };
+        }
+        namespace SealedInterfaceWithNestedTypealiases {
+            class Impl implements foo.SealedInterfaceWithNestedTypealiases {
+                constructor();
+                readonly __doNotUseOrImplementIt: foo.SealedInterfaceWithNestedTypealiases["__doNotUseOrImplementIt"];
+            }
+            namespace Impl {
+                /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+                namespace $metadata$ {
+                    const constructor: abstract new () => Impl;
+                }
+            }
+        }
+        class ClassWithIgnoredNestedTypealias {
+            constructor();
+        }
+        namespace ClassWithIgnoredNestedTypealias {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassWithIgnoredNestedTypealias;
+            }
+        }
+    }
+    namespace foo {
+        function consumeMyInt(value: number): number;
+        function consumeCallback(cb: Nullable<() => void>): Nullable<void>;
+        function consumeGenericAlias(value: foo.GenericClass<string>): string;
+        class ClassUsingAlias {
+            constructor(id: number, name: string);
+            get id(): number;
+            get name(): string;
+        }
+        namespace ClassUsingAlias {
+            /** @deprecated $metadata$ is used for internal purposes, please don't use it in your code, because it can be removed at any moment */
+            namespace $metadata$ {
+                const constructor: abstract new () => ClassUsingAlias;
+            }
+        }
+        function acceptInnerAlias(value: foo.GenericClass.Inner<string, number>): void;
+    }
+}

--- a/js/js.translator/testData/typescript-export/js/typealiases/typealiases.kt
+++ b/js/js.translator/testData/typescript-export/js/typealiases/typealiases.kt
@@ -1,0 +1,417 @@
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6
+// ^^^^^^
+// The feature is supported only in the Analysis API based TypeScript export
+// since IR doesn't have typealiases
+
+// CHECK_TYPESCRIPT_DECLARATIONS
+// RUN_PLAIN_BOX_FUNCTION
+// SKIP_NODE_JS
+// WITH_STDLIB
+// INFER_MAIN_MODULE
+// MODULE: JS_TESTS
+// LANGUAGE: +JsAllowExportTypealiases +JsExportingSuspendLambdas +NestedTypeAliases
+// FILE: typealiases.kt
+
+package foo
+
+@JsExport
+open class SomeClass(val value: String)
+
+@JsExport
+class GenericClass<T>(val value: T) {
+  inner class Inner<S>
+}
+
+@JsExport
+class GenericClassWithVariance<out T>(val value: T)
+
+@JsExport
+class TwoGenericParamsClass<A, B>(val first: A, val second: B)
+
+@JsExport
+interface SomeInterface {
+    val prop: String
+}
+
+@JsExport
+external interface SomeExternalInterface
+
+@JsExport
+enum class SomeEnum {
+    A, B, C
+}
+
+@JsExport
+object SomeObject {
+    val value: String = "object"
+}
+
+@JsExport
+public interface Comparable<in T> {
+    operator fun compareTo(other: T): kotlin.Int
+}
+
+@JsExport
+open class ClassWithConstraint<T : SomeClass>(val value: T) {
+    inner class InnerWithConstraints<S : SomeEnum>
+}
+
+@JsExport
+open class RecursiveBoundClass<T : Comparable<T>>(val value: T)
+
+// --- Primitive type aliases ---
+
+@JsExport
+typealias MyInt = Int
+
+@JsExport
+typealias MyString = String
+
+@JsExport
+typealias MyBoolean = Boolean
+
+@JsExport
+typealias MyDouble = Double
+
+@JsExport
+typealias MyByte = Byte
+
+@JsExport
+typealias MyShort = Short
+
+@JsExport
+typealias MyFloat = Float
+
+@JsExport
+typealias MyChar = Char
+
+@JsExport
+typealias MyAny = Any
+
+// --- Nullable type aliases ---
+
+@JsExport
+typealias NullableInt = Int?
+
+@JsExport
+typealias NullableString = String?
+
+@JsExport
+typealias NullableAny = Any?
+
+// --- Unsigned type aliases ---
+
+@JsExport
+typealias MyUByte = UByte
+
+@JsExport
+typealias MyUShort = UShort
+
+@JsExport
+typealias MyUInt = UInt
+
+// --- Array type aliases ---
+
+@JsExport
+typealias MyIntArray = IntArray
+
+@JsExport
+typealias MyBooleanArray = BooleanArray
+
+@JsExport
+typealias MyStringArray = Array<String>
+
+@JsExport
+typealias MyNullableIntArray = IntArray?
+
+@JsExport
+typealias NestedArray = Array<Array<String>>
+
+// --- Class/Interface/Enum/Object type aliases ---
+
+@JsExport
+typealias AliasSomeClass = SomeClass
+
+@JsExport
+typealias AliasSomeInterface = SomeInterface
+
+@JsExport
+typealias AliasSomeExternalInterface = SomeExternalInterface
+
+@JsExport
+typealias AliasSomeEnum = SomeEnum
+
+@JsExport
+typealias NullableSomeClass = SomeClass?
+
+// --- Generic type aliases (non-generic alias pointing to a concrete generic type) ---
+
+@JsExport
+typealias ConcreteGenericClass = GenericClass<String>
+
+@JsExport
+typealias ConcreteGenericClassInt = GenericClass<Int>
+
+@JsExport
+typealias ConcreteTwoGenericParamsClass = TwoGenericParamsClass<String, Int>
+
+// --- Generic type aliases (alias with type parameters) ---
+
+@JsExport
+typealias AliasGenericClass<T> = GenericClass<T>
+
+@JsExport
+typealias AliasTwoGenericParamsClass<A, B> = TwoGenericParamsClass<A, B>
+
+@JsExport
+typealias FlippedTwoGenericParamsClass<A, B> = TwoGenericParamsClass<B, A>
+
+@JsExport
+typealias PartiallySpecializedGenericClass<T> = TwoGenericParamsClass<String, T>
+
+// --- Generic type alias with constraint ---
+
+@JsExport
+typealias AliasClassWithConstraint<T> = ClassWithConstraint<T>
+
+@JsExport
+typealias AliasClassWithMultipleConstraints<T> = Pair<RecursiveBoundClass<T>, ClassWithConstraint<T>.InnerWithConstraints<T>>
+
+// Constraint inherited from an F-bound (exercises rewriting the bound in terms of the alias's parameter):
+@JsExport
+typealias AliasRecursiveBound<T> = RecursiveBoundClass<T>
+
+// Constraint inherited through an alias-to-alias chain (exercises full expansion):
+@JsExport
+typealias AliasOfConstrainedAlias<T> = AliasClassWithConstraint<T>
+
+// --- Nullable generic type aliases ---
+
+@JsExport
+typealias NullableGenericClass<T> = GenericClass<T>?
+
+@JsExport
+typealias GenericClassNullableParam<T> = GenericClass<T?>
+
+// --- Function type aliases ---
+
+@JsExport
+typealias SimpleCallback = () -> Unit
+
+@JsExport
+typealias IntToString = (Int) -> String
+
+@JsExport
+typealias BinaryOperation = (Int, Int) -> Int
+
+@JsExport
+typealias GenericTransformer<T, R> = (T) -> R
+
+@JsExport
+typealias NullableCallback = (() -> Unit)?
+
+@JsExport
+typealias CallbackWithNullableParam = (Int?) -> String?
+
+@JsExport
+typealias HigherOrderFunction = ((Int) -> String) -> Int
+
+@JsExport
+typealias CurriedFunction = (Int) -> (String) -> Boolean
+
+@JsExport
+typealias SuspendCallback = suspend () -> Unit
+
+@JsExport
+typealias SuspendTransformer<T, R> = suspend (T) -> R
+
+// --- Typealias to typealias ---
+
+@JsExport
+typealias AliasOfMyInt = MyInt
+
+@JsExport
+typealias AliasOfAliasSomeClass = AliasSomeClass
+
+@JsExport
+typealias AliasOfGenericAlias<T> = AliasGenericClass<T>
+
+// --- Throwable type alias ---
+
+@JsExport
+typealias MyThrowable = Throwable
+
+@JsExport
+typealias NullableThrowable = Throwable?
+
+// --- Nothing type alias ---
+
+@JsExport
+typealias MyNothing = Nothing
+
+// --- Unit type alias ---
+
+@JsExport
+typealias MyUnit = Unit
+
+// --- Nested typealiases (inside classes) ---
+
+@JsExport
+class ClassWithNestedTypealiases {
+    typealias NestedInt = Int
+    typealias NestedString = String
+    typealias NestedClassAlias = SomeClass
+    typealias NestedGenericAlias<T> = GenericClass<T>
+    typealias NestedConcreteGenericAlias = GenericClass<String>
+    typealias NestedCallback = () -> Unit
+    typealias NestedNullable = Int?
+
+    typealias Self = ClassWithNestedTypealiases
+}
+
+@JsExport
+class GenericClassWithNestedTypealiases<T> {
+    typealias NestedAlias = Int
+    typealias NestedGenericAlias<T, R> = TwoGenericParamsClass<T, R>
+
+    typealias Self<T> = GenericClassWithNestedTypealiases<T>
+}
+
+// --- Nested typealiases (inside interfaces) ---
+
+@JsExport
+interface InterfaceWithNestedTypealiases {
+    typealias InterfaceNestedInt = Int
+    typealias InterfaceNestedClassAlias = SomeClass
+    typealias InterfaceNestedGenericAlias<T> = GenericClass<T>
+    typealias InterfaceNestedCallback = (Int) -> String
+    typealias Self = InterfaceWithNestedTypealiases
+}
+
+// --- Nested typealiases (inside objects) ---
+
+@JsExport
+object ObjectWithNestedTypealiases {
+    typealias ObjectNestedInt = Int
+    typealias ObjectNestedClassAlias = SomeClass
+    typealias ObjectNestedGenericAlias<T> = GenericClass<T>
+    typealias Self = ObjectWithNestedTypealiases
+}
+
+// --- Nested typealiases (inside companion objects) ---
+
+@JsExport
+class ClassWithCompanionTypealiases {
+    companion object {
+        typealias CompanionNestedInt = Int
+        typealias CompanionNestedString = String
+        typealias CompanionNestedGenericAlias<T> = GenericClass<T>
+        typealias Self = ClassWithCompanionTypealiases.Companion
+    }
+}
+
+@JsExport
+class ClassWithNamedCompanionTypealiases {
+    companion object Named {
+        typealias NamedCompanionNestedAlias = String
+        typealias NamedCompanionGenericAlias<T> = GenericClass<T>
+        typealias Self = ClassWithNamedCompanionTypealiases.Named
+    }
+}
+
+// --- Nested typealiases (inside enum classes) ---
+
+@JsExport
+enum class EnumWithNestedTypealiases {
+    X, Y, Z;
+
+    typealias EnumNestedInt = Int
+    typealias EnumNestedClassAlias = SomeClass
+    typealias Self = EnumWithNestedTypealiases
+}
+
+// --- Nested typealiases (inside open/abstract classes) ---
+
+@JsExport
+open class OpenClassWithNestedTypealiases {
+    typealias OpenClassNestedAlias = String
+    typealias OpenClassNestedGenericAlias<T> = GenericClass<T>
+}
+
+@JsExport
+abstract class AbstractClassWithNestedTypealiases {
+    typealias AbstractNestedAlias = Int
+    typealias AbstractNestedClassAlias = SomeClass
+}
+
+// --- Nested typealiases (deeply nested in class within class) ---
+
+@JsExport
+class OuterWithNested {
+    class InnerNested {
+        typealias DeeplyNestedAlias = Int
+        typealias DeeplyNestedClassAlias = SomeClass
+    }
+
+    typealias OuterNestedAlias = String
+}
+
+// --- Nested typealiases (inside sealed class/interface) ---
+
+@JsExport
+sealed class SealedClassWithNestedTypealiases {
+    typealias SealedNestedAlias = Int
+    class Sub : SealedClassWithNestedTypealiases()
+}
+
+@JsExport
+sealed interface SealedInterfaceWithNestedTypealiases {
+    typealias SealedInterfaceNestedAlias = String
+    class Impl : SealedInterfaceWithNestedTypealiases
+}
+
+// --- Nested typealias with @JsExport.Ignore ---
+
+@JsExport
+class ClassWithIgnoredNestedTypealias {
+    typealias VisibleAlias = Int
+
+    @JsExport.Ignore
+    typealias IgnoredNestedAlias = String
+}
+
+// --- @JsExport.Ignore on typealias ---
+
+@JsExport.Ignore
+typealias IgnoredAlias = String
+
+// --- Typealiases used in exported declarations ---
+// FILE: usage.kt
+
+package foo
+
+@JsExport
+fun consumeMyInt(value: MyInt): MyInt = value + 1
+
+@JsExport
+fun consumeCallback(cb: SimpleCallback?) = cb?.invoke()
+
+@JsExport
+fun consumeGenericAlias(value: AliasGenericClass<String>): String = value.value
+
+@JsExport
+class ClassUsingAlias(val id: MyInt, val name: MyString)
+
+@JsExport
+typealias AliasWithVarianceInAliasedType<T> = GenericClass<in T>
+
+@JsExport
+typealias AliasWithVarianceInsideOfAliasedType<T> = GenericClassWithVariance<T>
+
+// Type alias to an inner class and references to it:
+@JsExport
+typealias AliasWithInnerClass<T, S> = GenericClass<T>.Inner<S>
+
+@JsExport
+fun acceptInnerAlias(value: AliasWithInnerClass<Int, String>) {}
+

--- a/js/js.translator/testData/typescript-export/js/typealiases/typealiases__main.ts
+++ b/js/js.translator/testData/typescript-export/js/typealiases/typealiases__main.ts
@@ -1,0 +1,331 @@
+// Runtime declarations used to produce values for the aliases below.
+import SomeClass = JS_TESTS.foo.SomeClass;
+import GenericClass = JS_TESTS.foo.GenericClass;
+import TwoGenericParamsClass = JS_TESTS.foo.TwoGenericParamsClass;
+import SomeEnum = JS_TESTS.foo.SomeEnum;
+import ClassUsingAlias = JS_TESTS.foo.ClassUsingAlias;
+import consumeMyInt = JS_TESTS.foo.consumeMyInt;
+import consumeCallback = JS_TESTS.foo.consumeCallback;
+import consumeGenericAlias = JS_TESTS.foo.consumeGenericAlias;
+import acceptInnerAlias = JS_TESTS.foo.acceptInnerAlias;
+import ClassWithNestedTypealiases = JS_TESTS.foo.ClassWithNestedTypealiases;
+import GenericClassWithNestedTypealiases = JS_TESTS.foo.GenericClassWithNestedTypealiases;
+import EnumWithNestedTypealiases = JS_TESTS.foo.EnumWithNestedTypealiases;
+import ObjectWithNestedTypealiases = JS_TESTS.foo.ObjectWithNestedTypealiases;
+import ClassWithCompanionTypealiases = JS_TESTS.foo.ClassWithCompanionTypealiases;
+import ClassWithNamedCompanionTypealiases = JS_TESTS.foo.ClassWithNamedCompanionTypealiases;
+
+// --- Primitive type aliases ---
+import MyInt = JS_TESTS.foo.MyInt;
+import MyString = JS_TESTS.foo.MyString;
+import MyBoolean = JS_TESTS.foo.MyBoolean;
+import MyDouble = JS_TESTS.foo.MyDouble;
+import MyByte = JS_TESTS.foo.MyByte;
+import MyShort = JS_TESTS.foo.MyShort;
+import MyFloat = JS_TESTS.foo.MyFloat;
+import MyChar = JS_TESTS.foo.MyChar;
+import MyAny = JS_TESTS.foo.MyAny;
+
+// --- Nullable type aliases ---
+import NullableInt = JS_TESTS.foo.NullableInt;
+import NullableString = JS_TESTS.foo.NullableString;
+import NullableAny = JS_TESTS.foo.NullableAny;
+
+// --- Unsigned type aliases ---
+import MyUByte = JS_TESTS.foo.MyUByte;
+import MyUShort = JS_TESTS.foo.MyUShort;
+import MyUInt = JS_TESTS.foo.MyUInt;
+
+// --- Array type aliases ---
+import MyIntArray = JS_TESTS.foo.MyIntArray;
+import MyBooleanArray = JS_TESTS.foo.MyBooleanArray;
+import MyStringArray = JS_TESTS.foo.MyStringArray;
+import MyNullableIntArray = JS_TESTS.foo.MyNullableIntArray;
+import NestedArray = JS_TESTS.foo.NestedArray;
+
+// --- Class/Interface/Enum/Object type aliases ---
+import AliasSomeClass = JS_TESTS.foo.AliasSomeClass;
+import AliasSomeInterface = JS_TESTS.foo.AliasSomeInterface;
+import AliasSomeExternalInterface = JS_TESTS.foo.AliasSomeExternalInterface;
+import AliasSomeEnum = JS_TESTS.foo.AliasSomeEnum;
+import NullableSomeClass = JS_TESTS.foo.NullableSomeClass;
+
+// --- Generic type aliases (non-generic alias pointing to a concrete generic type) ---
+import ConcreteGenericClass = JS_TESTS.foo.ConcreteGenericClass;
+import ConcreteGenericClassInt = JS_TESTS.foo.ConcreteGenericClassInt;
+import ConcreteTwoGenericParamsClass = JS_TESTS.foo.ConcreteTwoGenericParamsClass;
+
+// --- Generic type aliases (alias with type parameters) ---
+import AliasGenericClass = JS_TESTS.foo.AliasGenericClass;
+import AliasTwoGenericParamsClass = JS_TESTS.foo.AliasTwoGenericParamsClass;
+import FlippedTwoGenericParamsClass = JS_TESTS.foo.FlippedTwoGenericParamsClass;
+import PartiallySpecializedGenericClass = JS_TESTS.foo.PartiallySpecializedGenericClass;
+
+// --- Nullable generic type aliases ---
+import NullableGenericClass = JS_TESTS.foo.NullableGenericClass;
+import GenericClassNullableParam = JS_TESTS.foo.GenericClassNullableParam;
+
+// --- Function type aliases ---
+import SimpleCallback = JS_TESTS.foo.SimpleCallback;
+import IntToString = JS_TESTS.foo.IntToString;
+import BinaryOperation = JS_TESTS.foo.BinaryOperation;
+import GenericTransformer = JS_TESTS.foo.GenericTransformer;
+import NullableCallback = JS_TESTS.foo.NullableCallback;
+import CallbackWithNullableParam = JS_TESTS.foo.CallbackWithNullableParam;
+import HigherOrderFunction = JS_TESTS.foo.HigherOrderFunction;
+import CurriedFunction = JS_TESTS.foo.CurriedFunction;
+import SuspendCallback = JS_TESTS.foo.SuspendCallback;
+import SuspendTransformer = JS_TESTS.foo.SuspendTransformer;
+
+// --- Typealias to typealias ---
+import AliasOfMyInt = JS_TESTS.foo.AliasOfMyInt;
+import AliasOfAliasSomeClass = JS_TESTS.foo.AliasOfAliasSomeClass;
+import AliasOfGenericAlias = JS_TESTS.foo.AliasOfGenericAlias;
+
+// --- Throwable / Nothing / Unit type aliases ---
+import MyThrowable = JS_TESTS.foo.MyThrowable;
+import NullableThrowable = JS_TESTS.foo.NullableThrowable;
+import MyNothing = JS_TESTS.foo.MyNothing;
+import MyUnit = JS_TESTS.foo.MyUnit;
+
+// --- Aliases with variance / inner class ---
+import AliasWithVarianceInAliasedType = JS_TESTS.foo.AliasWithVarianceInAliasedType;
+import AliasWithVarianceInsideOfAliasedType = JS_TESTS.foo.AliasWithVarianceInsideOfAliasedType;
+import AliasWithInnerClass = JS_TESTS.foo.AliasWithInnerClass;
+
+// --- Nested typealiases (inside classes/interfaces/enums, reachable via public namespaces) ---
+import NestedInt = JS_TESTS.foo.ClassWithNestedTypealiases.NestedInt;
+import NestedString = JS_TESTS.foo.ClassWithNestedTypealiases.NestedString;
+import NestedClassAlias = JS_TESTS.foo.ClassWithNestedTypealiases.NestedClassAlias;
+import NestedGenericAlias = JS_TESTS.foo.ClassWithNestedTypealiases.NestedGenericAlias;
+import NestedConcreteGenericAlias = JS_TESTS.foo.ClassWithNestedTypealiases.NestedConcreteGenericAlias;
+import NestedCallback = JS_TESTS.foo.ClassWithNestedTypealiases.NestedCallback;
+import NestedNullable = JS_TESTS.foo.ClassWithNestedTypealiases.NestedNullable;
+import ClassSelf = JS_TESTS.foo.ClassWithNestedTypealiases.Self;
+import GenericNestedGenericAlias = JS_TESTS.foo.GenericClassWithNestedTypealiases.NestedGenericAlias;
+import GenericSelf = JS_TESTS.foo.GenericClassWithNestedTypealiases.Self;
+import InterfaceNestedInt = JS_TESTS.foo.InterfaceWithNestedTypealiases.InterfaceNestedInt;
+import InterfaceNestedClassAlias = JS_TESTS.foo.InterfaceWithNestedTypealiases.InterfaceNestedClassAlias;
+import InterfaceNestedGenericAlias = JS_TESTS.foo.InterfaceWithNestedTypealiases.InterfaceNestedGenericAlias;
+import InterfaceNestedCallback = JS_TESTS.foo.InterfaceWithNestedTypealiases.InterfaceNestedCallback;
+import InterfaceSelf = JS_TESTS.foo.InterfaceWithNestedTypealiases.Self;
+import EnumNestedInt = JS_TESTS.foo.EnumWithNestedTypealiases.EnumNestedInt;
+import EnumNestedClassAlias = JS_TESTS.foo.EnumWithNestedTypealiases.EnumNestedClassAlias;
+import EnumSelf = JS_TESTS.foo.EnumWithNestedTypealiases.Self;
+import OpenClassNestedAlias = JS_TESTS.foo.OpenClassWithNestedTypealiases.OpenClassNestedAlias;
+import AbstractNestedAlias = JS_TESTS.foo.AbstractClassWithNestedTypealiases.AbstractNestedAlias;
+import OuterNestedAlias = JS_TESTS.foo.OuterWithNested.OuterNestedAlias;
+import DeeplyNestedAlias = JS_TESTS.foo.OuterWithNested.InnerNested.DeeplyNestedAlias;
+import DeeplyNestedClassAlias = JS_TESTS.foo.OuterWithNested.InnerNested.DeeplyNestedClassAlias;
+import SealedNestedAlias = JS_TESTS.foo.SealedClassWithNestedTypealiases.SealedNestedAlias;
+import SealedInterfaceNestedAlias = JS_TESTS.foo.SealedInterfaceWithNestedTypealiases.SealedInterfaceNestedAlias;
+import VisibleAlias = JS_TESTS.foo.ClassWithIgnoredNestedTypealias.VisibleAlias;
+
+import ObjectSelf = JS_TESTS.foo.ObjectWithNestedTypealiases.Self;
+import CompanionSelf = JS_TESTS.foo.ClassWithCompanionTypealiases.Companion.Self;
+import NamedCompanionSelf = JS_TESTS.foo.ClassWithNamedCompanionTypealiases.Named.Self;
+
+function assert(condition: boolean) {
+    if (!condition) {
+        throw "Assertion failed";
+    }
+}
+
+function box(): string {
+    // // --- Primitive aliases ---
+    const myInt: MyInt = 42;
+    const myString: MyString = "str";
+    const myBoolean: MyBoolean = true;
+    const myDouble: MyDouble = 3.5;
+    const myByte: MyByte = 1;
+    const myShort: MyShort = 2;
+    const myFloat: MyFloat = 4.5;
+    const myChar: MyChar = 99 as MyChar;
+    const myAny: MyAny = {};
+    assert(myInt === 42);
+    assert(myString === "str");
+    assert(myBoolean === true);
+    assert(myDouble === 3.5);
+    assert(myByte + myShort === 3);
+    assert(myFloat === 4.5);
+    assert(myChar !== null);
+    assert(myAny !== null);
+
+    // --- Nullable aliases ---
+    const nullableInt: NullableInt = null;
+    const nullableString: NullableString = "x";
+    const nullableAny: NullableAny = undefined;
+    assert(nullableInt === null);
+    assert(nullableString === "x");
+    assert(nullableAny === undefined);
+
+    // --- Unsigned aliases ---
+    const uByte: MyUByte = 1 as MyUByte;
+    const uShort: MyUShort = 2 as MyUShort;
+    const uInt: MyUInt = 3 as MyUInt;
+    assert(uByte !== null && uShort !== null && uInt !== null);
+
+    // --- Array aliases ---
+    const intArray: MyIntArray = new Int32Array([1, 2, 3]);
+    const booleanArray: MyBooleanArray = [true, false];
+    const stringArray: MyStringArray = ["a", "b"];
+    const nullableIntArray: MyNullableIntArray = null;
+    const nestedArray: NestedArray = [["a"], ["b", "c"]];
+    assert(intArray.length === 3);
+    assert(booleanArray !== null);
+    assert(stringArray[0] === "a");
+    assert(nullableIntArray === null);
+    assert(nestedArray[1][1] === "c");
+
+    // --- Class / enum aliases ---
+    const aliasSomeClass: AliasSomeClass = new SomeClass("value");
+    assert(aliasSomeClass.value === "value");
+    const nullableSomeClass: NullableSomeClass = null;
+    assert(nullableSomeClass === null);
+    const aliasSomeEnum: AliasSomeEnum = SomeEnum.B;
+    assert(aliasSomeEnum.name === "B");
+    // Interface aliases are used purely in type positions (branded interfaces are not implementable).
+    let aliasSomeInterface: AliasSomeInterface;
+    let aliasSomeExternalInterface: AliasSomeExternalInterface;
+
+    // --- Concrete generic aliases ---
+    const concreteGeneric: ConcreteGenericClass = new GenericClass<string>("g");
+    assert(concreteGeneric.value === "g");
+    const concreteGenericInt: ConcreteGenericClassInt = new GenericClass<number>(7);
+    assert(concreteGenericInt.value === 7);
+    const concreteTwo: ConcreteTwoGenericParamsClass = new TwoGenericParamsClass<string, number>("k", 9);
+    assert(concreteTwo.first === "k" && concreteTwo.second === 9);
+
+    // --- Parameterized generic aliases ---
+    const aliasGeneric: AliasGenericClass<string> = new GenericClass<string>("ag");
+    assert(aliasGeneric.value === "ag");
+    const aliasTwo: AliasTwoGenericParamsClass<string, number> = new TwoGenericParamsClass<string, number>("f", 1);
+    assert(aliasTwo.first === "f" && aliasTwo.second === 1);
+    const flipped: FlippedTwoGenericParamsClass<string, number> = new TwoGenericParamsClass<number, string>(1, "f");
+    assert(flipped.first === 1 && flipped.second === "f");
+    const partial: PartiallySpecializedGenericClass<number> = new TwoGenericParamsClass<string, number>("p", 2);
+    assert(partial.first === "p" && partial.second === 2);
+
+    // --- Nullable generic aliases ---
+    const nullableGeneric: NullableGenericClass<string> = null;
+    assert(nullableGeneric === null);
+    const genericNullableParam: GenericClassNullableParam<string> = new GenericClass<string | null | undefined>(null);
+    assert(genericNullableParam.value === null);
+
+    // --- Function type aliases ---
+    const simpleCallback: SimpleCallback = () => {};
+    simpleCallback();
+    const intToString: IntToString = x => "" + x;
+    assert(intToString(5) === "5");
+    const binaryOperation: BinaryOperation = (a, b) => a + b;
+    assert(binaryOperation(2, 3) === 5);
+    const transformer: GenericTransformer<number, string> = x => "#" + x;
+    assert(transformer(1) === "#1");
+    const nullableCallback: NullableCallback = null;
+    assert(nullableCallback === null);
+    const callbackWithNullableParam: CallbackWithNullableParam = x => (x === null ? null : "" + x);
+    assert(callbackWithNullableParam(null) === null);
+    assert(callbackWithNullableParam(4) === "4");
+    const higherOrder: HigherOrderFunction = f => f(3).length;
+    assert(higherOrder(x => "abc") === 3);
+    const curried: CurriedFunction = a => b => a > 0 && b.length > 0;
+    assert(curried(1)("x") === true);
+    const suspendCallback: SuspendCallback = () => Promise.resolve();
+    assert(suspendCallback() instanceof Promise);
+    const suspendTransformer: SuspendTransformer<number, string> = x => Promise.resolve("" + x);
+    assert(suspendTransformer(1) instanceof Promise);
+
+    // --- Alias-to-alias chains ---
+    const aliasOfMyInt: AliasOfMyInt = 8;
+    assert(aliasOfMyInt === 8);
+    const aliasOfAliasSomeClass: AliasOfAliasSomeClass = new SomeClass("chain");
+    assert(aliasOfAliasSomeClass.value === "chain");
+    const aliasOfGenericAlias: AliasOfGenericAlias<string> = new GenericClass<string>("gg");
+    assert(aliasOfGenericAlias.value === "gg");
+
+    // --- Throwable / Nothing / Unit ---
+    const myThrowable: MyThrowable = new Error("e");
+    assert(myThrowable.message === "e");
+    const nullableThrowable: NullableThrowable = null;
+    assert(nullableThrowable === null);
+    let myNothing: MyNothing; // `never` — type-only usage.
+    const myUnit: MyUnit = undefined;
+    assert(myUnit === undefined);
+
+    // --- Aliases with variance / inner class ---
+    const varianceInAlias: AliasWithVarianceInAliasedType<string> = new GenericClass<string>("v");
+    assert(varianceInAlias.value === "v");
+    const varianceInsideAlias: AliasWithVarianceInsideOfAliasedType<string> = new GenericClass<string>("w") as any;
+    assert(varianceInsideAlias.value === "w");
+    let innerAlias: AliasWithInnerClass<number, string>; // inner-class alias — type-only usage.
+
+    // --- Exported functions/classes that consume aliases ---
+    assert(consumeMyInt(1) === 2);
+    assert(consumeCallback(() => {}) === undefined);
+    assert(consumeCallback(null) === null);
+    assert(consumeGenericAlias(new GenericClass<string>("payload")) === "payload");
+    acceptInnerAlias(undefined as any);
+
+    const classUsingAlias = new ClassUsingAlias(10, "name");
+    assert(classUsingAlias.id === 10);
+    assert(classUsingAlias.name === "name");
+
+    // --- Nested aliases (type-only usages via public namespaces) ---
+    const nestedInt: NestedInt = 1;
+    const nestedString: NestedString = "n";
+    const nestedClassAlias: NestedClassAlias = new SomeClass("nested");
+    const nestedGenericAlias: NestedGenericAlias<string> = new GenericClass<string>("ng");
+    const nestedConcreteGenericAlias: NestedConcreteGenericAlias = new GenericClass<string>("nc");
+    const nestedCallback: NestedCallback = () => {};
+    const nestedNullable: NestedNullable = null;
+    // `Self` aliases point back at their owner; exercise the constructable ones with real values.
+    const classSelf: ClassSelf = new ClassWithNestedTypealiases();
+    const genericSelf: GenericSelf<string> = new GenericClassWithNestedTypealiases<string>();
+    const enumSelf: EnumSelf = EnumWithNestedTypealiases.Z;
+    // Interface `Self` has no runtime constructor; use it in type positions (parameter + return).
+    const identityInterfaceSelf = (self: InterfaceSelf): InterfaceSelf => self;
+    // Object / companion-object `Self` aliases resolve to the singleton's own type (`typeof ...`).
+    const objectSelf: ObjectSelf = ObjectWithNestedTypealiases;
+    const companionSelf: CompanionSelf = ClassWithCompanionTypealiases.Companion;
+    const namedCompanionSelf: NamedCompanionSelf = ClassWithNamedCompanionTypealiases.Named;
+    let genericNestedGeneric: GenericNestedGenericAlias<string, number>;
+    const interfaceNestedInt: InterfaceNestedInt = 2;
+    let interfaceNestedClassAlias: InterfaceNestedClassAlias;
+    let interfaceNestedGenericAlias: InterfaceNestedGenericAlias<string>;
+    let interfaceNestedCallback: InterfaceNestedCallback;
+    const enumNestedInt: EnumNestedInt = 3;
+    let enumNestedClassAlias: EnumNestedClassAlias;
+    const openClassNestedAlias: OpenClassNestedAlias = "open";
+    const abstractNestedAlias: AbstractNestedAlias = 4;
+    const outerNestedAlias: OuterNestedAlias = "outer";
+    const deeplyNestedAlias: DeeplyNestedAlias = 5;
+    let deeplyNestedClassAlias: DeeplyNestedClassAlias;
+    const sealedNestedAlias: SealedNestedAlias = 6;
+    const sealedInterfaceNestedAlias: SealedInterfaceNestedAlias = "sealed";
+    const visibleAlias: VisibleAlias = 7;
+    assert(nestedInt === 1);
+    assert(nestedString === "n");
+    assert(nestedClassAlias.value === "nested");
+    assert(nestedGenericAlias.value === "ng");
+    assert(nestedConcreteGenericAlias.value === "nc");
+    nestedCallback();
+    assert(nestedNullable === null);
+    assert(classSelf instanceof ClassWithNestedTypealiases);
+    assert(genericSelf instanceof GenericClassWithNestedTypealiases);
+    assert(enumSelf.name === "Z");
+    assert(typeof identityInterfaceSelf === "function");
+    assert(objectSelf != null);
+    assert(companionSelf != null);
+    assert(namedCompanionSelf != null);
+    assert(interfaceNestedInt === 2);
+    assert(enumNestedInt === 3);
+    assert(openClassNestedAlias === "open");
+    assert(abstractNestedAlias === 4);
+    assert(outerNestedAlias === "outer");
+    assert(deeplyNestedAlias === 5);
+    assert(sealedNestedAlias === 6);
+    assert(sealedInterfaceNestedAlias === "sealed");
+    assert(visibleAlias === 7);
+
+    return "OK";
+}

--- a/js/typescript-export-model/src/org/jetbrains/kotlin/ir/backend/js/tsexport/ExportModel.kt
+++ b/js/typescript-export-model/src/org/jetbrains/kotlin/ir/backend/js/tsexport/ExportModel.kt
@@ -119,13 +119,23 @@ public data class ExportedPropertySetter(
 // TODO: Cover all cases with frontend and disable error declarations
 public class ErrorDeclaration(public val message: String) : ExportedDeclaration()
 
+public data class ExportedTypeAlias(
+    override val name: String,
+    val typeParameters: List<ExportedTypeParameter>,
+    val aliasedType: ExportedType,
+    val originalClassId: ClassId? = null,
+) : ExportedClassLikeDeclaration()
 
-public sealed class ExportedClass : ExportedDeclaration() {
+
+public sealed class ExportedClassLikeDeclaration : ExportedDeclaration() {
     public abstract val name: String
+}
+
+public sealed class ExportedClass : ExportedClassLikeDeclaration() {
     public abstract val members: List<ExportedDeclaration>
     public abstract val superClasses: List<ExportedType>
     public abstract val superInterfaces: List<ExportedType>
-    public abstract val nestedClasses: List<ExportedClass>
+    public abstract val nestedClasses: List<ExportedClassLikeDeclaration>
     public abstract val originalClassId: ClassId?
     public abstract val isCompanion: Boolean
     public abstract val isExternal: Boolean
@@ -140,7 +150,7 @@ public data class ExportedRegularClass(
     override val superInterfaces: List<ExportedType> = emptyList(),
     val typeParameters: List<ExportedTypeParameter>,
     override val members: List<ExportedDeclaration>,
-    override val nestedClasses: List<ExportedClass>,
+    override val nestedClasses: List<ExportedClassLikeDeclaration>,
     override val originalClassId: ClassId?,
     override val isExternal: Boolean,
 ) : ExportedClass() {
@@ -153,7 +163,7 @@ public data class ExportedObject(
     override val superClasses: List<ExportedType> = emptyList(),
     override val superInterfaces: List<ExportedType> = emptyList(),
     override val members: List<ExportedDeclaration>,
-    override val nestedClasses: List<ExportedClass>,
+    override val nestedClasses: List<ExportedClassLikeDeclaration>,
     val typeParameters: List<ExportedTypeParameter> = emptyList(),
     override val originalClassId: ClassId?,
     override val isExternal: Boolean,

--- a/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/ExportModelGenerator.kt
+++ b/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/ExportModelGenerator.kt
@@ -19,11 +19,15 @@ import org.jetbrains.kotlin.analysis.api.scopes.staticDeclaredMemberScope
 import org.jetbrains.kotlin.analysis.api.klib.reader.KaModules
 import org.jetbrains.kotlin.analysis.api.klib.reader.getAllDeclarations
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibraryModule
+import org.jetbrains.kotlin.analysis.api.components.buildSubstitutor
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.klibSourceFileName
+import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.analysis.api.types.KaTypeParameterType
 import org.jetbrains.kotlin.analysis.api.types.defaultType
 import org.jetbrains.kotlin.analysis.api.types.expandedSymbol
+import org.jetbrains.kotlin.analysis.api.types.fullyExpandedType
 import org.jetbrains.kotlin.analysis.api.types.isAnyType
 import org.jetbrains.kotlin.analysis.api.types.isNullable
 import org.jetbrains.kotlin.builtins.StandardNames
@@ -37,6 +41,7 @@ import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.resolve.DataClassResolver
 import org.jetbrains.kotlin.utils.*
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
+import org.jetbrains.kotlin.utils.addToStdlib.takeIfNotEmpty
 
 public const val EXTENSION_RECEIVER_NAME: String = "_this_"
 
@@ -113,7 +118,7 @@ internal class ExportModelGenerator(private val config: TypeScriptExportConfig) 
             is KaNamedFunctionSymbol -> listOfNotNull(exportFunction(declaration, parent = null, classTypeParameterScope = emptyMap()))
             is KaPropertySymbol -> exportProperty(declaration, parent = null, classTypeParameterScope = emptyMap())
             is KaNamedClassSymbol -> listOfNotNull(exportClass(declaration, parent = null, outerClassTypeParameterScope = emptyMap()))
-            is KaTypeAliasSymbol -> listOf(ErrorDeclaration("Type alias declarations are not implemented yet"))
+            is KaTypeAliasSymbol -> listOf(exportTypeAlias(declaration))
             else -> return null
         }
 
@@ -194,6 +199,82 @@ internal class ExportModelGenerator(private val config: TypeScriptExportConfig) 
                 isExternal = klass.isExternal,
             )
         }.withAttributes(klass)
+    }
+
+    context(_: KaSession)
+    private fun exportTypeAlias(typeAlias: KaTypeAliasSymbol): ExportedTypeAlias {
+        // Kotlin type aliases cannot declare bounds on their own type parameters, but the aliased type may use them in positions that
+        // carry constraints (e.g. `typealias Foo<T> = X<T>` where `class X<T : Number>`). Inherit those constraints so the generated
+        // TypeScript type alias is valid.
+        val inheritedBounds = collectInheritedTypeParameterBounds(typeAlias)
+        val typeParameterScope = TypeParameterScope(
+            container = typeAlias,
+            config = config,
+            transitivelyExportedClasses = pendingTransitivelyExportedClasses,
+            superTypeApproximator = superTypeApproximator,
+            inheritedBounds = inheritedBounds,
+        )
+        return ExportedTypeAlias(
+            name = typeAlias.getExportedIdentifier(),
+            typeParameters = typeParameterScope.values.toList(),
+            aliasedType = exportType(typeAlias.expandedType, typeParameterScope),
+            originalClassId = typeAlias.classId,
+        ).withAttributes(typeAlias)
+    }
+
+    /**
+     * Computes the upper bounds each of [typeAlias]'s own type parameters must inherit from the positions where it is used.
+     *
+     * Since a Kotlin type alias cannot declare bounds itself, but its TypeScript counterpart must, we look at the *fully expanded* aliased
+     * type (so that constraints are inherited even through alias-to-alias chains) and, for every position where one of the alias's type
+     * parameters is used directly as a type argument of a class, collect that class type parameter's upper bounds.
+     *
+     * The bounds are rewritten via a substitutor mapping the used class's type parameters to the actual type arguments at that position, so
+     * that F-bounds like `class X<T : Comparable<T>>` correctly become `Comparable<T>` in terms of the alias's parameter.
+     */
+    context(_: KaSession)
+    private fun collectInheritedTypeParameterBounds(typeAlias: KaTypeAliasSymbol): Map<KaTypeParameterSymbol, List<KaType>> {
+        val aliasParameters = typeAlias.typeParameters.takeIfNotEmpty()?.toHashSet()
+            ?: return emptyMap()
+
+        // Guard against self-referential types (e.g. a type parameter whose bound references itself).
+        val visited = hashSetOf<KaType>()
+        val result = hashMapOf<KaTypeParameterSymbol, MutableList<KaType>>()
+
+        fun visit(type: KaType) {
+            if (type !is KaClassType || !visited.add(type)) return
+
+            // Collect (class type parameter -> actual type argument) pairs across all qualifier segments (to also cover inner classes),
+            // and build a substitutor from them so that inherited bounds are expressed in terms of the alias's type parameters.
+            val positions = mutableListOf<Pair<KaTypeParameterSymbol, KaType>>()
+            val substitutor = buildSubstitutor {
+                for (qualifier in type.qualifiers) {
+                    val classTypeParameters = qualifier.symbol.typeParameters
+                    for ([index, classTypeParameter] in classTypeParameters.withIndex()) {
+                        val argument = qualifier.typeArguments.getOrNull(index)?.type ?: continue
+                        substitution(classTypeParameter, argument)
+                        positions += classTypeParameter to argument
+                    }
+                }
+            }
+
+            for ([classTypeParameter, argument] in positions) {
+                if (argument is KaTypeParameterType && argument.symbol in aliasParameters) {
+                    val bounds = classTypeParameter.upperBounds.map(substitutor::substitute).takeIfNotEmpty() ?: continue
+
+                    val existingBounds = result.getOrPut(argument.symbol, ::mutableListOf)
+
+                    existingBounds += bounds
+                }
+
+                visit(argument)
+            }
+        }
+
+        // fullyExpandedType is used for skipping an alias-alias chain
+        visit(typeAlias.expandedType.fullyExpandedType)
+
+        return result
     }
 
     context(_: KaSession)
@@ -633,7 +714,7 @@ internal class ExportModelGenerator(private val config: TypeScriptExportConfig) 
         typeParameterScope: TypeParameterScope,
     ): ExportedClassDeclarationsInfo {
         val members = mutableListOf<ExportedDeclaration>()
-        val nestedClasses = mutableListOf<ExportedClass>()
+        val nestedClasses = mutableListOf<ExportedClassLikeDeclaration>()
         val defaultImplementations = mutableListOf<ExportedDeclaration>()
         val isCompanionObject = klass.classKind == KaClassKind.COMPANION_OBJECT
 
@@ -764,8 +845,7 @@ internal class ExportModelGenerator(private val config: TypeScriptExportConfig) 
                 }
                 is KaTypeAliasSymbol -> {
                     if (!nested.isEffectivelyExported(config, includingImplicitExport = true)) continue
-                    // TODO(KT-49795): Export type aliases
-                    continue
+                    nestedClasses.add(exportTypeAlias(nested))
                 }
                 else -> continue
             }
@@ -921,7 +1001,7 @@ internal class ExportModelGenerator(private val config: TypeScriptExportConfig) 
 
     private data class ExportedClassDeclarationsInfo(
         val members: List<ExportedDeclaration>,
-        val nestedClasses: List<ExportedClass>,
+        val nestedClasses: List<ExportedClassLikeDeclaration>,
     )
 
     private fun KaNamedClassSymbol.shouldContainImplementableSymbolProperty(hasNotExportedAbstractMember: Boolean): Boolean =

--- a/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeExporter.kt
+++ b/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeExporter.kt
@@ -44,6 +44,18 @@ internal class TypeExporter(
 
     context(_: KaSession)
     internal fun exportType(type: KaType, inlineClassesShouldBeUnboxed: Boolean = false): ExportedType {
+        val abbreviation = type.abbreviation
+        val typeToProcess = when (val symbol = abbreviation?.symbol) {
+            is KaTypeAliasSymbol if symbol.isEffectivelyExported(config) -> abbreviation
+            else -> type
+        }
+
+        return exportTypeOrAlias(typeToProcess, inlineClassesShouldBeUnboxed)
+    }
+
+
+    context(_: KaSession)
+    private fun exportTypeOrAlias(type: KaType, inlineClassesShouldBeUnboxed: Boolean): ExportedType {
         if (type is KaDynamicType || type in currentlyProcessedTypes)
             return Primitive.Any
 
@@ -202,8 +214,16 @@ internal class TypeExporter(
                 }.withImplicitlyExported(isImplicitlyExported, exportedSupertype)
             }
             is KaTypeAliasSymbol -> {
-                // TODO(KT-49795): Don't expand, export as a type alias reference instead.
-                exportType(type.fullyExpandedType)
+                if (isExported) {
+                    ClassType(
+                        name = symbol.getExportedFqName(shouldIncludePackage = config.generateNamespacesForPackages, config),
+                        arguments = exportAllTypeArguments(type),
+                        classId = symbol.classId,
+                    )
+                } else {
+                    // Non-exported aliases (e.g. @JsExport.Ignore, private) keep being expanded to their underlying type.
+                    exportType(type.fullyExpandedType)
+                }
             }
             is KaAnonymousObjectSymbol -> ErrorType("Anonymous objects are not supported")
         }

--- a/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeParameterScope.kt
+++ b/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeParameterScope.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaTypeParameterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KaNamedSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.typeParameters
+import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.ir.backend.js.tsexport.ExportedType
 import org.jetbrains.kotlin.ir.backend.js.tsexport.ExportedType.Primitive
 import org.jetbrains.kotlin.ir.backend.js.tsexport.ExportedTypeParameter
@@ -63,6 +64,7 @@ internal fun TypeParameterScope(
     superTypeApproximator: SuperTypeApproximator,
     outerScope: TypeParameterScope = emptyMap(),
     renameOuterTypeParameters: Boolean = false,
+    inheritedBounds: Map<KaTypeParameterSymbol, List<KaType>> = emptyMap(),
 ): TypeParameterScope {
     val newTypeParameters = container.typeParameters
     if (!renameOuterTypeParameters && newTypeParameters.isEmpty()) return outerScope
@@ -101,7 +103,7 @@ internal fun TypeParameterScope(
                 break
             }
             i += 1
-            val constraints = tp.upperBounds
+            val constraints = (tp.upperBounds + inheritedBounds[tp].orEmpty())
                 .mapNotNull {
                     val exportedType = TypeExporter(config, this, transitivelyExportedClasses, superTypeApproximator).exportType(it)
                     if (exportedType is ExportedType.ErrorType) return@mapNotNull null

--- a/js/typescript-printer/src/org/jetbrains/kotlin/ir/backend/js/tsexport/ExportModelToTsDeclarations.kt
+++ b/js/typescript-printer/src/org/jetbrains/kotlin/ir/backend/js/tsexport/ExportModelToTsDeclarations.kt
@@ -96,6 +96,7 @@ public class ExportModelToTsDeclarations(private val moduleKind: ModuleKind) {
     private fun ExportedDeclaration.toTypeScript(indent: String, prefix: String = ""): String =
         attributes.toTypeScript(indent) + indent + when (this) {
             is ErrorDeclaration -> generateTypeScriptString()
+            is ExportedTypeAlias -> generateTypeScriptString(indent, prefix)
             is ExportedConstructor -> generateTypeScriptString(indent)
             is ExportedConstructSignature -> generateTypeScriptString(indent)
             is ExportedNamespace -> generateTypeScriptString(indent, prefix)
@@ -371,6 +372,11 @@ public class ExportModelToTsDeclarations(private val moduleKind: ModuleKind) {
         val objectMetadata = ExportedNamespace(name, listOf(generateMetadataNamespace(metadataMembers))).toTypeScript(indent, prefix)
 
         return "$objectClass\n$objectMetadata${generateDefaultExportIfNeed(name, indent)}"
+    }
+
+    private fun ExportedTypeAlias.generateTypeScriptString(indent: String, prefix: String): String {
+        val renderedTypeParameters = renderTypeParameters(typeParameters, includeVariance = true)
+        return "${prefix}type $name$renderedTypeParameters = ${aliasedType.toTypeScript(indent)};"
     }
 
     private fun ExportedRegularClass.generateTypeScriptString(indent: String, prefix: String): String {

--- a/libraries/stdlib/common/src/kotlin/JsAnnotationsH.kt
+++ b/libraries/stdlib/common/src/kotlin/JsAnnotationsH.kt
@@ -95,21 +95,18 @@ public annotation class ExperimentalJsStatic
  *
  * It is currently prohibited to export the following kinds of declarations:
  *
- *   * `expect` declarations
  *   * inline functions with reified type parameters
- *   * suspend functions
  *   * secondary constructors without `@JsName`
  *   * extension properties
- *   * enum classes
- *   * annotation classes
  *
  * Signatures of exported declarations must only contain "exportable" types:
  *
- *   * `dynamic`, `Any`, `String`, `Boolean`, `Byte`, `Short`, `Int`, `Float`, `Double`
- *   * `BooleanArray`, `ByteArray`, `ShortArray`, `IntArray`, `FloatArray`, `DoubleArray`
- *   * `Array<exportable-type>`
+ *   * `dynamic`, `Any`, `String`, `Boolean`, `Byte`, `Short`, `Int`, `Float`, `Double`, `Long`
+ *   * `BooleanArray`, `ByteArray`, `ShortArray`, `IntArray`, `FloatArray`, `DoubleArray`, `LongArray`
+ *   * `Array<exportable-type>`,
+ *   * `(Mutable)List<exportable-type>`, `(Mutable)Map<exportable-type, exportable-type>`, `(Mutable)Set<exportable-type>`
  *   * Function types with exportable parameters and return types
- *   * `external` or `@JsExport` classes and interfaces
+ *   * `external` or `@JsExport` classes, objects, enums, interfaces
  *   * Nullable counterparts of types above
  *   * Unit return type. Must not be nullable
  *
@@ -117,7 +114,7 @@ public annotation class ExperimentalJsStatic
  */
 @ExperimentalJsExport
 @Retention(AnnotationRetention.BINARY)
-@Target(CLASS, PROPERTY, FUNCTION, FILE)
+@Target(CLASS, PROPERTY, FUNCTION, FILE, TYPEALIAS)
 @SinceKotlin("1.4")
 @OptionalExpectation
 public expect annotation class JsExport() {
@@ -127,7 +124,7 @@ public expect annotation class JsExport() {
      */
     @ExperimentalJsExport
     @Retention(AnnotationRetention.BINARY)
-    @Target(CLASS, PROPERTY, FUNCTION, CONSTRUCTOR)
+    @Target(CLASS, PROPERTY, FUNCTION, CONSTRUCTOR, TYPEALIAS)
     @SinceKotlin("1.8")
     @OptionalExpectation
     public annotation class Ignore()

--- a/libraries/stdlib/js/src/kotlin/annotationsJs.kt
+++ b/libraries/stdlib/js/src/kotlin/annotationsJs.kt
@@ -208,19 +208,16 @@ public actual annotation class JsQualifier(actual val value: String)
  *
  * It is currently prohibited to export the following kinds of declarations:
  *
- *   * `expect` declarations
  *   * inline functions with reified type parameters
- *   * suspend functions
  *   * secondary constructors without `@JsName`
  *   * extension properties
- *   * enum classes
- *   * annotation classes
  *
  * Signatures of exported declarations must only contain "exportable" types:
  *
- *   * `dynamic`, `Any`, `String`, `Boolean`, `Byte`, `Short`, `Int`, `Float`, `Double`
- *   * `BooleanArray`, `ByteArray`, `ShortArray`, `IntArray`, `FloatArray`, `DoubleArray`
- *   * `Array<exportable-type>`
+ *   * `dynamic`, `Any`, `String`, `Boolean`, `Byte`, `Short`, `Int`, `Float`, `Double`, `Long`
+ *   * `BooleanArray`, `ByteArray`, `ShortArray`, `IntArray`, `FloatArray`, `DoubleArray`, `LongArray`
+ *   * `Array<exportable-type>`,
+ *   * `(Mutable)List<exportable-type>`, `(Mutable)Map<exportable-type, exportable-type>`, `(Mutable)Set<exportable-type>`
  *   * Function types with exportable parameters and return types
  *   * `external` or `@JsExport` classes and interfaces
  *   * Nullable counterparts of types above
@@ -230,7 +227,7 @@ public actual annotation class JsQualifier(actual val value: String)
  */
 @ExperimentalJsExport
 @Retention(AnnotationRetention.BINARY)
-@Target(CLASS, PROPERTY, FUNCTION, FILE)
+@Target(CLASS, PROPERTY, FUNCTION, FILE, TYPEALIAS)
 @SinceKotlin("1.3")
 public actual annotation class JsExport {
     /**
@@ -239,7 +236,7 @@ public actual annotation class JsExport {
      */
     @ExperimentalJsExport
     @Retention(AnnotationRetention.BINARY)
-    @Target(CLASS, PROPERTY, FUNCTION, CONSTRUCTOR)
+    @Target(CLASS, PROPERTY, FUNCTION, CONSTRUCTOR, TYPEALIAS)
     @SinceKotlin("1.8")
     public actual annotation class Ignore
 


### PR DESCRIPTION
When a typealias is annotated with @JsExport, it is now properly included in the generated TypeScript declaration (.d.ts) files as.

^KT-49795 Fixed