### PR TITLE
[Klib] Rework serialization logic for `IrTypeAlias`

### DIFF
--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/BasicIrModuleDeserializer.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/BasicIrModuleDeserializer.kt
@@ -29,6 +29,9 @@ import org.jetbrains.kotlin.backend.common.serialization.proto.IrFile as ProtoFi
  * @property allowErrorNodes Whether error nodes are allowed during IR deserialization and initialization.
  *   Caution: This setting is not safe to use, as it can lead to crashes in the frontend or backend.
  *   The only legal case for using this setting is the `dump-ir` command of the `klib` command-line tool.
+ * @property deserializeTypeAliases Whether to deserialize [org.jetbrains.kotlin.ir.declarations.IrTypeAlias] declarations.
+ *   Type aliases don't need to be (de)serialized anymore. See KT-86632.
+ *   The only case for enabling it is the klib tool and its ability to dump (even older) KLIBs.
  */
 abstract class BasicIrModuleDeserializer(
     val linker: KotlinIrLinker,
@@ -37,6 +40,7 @@ abstract class BasicIrModuleDeserializer(
     override val strategyResolver: (String) -> DeserializationStrategy,
     libraryAbiVersion: KotlinAbiVersion,
     private val allowErrorNodes: Boolean = false,
+    private val deserializeTypeAliases: Boolean = false,
 ) : IrModuleDeserializer(moduleDescriptor, libraryAbiVersion) {
 
     private val fileToDeserializerMap = mutableMapOf<IrFile, IrFileDeserializer>()
@@ -68,7 +72,15 @@ abstract class BasicIrModuleDeserializer(
                 val file = fileReader.createFile(moduleFragment, fileProto, linker.fileEntryDeserializer)
 
                 _definedPackageNames += file.packageFqName
-                this += deserializeIrFile(fileProto, file, fileReader, i, this@BasicIrModuleDeserializer, allowErrorNodes)
+                this += deserializeIrFile(
+                    fileProto,
+                    file,
+                    fileReader,
+                    i,
+                    this@BasicIrModuleDeserializer,
+                    allowErrorNodes,
+                    deserializeTypeAliases
+                )
 
                 if (!strategyResolver(file.fileEntry.name).onDemand)
                     moduleFragment.files.add(file)
@@ -103,7 +115,7 @@ abstract class BasicIrModuleDeserializer(
 
     private fun deserializeIrFile(
         fileProto: ProtoFile, file: IrFile, fileReader: IrLibraryFileFromBytes,
-        fileIndex: Int, moduleDeserializer: IrModuleDeserializer, allowErrorNodes: Boolean,
+        fileIndex: Int, moduleDeserializer: IrModuleDeserializer, allowErrorNodes: Boolean, deserializeTypeAliases: Boolean,
     ): FileDeserializationState {
         val fileStrategy = strategyResolver(file.fileEntry.name)
 
@@ -121,6 +133,7 @@ abstract class BasicIrModuleDeserializer(
                     else -> DeserializeFunctionBodies.NONE
                 },
                 fixSwappedKProperty2TypeParameterOrder = moduleDeserializer.compatibilityMode.swappedKProperty2TypeParameterOrder,
+                deserializeTypeAliases = deserializeTypeAliases,
             ),
             moduleDeserializer,
         )

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrDeclarationDeserializer.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrDeclarationDeserializer.kt
@@ -383,6 +383,7 @@ class IrDeclarationDeserializer(
                     val oldDeclarations = declarations.toSet()
                     proto.declarationList
                         .asSequence()
+                        .filterNot { !settings.deserializeTypeAliases && it.declaratorCase == IR_TYPE_ALIAS }
                         .filterNot { isSkippedFakeOverride(it, this) }
                         // On JVM, deserialization may fill bodies of existing declarations, so avoid adding duplicates.
                         .mapNotNullTo(declarations) { declProto -> deserializeDeclaration(declProto, startOffset).takeIf { it !in oldDeclarations } }
@@ -415,6 +416,8 @@ class IrDeclarationDeserializer(
         val ctor = irClass.primaryConstructor ?: error("Full value class has no primary constructor: ${irClass.render()}")
         return FullValueClassRepresentation(ctor.parameters.map { it.name to it.type as IrSimpleType })
     }
+
+    internal val deserializeTypeAliases: Boolean get() = settings.deserializeTypeAliases
 
     private fun deserializeIrTypeAlias(proto: ProtoTypeAlias, parentStart: Int?): IrTypeAlias =
         withDeserializedIrDeclarationBase(proto.base, parentStart, setParent = false) { symbol, uniqId, startOffset, endOffset, origin, fcode ->

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrDeserializationSettings.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrDeserializationSettings.kt
@@ -30,6 +30,9 @@ import org.jetbrains.kotlin.ir.types.IrType
  * @property fixSwappedKProperty2TypeParameterOrder If `true`, the type parameter order of `KProperty2`/`KMutableProperty2`
  *   in deserialized property references is swapped to compensate for the legacy order that was used in KLIBs
  *   compiled with Kotlin <= 2.1 (ABI version <= 1.201.0). See KT-75112, KT-86180.
+ * @property deserializeTypeAliases Whether to deserialize [org.jetbrains.kotlin.ir.declarations.IrTypeAlias] declarations.
+ *   Type aliases don't need to be (de)serialized anymore. See KT-86632.
+ *   The only case for enabling it is the klib tool and its ability to dump (even older) KLIBs.
  */
 class IrDeserializationSettings(
     val allowErrorNodes: Boolean = false,
@@ -37,6 +40,7 @@ class IrDeserializationSettings(
     val deserializeFunctionBodies: DeserializeFunctionBodies = DeserializeFunctionBodies.ALL,
     val nullableAnyAsAnnotationConstructorCallType: IrType? = null,
     val fixSwappedKProperty2TypeParameterOrder: Boolean = false,
+    val deserializeTypeAliases: Boolean = false,
 ) {
     enum class DeserializeFunctionBodies { ALL, ONLY_INLINE, NONE }
 }

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrFileDeserializer.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrFileDeserializer.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.descriptors.impl.EmptyPackageFragmentDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
-import org.jetbrains.kotlin.ir.declarations.IrTypeAlias
 import org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrFileSymbolImpl
 import org.jetbrains.kotlin.ir.types.defaultTypeWithoutArguments
@@ -39,7 +38,7 @@ abstract class IrFileDeserializer {
     abstract val declarationDeserializer: IrDeclarationDeserializer
     abstract val reversedSignatureIndex: Map<IdSignature, Int>
 
-    abstract fun deserializeDeclaration(idSig: IdSignature): IrDeclaration
+    abstract fun deserializeDeclaration(idSig: IdSignature): IrDeclaration?
 
     /**
      * Deserializes file-level annotations for the current [IrFile].
@@ -75,11 +74,11 @@ class IrFileDeserializerImpl(
     /** Once deserialized this property is set to `null`. */
     private var protoAnnotationsPendingDeserialization: List<ProtoAnnotation>? = fileProto.annotationList
 
-    override fun deserializeDeclaration(idSig: IdSignature): IrDeclaration {
-        return declarationDeserializer.deserializeDeclaration(loadTopLevelDeclarationProto(idSig), file.startOffset).also {
-            // Type alias can be accidentally deserialized twice. We shouldn't add it into the declaration list for the second time.
-            // It would be better to avoid type alias deserialization all together, but we don't know that until we parse proto.
-            if (it is IrTypeAlias && file.declarations.contains(it)) return@also
+    override fun deserializeDeclaration(idSig: IdSignature): IrDeclaration? {
+        val proto = loadTopLevelDeclarationProto(idSig)
+        if (!declarationDeserializer.deserializeTypeAliases && proto.declaratorCase == ProtoDeclaration.DeclaratorCase.IR_TYPE_ALIAS)
+            return null
+        return declarationDeserializer.deserializeDeclaration(proto, file.startOffset).also {
             file.declarations += it
         }
     }
@@ -237,10 +236,10 @@ class FileDeserializationStateImpl(
             val topLevelDeclarationSymbol = symbolDeserializer.deserializedSymbolsWithOwnersInCurrentFile[topLevelDeclarationSignature]
             if (topLevelDeclarationSymbol == null || !topLevelDeclarationSymbol.isBound) {
                 // Perform actual deserialization:
-                val topLevelDeclaration = fileDeserializer.deserializeDeclaration(topLevelDeclarationSignature)
-
-                // Enqueue the deserialized declaration to the PL engine for further processing.
-                linker.partialLinkageSupport.enqueueDeclaration(topLevelDeclaration)
+                fileDeserializer.deserializeDeclaration(topLevelDeclarationSignature)?.let {
+                    // Enqueue the deserialized declaration to the PL engine for further processing.
+                    linker.partialLinkageSupport.enqueueDeclaration(it)
+                }
             }
 
             // Remove it from the queue:

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrFileSerializer.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/IrFileSerializer.kt
@@ -99,7 +99,6 @@ import org.jetbrains.kotlin.backend.common.serialization.proto.IrSyntheticBodyKi
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrThrow as ProtoThrow
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrTry as ProtoTry
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrType as ProtoType
-import org.jetbrains.kotlin.backend.common.serialization.proto.IrTypeAlias as ProtoTypeAlias
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrTypeOp as ProtoTypeOp
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrTypeOperator as ProtoTypeOperator
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrTypeParameter as ProtoTypeParameter
@@ -1520,19 +1519,6 @@ open class IrFileSerializer(
             underlyingPropertyType = serializeIrType(representation.underlyingType)
         }.build()
 
-    private fun serializeIrTypeAlias(typeAlias: IrTypeAlias, parent: IrElement?): ProtoTypeAlias {
-        val proto = ProtoTypeAlias.newBuilder()
-
-        proto.setBase(serializeIrDeclarationBase(typeAlias, parent, TypeAliasFlags.encode(typeAlias))).nameType =
-            serializeNameAndType(typeAlias.name, typeAlias.expandedType)
-
-        typeAlias.typeParameters.forEach {
-            proto.addTypeParameter(serializeIrTypeParameter(it, typeAlias))
-        }
-
-        return proto.build()
-    }
-
     private fun serializeIrEnumEntry(enumEntry: IrEnumEntry, parent: IrElement?): ProtoEnumEntry {
         val proto = ProtoEnumEntry.newBuilder()
             .setBase(serializeIrDeclarationBase(enumEntry, parent, null))
@@ -1573,10 +1559,8 @@ open class IrFileSerializer(
                 proto.irProperty = serializeIrProperty(declaration, parent)
             is IrLocalDelegatedProperty ->
                 proto.irLocalDelegatedProperty = serializeIrLocalDelegatedProperty(declaration, parent)
-            is IrTypeAlias ->
-                proto.irTypeAlias = serializeIrTypeAlias(declaration, parent)
             else ->
-                TODO("Declaration serialization not supported yet: $declaration")
+                error("Serialization of ${declaration::class.java} is not supported: $declaration")
         }
 
         return proto.build()
@@ -1654,12 +1638,13 @@ open class IrFileSerializer(
         settings.publicAbiOnly
                 && !isInsideInline
                 && (declaration as? IrDeclarationWithVisibility)?.let { !it.visibility.isPublicAPI && it.visibility != INTERNAL } == true
-                // Always keep private interfaces and type aliases as they can be part of public type hierarchies.
-                && (declaration as? IrClass)?.isInterface != true && declaration !is IrTypeAlias
+                // Always keep private interfaces as they can be part of public type hierarchies.
+                && (declaration as? IrClass)?.isInterface != true
 
     open fun memberNeedsSerialization(member: IrDeclaration): Boolean {
         val parent = member.parent
         require(parent is IrClass)
+        if (member is IrTypeAlias) return false
         if (backendSpecificSerializeAllMembers(parent)) return true
         if (settings.bodiesOnlyForInlines && member is IrAnonymousInitializer && parent.visibility != DescriptorVisibilities.LOCAL)
             return false
@@ -1674,6 +1659,7 @@ open class IrFileSerializer(
 
         if (backendSpecificExplicitRoot(file)) {
             for (declaration in file.declarations) {
+                if (declaration is IrTypeAlias) continue
                 if (backendSpecificExplicitRootExclusion(declaration)) continue
                 proto.addExplicitlyExportedToCompiler(serializeIrSymbol(declaration.symbol))
             }
@@ -1727,6 +1713,10 @@ open class IrFileSerializer(
             .addAllAnnotation(serializeAnnotations(file.annotations, file))
 
         file.declarations.forEach {
+            if (it is IrTypeAlias) {
+                // KT-86632: Type aliases are not serialized into klibs.
+                return@forEach
+            }
             if (skipIfPrivate(it)) {
                 // Skip the declaration if producing header klib and the declaration is not public.
                 return@forEach

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/encodings/BinaryFlags.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/encodings/BinaryFlags.kt
@@ -187,13 +187,6 @@ value class TypeAliasFlags(val flags: Long) {
     val isActual: Boolean get() = IrFlags.IS_ACTUAL.get(flags.toInt())
 
     companion object {
-        fun encode(typeAlias: IrTypeAlias): Long {
-            return typeAlias.run {
-                val visibility = ProtoEnumFlags.visibility(visibility.normalize().delegate)
-                IrFlags.getTypeAliasFlags(annotations.isNotEmpty(), visibility, isActual).toLong()
-            }
-        }
-
         fun decode(code: Long) = TypeAliasFlags(code)
     }
 }

--- a/compiler/testData/codegen/box/typealias/typeAliasUsedAcrossModules.ir.txt
+++ b/compiler/testData/codegen/box/typealias/typeAliasUsedAcrossModules.ir.txt
@@ -1,0 +1,30 @@
+Module: a
+FILE fqName:a fileName:/a.kt
+  TYPEALIAS name:A visibility:public expandedType:kotlin.String
+Module: b
+FILE fqName:b fileName:/b.kt
+  FUN name:foo visibility:public modality:FINAL returnType:kotlin.String
+    VALUE_PARAMETER kind:Regular name:a index:0 type:kotlin.String
+    VALUE_PARAMETER kind:Regular name:f index:1 type:kotlin.Function1<kotlin.String, kotlin.String>
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun foo (a: kotlin.String, f: kotlin.Function1<kotlin.String, kotlin.String>): kotlin.String declared in b'
+        CALL 'public abstract fun invoke (p1: P1 of kotlin.Function1): R of kotlin.Function1 declared in kotlin.Function1' type=kotlin.String origin=INVOKE
+          ARG <this>: GET_VAR 'f: kotlin.Function1<kotlin.String, kotlin.String> declared in b.foo' type=kotlin.Function1<kotlin.String, kotlin.String> origin=VARIABLE_AS_FUNCTION
+          ARG p1: GET_VAR 'a: kotlin.String declared in b.foo' type=kotlin.String origin=null
+Module: main
+FILE fqName:<root> fileName:/main.kt
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:x type:kotlin.String [val]
+        CONST String type=kotlin.String value="OK"
+      VAR name:res type:kotlin.String [val]
+        CALL 'public final fun foo (a: kotlin.String, f: kotlin.Function1<kotlin.String, kotlin.String>): kotlin.String declared in b' type=kotlin.String origin=null
+          ARG a: GET_VAR 'val x: kotlin.String declared in <root>.box' type=kotlin.String origin=null
+          ARG f: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.String> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String
+              VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: kotlin.String): kotlin.String declared in <root>.box'
+                  GET_VAR 'it: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        GET_VAR 'val res: kotlin.String declared in <root>.box' type=kotlin.String origin=null

--- a/compiler/testData/codegen/box/typealias/typeAliasUsedAcrossModules.kt
+++ b/compiler/testData/codegen/box/typealias/typeAliasUsedAcrossModules.kt
@@ -1,0 +1,25 @@
+// DUMP_IR
+// MODULE: a
+// FILE: a.kt
+package a
+
+typealias A = String
+
+// MODULE: b(a)
+// FILE: b.kt
+package b
+
+import a.A
+
+fun foo(a: A, f: (A) -> A): A = f(a)
+
+// MODULE: main(a, b)
+// FILE: main.kt
+import a.A
+import b.foo
+
+fun box(): String {
+    val x: A = "OK"
+    val res: A = foo(x) { it }
+    return res
+}

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/SerializedIrDumpHandler.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/SerializedIrDumpHandler.kt
@@ -216,6 +216,9 @@ open class SerializedIrDumpHandler(
                      * As a much simpler approach, fake overrides in local classes are not dumped both before and after serialization.
                      */
                     true
+                } else if (declaration is IrTypeAlias && !isAfterDeserialization) {
+                    /** KT-86632: Type aliases are not serialized into KLIBs. */
+                    true
                 } else {
                     false
                 }

--- a/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolIrLinker.kt
+++ b/kotlin-native/klib/src/org/jetbrains/kotlin/cli/klib/KlibToolIrLinker.kt
@@ -58,5 +58,6 @@ internal class KlibToolIrLinker(
         klib = klib,
         libraryAbiVersion = klib.versions.abiVersion ?: KotlinAbiVersion.CURRENT,
         allowErrorNodes = true,
+        deserializeTypeAliases = true,
     )
 }

--- a/native/native.tests/testData/caches/ic/ungrouped/typealiasChange/lib/module.info
+++ b/native/native.tests/testData/caches/ic/ungrouped/typealiasChange/lib/module.info
@@ -8,10 +8,12 @@ STEP 0:
 STEP 1:
     modifications:
         U : file1.1.kt -> file1.kt
-    modified cache: file1.kt, file2.kt
+    modified cache: file2.kt
+    unchanged cache: file1.kt
 
 // file1.kt: typealias A targets back to Dog
 STEP 2:
     modifications:
         U : file1.kt -> file1.kt
-    modified cache: file1.kt, file2.kt
+    modified cache: file2.kt
+    unchanged cache: file1.kt

--- a/native/native.tests/testData/klib/dump-ir/typealias.ir.txt
+++ b/native/native.tests/testData/klib/dump-ir/typealias.ir.txt
@@ -6,6 +6,3 @@ MODULE_FRAGMENT name:<typealias.kt>
         BLOCK_BODY
           DELEGATING_CONSTRUCTOR_CALL 'kotlin/Any.<init>|<init>(){}[0]'
           INSTANCE_INITIALIZER_CALL classDescriptor='test/ClassName|null[0]' type=kotlin.Unit
-    TYPEALIAS name:PublicTypeAlias signature:test/PublicTypeAlias|null[0] visibility:public expandedType:test.ClassName
-    TYPEALIAS name:InternalTypeAlias signature:test/InternalTypeAlias|null[0] visibility:internal expandedType:test.ClassName
-    TYPEALIAS name:PrivateTypeAlias signature:[ File 'typealias.kt' <- test/PrivateTypeAlias|null[0] ] visibility:private expandedType:test.ClassName

--- a/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.tl.v1.txt
+++ b/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.tl.v1.txt
@@ -1,9 +1,8 @@
-// Declared signatures: 25
+// Declared signatures: 23
 visibility/InternalClass|null[0]
 visibility/InternalPAClassInternalMembers|null[0]
 visibility/InternalPAClassInternalPAMembers|null[0]
 visibility/InternalPAClass|null[0]
-visibility/InternalTypeAlias|null[0]
 visibility/PublicAbstractClassProtectedMembers|null[0]
 visibility/PublicClassInternalMembers|null[0]
 visibility/PublicClassInternalPAMembers|null[0]
@@ -11,7 +10,6 @@ visibility/PublicClassPrivateMembers|null[0]
 visibility/PublicClassProtectedMembers|null[0]
 visibility/PublicClass|null[0]
 visibility/PublicOpenClassProtectedMembers|null[0]
-visibility/PublicTypeAlias|null[0]
 visibility/internalFun|1659039888467355008[0]
 visibility/internalPAFun|6209200454159161588[0]
 visibility/internalPAVal|-6296713716360945427[0]

--- a/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.tl.v2.txt
+++ b/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.tl.v2.txt
@@ -1,9 +1,8 @@
-// Declared signatures: 25
+// Declared signatures: 23
 visibility/InternalClass|null[0]
 visibility/InternalPAClassInternalMembers|null[0]
 visibility/InternalPAClassInternalPAMembers|null[0]
 visibility/InternalPAClass|null[0]
-visibility/InternalTypeAlias|null[0]
 visibility/PublicAbstractClassProtectedMembers|null[0]
 visibility/PublicClassInternalMembers|null[0]
 visibility/PublicClassInternalPAMembers|null[0]
@@ -11,7 +10,6 @@ visibility/PublicClassPrivateMembers|null[0]
 visibility/PublicClassProtectedMembers|null[0]
 visibility/PublicClass|null[0]
 visibility/PublicOpenClassProtectedMembers|null[0]
-visibility/PublicTypeAlias|null[0]
 visibility/internalFun|internalFun(){}[0]
 visibility/internalPAFun|internalPAFun(){}[0]
 visibility/internalPAVal|{}internalPAVal[0]

--- a/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.v1.txt
+++ b/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.v1.txt
@@ -1,4 +1,4 @@
-// Declared signatures: 98
+// Declared signatures: 96
 visibility/InternalClass.<init>|1280618353163213788[0]
 visibility/InternalClass.NestedClass.<init>|-5645683436151566731[0]
 visibility/InternalClass.NestedClass|null[0]
@@ -27,7 +27,6 @@ visibility/InternalPAClassInternalPAMembers.property.<get-property>|483883148714
 visibility/InternalPAClassInternalPAMembers.property|4634558160746314112[0]
 visibility/InternalPAClassInternalPAMembers|null[0]
 visibility/InternalPAClass|null[0]
-visibility/InternalTypeAlias|null[0]
 visibility/PublicAbstractClassProtectedMembers.<init>|1280618353163213788[0]
 visibility/PublicAbstractClassProtectedMembers.NestedClass.<init>|-5645683436151566731[0]
 visibility/PublicAbstractClassProtectedMembers.NestedClass|null[0]
@@ -71,7 +70,6 @@ visibility/PublicOpenClassProtectedMembers.function|-3322893411126713785[0]
 visibility/PublicOpenClassProtectedMembers.property.<get-property>|4838831487146901942[0]
 visibility/PublicOpenClassProtectedMembers.property|4634558160746314112[0]
 visibility/PublicOpenClassProtectedMembers|null[0]
-visibility/PublicTypeAlias|null[0]
 visibility/internalFun|1659039888467355008[0]
 visibility/internalPAFun|6209200454159161588[0]
 visibility/internalPAVal.<get-internalPAVal>|-2220884681594955448[0]

--- a/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.v2.txt
+++ b/native/native.tests/testData/klib/dump-signatures/visibility.ir-signatures.v2.txt
@@ -1,4 +1,4 @@
-// Declared signatures: 98
+// Declared signatures: 96
 visibility/InternalClass.<init>|<init>(kotlin.String){}[0]
 visibility/InternalClass.NestedClass.<init>|<init>(){}[0]
 visibility/InternalClass.NestedClass|null[0]
@@ -27,7 +27,6 @@ visibility/InternalPAClassInternalPAMembers.property.<get-property>|<get-propert
 visibility/InternalPAClassInternalPAMembers.property|{}property[0]
 visibility/InternalPAClassInternalPAMembers|null[0]
 visibility/InternalPAClass|null[0]
-visibility/InternalTypeAlias|null[0]
 visibility/PublicAbstractClassProtectedMembers.<init>|<init>(kotlin.String){}[0]
 visibility/PublicAbstractClassProtectedMembers.NestedClass.<init>|<init>(){}[0]
 visibility/PublicAbstractClassProtectedMembers.NestedClass|null[0]
@@ -71,7 +70,6 @@ visibility/PublicOpenClassProtectedMembers.function|function(){}[0]
 visibility/PublicOpenClassProtectedMembers.property.<get-property>|<get-property>(){}[0]
 visibility/PublicOpenClassProtectedMembers.property|{}property[0]
 visibility/PublicOpenClassProtectedMembers|null[0]
-visibility/PublicTypeAlias|null[0]
 visibility/internalFun|internalFun(){}[0]
 visibility/internalPAFun|internalPAFun(){}[0]
 visibility/internalPAVal.<get-internalPAVal>|<get-internalPAVal>(){}[0]


### PR DESCRIPTION
Backward/Forward Compatibility run: https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KlibBackwardAndForwardCompatibilityTestsNightly/992859318
(All failures inherited from master branch)