### PR TITLE
Fix Wasm IC build for the case when gradle cleans output directory

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -12376,6 +12376,51 @@
                                                 "deprecatedMessage": "Use kotlinc-wasm or the KotlinWasmCompiler class instead to compile to WebAssembly."
                                             },
                                             {
+                                                "name": "Xwasm-IC-generate-unchanged-modules",
+                                                "shortName": null,
+                                                "deprecatedName": null,
+                                                "description": {
+                                                    "current": "Regenerate unchanged modules in multimodule IC.",
+                                                    "valueInVersions": []
+                                                },
+                                                "delimiter": null,
+                                                "affectsCompilationOutcome": true,
+                                                "restrictedToCompilerPhase": "BACKEND_COMPILATION",
+                                                "valueType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "valueDescription": {
+                                                    "current": null,
+                                                    "valueInVersions": []
+                                                },
+                                                "releaseVersionsMetadata": {
+                                                    "introducedVersion": "2.4.20",
+                                                    "stabilizedVersion": null,
+                                                    "deprecatedVersion": null,
+                                                    "removedVersion": null
+                                                },
+                                                "argumentType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "deprecatedMessage": null
+                                            },
+                                            {
                                                 "name": "Xwasm-debug-friendly",
                                                 "shortName": null,
                                                 "deprecatedName": null,
@@ -14420,6 +14465,51 @@
                                                     }
                                                 },
                                                 "deprecatedMessage": "Use kotlinc-wasm or the KotlinWasmCompiler class instead to compile to WebAssembly."
+                                            },
+                                            {
+                                                "name": "Xwasm-IC-generate-unchanged-modules",
+                                                "shortName": null,
+                                                "deprecatedName": null,
+                                                "description": {
+                                                    "current": "Regenerate unchanged modules in multimodule IC.",
+                                                    "valueInVersions": []
+                                                },
+                                                "delimiter": null,
+                                                "affectsCompilationOutcome": true,
+                                                "restrictedToCompilerPhase": "BACKEND_COMPILATION",
+                                                "valueType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "valueDescription": {
+                                                    "current": null,
+                                                    "valueInVersions": []
+                                                },
+                                                "releaseVersionsMetadata": {
+                                                    "introducedVersion": "2.4.20",
+                                                    "stabilizedVersion": null,
+                                                    "deprecatedVersion": null,
+                                                    "removedVersion": null
+                                                },
+                                                "argumentType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "deprecatedMessage": null
                                             },
                                             {
                                                 "name": "Xwasm-debug-friendly",

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
@@ -70,6 +70,18 @@ val actualWasmArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.wa
     }
 
     compilerArgument {
+        name = "Xwasm-IC-generate-unchanged-modules"
+        compilerName = "regenerateUnchangedModules"
+        description = "Regenerate unchanged modules in multimodule IC.".asReleaseDependent()
+        valueType = BooleanType.defaultFalse
+
+        lifecycle(
+            introducedVersion = KotlinReleaseVersion.v2_4_20,
+        )
+        restrictedToCompilerPhase = KotlinCompilerPhase.BACKEND_COMPILATION
+    }
+
+    compilerArgument {
         name = "Xwasm-included-module-only"
         description = "Compile only a module passed using `-include` option.".asReleaseDependent()
         valueType = BooleanType.defaultFalse

--- a/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
+++ b/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
@@ -1116,6 +1116,7 @@ public abstract interface class org/jetbrains/kotlin/buildtools/api/arguments/Wa
 	public static final field X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_GENERATE_DWARF Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_GENERATE_WAT Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
+	public static final field X_WASM_IC_GENERATE_UNCHANGED_MODULES Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_INCLUDED_MODULE_ONLY Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_INTERNAL_LOCAL_VARIABLE_PREFIX Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;
 	public static final field X_WASM_NO_JSTAG Lorg/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments$WasmCompilerLinkingArgument;

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/WasmCompilerLinkingArguments.kt
@@ -79,6 +79,16 @@ public interface WasmCompilerLinkingArguments : WasmCompilerArguments,
         WasmCompilerLinkingArgument("X_WASM_DEBUG_FRIENDLY", KotlinReleaseVersion(2, 1, 20))
 
     /**
+     * Regenerate unchanged modules in multimodule IC.
+     *
+     * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
+     */
+    @JvmField
+    @ExperimentalCompilerArgument
+    public val X_WASM_IC_GENERATE_UNCHANGED_MODULES: WasmCompilerLinkingArgument<Boolean> =
+        WasmCompilerLinkingArgument("X_WASM_IC_GENERATE_UNCHANGED_MODULES", KotlinReleaseVersion(2, 4, 20))
+
+    /**
      * Compile only a module passed using `-include` option.
      *
      * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/WasmArgumentsImpl.kt
@@ -34,6 +34,7 @@ import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Co
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_GENERATE_CLOSED_WORLD_MULTIMODULE
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_GENERATE_DWARF
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_GENERATE_WAT
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_IC_GENERATE_UNCHANGED_MODULES
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_INCLUDED_MODULE_ONLY
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_INTERNAL_LOCAL_VARIABLE_PREFIX
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.WasmArgumentsImpl.Companion.X_WASM_KCLASS_FQN
@@ -142,6 +143,7 @@ internal class WasmArgumentsImpl(
     if (X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE in this) { arguments.irDceDumpReachabilityInfoToFile = get(X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE)?.absolutePathStringOrThrow()}
     if (X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE in this) { arguments.irDceDumpDeclarationIrSizesToFile = get(X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE)?.absolutePathStringOrThrow()}
     if (X_WASM in this) { arguments.wasm = get(X_WASM)}
+    if (X_WASM_IC_GENERATE_UNCHANGED_MODULES in this) { arguments.regenerateUnchangedModules = get(X_WASM_IC_GENERATE_UNCHANGED_MODULES)}
     if (X_WASM_DEBUG_FRIENDLY in this) { arguments.forceDebugFriendlyCompilation = get(X_WASM_DEBUG_FRIENDLY)}
     if (X_WASM_DEBUG_INFO in this) { arguments.wasmDebug = get(X_WASM_DEBUG_INFO)}
     if (X_WASM_DEBUGGER_CUSTOM_FORMATTERS in this) { arguments.debuggerCustomFormatters = get(X_WASM_DEBUGGER_CUSTOM_FORMATTERS)}
@@ -171,6 +173,7 @@ internal class WasmArgumentsImpl(
     try { this[X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE] = arguments.irDceDumpReachabilityInfoToFile?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE] = arguments.irDceDumpDeclarationIrSizesToFile?.let { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM] = arguments.wasm } catch (_: NoSuchMethodError) {  }
+    try { this[X_WASM_IC_GENERATE_UNCHANGED_MODULES] = arguments.regenerateUnchangedModules } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_DEBUG_FRIENDLY] = arguments.forceDebugFriendlyCompilation } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_DEBUG_INFO] = arguments.wasmDebug } catch (_: NoSuchMethodError) {  }
     try { this[X_WASM_DEBUGGER_CUSTOM_FORMATTERS] = arguments.debuggerCustomFormatters } catch (_: NoSuchMethodError) {  }
@@ -198,6 +201,7 @@ internal class WasmArgumentsImpl(
     if (X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE in this) { arguments.irDceDumpReachabilityInfoToFile = get(X_IR_DCE_DUMP_REACHABILITY_INFO_TO_FILE)?.absolutePathStringOrThrow()}
     if (X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE in this) { arguments.irDceDumpDeclarationIrSizesToFile = get(X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE)?.absolutePathStringOrThrow()}
     if (X_WASM in this) { arguments.wasm = get(X_WASM)}
+    if (X_WASM_IC_GENERATE_UNCHANGED_MODULES in this) { arguments.regenerateUnchangedModules = get(X_WASM_IC_GENERATE_UNCHANGED_MODULES)}
     if (X_WASM_DEBUG_FRIENDLY in this) { arguments.forceDebugFriendlyCompilation = get(X_WASM_DEBUG_FRIENDLY)}
     if (X_WASM_DEBUG_INFO in this) { arguments.wasmDebug = get(X_WASM_DEBUG_INFO)}
     if (X_WASM_DEBUGGER_CUSTOM_FORMATTERS in this) { arguments.debuggerCustomFormatters = get(X_WASM_DEBUGGER_CUSTOM_FORMATTERS)}
@@ -257,6 +261,9 @@ internal class WasmArgumentsImpl(
         WasmArgument("X_IR_DUMP_DECLARATION_IR_SIZES_TO_FILE")
 
     public val X_WASM: WasmArgument<Boolean> = WasmArgument("X_WASM")
+
+    public val X_WASM_IC_GENERATE_UNCHANGED_MODULES: WasmArgument<Boolean> =
+        WasmArgument("X_WASM_IC_GENERATE_UNCHANGED_MODULES")
 
     public val X_WASM_DEBUG_FRIENDLY: WasmArgument<Boolean> = WasmArgument("X_WASM_DEBUG_FRIENDLY")
 

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JSCompilerArgumentsToKotlinWasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JSCompilerArgumentsToKotlinWasmCompilerArgumentsCopyGenerated.kt
@@ -16,6 +16,7 @@ fun copyK2JSCompilerArguments(from: K2JSCompilerArguments, to: KotlinWasmCompile
     to.includeUnavailableSourcesIntoSourceMap = from.includeUnavailableSourcesIntoSourceMap
     to.irDceDumpDeclarationIrSizesToFile = from.irDceDumpDeclarationIrSizesToFile
     to.irDceDumpReachabilityInfoToFile = from.irDceDumpReachabilityInfoToFile
+    to.regenerateUnchangedModules = from.regenerateUnchangedModules
     @Suppress("DEPRECATION")
     to.wasm = from.wasm
     to.wasmDebug = from.wasmDebug

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
@@ -45,6 +45,16 @@ sealed class K2WasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         }
 
     @Argument(
+        value = "-Xwasm-IC-generate-unchanged-modules",
+        description = "Regenerate unchanged modules in multimodule IC.",
+    )
+    var regenerateUnchangedModules: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xwasm-debug-friendly",
         description = "Avoid optimizations that can break debugging.",
     )

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArgumentsCopyGenerated.kt
@@ -17,6 +17,7 @@ fun copyK2WasmCompilerArguments(from: K2WasmCompilerArguments, to: K2WasmCompile
     to.includeUnavailableSourcesIntoSourceMap = from.includeUnavailableSourcesIntoSourceMap
     to.irDceDumpDeclarationIrSizesToFile = from.irDceDumpDeclarationIrSizesToFile
     to.irDceDumpReachabilityInfoToFile = from.irDceDumpReachabilityInfoToFile
+    to.regenerateUnchangedModules = from.regenerateUnchangedModules
     @Suppress("DEPRECATION")
     to.wasm = from.wasm
     to.wasmDebug = from.wasmDebug

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
@@ -46,6 +46,16 @@ class KotlinWasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         }
 
     @Argument(
+        value = "-Xwasm-IC-generate-unchanged-modules",
+        description = "Regenerate unchanged modules in multimodule IC.",
+    )
+    var regenerateUnchangedModules: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xwasm-debug-friendly",
         description = "Avoid optimizations that can break debugging.",
     )

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArgumentsCopyGenerated.kt
@@ -16,6 +16,7 @@ fun copyKotlinWasmCompilerArguments(from: KotlinWasmCompilerArguments, to: Kotli
     to.includeUnavailableSourcesIntoSourceMap = from.includeUnavailableSourcesIntoSourceMap
     to.irDceDumpDeclarationIrSizesToFile = from.irDceDumpDeclarationIrSizesToFile
     to.irDceDumpReachabilityInfoToFile = from.irDceDumpReachabilityInfoToFile
+    to.regenerateUnchangedModules = from.regenerateUnchangedModules
     @Suppress("DEPRECATION")
     to.wasm = from.wasm
     to.wasmDebug = from.wasmDebug

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/KotlinIr2WasmIrCompilerIC.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/KotlinIr2WasmIrCompilerIC.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.config.moduleName
 import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
 import org.jetbrains.kotlin.js.config.outputName
 import org.jetbrains.kotlin.wasm.config.wasmGenerateClosedWorldMultimodule
+import org.jetbrains.kotlin.wasm.config.wasmIcGenerateUnchangedModules
 import org.jetbrains.kotlin.wasm.config.wasmIncludedModuleOnly
 import kotlin.collections.mutableSetOf
 import kotlin.collections.set
@@ -198,7 +199,7 @@ fun compileIncrementallyMultimodule(
     val kotlinTestArtifact = artifacts.firstOrNull { it.moduleName == "<kotlin-test>" }
 
     val [toRecompile, toDependency] = artifacts.partition { artifact ->
-        artifact.forceRebuildWasm || artifact.fileArtifacts.any { it.isModified() }
+        configuration.wasmIcGenerateUnchangedModules || artifact.forceRebuildWasm || artifact.fileArtifacts.any { it.isModified() }
     }
 
     val builtInFragments = mutableListOf<WasmIrProgramFragmentsMultimodule>()

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmConfigurationUpdater.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmConfigurationUpdater.kt
@@ -59,6 +59,7 @@ object WasmConfigurationUpdater : ConfigurationUpdater<KotlinWasmCompilerArgumen
         configuration.put(WasmConfigurationKeys.WASM_ENABLE_ASSERTS, arguments.wasmEnableAsserts)
         configuration.put(WasmConfigurationKeys.WASM_GENERATE_WAT, arguments.wasmGenerateWat)
         configuration.put(WasmConfigurationKeys.WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS, arguments.wasmUseTrapsInsteadOfExceptions)
+        configuration.put(WasmConfigurationKeys.WASM_IC_GENERATE_UNCHANGED_MODULES, arguments.regenerateUnchangedModules)
 
         val wasmTarget = arguments.wasmTarget?.let(WasmTarget::fromName)
 

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/WasmConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/WasmConfigurationKeysContainer.kt
@@ -17,6 +17,7 @@ object WasmConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.wasm
     val WASM_GENERATE_WAT by key<Boolean>()
     val WASM_TARGET by key<WasmTarget>(defaultValue = "WasmTarget.JS")
     val WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS by key<Boolean>()
+    val WASM_IC_GENERATE_UNCHANGED_MODULES by key<Boolean>()
     val WASM_USE_NEW_EXCEPTION_PROPOSAL by key<Boolean>()
     val WASM_USE_STACK_SWITCHING_PROPOSAL by key<Boolean>()
     val WASM_NO_JS_TAG by key<Boolean>("Don't use WebAssembly.JSTag for throwing and catching exceptions")

--- a/compiler/testData/cli/js/jsExtraHelp.out
+++ b/compiler/testData/cli/js/jsExtraHelp.out
@@ -31,6 +31,8 @@ where advanced options include:
                              Dump the IR size of each declaration into a file. The format will be chosen automatically depending on the file extension. Supported output formats include JSON for .json, a JS const initialized with a plain object containing information for .js, and plain text for all other file types.
   -Xwasm                     Use the WebAssembly compiler backend.
                              The option is deprecated since Kotlin $ABI_VERSION$. It will be removed in one of the future releases. Use kotlinc-wasm or the KotlinWasmCompiler class instead to compile to WebAssembly.
+  -Xwasm-IC-generate-unchanged-modules
+                             Regenerate unchanged modules in multimodule IC.
   -Xwasm-debug-friendly      Avoid optimizations that can break debugging.
   -Xwasm-debug-info          Add debug info to the compiled WebAssembly module.
   -Xwasm-debugger-custom-formatters

--- a/compiler/testData/cli/wasm/wasmExtraHelp.out
+++ b/compiler/testData/cli/wasm/wasmExtraHelp.out
@@ -6,6 +6,8 @@ where advanced options include:
                              Dump the IR size of each declaration into a file. The format will be chosen automatically depending on the file extension. Supported output formats include JSON for .json, a JS const initialized with a plain object containing information for .js, and plain text for all other file types.
   -Xwasm                     Use the WebAssembly compiler backend.
                              The option is deprecated since Kotlin $ABI_VERSION$. It will be removed in one of the future releases. Use kotlinc-wasm or the KotlinWasmCompiler class instead to compile to WebAssembly.
+  -Xwasm-IC-generate-unchanged-modules
+                             Regenerate unchanged modules in multimodule IC.
   -Xwasm-debug-friendly      Avoid optimizations that can break debugging.
   -Xwasm-debug-info          Add debug info to the compiled WebAssembly module.
   -Xwasm-debugger-custom-formatters

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
@@ -209,6 +209,59 @@ class KotlinWasmGradlePluginIT : AbstractKotlinWasmGradlePluginIT() {
         }
     }
 
+    @OptIn(ExperimentalWasmDsl::class)
+    @DisplayName("Check js target with per-module closed world incremental build with rerun tasks")
+    @GradleTest
+    fun jsTargetPerModuleClosedWorldWithRerunTasks(gradleVersion: GradleVersion) {
+        project("new-mpp-wasm-js", gradleVersion) {
+            buildGradleKts.modify {
+                it.replace("<JsEngine>", "d8")
+            }
+
+            buildScriptInjection {
+                kotlinMultiplatform.wasmJs {
+                    binaries.executable()
+                }
+            }
+
+            build(
+                ":compileDevelopmentExecutableKotlinWasmJs",
+                buildOptions = defaultBuildOptions.copy(
+                    wasmOptions = BuildOptions.WasmOptions(compilationMode = WasmCompilationMode.MULTIMODULE_CLOSED_WORLD)
+                ),
+            ) {
+                assertHasDiagnostic(
+                    KotlinToolingDiagnostics.ExperimentalFeatureWarning,
+                    "Wasm compilation mode selecting"
+                )
+
+                assertTasksExecuted(":compileDevelopmentExecutableKotlinWasmJs")
+
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/redefined-wasm-module-name.wasm")
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/kotlin-kotlin-stdlib.wasm")
+            }
+
+            build(
+                ":compileDevelopmentExecutableKotlinWasmJs",
+                *rerunTask(":compileDevelopmentExecutableKotlinWasmJs"),
+                buildOptions = defaultBuildOptions.copy(
+                    wasmOptions = BuildOptions.WasmOptions(compilationMode = WasmCompilationMode.MULTIMODULE_CLOSED_WORLD)
+                )
+            ) {
+                assertHasDiagnostic(
+                    KotlinToolingDiagnostics.ExperimentalFeatureWarning,
+                    "Wasm compilation mode selecting"
+                )
+
+                assertTasksExecuted(":compileDevelopmentExecutableKotlinWasmJs")
+
+                // Incremental build should not remove unchanged files
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/redefined-wasm-module-name.wasm")
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/kotlin-kotlin-stdlib.wasm")
+            }
+        }
+    }
+
     @DisplayName("Check js target with binaryen with custom per-file argument")
     @GradleTest
     fun jsTargetWithBinaryenCustomPerFileArgument(gradleVersion: GradleVersion) {

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -3148,6 +3148,7 @@ public final class org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrCompilati
 
 public abstract class org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrLink : org/jetbrains/kotlin/gradle/tasks/Kotlin2JsCompile, org/jetbrains/kotlin/gradle/plugin/statistics/UsesBuildFusService {
 	public fun <init> (Lorg/gradle/api/Project;Lorg/jetbrains/kotlin/gradle/plugin/KotlinPlatformType;Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/workers/WorkerExecutor;)V
+	public synthetic fun callCompilerAsync$kotlin_gradle_plugin_common (Lorg/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments;Lorg/gradle/work/InputChanges;Lorg/jetbrains/kotlin/gradle/tasks/TaskOutputsBackup;)V
 	protected fun cleanOutputsAndLocalState (Ljava/lang/String;)V
 	protected fun contributeAdditionalCompilerArguments (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilerArgumentsProducer$ContributeCompilerArgumentsContext;)V
 	public final fun getIncrementalJsIr ()Z

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrLink.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrLink.kt
@@ -11,6 +11,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.work.InputChanges
 import org.gradle.work.NormalizeLineEndings
 import org.gradle.workers.WorkerExecutor
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
@@ -28,6 +29,7 @@ import org.jetbrains.kotlin.gradle.targets.wasm.WasmCompilationMode
 import org.jetbrains.kotlin.gradle.targets.wasm.WasmCompilationMode.Companion.toArgument
 import org.jetbrains.kotlin.gradle.tasks.K2MultiplatformStructure
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+import org.jetbrains.kotlin.gradle.tasks.TaskOutputsBackup
 import org.jetbrains.kotlin.gradle.utils.KotlinJsCompilerOptionsDefault
 import org.jetbrains.kotlin.platform.js.JsPlatforms
 import javax.inject.Inject
@@ -115,6 +117,18 @@ abstract class KotlinJsIrLink
 
     override fun isIncrementalCompilationEnabled(): Boolean = false
 
+    override fun callCompilerAsync(
+        args: K2JSCompilerArguments,
+        inputChanges: InputChanges,
+        taskOutputsBackup: TaskOutputsBackup?,
+    ) {
+        if (!inputChanges.isIncremental && isWasmPlatform) {
+            args.regenerateUnchangedModules = true
+        }
+
+        super.callCompilerAsync(args, inputChanges, taskOutputsBackup)
+    }
+
     override fun contributeAdditionalCompilerArguments(context: ContributeCompilerArgumentsContext<K2JSCompilerArguments>) {
         context.primitive { args ->
             args.irProduceJs = true
@@ -150,6 +164,9 @@ abstract class KotlinJsIrLink
             }
         }
     }
+
+    private val isWasmPlatform: Boolean =
+        target == KotlinPlatformType.wasm
 
     override fun processArgsBeforeCompile(args: K2JSCompilerArguments) {
         if (!isWasmPlatformValue) {

--- a/wasm/wasm.frontend/gen/org/jetbrains/kotlin/wasm/config/WasmConfigurationKeys.kt
+++ b/wasm/wasm.frontend/gen/org/jetbrains/kotlin/wasm/config/WasmConfigurationKeys.kt
@@ -37,6 +37,9 @@ object WasmConfigurationKeys {
     val WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS = CompilerConfigurationKey.create<Boolean>("WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS")
 
     @JvmField
+    val WASM_IC_GENERATE_UNCHANGED_MODULES = CompilerConfigurationKey.create<Boolean>("WASM_IC_GENERATE_UNCHANGED_MODULES")
+
+    @JvmField
     val WASM_USE_NEW_EXCEPTION_PROPOSAL = CompilerConfigurationKey.create<Boolean>("WASM_USE_NEW_EXCEPTION_PROPOSAL")
 
     @JvmField
@@ -110,6 +113,10 @@ var CompilerConfiguration.wasmTarget: WasmTarget
 var CompilerConfiguration.wasmUseTrapsInsteadOfExceptions: Boolean
     get() = getBoolean(WasmConfigurationKeys.WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS)
     set(value) { put(WasmConfigurationKeys.WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS, value) }
+
+var CompilerConfiguration.wasmIcGenerateUnchangedModules: Boolean
+    get() = getBoolean(WasmConfigurationKeys.WASM_IC_GENERATE_UNCHANGED_MODULES)
+    set(value) { put(WasmConfigurationKeys.WASM_IC_GENERATE_UNCHANGED_MODULES, value) }
 
 var CompilerConfiguration.wasmUseNewExceptionProposal: Boolean
     get() = getBoolean(WasmConfigurationKeys.WASM_USE_NEW_EXCEPTION_PROPOSAL)


### PR DESCRIPTION
Running gradle with --rerun-tasks cleans output directory which cause lack of wasm files in Wasm IC build step. This is because the IC does not make files for a modules, that did not change.

Fixed KT-87066