### PR TITLE
[JVM] Fix NPE in JvmInlineClassLowering for == on generic value class…

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
@@ -382,6 +382,11 @@ internal class JvmInlineClassLowering(private val context: JvmBackendContext) : 
         if (!leftIsUnboxed && !rightIsUnboxed)
             return null
 
+        // If the left operand's type is a type parameter (e.g., the value of a generic value class
+        // after field-getter lowering erases the concrete type to T), we cannot specialize.
+        if (left.type.classOrNull == null)
+            return null
+
         // Precondition: left is an unboxed inline class type
         fun equals(left: IrExpression, right: IrExpression): IrExpression {
             // Unsigned types use primitive comparisons

--- a/compiler/testData/codegen/box/inlineClasses/equalityGenericValueClassWrappingValueClass.kt
+++ b/compiler/testData/codegen/box/inlineClasses/equalityGenericValueClassWrappingValueClass.kt
@@ -1,0 +1,26 @@
+// WITH_STDLIB
+// WORKS_WHEN_VALUE_CLASS
+
+OPTIONAL_JVM_INLINE_ANNOTATION
+value class IntValue(val value: Int)
+
+OPTIONAL_JVM_INLINE_ANNOTATION
+value class Wrapper<T>(val value: T)
+
+fun boom(w1: Wrapper<IntValue>): Boolean = w1.value == IntValue(1)
+fun boomNeq(w1: Wrapper<IntValue>): Boolean = w1.value != IntValue(1)
+fun boomExplicit(w1: Wrapper<IntValue>): Boolean = w1.value.equals(IntValue(1))
+
+fun box(): String {
+    val w = Wrapper(IntValue(1))
+    val wOther = Wrapper(IntValue(2))
+
+    if (!boom(w)) return "Fail 1"
+    if (boom(wOther)) return "Fail 2"
+    if (boomNeq(w)) return "Fail 3"
+    if (!boomNeq(wOther)) return "Fail 4"
+    if (!boomExplicit(w)) return "Fail 5"
+    if (boomExplicit(wOther)) return "Fail 6"
+
+    return "OK"
+}


### PR DESCRIPTION
… field

After child transformation, the field getter of a generic value class erases the concrete type to type parameter T, causing `classOrNull!!` to NPE in `specializeEqualsCall`. Bail out when `left.type.classOrNull` is null, falling back to standard equals.

^KT-87327 Fixed