### PR TITLE
[Swift Export] Reexport SwiftPM-imported cinterop klibs in KGP

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportIT.kt
@@ -7,7 +7,9 @@ package org.jetbrains.kotlin.gradle.native
 
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.apple.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME
 import org.jetbrains.kotlin.gradle.apple.createLocalSwiftPackage
+import org.jetbrains.kotlin.gradle.apple.describeSwiftPackage
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
@@ -30,6 +32,7 @@ import kotlin.io.path.writeText
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OsCondition(supportedOn = [OS.MAC], enabledOnCI = [OS.MAC])
 @DisplayName("Tests for Swift Export")
@@ -937,6 +940,166 @@ class SwiftExportIT : KGPBaseTest() {
                 environmentVariables = envVars,
             ) {
                 assertNoDiagnostic(KotlinToolingDiagnostics.SwiftPMLinkagePackageNotIntegratedInXcodeProject)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalSwiftExportDsl::class)
+    @DisplayName("KT-80632: a SwiftPM-import cinterop klib is reexported through Swift Export")
+    @GradleTest
+    fun testSwiftPMImportCinteropIsReexportedThroughSwiftExport(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        // Use emptyxcode so that swiftPMDependencies can resolve the local Swift package via xcodebuild.
+        project("emptyxcode", gradleVersion) {
+            val localSwiftPackageRelativePath = "../localSwiftPackage"
+            val localPackageDir = projectPath.resolve(localSwiftPackageRelativePath)
+            val targetName = "LocalSwiftPackage"
+            createLocalSwiftPackage(localPackageDir, packageName = targetName)
+
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+                    iosSimulatorArm64()
+
+                    // Expose the imported package's Objective-C type in the exported API. This forces Swift Export
+                    // to reexport the `LocalSwiftPackage` module and emit `import LocalSwiftPackage`, which only
+                    // resolves if the generated SPM package depends on the SwiftPM-import synthetic package.
+                    sourceSets.appleMain.get().compileSource(
+                        """
+                            @file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+                            package producer
+                            import swiftPMImport.shared.LocalHelper
+                            fun roundTrip(helper: LocalHelper): LocalHelper = helper
+                        """.trimIndent()
+                    )
+
+                    with(swiftImport) {
+                        localSwiftPackage(
+                            directory = project.layout.projectDirectory.dir(localSwiftPackageRelativePath),
+                            products = listOf(targetName),
+                        )
+                    }
+                }
+            }
+
+            // The synthetic linkage package must be integrated into the Xcode project (and PROJECT_FILE_PATH set)
+            // for embedSwiftExportForXcode's integration check to pass, mirroring the sibling swiftPMImport tests.
+            val iosAppXcodeProj = projectPath.resolve("iosApp/iosApp.xcodeproj")
+
+            // The template's script phase drives the framework embed task; this project uses Swift Export.
+            val pbxproj = iosAppXcodeProj.resolve("project.pbxproj")
+            pbxproj.writeText(pbxproj.readText().replace(":embedAndSignAppleFrameworkForXcode", ":embedSwiftExportForXcode"))
+
+            val envVars = swiftExportEmbedAndSignEnvVariables(
+                testBuildDir,
+                customVariables = mapOf(
+                    "XCODEPROJ_PATH" to "iosApp/iosApp.xcodeproj",
+                    "PROJECT_FILE_PATH" to iosAppXcodeProj.absolutePathString(),
+                )
+            )
+
+            build(
+                ":integrateLinkagePackage",
+                environmentVariables = envVars
+            )
+
+            val derivedDataPath = projectPath.resolve("iosApp/iosApp.derivedData")
+            buildXcodeProject(
+                xcodeproj = iosAppXcodeProj,
+                action = XcodeBuildAction.Build,
+                destination = "generic/platform=iOS Simulator",
+                buildSettingOverrides = mapOf(
+                    "ARCHS" to "arm64",
+                ),
+                derivedDataPath = derivedDataPath,
+            )
+
+            // The generated package declares the resolved synthetic package as a real SPM dependency. Its identity is
+            // the directory name, which under fingerprint coordination is a hash, so assert on the dependency kind and
+            // on the umbrella product the Swift Export target consumes instead.
+            val generatedPackage = describeSwiftPackage(projectPath.resolve("build/SPMPackage/iosSimulatorArm64/debug"))
+            assertEquals(
+                listOf("fileSystem"),
+                generatedPackage.dependencies.map { it.type },
+                "the generated package should depend on the synthetic package by path"
+            )
+            assertContains(
+                generatedPackage.targets.flatMap { it.productDependencies },
+                SYNTHETIC_IMPORT_TARGET_MAGIC_NAME,
+                "a target should consume the synthetic package's umbrella product"
+            )
+
+            // The imported package's object files must not be packed into the Swift Export library: the consuming
+            // app builds the imported packages itself, so packing them here would duplicate their symbols.
+            val packageLibrary = projectPath.resolve("build/SPMBuild/iosSimulatorArm64/debug/dd-a-files/libSharedLibrary.a")
+            assertFileExists(packageLibrary)
+            val archivedObjects = runProcess(listOf("ar", "-t", packageLibrary.absolutePathString()), projectPath.toFile()).output
+            assertTrue(
+                archivedObjects.lines().none { it.contains(targetName) },
+                "Expected no $targetName object files in the Swift Export library, got:\n$archivedObjects"
+            )
+
+            // The copy step delivered the exported module's interfaces into the app's BUILT_PRODUCTS_DIR.
+            // (The imported package's products also live there — built by the app itself through the
+            // integrated linkage package, not stomped by the copy step, which filters to own modules.)
+            val builtProductsDir = derivedDataPath.resolve("Build/Products/Debug-iphonesimulator")
+            assertDirectoryExists(builtProductsDir.resolve("Shared.swiftmodule"))
+        }
+    }
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalSwiftExportDsl::class)
+    @DisplayName("KT-80632: Swift Export without swiftPMDependencies emits no cinterop package dependency")
+    @GradleTest
+    fun testSwiftExportWithoutSwiftPMImportHasNoCinteropDependency(
+        gradleVersion: GradleVersion,
+        @TempDir testBuildDir: Path,
+    ) {
+        project("emptyxcode", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+            settingsBuildScriptInjection {
+                settings.rootProject.name = "shared"
+            }
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    iosArm64()
+
+                    sourceSets.appleMain.get().compileSource(
+                        """
+                            package producer
+                            fun greeting(): String = "Hello"
+                        """.trimIndent()
+                    )
+
+                    with(swiftExport) {
+                        configure {
+                            freeCompilerArgs.add("-Xpartial-linkage-loglevel=error")
+                        }
+                    }
+                }
+            }
+
+            build(
+                ":embedSwiftExportForXcode",
+                environmentVariables = swiftExportEmbedAndSignEnvVariables(testBuildDir)
+            ) {
+                // No Swift package imported => the manifest must stay free of any package dependency, confirming the
+                // cinterop reexport wiring only engages for SwiftPM-import klibs.
+                val generatedPackage = describeSwiftPackage(projectPath.resolve("build/SPMPackage/iosArm64/debug"))
+                assertEquals(
+                    emptyList(),
+                    generatedPackage.dependencies,
+                    "Expected no SPM package dependency without swiftPMDependencies"
+                )
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SwiftExport.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
@@ -24,6 +23,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftEx
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.exportedSwiftExportApiConfiguration
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.normalizedSwiftExportModuleName
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.whenSwiftPMImportAvailable
 import org.jetbrains.kotlin.gradle.plugin.mpp.internal
 import org.jetbrains.kotlin.gradle.tasks.locateOrRegisterTask
 import org.jetbrains.kotlin.gradle.utils.*
@@ -90,6 +90,7 @@ internal fun Project.registerSwiftExportTask(
         swiftApiLibraryName = swiftApiLibraryName,
         swiftExportTask = swiftExportTask
     )
+
     val packageBuild = registerSPMPackageBuild(
         taskNamePrefix = taskNamePrefix,
         taskGroup = taskGroup,
@@ -108,7 +109,7 @@ internal fun Project.registerSwiftExportTask(
         packageBuildTask = packageBuild
     )
 
-    return registerCopyTask(
+    val copyTask = registerCopyTask(
         taskGroup = taskGroup,
         configuration = buildConfiguration,
         libraryName = mergeLibrariesTask.map { it.library.getFile().name },
@@ -116,6 +117,33 @@ internal fun Project.registerSwiftExportTask(
         packageBuildTask = packageBuild,
         mergeLibrariesTask = mergeLibrariesTask
     )
+
+    target.whenSwiftPMImportAvailable { products ->
+        swiftExportTask.configure { task ->
+            task.cinteropModuleName.set(products.cinteropModuleName)
+            task.cinteropModuleArtifact.fileProvider(products.cinteropKlib)
+        }
+        packageGenerationTask.configure { task ->
+            task.swiftPMImportProductName.set(products.umbrellaProductName)
+            task.swiftPMImportPackageRoot.set(products.syntheticPackageLocalRoot)
+            task.swiftPMImportFingerprint.set(products.syntheticPackageFingerprint)
+            task.swiftPMImportCoordinationService.set(products.coordinationService)
+            task.dependsOn(products.fetchTask)
+        }
+        packageBuild.configure { task ->
+            task.swiftPMImportPackageRoot.set(products.syntheticPackageLocalRoot)
+            task.swiftPMImportCheckout.set(products.swiftPMLocalCheckout)
+            task.swiftPMImportFingerprint.set(products.syntheticPackageFingerprint)
+            task.swiftPMImportCoordinationService.set(products.coordinationService)
+            task.dependsOn(products.fetchTask)
+        }
+        copyTask.configure { task ->
+            task.filterInterfacesToOwnModules.set(true)
+            task.swiftModulesFile.set(swiftExportTask.map { it.parameters.swiftModulesFile.get() })
+        }
+    }
+
+    return copyTask
 }
 
 private fun Project.registerSwiftExportRun(
@@ -331,7 +359,7 @@ private fun Project.registerCopyTask(
     packageGenerationTask: TaskProvider<GenerateSPMPackageFromSwiftExport>,
     packageBuildTask: TaskProvider<BuildSPMSwiftExportPackage>,
     mergeLibrariesTask: TaskProvider<MergeStaticLibrariesTask>,
-): TaskProvider<out Task> {
+): TaskProvider<CopySwiftExportIntermediatesForConsumer> {
 
     val copyTaskName = lowerCamelCaseName(
         "copy",

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/BuildSPMSwiftExportPackage.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/BuildSPMSwiftExportPackage.kt
@@ -7,6 +7,8 @@ package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -15,6 +17,9 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FetchSyntheticImportProjectPackages
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportFingerprintedCoordinationService
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.sharedCheckoutFor
 import org.jetbrains.kotlin.gradle.utils.getFile
 import org.jetbrains.kotlin.gradle.utils.property
 import org.jetbrains.kotlin.gradle.utils.relativeOrAbsolute
@@ -26,7 +31,7 @@ import javax.inject.Inject
 @DisableCachingByDefault(because = "Swift Export is experimental, so no caching for now")
 internal abstract class BuildSPMSwiftExportPackage @Inject constructor(
     providerFactory: ProviderFactory,
-    objectFactory: ObjectFactory,
+    private val objectFactory: ObjectFactory,
 ) : DefaultTask() {
     init {
         onlyIf { HostManager.hostIsMac }
@@ -60,9 +65,43 @@ internal abstract class BuildSPMSwiftExportPackage @Inject constructor(
         providerFactory.environmentVariable("TARGET_DEVICE_IDENTIFIER")
     )
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Internal
     abstract val packageRoot: DirectoryProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    protected val packageRootTrackedFiles: FileTree
+        get() = packageRoot.packageFilesWithoutSwiftPMState()
+
+    @get:Internal
+    abstract val swiftPMImportPackageRoot: DirectoryProperty
+
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val swiftPMImportFingerprint: RegularFileProperty
+
+    @get:Internal
+    abstract val swiftPMImportCoordinationService: Property<SwiftImportFingerprintedCoordinationService>
+
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    protected val swiftPMImportPackageTrackedFiles: FileCollection
+        get() = if (swiftPMImportPackageRoot.isPresent) {
+            swiftPMImportPackageRoot.packageFilesWithoutSwiftPMState()
+        } else {
+            objectFactory.fileCollection()
+        }
+
+    private fun DirectoryProperty.packageFilesWithoutSwiftPMState(): FileTree = asFileTree.matching {
+        it.exclude("Package.resolved")
+        it.exclude(".swiftpm")
+        it.exclude(".build")
+    }
+
+    @get:Internal
+    abstract val swiftPMImportCheckout: DirectoryProperty
 
     @get:OutputDirectory
     abstract val packageDerivedData: DirectoryProperty
@@ -128,12 +167,19 @@ internal abstract class BuildSPMSwiftExportPackage @Inject constructor(
 
         val derivedData = packageDerivedData.getFile()
 
+        val effectiveCheckout = swiftPMImportFingerprint.orNull?.asFile
+            ?.let { swiftPMImportCoordinationService.get().sharedCheckoutFor(it) }
+            ?: swiftPMImportCheckout.orNull?.asFile
+        val checkoutArguments = effectiveCheckout?.let {
+            listOf(FetchSyntheticImportProjectPackages.XCODEBUILD_SWIFTPM_CHECKOUT_PATH_PARAMETER, it.absolutePath)
+        } ?: emptyList()
+
         val command = listOf(
             "xcodebuild",
             "-derivedDataPath", derivedData.relativeOrAbsolute(packageRootPath),
             "-scheme", swiftModuleName,
             "-destination", destination(),
-        ) + (intermediatesDestination + buildArguments).map { (k, v) -> "$k=$v" }
+        ) + checkoutArguments + (intermediatesDestination + buildArguments).map { (k, v) -> "$k=$v" }
 
         // FIXME: This will not work with dynamic libraries
         runCommand(
@@ -141,8 +187,9 @@ internal abstract class BuildSPMSwiftExportPackage @Inject constructor(
             logger = logger,
             processConfiguration = {
                 environment().apply {
-                    keys.filter {
-                        AppleSdk.xcodeEnvironmentDebugDylibVars.contains(it)
+                    val exactRemovals = AppleSdk.xcodeEnvironmentDebugDylibVars + "EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES"
+                    keys.filter { key ->
+                        key in exactRemovals || key.startsWith("OTHER_") || key.startsWith("ASSETCATALOG_")
                     }.forEach {
                         remove(it)
                     }
@@ -154,15 +201,39 @@ internal abstract class BuildSPMSwiftExportPackage @Inject constructor(
     }
 
     private fun packObjectFilesIntoLibrary() {
-        val objectFilePaths = objectFilesPath.asFileTree.filter {
+        val objectFiles = objectFilesPath.asFileTree.filter {
             it.extension == "o"
         }.files.toList()
 
-        if (objectFilePaths.isEmpty()) {
+        if (objectFiles.isEmpty()) {
             error("Synthetic package build didn't produce any object files")
         }
 
+        // When the package depends on the SwiftPM-import synthetic package, xcodebuild also drops the imported
+        // packages' object files into the redirected TARGET_BUILD_DIR. Those must not be packed: the consuming app
+        // links the imported packages itself (via the integrated linkage package), so packing them here would
+        // duplicate their symbols in the final binary.
+        val ownTargetNames = ownTargetNames()
+        val objectFilePaths = if (ownTargetNames == null) objectFiles else {
+            objectFiles.filter { it.nameWithoutExtension in ownTargetNames }
+        }
+
+        if (objectFilePaths.isEmpty()) {
+            error(
+                "None of the produced object files matched the generated package's targets $ownTargetNames. " +
+                        "Produced object files: ${objectFiles.map { it.name }}"
+            )
+        }
+
         libraryTools.mergeLibraries(objectFilePaths, packageLibrary.getFile())
+    }
+
+    private fun ownTargetNames(): Set<String>? {
+        if (!swiftPMImportPackageRoot.isPresent) return null
+        val sources = packageRootPath.resolve(GenerateSPMPackageFromSwiftExport.SOURCES_DIRECTORY)
+        val targetDirectories = sources.listFiles { file -> file.isDirectory }
+            ?: error("Expected the generated package's target sources at $sources")
+        return targetDirectories.map { it.name }.toSet()
     }
 
     private fun destination(): String {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/CopySwiftExportIntermediatesForConsumer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/CopySwiftExportIntermediatesForConsumer.kt
@@ -11,6 +11,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.*
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.SerializationTools
 import java.io.File
 import javax.inject.Inject
 
@@ -45,6 +46,14 @@ internal abstract class CopySwiftExportIntermediatesForConsumer @Inject construc
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val interfaces: ConfigurableFileCollection = objectFactory.fileCollection()
 
+    @get:Input
+    val filterInterfacesToOwnModules: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(false)
+
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val swiftModulesFile: RegularFileProperty
+
     fun addInterface(swiftInterface: Provider<File>) {
         interfaces.from(swiftInterface)
     }
@@ -67,13 +76,22 @@ internal abstract class CopySwiftExportIntermediatesForConsumer @Inject construc
     }
 
     private fun copyInterfaces() {
+        val ownModulePatterns = ownSwiftModuleNames()?.map { "$it.swiftmodule/**" }
         interfaces.files.forEach { swiftInterface ->
             fileSystem.copy { spec ->
                 spec.from(swiftInterface)
                 spec.into(builtProductsDirectory)
                 spec.includeEmptyDirs = false
+                ownModulePatterns?.forEach { spec.include(it) }
             }
         }
+    }
+
+    private fun ownSwiftModuleNames(): List<String>? {
+        if (!filterInterfacesToOwnModules.get()) return null
+        val modulesFile = swiftModulesFile.orNull?.asFile
+            ?: error("swiftModulesFile must be set when filterInterfacesToOwnModules is enabled")
+        return SerializationTools.readFromJson(modulesFile.readText()).modules.map { it.name }
     }
 
     private fun copyOtherIncludes() {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/GenerateSPMPackageFromSwiftExport.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/GenerateSPMPackageFromSwiftExport.kt
@@ -9,12 +9,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.*
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.ModuleMapGenerator
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.SerializationTools
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportFingerprintedCoordinationService
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.sharedPackageRootFor
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.GradleSwiftExportModule
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.GradleSwiftExportModules
 import org.jetbrains.kotlin.gradle.utils.CommaSeparatedEntriesBuilder
 import org.jetbrains.kotlin.gradle.utils.StringBlockBuilder
 import org.jetbrains.kotlin.gradle.utils.buildStringBlock
@@ -49,6 +51,26 @@ internal abstract class GenerateSPMPackageFromSwiftExport @Inject constructor(
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val swiftModulesFile: RegularFileProperty
 
+    @get:Optional
+    @get:Input
+    abstract val swiftPMImportProductName: Property<String>
+
+    @get:Internal
+    abstract val swiftPMImportPackageRoot: DirectoryProperty
+
+    @get:Optional
+    @get:Input
+    protected val swiftPMImportPackageRootPath: Provider<String>
+        get() = swiftPMImportPackageRoot.locationOnly.map { it.asFile.absolutePath }
+
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val swiftPMImportFingerprint: RegularFileProperty
+
+    @get:Internal
+    abstract val swiftPMImportCoordinationService: Property<SwiftImportFingerprintedCoordinationService>
+
     @get:OutputDirectory
     abstract val packagePath: DirectoryProperty
 
@@ -59,7 +81,7 @@ internal abstract class GenerateSPMPackageFromSwiftExport @Inject constructor(
 
     @get:OutputDirectory
     val sourcesPath: DirectoryProperty = objectFactory.directoryProperty().apply {
-        set(packagePath.dir("Sources"))
+        set(packagePath.dir(SOURCES_DIRECTORY))
     }
 
     private val swiftLibrary get() = swiftLibraryName.get()
@@ -143,7 +165,17 @@ internal abstract class GenerateSPMPackageFromSwiftExport @Inject constructor(
 
     private fun createPackageManifest(modules: List<GradleSwiftExportModule>) {
         val manifest = packagePath.getFile().resolve("Package.swift")
-        val content = SPMManifestGenerator.generateManifest(swiftApiModule, swiftLibrary, kotlinRuntimeModule, modules)
+        val cinteropImport = if (swiftPMImportProductName.isPresent && swiftPMImportPackageRoot.isPresent) {
+            val root = swiftPMImportFingerprint.orNull?.asFile
+                ?.let { swiftPMImportCoordinationService.get().sharedPackageRootFor(it) }
+                ?: swiftPMImportPackageRoot.getFile()
+            CinteropPackageImport(
+                path = root.absolutePath,
+                productName = swiftPMImportProductName.get(),
+                packageIdentity = root.name,
+            )
+        } else null
+        val content = SPMManifestGenerator.generateManifest(swiftApiModule, swiftLibrary, kotlinRuntimeModule, modules, cinteropImport)
         manifest.writeText(content)
     }
 
@@ -154,6 +186,18 @@ internal abstract class GenerateSPMPackageFromSwiftExport @Inject constructor(
             it.into(includesPath.dir(name))
         }
     }
+
+    companion object {
+        const val SOURCES_DIRECTORY = "Sources"
+    }
+}
+
+internal data class CinteropPackageImport(
+    val path: String,
+    val productName: String,
+    val packageIdentity: String,
+) {
+    fun productExpression(): String = ".product(name: \"$productName\", package: \"$packageIdentity\")"
 }
 
 internal object SPMManifestGenerator {
@@ -163,6 +207,7 @@ internal object SPMManifestGenerator {
         swiftLibrary: String,
         kotlinRuntime: String,
         modules: List<GradleSwiftExportModule>,
+        cinteropImport: CinteropPackageImport? = null,
     ): String = buildStringBlock {
         line("// swift-tools-version: 5.9")
         line()
@@ -180,10 +225,17 @@ internal object SPMManifestGenerator {
                         }
                     }
                 }
+                if (cinteropImport != null) {
+                    entry {
+                        block("dependencies: [", "]") {
+                            line(".package(path: \"${cinteropImport.path}\")")
+                        }
+                    }
+                }
                 entry {
                     block("targets: [", "]") {
                         commaSeparatedEntries {
-                            emitTargetDefinitions(modules, kotlinRuntime)
+                            emitTargetDefinitions(modules, kotlinRuntime, cinteropImport?.productExpression())
                             entry { emitTarget(kotlinRuntime) }
                         }
                     }
@@ -206,12 +258,14 @@ internal object SPMManifestGenerator {
     private fun StringBlockBuilder.emitTarget(
         name: String,
         dependencies: List<String>? = null,
+        rawDependencies: List<String> = emptyList(),
     ) {
         block(".target(", ")") {
             commaSeparatedEntries {
                 entry { line("name: \"$name\"") }
-                if (dependencies != null) {
-                    entry { line("dependencies: [${dependencies.joinToString(", ") { "\"$it\"" }}]") }
+                val deps = (dependencies?.map { "\"$it\"" } ?: emptyList()) + rawDependencies
+                if (deps.isNotEmpty()) {
+                    entry { line("dependencies: [${deps.joinToString(", ")}]") }
                 }
             }
         }
@@ -220,9 +274,12 @@ internal object SPMManifestGenerator {
     private fun CommaSeparatedEntriesBuilder.emitTargetDefinitions(
         modules: List<GradleSwiftExportModule>,
         kotlinRuntime: String,
+        cinteropProductExpression: String?,
     ) {
+        // The reexported cinterop's `import`s live in the Swift API targets, so each gets the product dependency.
+        val rawDependencies = listOfNotNull(cinteropProductExpression)
         modules.forEach { module ->
-            entry { emitTarget(module.name, module.spmDependencies(kotlinRuntime)) }
+            entry { emitTarget(module.name, module.spmDependencies(kotlinRuntime), rawDependencies) }
             if (module is GradleSwiftExportModule.BridgesToKotlin) {
                 entry { emitTarget(module.bridgeName) }
             }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/tasks/SwiftExportTask.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.plugin.diagnostics.UsesKotlinToolingDiagnosti
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportAction
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.SwiftExportTaskParameters
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createFullyExportedSwiftExportedModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.createTransitiveSwiftExportedModule
 import org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeProvider
 import org.jetbrains.kotlin.gradle.utils.getFile
 import org.jetbrains.kotlin.konan.target.Distribution
@@ -45,6 +46,15 @@ internal abstract class SwiftExportTask @Inject constructor(
 
     @get:Nested
     abstract val mainModuleInput: ModuleInput
+
+    @get:Input
+    @get:Optional
+    abstract val cinteropModuleName: Property<String>
+
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val cinteropModuleArtifact: RegularFileProperty
 
     @get:Nested
     abstract val kotlinNativeProvider: Property<KotlinNativeProvider>
@@ -84,6 +94,14 @@ internal abstract class SwiftExportTask @Inject constructor(
                         mainModuleInput.artifact.getFile()
                     )
                 )
+                if (cinteropModuleName.isPresent) {
+                    add(
+                        createTransitiveSwiftExportedModule(
+                            cinteropModuleName.get(),
+                            cinteropModuleArtifact.getFile()
+                        )
+                    )
+                }
             }
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/GenerateSyntheticLinkageImportProject.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/GenerateSyntheticLinkageImportProject.kt
@@ -491,6 +491,8 @@ internal abstract class GenerateSyntheticLinkageImportProject : DefaultTask(), U
 
         const val TASK_NAME = "generateSyntheticLinkageSwiftPMImportProject"
         const val SYNTHETIC_IMPORT_TARGET_MAGIC_NAME = "KotlinMultiplatformLinkedPackage"
+
+        const val SWIFT_PM_IMPORT_CINTEROP_NAME = "swiftPMImport"
         const val SYNTHETIC_IMPORT_DYLIB = "KotlinMultiplatformLinkedPackageDylib"
         const val SUBPACKAGES = "subpackages"
         const val MANIFEST_NAME = "Package.swift"

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
@@ -156,9 +156,8 @@ internal val SwiftImportSetupAction = KotlinProjectSetupAction {
     }
 
     val hasDirectOrTransitiveSwiftPMDependencies = hasDirectOrTransitiveSwiftPMDependencies()
-    val fetchSyntheticImportProjectPackages = project.locateOrRegisterTask<FetchSyntheticImportProjectPackages>(
-        FetchSyntheticImportProjectPackages.TASK_NAME,
-    ) {
+    val fetchSyntheticImportProjectPackages = project.locateOrRegisterSwiftPMImportFetchTask()
+    fetchSyntheticImportProjectPackages.configure {
         it.onlyIf("SwiftPM import is only supported on macOS hosts") { isMacOSHost }
         it.onlyIf { hasDirectOrTransitiveSwiftPMDependencies.get() }
         it.ideaSyncEnabled.set(ideaSyncEnabled)
@@ -284,7 +283,7 @@ internal val SwiftImportSetupAction = KotlinProjectSetupAction {
             target.konanTarget,
         )
 
-        val cinteropName = "swiftPMImport"
+        val cinteropName = GenerateSyntheticLinkageImportProject.SWIFT_PM_IMPORT_CINTEROP_NAME
         val targetPlatform = target.konanTarget.applePlatform
         // use sdk for a more conventional name
         val targetSdk = target.konanTarget.appleTarget.sdk
@@ -932,6 +931,17 @@ internal fun Project.registerPackageGeneration(
         it.syntheticProductType.set(syntheticImportProjectProductType)
     }
 }
+
+internal fun Project.locateOrRegisterCoordinationService(): Provider<SwiftImportFingerprintedCoordinationService> =
+    SwiftImportFingerprintedCoordinationService.registerIfAbsent(
+        this,
+        provideXcodeDumpsDir(),
+        provideCheckoutDir(),
+        provideSyntheticPackageDir(),
+    )
+
+internal fun Project.locateOrRegisterSwiftPMImportFetchTask(): TaskProvider<FetchSyntheticImportProjectPackages> =
+    locateOrRegisterTask(FetchSyntheticImportProjectPackages.TASK_NAME)
 
 internal const val SHARED_XCODE_DUMP_DIR = "build/kotlin/swiftPMXcodeDumps"
 private fun Project.provideXcodeDumpsDir(): Provider<Directory> =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftPMImportProducts.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftPMImportProducts.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.tasks.CInteropProcess
+import org.jetbrains.kotlin.gradle.tasks.locateTask
+import java.io.File
+
+internal class SwiftPMImportProducts(
+    /** Module name of the reexported cinterop klib. */
+    val cinteropModuleName: Provider<String>,
+    /** The cinterop klib bundling the imported package's Objective-C modules (klib manifest `interop=true`). */
+    val cinteropKlib: Provider<File>,
+    /**
+     * The in-project root of the synthetic SPM package. With fingerprint coordination enabled this holds a
+     * *synced copy* of the shared owner package — content-identical (useful as a tracked input) but not
+     * consumable as a `.package(path:)` dependency, because its relative references are baked against the
+     * owner's location; resolve the consumable root with [sharedPackageRootFor] in that case.
+     */
+    val syntheticPackageLocalRoot: Provider<Directory>,
+    /**
+     * The synthetic package's fingerprint file; present only when fingerprint coordination is enabled. Its
+     * hash keys the shared owner locations ([sharedPackageRootFor], [sharedCheckoutFor]) — read it only at
+     * execution time, from tasks that depend on [fetchTask].
+     */
+    val syntheticPackageFingerprint: Provider<RegularFile>,
+    /** The service that maps a fingerprint hash to the shared owner locations. */
+    val coordinationService: Provider<SwiftImportFingerprintedCoordinationService>,
+    /** The umbrella library product vended by the synthetic package. */
+    val umbrellaProductName: String,
+    /**
+     * The in-project SwiftPM checkout. Like [syntheticPackageLocalRoot], with fingerprint coordination the
+     * populated checkout is the shared one ([sharedCheckoutFor]). A consumer that resolves the synthetic
+     * package itself should pass the effective checkout to xcodebuild (`-clonedSourcePackagesDirPath`) to
+     * reuse the fetched remote packages.
+     */
+    val swiftPMLocalCheckout: Provider<Directory>,
+    /**
+     * The task running `swift package resolve` on the synthetic package. Its output locations are not
+     * task-managed output properties, so consumers must `dependsOn` this task explicitly.
+     */
+    val fetchTask: TaskProvider<*>,
+)
+
+private fun packageHash(fingerprintFile: File): String = fingerprintFile.readSwiftImportFingerprint().incrementalFingerprint
+
+internal fun SwiftImportFingerprintedCoordinationService.sharedPackageRootFor(fingerprintFile: File): File =
+    sharedPackageGenerationRoot(packageHash(fingerprintFile))
+
+internal fun SwiftImportFingerprintedCoordinationService.sharedCheckoutFor(fingerprintFile: File): File =
+    sharedCheckoutDir(packageHash(fingerprintFile))
+
+internal fun KotlinNativeTarget.whenSwiftPMImportAvailable(onAvailable: (SwiftPMImportProducts) -> Unit) {
+    val mainCompilation = compilations.getByName(KotlinCompilation.MAIN_COMPILATION_NAME)
+    mainCompilation.cinterops
+        .matching { it.name == GenerateSyntheticLinkageImportProject.SWIFT_PM_IMPORT_CINTEROP_NAME }
+        .all { cinterop ->
+            val cinteropTask = project.locateTask<CInteropProcess>(cinterop.interopProcessingTaskName) ?: return@all
+            val fetchTask = project.locateOrRegisterSwiftPMImportFetchTask()
+            onAvailable(
+                SwiftPMImportProducts(
+                    cinteropModuleName = cinteropTask.map { it.moduleName },
+                    cinteropKlib = cinteropTask.flatMap { it.klibOutput },
+                    syntheticPackageLocalRoot = fetchTask.flatMap { it.syntheticImportProjectRoot },
+                    syntheticPackageFingerprint = fetchTask.flatMap { it.syntheticPackageFingerprint.fingerprintFile },
+                    coordinationService = project.locateOrRegisterCoordinationService(),
+                    umbrellaProductName = GenerateSyntheticLinkageImportProject.SYNTHETIC_IMPORT_TARGET_MAGIC_NAME,
+                    swiftPMLocalCheckout = fetchTask.flatMap { it.swiftPMDependenciesCheckout },
+                    fetchTask = fetchTask,
+                )
+            )
+        }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportManifestGeneratorTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportManifestGeneratorTest.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle.unitTests
 
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.GradleSwiftExportFiles
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.GradleSwiftExportModule
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.CinteropPackageImport
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.tasks.SPMManifestGenerator
 import kotlin.test.Test
 import java.io.File
@@ -88,6 +89,25 @@ class SwiftExportManifestGeneratorTest {
         val expectedManifest = singleModuleManifestGold()
 
         assertEquals(expectedManifest, manifest)
+    }
+
+    @Test
+    fun `test swift export SPM manifest with reexported cinterop package dependency`() {
+        val swiftApiModule = "Shared"
+
+        val manifest = SPMManifestGenerator.generateManifest(
+            swiftApiModule,
+            "SharedLibrary",
+            "KotlinRuntime",
+            sharedModulesFixture(swiftApiModule),
+            CinteropPackageImport(
+                path = "/repo/build/kotlin/swiftImport",
+                productName = "KotlinMultiplatformLinkedPackage",
+                packageIdentity = "swiftImport",
+            )
+        )
+
+        assertEquals(cinteropDependencyManifestGold(), manifest)
     }
 
     private fun sharedModulesFixture(swiftApiModule: String): List<GradleSwiftExportModule> = listOf(
@@ -247,6 +267,40 @@ class SwiftExportManifestGeneratorTest {
                 .target(
                     name: "SingleModule",
                     dependencies: ["KotlinRuntime"]
+                ),
+                .target(
+                    name: "KotlinRuntime"
+                )
+            ]
+        )
+    """.trimIndent() + "\n"
+
+    private fun cinteropDependencyManifestGold() = """
+        // swift-tools-version: 5.9
+
+        import PackageDescription
+        let package = Package(
+            name: "Shared",
+            products: [
+                .library(
+                    name: "SharedLibrary",
+                    targets: ["Shared", "Dependency"]
+                )
+            ],
+            dependencies: [
+                .package(path: "/repo/build/kotlin/swiftImport")
+            ],
+            targets: [
+                .target(
+                    name: "Shared",
+                    dependencies: ["Dependency", "SharedBridge", "KotlinRuntime", .product(name: "KotlinMultiplatformLinkedPackage", package: "swiftImport")]
+                ),
+                .target(
+                    name: "SharedBridge"
+                ),
+                .target(
+                    name: "Dependency",
+                    dependencies: ["KotlinRuntime", .product(name: "KotlinMultiplatformLinkedPackage", package: "swiftImport")]
                 ),
                 .target(
                     name: "KotlinRuntime"


### PR DESCRIPTION
Swift Export's standalone runner already reexports a cinterop klib that bundles Objective-C modules: it detects such a klib by the manifest property `interop=true`, imports every module the klib declares, and references the types bare. This had no Kotlin Gradle Plugin wiring, so the capability was unreachable from a real build.

Wire it in, scoped to the SwiftPM-import feature. When a project imports a Swift package, KGP already builds a `swiftPMImport` cinterop klib for that package; this hands that klib (and only that klib) to the Swift Export task as an extra input module. The runner then auto-detects it and reexports its Objective-C modules to Swift.

For the emitted `import <ObjCModule>` lines to resolve when the generated package is built, the Swift Export `Package.swift` now declares a dependency on the synthetic package produced by SwiftPM import (`.package(path:)`) and pulls in its umbrella product. SwiftPM's transitive module visibility makes the bundled modules importable through that single product; the package identity is the synthetic package's directory name.

The SwiftPM-import feature exposes this through a typed contract (`SwiftPMImportProducts` / `whenSwiftPMImportAvailable`) so Swift Export consumes the cinterop klib and synthetic package without knowing the cinterop name, its task type, or the synthetic-package task.

^KT-80632