### PR TITLE
[IR] Migrate remaining descriptor-based calls of `createEmptyExternalPackageFragment`

### DIFF
--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
@@ -132,8 +132,8 @@ private class Fir2IrPipeline(
     val irModuleFragmentPostCompute: (IrModuleFragment) -> Unit,
 ) {
     private class Fir2IrConversionResult(
-        val mainIrFragment: IrModuleFragmentImpl,
-        val dependentIrFragments: List<IrModuleFragmentImpl>,
+        val mainIrFragment: IrModuleFragment,
+        val dependentIrFragments: List<IrModuleFragment>,
         val componentsStoragePerSourceSession: Map<FirSession, Fir2IrComponentsStorage>,
         val commonMemberStorage: Fir2IrCommonMemberStorage,
         val generatedDataValueClassSyntheticFunctions: Map<IrClass, DataValueClassGeneratedMembersInfo>,

--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
@@ -245,7 +245,7 @@ private class Fir2IrPipeline(
         val expectActualMap = irActualizer?.actualizeCallablesAndMergeModules() ?: IrExpectActualMap()
 
         val pluginContext = Fir2IrPluginContext(
-            componentsStorage, irBuiltIns, componentsStorage.moduleDescriptor, symbolTable,
+            componentsStorage, irBuiltIns, symbolTable,
             @OptIn(MessageCollectorAccess::class) // deprecated in IrPluginContext
             fir2IrConfiguration.messageCollector,
             fir2IrConfiguration.diagnosticReporter

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrComponentsStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrComponentsStorage.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.fir.resolve.ScopeSession
 import org.jetbrains.kotlin.ir.IrLock
 import org.jetbrains.kotlin.ir.IrProvider
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
 import org.jetbrains.kotlin.ir.util.KotlinMangler
 import org.jetbrains.kotlin.ir.util.SymbolRemapper
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
@@ -40,14 +42,16 @@ class Fir2IrComponentsStorage(
 
     override val filesBeingCompiled: Set<FirFile>? = runIf(configuration.allowNonCachedDeclarations) { fir.toSet() }
 
-    val moduleDescriptor: FirModuleDescriptor = FirModuleDescriptor.createSourceModuleDescriptor(session, kotlinBuiltIns)
+    val module: IrModuleFragment = IrModuleFragmentImpl(
+        FirModuleDescriptor.createSourceModuleDescriptor(session, kotlinBuiltIns)
+    )
 
     private val conversionScope = Fir2IrConversionScope(configuration)
 
-    override val converter: Fir2IrConverter = Fir2IrConverter(moduleDescriptor, this, conversionScope)
+    override val converter: Fir2IrConverter = Fir2IrConverter(this, conversionScope)
 
     override val classifierStorage: Fir2IrClassifierStorage = Fir2IrClassifierStorage(this, commonMemberStorage, conversionScope)
-    override val declarationStorage: Fir2IrDeclarationStorage = Fir2IrDeclarationStorage(this, moduleDescriptor, commonMemberStorage)
+    override val declarationStorage: Fir2IrDeclarationStorage = Fir2IrDeclarationStorage(this, module, commonMemberStorage)
 
     override val callablesGenerator: Fir2IrCallableDeclarationsGenerator = Fir2IrCallableDeclarationsGenerator(this)
     override val classifiersGenerator: Fir2IrClassifiersGenerator = Fir2IrClassifiersGenerator(this)

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConverter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrConverter.kt
@@ -60,7 +60,6 @@ import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.psi.KtFile
 
 class Fir2IrConverter(
-    private val moduleDescriptor: FirModuleDescriptor,
     private val c: Fir2IrComponents,
     private val conversionScope: Fir2IrConversionScope,
 ) : Fir2IrComponents by c {
@@ -69,7 +68,7 @@ class Fir2IrConverter(
 
     private fun runSourcesConversion(
         allFirFiles: List<FirFile>,
-        irModuleFragment: IrModuleFragmentImpl,
+        irModuleFragment: IrModuleFragment,
         fir2irVisitor: Fir2IrVisitor
     ) {
         for (firFile in allFirFiles) {
@@ -143,7 +142,7 @@ class Fir2IrConverter(
         }
         val irFile = IrFileImpl(
             fileEntry,
-            moduleDescriptor.getPackage(file.packageFqName).fragments.first(),
+            moduleFragment.descriptor.getPackage(file.packageFqName).fragments.first(),
             moduleFragment
         )
         if (file.origin is FirDeclarationOrigin.Synthetic.PluginFile) {
@@ -602,12 +601,12 @@ class Fir2IrConverter(
     }
 
     companion object {
-        fun generateIrModuleFragment(components: Fir2IrComponentsStorage, firFiles: List<FirFile>): IrModuleFragmentImpl {
+        fun generateIrModuleFragment(components: Fir2IrComponentsStorage, firFiles: List<FirFile>): IrModuleFragment {
             val session = components.session
 
             session.lazyDeclarationResolver.disableLazyResolveContractChecks()
 
-            val irModuleFragment = IrModuleFragmentImpl(components.moduleDescriptor)
+            val irModuleFragment = components.module
 
             val allFirFiles = buildList {
                 addAll(session.createFilesWithBuiltinsSyntheticDeclarationsIfNeeded())

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrDeclarationStorage.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin.Companion.FILLED_FOR_UNBOUND_SYMBOL
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
+import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
 import org.jetbrains.kotlin.ir.expressions.IrSyntheticBodyKind
 import org.jetbrains.kotlin.ir.irFlag
 import org.jetbrains.kotlin.ir.symbols.*
@@ -66,12 +67,12 @@ import java.util.concurrent.ConcurrentHashMap
 
 class Fir2IrDeclarationStorage(
     private val c: Fir2IrComponents,
-    private val sourceModuleDescriptor: FirModuleDescriptor,
+    private val sourceModule: IrModuleFragment,
     commonMemberStorage: Fir2IrCommonMemberStorage
 ) : Fir2IrComponents by c {
 
     private val fragmentCache: ConcurrentHashMap<FqName, ExternalPackageFragments> = ConcurrentHashMap()
-    private val moduleDescriptorCache: ConcurrentHashMap<FirModuleData, FirModuleDescriptor> = ConcurrentHashMap()
+    private val irModuleCache: ConcurrentHashMap<FirModuleData, IrModuleFragment> = ConcurrentHashMap()
 
     private class ExternalPackageFragments(
         val fragmentsForDependencies: ConcurrentHashMap<FirModuleData, IrExternalPackageFragment>,
@@ -226,12 +227,10 @@ class Fir2IrDeclarationStorage(
 
     // ------------------------------------ package fragments ------------------------------------
 
-    fun getDependenciesModuleDescriptor(moduleData: FirModuleData): FirModuleDescriptor {
-        return moduleDescriptorCache.getOrPut(moduleData) {
-            FirModuleDescriptor.createDependencyModuleDescriptor(
-                moduleData,
-                sourceModuleDescriptor.builtIns
-            )
+    fun getDependenciesIrModule(moduleData: FirModuleData): IrModuleFragment {
+        return irModuleCache.getOrPut(moduleData) {
+            val moduleDescriptor = FirModuleDescriptor.createDependencyModuleDescriptor(moduleData, sourceModule.descriptor.builtIns)
+            IrModuleFragmentImpl(moduleDescriptor)
         }
     }
 
@@ -251,7 +250,7 @@ class Fir2IrDeclarationStorage(
     ): IrExternalPackageFragment {
         val isBuiltIn = allowBuiltins && fqName in BUILT_INS_PACKAGE_FQ_NAMES
         val fragments = fragmentCache.getOrPut(fqName) {
-            val fragmentForPrecompiledBinaries = callablesGenerator.createExternalPackageFragment(fqName, sourceModuleDescriptor)
+            val fragmentForPrecompiledBinaries = callablesGenerator.createExternalPackageFragment(fqName, sourceModule)
             ExternalPackageFragments(ConcurrentHashMap(), ConcurrentHashMap(), fragmentForPrecompiledBinaries)
         }
         // Make sure that external package fragments have a different module descriptor. The module descriptors are compared
@@ -260,14 +259,14 @@ class Fir2IrDeclarationStorage(
         return when (firOrigin) {
             FirDeclarationOrigin.Precompiled -> fragments.fragmentForPrecompiledBinaries
             else -> {
-                val moduleDescriptor = getDependenciesModuleDescriptor(moduleData)
+                val irModule = getDependenciesIrModule(moduleData)
                 if (isBuiltIn) {
                     fragments.builtinFragmentsForDependencies.getOrPut(moduleData) {
-                        callablesGenerator.createExternalPackageFragment(FirBuiltInsPackageFragment(fqName, moduleDescriptor))
+                        callablesGenerator.createExternalPackageFragment(fqName, irModule, ::FirBuiltInsPackageFragment)
                     }
                 } else {
                     fragments.fragmentsForDependencies.getOrPut(moduleData) {
-                        callablesGenerator.createExternalPackageFragment(fqName, moduleDescriptor)
+                        callablesGenerator.createExternalPackageFragment(fqName, irModule)
                     }
                 }
             }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrPluginContext.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrPluginContext.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.backend.common.extensions.DeclarationFinder
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.LanguageVersionSettings
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.backend.utils.unsubstitutedScope
 import org.jetbrains.kotlin.fir.declarations.fullyExpandedClass
@@ -45,7 +44,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
 class Fir2IrPluginContext(
     private val c: Fir2IrComponents,
     override val irBuiltIns: IrBuiltIns,
-    @property:ObsoleteDescriptorBasedAPI override val moduleDescriptor: ModuleDescriptor,
     @property:ObsoleteDescriptorBasedAPI override val symbolTable: ReferenceSymbolTable,
     @property:Deprecated(
         "Consider using diagnosticReporter instead. See https://youtrack.jetbrains.com/issue/KT-78277 for more details",

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/IrBuiltInsOverFir.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/IrBuiltInsOverFir.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.descriptors.FirModuleDescriptor
 import org.jetbrains.kotlin.fir.languageVersionSettings
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.resolve.providers.getRegularClassSymbolByClassId
@@ -32,7 +31,6 @@ import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.name.*
 import org.jetbrains.kotlin.types.Variance
-import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
 
 @OptIn(Fir2IrBuiltInsInternals::class, InternalSymbolFinderAPI::class)
 class IrBuiltInsOverFir(
@@ -42,13 +40,13 @@ class IrBuiltInsOverFir(
 
     // ------------------------------------- basic stuff -------------------------------------
 
-    private val moduleDescriptor: FirModuleDescriptor = run {
+    private val irModule: IrModuleFragment = run {
         val session = c.session
         val moduleData = when (session.languageVersionSettings.getFlag(AnalysisFlags.stdlibCompilation)) {
             false -> session.moduleData.dependencies.first()
             true -> session.moduleData
         }
-        c.declarationStorage.getDependenciesModuleDescriptor(moduleData)
+        c.declarationStorage.getDependenciesIrModule(moduleData)
     }
 
     private val session: FirSession
@@ -262,7 +260,7 @@ class IrBuiltInsOverFir(
 
     // ------------------------------------- private utilities -------------------------------------
     private fun createPackage(fqName: FqName): IrExternalPackageFragment =
-        createEmptyExternalPackageFragment(moduleDescriptor, fqName)
+        createEmptyExternalPackageFragment(irModule, fqName)
 
     private fun createFunction(
         name: String,

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/Fir2IrCallableDeclarationsGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/Fir2IrCallableDeclarationsGenerator.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.fir.declarations.*
 import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertyGetter
 import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertySetter
 import org.jetbrains.kotlin.fir.declarations.utils.*
-import org.jetbrains.kotlin.fir.descriptors.FirModuleDescriptor
 import org.jetbrains.kotlin.fir.descriptors.FirPackageFragmentDescriptor
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
@@ -54,13 +53,13 @@ import kotlin.contracts.contract
 class Fir2IrCallableDeclarationsGenerator(private val c: Fir2IrComponents) : Fir2IrComponents by c {
     // ------------------------------------ package fragments ------------------------------------
 
-    internal fun createExternalPackageFragment(fqName: FqName, moduleDescriptor: FirModuleDescriptor): IrExternalPackageFragment {
-        return createExternalPackageFragment(FirPackageFragmentDescriptor(fqName, moduleDescriptor))
-    }
-
-    internal fun createExternalPackageFragment(packageFragmentDescriptor: PackageFragmentDescriptor): IrExternalPackageFragment {
-        val symbol = IrExternalPackageFragmentSymbolImpl(packageFragmentDescriptor)
-        return IrExternalPackageFragmentImpl(symbol, packageFragmentDescriptor.fqName)
+    internal fun createExternalPackageFragment(
+        fqName: FqName,
+        module: IrModuleFragment,
+        createPackageFragmentDescriptor: (FqName, ModuleDescriptor) -> PackageFragmentDescriptor = ::FirPackageFragmentDescriptor,
+    ): IrExternalPackageFragment {
+        val symbol = IrExternalPackageFragmentSymbolImpl(createPackageFragmentDescriptor(fqName, module.descriptor))
+        return IrExternalPackageFragmentImpl(symbol, fqName)
     }
 
     // ------------------------------------ functions ------------------------------------

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/extensions/IrPluginContext.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/extensions/IrPluginContext.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.backend.common.extensions
 
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.LanguageVersionSettings
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
@@ -132,9 +131,6 @@ interface IrPluginContext : IrGeneratorContext {
 
     @ObsoleteDescriptorBasedAPI
     val symbolTable: ReferenceSymbolTable
-
-    @ObsoleteDescriptorBasedAPI
-    val moduleDescriptor: ModuleDescriptor
 
 }
 

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/extensions/IrPluginContextImpl.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/extensions/IrPluginContextImpl.kt
@@ -47,9 +47,6 @@ open class IrPluginContextImpl(
 
     override val platform: TargetPlatform? = module.platform
 
-    @OptIn(ObsoleteDescriptorBasedAPI::class)
-    override val moduleDescriptor: ModuleDescriptor = module
-
     @ObsoleteDescriptorBasedAPI
     override val symbolTable: ReferenceSymbolTable = st
 

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -109,7 +109,7 @@ class JvmIrCodegenFactory(
 
         val evaluatorData = ideCodegenSettings.evaluatorData
         val context = JvmBackendContext(
-            state, irBuiltIns, symbolTable, debuggerExtensions,
+            state, irBuiltIns, irModuleFragment, symbolTable, debuggerExtensions,
             backendExtension, irPluginContext, evaluatorData
         )
         val generationExtensions = state.configuration.filteredExtensions

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -109,8 +109,8 @@ class JvmIrCodegenFactory(
 
         val evaluatorData = ideCodegenSettings.evaluatorData
         val context = JvmBackendContext(
-            state, irBuiltIns, irModuleFragment, symbolTable, debuggerExtensions,
-            backendExtension, irPluginContext, evaluatorData
+            state, irBuiltIns, symbolTable, debuggerExtensions,
+            backendExtension, irPluginContext, evaluatorData, irModuleFragment
         )
         val generationExtensions = state.configuration.filteredExtensions
             .mapNotNull { it.getPlatformIntrinsicExtension(context) as? JvmIrIntrinsicExtension }

--- a/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
+++ b/compiler/ir/backend.jvm/entrypoint/src/org/jetbrains/kotlin/backend/jvm/JvmIrCodegenFactory.kt
@@ -109,8 +109,8 @@ class JvmIrCodegenFactory(
 
         val evaluatorData = ideCodegenSettings.evaluatorData
         val context = JvmBackendContext(
-            state, irBuiltIns, symbolTable, debuggerExtensions,
-            backendExtension, irPluginContext, evaluatorData, irModuleFragment
+            state, irBuiltIns, irModuleFragment, symbolTable, debuggerExtensions,
+            backendExtension, irPluginContext, evaluatorData
         )
         val generationExtensions = state.configuration.filteredExtensions
             .mapNotNull { it.getPlatformIntrinsicExtension(context) as? JvmIrIntrinsicExtension }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -40,11 +40,12 @@ import org.jetbrains.org.objectweb.asm.Type
 class JvmBackendContext(
     val state: GenerationState,
     override val irBuiltIns: IrBuiltIns,
+    irModule: IrModuleFragment,
     val symbolTable: SymbolTable,
     val debuggerExtensions: JvmDebuggerExtensions?,
     val backendExtension: JvmBackendExtension,
     val irPluginContext: IrPluginContext?,
-    val evaluatorData: JvmEvaluatorData?
+    val evaluatorData: JvmEvaluatorData?,
 ) : CommonBackendContext {
     class SharedLocalDeclarationsData(
         val closureBuilders: MutableMap<IrDeclaration, ClosureBuilder> = mutableMapOf<IrDeclaration, ClosureBuilder>(),
@@ -69,9 +70,9 @@ class JvmBackendContext(
 
     override val diagnosticReporter = KtDiagnosticReporterWithImplicitIrBasedContext(state.diagnosticReporter, config.languageVersionSettings)
 
-    override val symbols = JvmSymbols(this)
+    override val symbols = JvmSymbols(this, irModule)
 
-    override val sharedVariablesManager = JvmSharedVariablesManager(state.module, symbols, irBuiltIns, irFactory)
+    override val sharedVariablesManager = JvmSharedVariablesManager(symbols, irBuiltIns, irModule, irFactory)
 
     lateinit var getIntrinsic: (IrFunctionSymbol) -> IntrinsicMarker?
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -40,12 +40,12 @@ import org.jetbrains.org.objectweb.asm.Type
 class JvmBackendContext(
     val state: GenerationState,
     override val irBuiltIns: IrBuiltIns,
-    irModule: IrModuleFragment,
     val symbolTable: SymbolTable,
     val debuggerExtensions: JvmDebuggerExtensions?,
     val backendExtension: JvmBackendExtension,
     val irPluginContext: IrPluginContext?,
     val evaluatorData: JvmEvaluatorData?,
+    module: IrModuleFragment,
 ) : CommonBackendContext {
     class SharedLocalDeclarationsData(
         val closureBuilders: MutableMap<IrDeclaration, ClosureBuilder> = mutableMapOf<IrDeclaration, ClosureBuilder>(),
@@ -70,9 +70,9 @@ class JvmBackendContext(
 
     override val diagnosticReporter = KtDiagnosticReporterWithImplicitIrBasedContext(state.diagnosticReporter, config.languageVersionSettings)
 
-    override val symbols = JvmSymbols(this, irModule)
+    override val symbols = JvmSymbols(this, module)
 
-    override val sharedVariablesManager = JvmSharedVariablesManager(symbols, irBuiltIns, irModule, irFactory)
+    override val sharedVariablesManager = JvmSharedVariablesManager(module, symbols, irBuiltIns, irFactory)
 
     lateinit var getIntrinsic: (IrFunctionSymbol) -> IntrinsicMarker?
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -40,12 +40,12 @@ import org.jetbrains.org.objectweb.asm.Type
 class JvmBackendContext(
     val state: GenerationState,
     override val irBuiltIns: IrBuiltIns,
+    irModule: IrModuleFragment,
     val symbolTable: SymbolTable,
     val debuggerExtensions: JvmDebuggerExtensions?,
     val backendExtension: JvmBackendExtension,
     val irPluginContext: IrPluginContext?,
     val evaluatorData: JvmEvaluatorData?,
-    module: IrModuleFragment,
 ) : CommonBackendContext {
     class SharedLocalDeclarationsData(
         val closureBuilders: MutableMap<IrDeclaration, ClosureBuilder> = mutableMapOf<IrDeclaration, ClosureBuilder>(),
@@ -70,9 +70,9 @@ class JvmBackendContext(
 
     override val diagnosticReporter = KtDiagnosticReporterWithImplicitIrBasedContext(state.diagnosticReporter, config.languageVersionSettings)
 
-    override val symbols = JvmSymbols(this, module)
+    override val symbols = JvmSymbols(this, irModule)
 
-    override val sharedVariablesManager = JvmSharedVariablesManager(module, symbols, irBuiltIns, irFactory)
+    override val sharedVariablesManager = JvmSharedVariablesManager(symbols, irBuiltIns, irModule, irFactory)
 
     lateinit var getIntrinsic: (IrFunctionSymbol) -> IntrinsicMarker?
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmReflectSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmReflectSymbols.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.builders.declarations.addFunction
 import org.jetbrains.kotlin.ir.builders.declarations.addValueParameter
 import org.jetbrains.kotlin.ir.builders.declarations.buildClass
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.declarations.createEmptyExternalPackageFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -23,13 +24,13 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-class JvmReflectSymbols(val context: JvmBackendContext) {
+class JvmReflectSymbols(val context: JvmBackendContext, irModule: IrModuleFragment) {
     private val irBuiltIns: IrBuiltIns = context.irBuiltIns
 
     private val javaLangReflect: FqName = FqName("java.lang.reflect")
 
     private val javaLangReflectPackage: IrPackageFragment =
-        createEmptyExternalPackageFragment(context.state.module, javaLangReflect)
+        createEmptyExternalPackageFragment(irModule, javaLangReflect)
 
     val javaLangReflectField: IrClassSymbol =
         createJavaLangReflectClass(FqName("java.lang.reflect.Field")) { klass ->

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmReflectSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmReflectSymbols.kt
@@ -24,13 +24,13 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-class JvmReflectSymbols(val context: JvmBackendContext, module: IrModuleFragment) {
+class JvmReflectSymbols(val context: JvmBackendContext, irModule: IrModuleFragment) {
     private val irBuiltIns: IrBuiltIns = context.irBuiltIns
 
     private val javaLangReflect: FqName = FqName("java.lang.reflect")
 
     private val javaLangReflectPackage: IrPackageFragment =
-        createEmptyExternalPackageFragment(module, javaLangReflect)
+        createEmptyExternalPackageFragment(irModule, javaLangReflect)
 
     val javaLangReflectField: IrClassSymbol =
         createJavaLangReflectClass(FqName("java.lang.reflect.Field")) { klass ->

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmReflectSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmReflectSymbols.kt
@@ -24,13 +24,13 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-class JvmReflectSymbols(val context: JvmBackendContext, irModule: IrModuleFragment) {
+class JvmReflectSymbols(val context: JvmBackendContext, module: IrModuleFragment) {
     private val irBuiltIns: IrBuiltIns = context.irBuiltIns
 
     private val javaLangReflect: FqName = FqName("java.lang.reflect")
 
     private val javaLangReflectPackage: IrPackageFragment =
-        createEmptyExternalPackageFragment(irModule, javaLangReflect)
+        createEmptyExternalPackageFragment(module, javaLangReflect)
 
     val javaLangReflectField: IrClassSymbol =
         createJavaLangReflectClass(FqName("java.lang.reflect.Field")) { klass ->

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSharedVariablesManager.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSharedVariablesManager.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.backend.jvm
 
 import org.jetbrains.kotlin.backend.common.ir.SharedVariablesManager
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.declarations.*
@@ -26,13 +25,13 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 class JvmSharedVariablesManager(
-    module: ModuleDescriptor,
     val symbols: JvmSymbols,
     val irBuiltIns: IrBuiltIns,
+    irModule: IrModuleFragment,
     irFactory: IrFactory,
 ) : SharedVariablesManager() {
     private val jvmInternalPackage = createEmptyExternalPackageFragment(
-        module, FqName("kotlin.jvm.internal")
+        irModule, FqName("kotlin.jvm.internal")
     )
 
     private val refNamespaceClass = irFactory.addClass(jvmInternalPackage) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSharedVariablesManager.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSharedVariablesManager.kt
@@ -25,13 +25,13 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 class JvmSharedVariablesManager(
+    module: IrModuleFragment,
     val symbols: JvmSymbols,
     val irBuiltIns: IrBuiltIns,
-    irModule: IrModuleFragment,
     irFactory: IrFactory,
 ) : SharedVariablesManager() {
     private val jvmInternalPackage = createEmptyExternalPackageFragment(
-        irModule, FqName("kotlin.jvm.internal")
+        module, FqName("kotlin.jvm.internal")
     )
 
     private val refNamespaceClass = irFactory.addClass(jvmInternalPackage) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSharedVariablesManager.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSharedVariablesManager.kt
@@ -25,13 +25,13 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 class JvmSharedVariablesManager(
-    module: IrModuleFragment,
     val symbols: JvmSymbols,
     val irBuiltIns: IrBuiltIns,
+    irModule: IrModuleFragment,
     irFactory: IrFactory,
 ) : SharedVariablesManager() {
     private val jvmInternalPackage = createEmptyExternalPackageFragment(
-        module, FqName("kotlin.jvm.internal")
+        irModule, FqName("kotlin.jvm.internal")
     )
 
     private val refNamespaceClass = irFactory.addClass(jvmInternalPackage) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -46,6 +46,7 @@ import java.lang.invoke.MethodType
 
 class JvmSymbols(
     private val context: JvmBackendContext,
+    private val irModule: IrModuleFragment,
 ) : BackendSymbols(context.irBuiltIns) {
     private val irBuiltIns = context.irBuiltIns
     private val storageManager = LockBasedStorageManager(this::class.java.simpleName)
@@ -82,7 +83,7 @@ class JvmSymbols(
     val kotlinJvmInternalInvokeDynamicPackage: IrPackageFragment = createPackage(FqName("kotlin.jvm.internal.invokeDynamic"))
 
     private fun createPackage(fqName: FqName): IrPackageFragment =
-        createEmptyExternalPackageFragment(context.state.module, fqName)
+        createEmptyExternalPackageFragment(irModule, fqName)
 
     private fun createClass(
         fqName: FqName,
@@ -566,7 +567,7 @@ class JvmSymbols(
     }
 
     val javaLangReflectSymbols: JvmReflectSymbols by lazy {
-        JvmReflectSymbols(context)
+        JvmReflectSymbols(context, irModule)
     }
 
     override val functionAdapter: IrClassSymbol = createClass(FqName("kotlin.jvm.internal.FunctionAdapter"), ClassKind.INTERFACE) { klass ->
@@ -1074,7 +1075,7 @@ class JvmSymbols(
         private val javaLangAnnotation: FqName = FqName("java.lang.annotation")
 
         private val javaLangAnnotationPackage: IrPackageFragment =
-            createEmptyExternalPackageFragment(context.state.module, javaLangAnnotation)
+            createEmptyExternalPackageFragment(irModule, javaLangAnnotation)
 
         private fun buildClass(
             fqName: FqName,

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -46,7 +46,7 @@ import java.lang.invoke.MethodType
 
 class JvmSymbols(
     private val context: JvmBackendContext,
-    private val module: IrModuleFragment,
+    private val irModule: IrModuleFragment,
 ) : BackendSymbols(context.irBuiltIns) {
     private val irBuiltIns = context.irBuiltIns
     private val storageManager = LockBasedStorageManager(this::class.java.simpleName)
@@ -83,7 +83,7 @@ class JvmSymbols(
     val kotlinJvmInternalInvokeDynamicPackage: IrPackageFragment = createPackage(FqName("kotlin.jvm.internal.invokeDynamic"))
 
     private fun createPackage(fqName: FqName): IrPackageFragment =
-        createEmptyExternalPackageFragment(module, fqName)
+        createEmptyExternalPackageFragment(irModule, fqName)
 
     private fun createClass(
         fqName: FqName,
@@ -567,7 +567,7 @@ class JvmSymbols(
     }
 
     val javaLangReflectSymbols: JvmReflectSymbols by lazy {
-        JvmReflectSymbols(context, module)
+        JvmReflectSymbols(context, irModule)
     }
 
     override val functionAdapter: IrClassSymbol = createClass(FqName("kotlin.jvm.internal.FunctionAdapter"), ClassKind.INTERFACE) { klass ->
@@ -1075,7 +1075,7 @@ class JvmSymbols(
         private val javaLangAnnotation: FqName = FqName("java.lang.annotation")
 
         private val javaLangAnnotationPackage: IrPackageFragment =
-            createEmptyExternalPackageFragment(module, javaLangAnnotation)
+            createEmptyExternalPackageFragment(irModule, javaLangAnnotation)
 
         private fun buildClass(
             fqName: FqName,

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmSymbols.kt
@@ -46,7 +46,7 @@ import java.lang.invoke.MethodType
 
 class JvmSymbols(
     private val context: JvmBackendContext,
-    private val irModule: IrModuleFragment,
+    private val module: IrModuleFragment,
 ) : BackendSymbols(context.irBuiltIns) {
     private val irBuiltIns = context.irBuiltIns
     private val storageManager = LockBasedStorageManager(this::class.java.simpleName)
@@ -83,7 +83,7 @@ class JvmSymbols(
     val kotlinJvmInternalInvokeDynamicPackage: IrPackageFragment = createPackage(FqName("kotlin.jvm.internal.invokeDynamic"))
 
     private fun createPackage(fqName: FqName): IrPackageFragment =
-        createEmptyExternalPackageFragment(irModule, fqName)
+        createEmptyExternalPackageFragment(module, fqName)
 
     private fun createClass(
         fqName: FqName,
@@ -567,7 +567,7 @@ class JvmSymbols(
     }
 
     val javaLangReflectSymbols: JvmReflectSymbols by lazy {
-        JvmReflectSymbols(context, irModule)
+        JvmReflectSymbols(context, module)
     }
 
     override val functionAdapter: IrClassSymbol = createClass(FqName("kotlin.jvm.internal.FunctionAdapter"), ClassKind.INTERFACE) { klass ->
@@ -1075,7 +1075,7 @@ class JvmSymbols(
         private val javaLangAnnotation: FqName = FqName("java.lang.annotation")
 
         private val javaLangAnnotationPackage: IrPackageFragment =
-            createEmptyExternalPackageFragment(irModule, javaLangAnnotation)
+            createEmptyExternalPackageFragment(module, javaLangAnnotation)
 
         private fun buildClass(
             fqName: FqName,

--- a/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/descriptors/IrBuiltInsOverDescriptors.kt
+++ b/compiler/ir/ir.psi2ir/src/org/jetbrains/kotlin/psi2ir/descriptors/IrBuiltInsOverDescriptors.kt
@@ -17,10 +17,8 @@ import org.jetbrains.kotlin.descriptors.impl.ValueParameterDescriptorImpl
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.ir.*
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.descriptors.IrBuiltinValueParameterDescriptorImpl
-import org.jetbrains.kotlin.ir.descriptors.IrBuiltinsPackageFragmentDescriptorImpl
-import org.jetbrains.kotlin.ir.descriptors.IrDescriptorBasedFunctionFactory
-import org.jetbrains.kotlin.ir.descriptors.IrSimpleBuiltinOperatorDescriptorImpl
+import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
+import org.jetbrains.kotlin.ir.descriptors.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrAnnotationImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
@@ -75,7 +73,8 @@ class IrBuiltInsOverDescriptors(
     private val builtInsModule = builtIns.builtInsModule
 
     private val kotlinInternalPackage = StandardClassIds.BASE_INTERNAL_PACKAGE
-    override val kotlinInternalPackageFragment = createEmptyExternalPackageFragment(builtInsModule, kotlinInternalPackage)
+    override val kotlinInternalPackageFragment =
+        createEmptyExternalPackageFragment(IrModuleFragmentImpl(builtInsModule), kotlinInternalPackage)
 
     private val packageFragmentDescriptor = IrBuiltinsPackageFragmentDescriptorImpl(builtInsModule, KOTLIN_INTERNAL_IR_FQN)
 

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrPackageFragments.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrPackageFragments.kt
@@ -46,9 +46,3 @@ fun createEmptyExternalPackageFragment(module: IrModuleFragment, fqName: FqName)
     IrExternalPackageFragmentImpl(
         IrExternalPackageFragmentSymbolImpl(EmptyPackageFragmentDescriptor(module.descriptor, fqName)), fqName
     )
-
-fun createEmptyExternalPackageFragment(module: ModuleDescriptor, fqName: FqName): IrExternalPackageFragment =
-    // TODO(KT-87300): Migrate all usages of this function to the one with `IrModuleFragment` instead of `ModuleDescriptor`
-    IrExternalPackageFragmentImpl(
-        IrExternalPackageFragmentSymbolImpl(EmptyPackageFragmentDescriptor(module, fqName)), fqName
-    )

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
@@ -64,6 +64,7 @@ abstract class AbstractLiveLiteralTransformTests : AbstractIrTransformTest() {
                                     liveLiteralsV2Enabled,
                                     keyVisitor,
                                     pluginContext,
+                                    moduleFragment,
                                     ModuleMetricsImpl("temp", featureFlags) { type, fileContainingDependent ->
                                         stabilityInferencer.stabilityOf(
                                             type,
@@ -71,7 +72,7 @@ abstract class AbstractLiveLiteralTransformTests : AbstractIrTransformTest() {
                                         )
                                     },
                                     stabilityInferencer,
-                                    featureFlags
+                                    featureFlags,
                                 ) {
                                     override fun makeKeySet(): MutableSet<String> {
                                         return super.makeKeySet().also { builtKeys = it }

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
@@ -64,6 +64,7 @@ abstract class AbstractLiveLiteralTransformTests : AbstractIrTransformTest() {
                                     liveLiteralsV2Enabled,
                                     keyVisitor,
                                     pluginContext,
+                                    moduleFragment,
                                     ModuleMetricsImpl("temp", featureFlags) { type, fileContainingDependent ->
                                         stabilityInferencer.stabilityOf(
                                             type,
@@ -72,7 +73,6 @@ abstract class AbstractLiveLiteralTransformTests : AbstractIrTransformTest() {
                                     },
                                     stabilityInferencer,
                                     featureFlags,
-                                    moduleFragment,
                                 ) {
                                     override fun makeKeySet(): MutableSet<String> {
                                         return super.makeKeySet().also { builtKeys = it }

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/AbstractLiveLiteralTransformTests.kt
@@ -64,7 +64,6 @@ abstract class AbstractLiveLiteralTransformTests : AbstractIrTransformTest() {
                                     liveLiteralsV2Enabled,
                                     keyVisitor,
                                     pluginContext,
-                                    moduleFragment,
                                     ModuleMetricsImpl("temp", featureFlags) { type, fileContainingDependent ->
                                         stabilityInferencer.stabilityOf(
                                             type,
@@ -73,6 +72,7 @@ abstract class AbstractLiveLiteralTransformTests : AbstractIrTransformTest() {
                                     },
                                     stabilityInferencer,
                                     featureFlags,
+                                    moduleFragment,
                                 ) {
                                     override fun makeKeySet(): MutableSet<String> {
                                         return super.makeKeySet().also { builtKeys = it }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
@@ -77,6 +77,7 @@ class ComposeIrGenerationExtension(
         if (pluginContext.platform.isNative()) {
             AddHiddenFromObjCLowering(
                 pluginContext,
+                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
@@ -85,6 +86,7 @@ class ComposeIrGenerationExtension(
 
         ClassStabilityTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
@@ -99,6 +101,7 @@ class ComposeIrGenerationExtension(
                 usePerFileEnabledFlag = liveLiteralsV2Enabled,
                 keyVisitor = DurableKeyVisitor(),
                 context = pluginContext,
+                irModule = moduleFragment,
                 metrics = metrics,
                 stabilityInferencer = stabilityInferencer,
                 featureFlags = featureFlags,
@@ -111,6 +114,7 @@ class ComposeIrGenerationExtension(
 
         val functionKeyTransformer = DurableFunctionKeyTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
@@ -127,9 +131,10 @@ class ComposeIrGenerationExtension(
         // Generate default wrappers for virtual functions
         ComposableDefaultParamLowering(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
-            featureFlags
+            featureFlags,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -140,6 +145,7 @@ class ComposeIrGenerationExtension(
         // ComposerLambdaMemoization so the patched type propagates into `remember<T>` wrappers.
         AdaptedComposableReferenceTypePatcher(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
@@ -150,6 +156,7 @@ class ComposeIrGenerationExtension(
         // Memoize normal lambdas and wrap composable lambdas
         ComposerLambdaMemoization(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
@@ -162,6 +169,7 @@ class ComposeIrGenerationExtension(
         // parameter.
         ComposerParamTransformer(
             pluginContext,
+            moduleFragment,
             stabilityInferencer,
             metrics,
             featureFlags,
@@ -171,6 +179,7 @@ class ComposeIrGenerationExtension(
 
         ComposableTargetAnnotationsTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
@@ -184,6 +193,7 @@ class ComposeIrGenerationExtension(
 
         ComposableFunctionBodyTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             sourceInformationEnabled,
@@ -197,6 +207,7 @@ class ComposeIrGenerationExtension(
         if (isKlibTarget) {
             KlibAssignableParamTransformer(
                 pluginContext,
+                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
@@ -206,6 +217,7 @@ class ComposeIrGenerationExtension(
         if (pluginContext.platform.isJs() || pluginContext.platform.isWasm()) {
             WrapJsComposableLambdaLowering(
                 pluginContext,
+                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
@@ -77,20 +77,20 @@ class ComposeIrGenerationExtension(
         if (pluginContext.platform.isNative()) {
             AddHiddenFromObjCLowering(
                 pluginContext,
-                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
+                moduleFragment,
             ).lower(moduleFragment)
         }
 
         ClassStabilityTransformer(
             pluginContext,
-            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
             pluginContext.diagnosticReporter,
+            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -101,10 +101,10 @@ class ComposeIrGenerationExtension(
                 usePerFileEnabledFlag = liveLiteralsV2Enabled,
                 keyVisitor = DurableKeyVisitor(),
                 context = pluginContext,
-                irModule = moduleFragment,
                 metrics = metrics,
                 stabilityInferencer = stabilityInferencer,
                 featureFlags = featureFlags,
+                irModule = moduleFragment,
             ).lower(moduleFragment)
         }
 
@@ -114,10 +114,10 @@ class ComposeIrGenerationExtension(
 
         val functionKeyTransformer = DurableFunctionKeyTransformer(
             pluginContext,
-            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
+            moduleFragment,
         )
 
         functionKeyTransformer.lower(moduleFragment)
@@ -131,10 +131,10 @@ class ComposeIrGenerationExtension(
         // Generate default wrappers for virtual functions
         ComposableDefaultParamLowering(
             pluginContext,
-            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
+            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -145,10 +145,10 @@ class ComposeIrGenerationExtension(
         // ComposerLambdaMemoization so the patched type propagates into `remember<T>` wrappers.
         AdaptedComposableReferenceTypePatcher(
             pluginContext,
-            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
+            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -156,10 +156,10 @@ class ComposeIrGenerationExtension(
         // Memoize normal lambdas and wrap composable lambdas
         ComposerLambdaMemoization(
             pluginContext,
-            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
+            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -169,20 +169,20 @@ class ComposeIrGenerationExtension(
         // parameter.
         ComposerParamTransformer(
             pluginContext,
-            moduleFragment,
             stabilityInferencer,
             metrics,
             featureFlags,
+            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
 
         ComposableTargetAnnotationsTransformer(
             pluginContext,
-            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
+            moduleFragment,
         ).lower(moduleFragment)
 
         // transform calls to the currentComposer to just use the local parameter from the
@@ -193,13 +193,13 @@ class ComposeIrGenerationExtension(
 
         ComposableFunctionBodyTransformer(
             pluginContext,
-            moduleFragment,
             metrics,
             stabilityInferencer,
             sourceInformationEnabled,
             traceMarkersEnabled,
             targetRuntimeVersion,
             featureFlags,
+            moduleFragment,
         ).lower(moduleFragment)
 
         ComposableAnnotationRemover().lower(moduleFragment)
@@ -207,20 +207,20 @@ class ComposeIrGenerationExtension(
         if (isKlibTarget) {
             KlibAssignableParamTransformer(
                 pluginContext,
-                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
+                moduleFragment,
             ).lower(moduleFragment)
         }
 
         if (pluginContext.platform.isJs() || pluginContext.platform.isWasm()) {
             WrapJsComposableLambdaLowering(
                 pluginContext,
-                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
+                moduleFragment,
             ).lower(moduleFragment)
         }
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
@@ -77,20 +77,20 @@ class ComposeIrGenerationExtension(
         if (pluginContext.platform.isNative()) {
             AddHiddenFromObjCLowering(
                 pluginContext,
+                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
-                moduleFragment,
             ).lower(moduleFragment)
         }
 
         ClassStabilityTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
             pluginContext.diagnosticReporter,
-            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -101,10 +101,10 @@ class ComposeIrGenerationExtension(
                 usePerFileEnabledFlag = liveLiteralsV2Enabled,
                 keyVisitor = DurableKeyVisitor(),
                 context = pluginContext,
+                irModule = moduleFragment,
                 metrics = metrics,
                 stabilityInferencer = stabilityInferencer,
                 featureFlags = featureFlags,
-                irModule = moduleFragment,
             ).lower(moduleFragment)
         }
 
@@ -114,10 +114,10 @@ class ComposeIrGenerationExtension(
 
         val functionKeyTransformer = DurableFunctionKeyTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
-            moduleFragment,
         )
 
         functionKeyTransformer.lower(moduleFragment)
@@ -131,10 +131,10 @@ class ComposeIrGenerationExtension(
         // Generate default wrappers for virtual functions
         ComposableDefaultParamLowering(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
-            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -145,10 +145,10 @@ class ComposeIrGenerationExtension(
         // ComposerLambdaMemoization so the patched type propagates into `remember<T>` wrappers.
         AdaptedComposableReferenceTypePatcher(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
-            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -156,10 +156,10 @@ class ComposeIrGenerationExtension(
         // Memoize normal lambdas and wrap composable lambdas
         ComposerLambdaMemoization(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
-            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
@@ -169,20 +169,20 @@ class ComposeIrGenerationExtension(
         // parameter.
         ComposerParamTransformer(
             pluginContext,
+            moduleFragment,
             stabilityInferencer,
             metrics,
             featureFlags,
-            moduleFragment,
         ).lower(moduleFragment)
 
         ProgressManager.checkCanceled()
 
         ComposableTargetAnnotationsTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             featureFlags,
-            moduleFragment,
         ).lower(moduleFragment)
 
         // transform calls to the currentComposer to just use the local parameter from the
@@ -193,13 +193,13 @@ class ComposeIrGenerationExtension(
 
         ComposableFunctionBodyTransformer(
             pluginContext,
+            moduleFragment,
             metrics,
             stabilityInferencer,
             sourceInformationEnabled,
             traceMarkersEnabled,
             targetRuntimeVersion,
             featureFlags,
-            moduleFragment,
         ).lower(moduleFragment)
 
         ComposableAnnotationRemover().lower(moduleFragment)
@@ -207,20 +207,20 @@ class ComposeIrGenerationExtension(
         if (isKlibTarget) {
             KlibAssignableParamTransformer(
                 pluginContext,
+                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
-                moduleFragment,
             ).lower(moduleFragment)
         }
 
         if (pluginContext.platform.isJs() || pluginContext.platform.isWasm()) {
             WrapJsComposableLambdaLowering(
                 pluginContext,
+                moduleFragment,
                 metrics,
                 stabilityInferencer,
                 featureFlags,
-                moduleFragment,
             ).lower(moduleFragment)
         }
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -71,6 +71,7 @@ object ComposeCompilerKey : GeneratedDeclarationKey()
 
 abstract class AbstractComposeLowering(
     val context: IrPluginContext,
+    private val irModule: IrModuleFragment,
     val metrics: ModuleMetrics,
     val stabilityInferencer: StabilityInferencer,
     private val featureFlags: FeatureFlags,
@@ -1245,7 +1246,6 @@ abstract class AbstractComposeLowering(
 
     // Construct a reference to the JVM specific <unsafe-coerce> intrinsic.
     // This code should be kept in sync with the declaration in JvmSymbols.kt.
-    @OptIn(ObsoleteDescriptorBasedAPI::class)
     private val unsafeCoerceIntrinsic: IrSimpleFunctionSymbol? by lazy {
         if (context.platform.isJvm()) {
             context.irFactory.buildFun {
@@ -1253,7 +1253,7 @@ abstract class AbstractComposeLowering(
                 origin = IrDeclarationOrigin.IR_BUILTINS_STUB
             }.apply {
                 parent = createEmptyExternalPackageFragment(
-                    context.moduleDescriptor,
+                    irModule,
                     FqName("kotlin.jvm.internal")
                 )
                 val src = addTypeParameter("T", context.irBuiltIns.anyNType)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -71,10 +71,10 @@ object ComposeCompilerKey : GeneratedDeclarationKey()
 
 abstract class AbstractComposeLowering(
     val context: IrPluginContext,
-    private val irModule: IrModuleFragment,
     val metrics: ModuleMetrics,
     val stabilityInferencer: StabilityInferencer,
     private val featureFlags: FeatureFlags,
+    protected val irModule: IrModuleFragment,
 ) : IrElementTransformerVoid(), ModuleLoweringPass {
     protected val builtIns = context.irBuiltIns
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -71,10 +71,10 @@ object ComposeCompilerKey : GeneratedDeclarationKey()
 
 abstract class AbstractComposeLowering(
     val context: IrPluginContext,
+    private val irModule: IrModuleFragment,
     val metrics: ModuleMetrics,
     val stabilityInferencer: StabilityInferencer,
     private val featureFlags: FeatureFlags,
-    protected val irModule: IrModuleFragment,
 ) : IrElementTransformerVoid(), ModuleLoweringPass {
     protected val builtIns = context.irBuiltIns
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AdaptedComposableReferenceTypePatcher.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AdaptedComposableReferenceTypePatcher.kt
@@ -46,10 +46,11 @@ import org.jetbrains.kotlin.name.Name
  */
 class AdaptedComposableReferenceTypePatcher(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AdaptedComposableReferenceTypePatcher.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AdaptedComposableReferenceTypePatcher.kt
@@ -46,11 +46,11 @@ import org.jetbrains.kotlin.name.Name
  */
 class AdaptedComposableReferenceTypePatcher(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AdaptedComposableReferenceTypePatcher.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AdaptedComposableReferenceTypePatcher.kt
@@ -46,11 +46,11 @@ import org.jetbrains.kotlin.name.Name
  */
 class AdaptedComposableReferenceTypePatcher(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
@@ -54,11 +54,12 @@ enum class StabilityBits(val bits: Int) {
  */
 class ClassStabilityTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
     private val reporter: IrDiagnosticReporter,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ClassLoweringPass,
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
@@ -54,12 +54,12 @@ enum class StabilityBits(val bits: Int) {
  */
 class ClassStabilityTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
     private val reporter: IrDiagnosticReporter,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ClassLoweringPass,
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
@@ -54,12 +54,12 @@ enum class StabilityBits(val bits: Int) {
  */
 class ClassStabilityTransformer(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
     private val reporter: IrDiagnosticReporter,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
     ClassLoweringPass,
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableDefaultParamLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableDefaultParamLowering.kt
@@ -84,10 +84,11 @@ import org.jetbrains.kotlin.name.Name
  */
 class ComposableDefaultParamLowering(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags) {
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags) {
     private val originalToTransformed = mutableMapOf<IrSimpleFunction, IrSimpleFunction>()
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableDefaultParamLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableDefaultParamLowering.kt
@@ -84,11 +84,11 @@ import org.jetbrains.kotlin.name.Name
  */
 class ComposableDefaultParamLowering(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule) {
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags) {
     private val originalToTransformed = mutableMapOf<IrSimpleFunction, IrSimpleFunction>()
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableDefaultParamLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableDefaultParamLowering.kt
@@ -84,11 +84,11 @@ import org.jetbrains.kotlin.name.Name
  */
 class ComposableDefaultParamLowering(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags) {
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule) {
     private val originalToTransformed = mutableMapOf<IrSimpleFunction, IrSimpleFunction>()
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -379,6 +379,7 @@ interface IrChangedBitMaskVariable : IrChangedBitMaskValue {
  */
 class ComposableFunctionBodyTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     private val collectSourceInformation: Boolean,
@@ -386,7 +387,7 @@ class ComposableFunctionBodyTransformer(
     targetRuntimeVersion: ComposeRuntimeVersion?,
     featureFlags: FeatureFlags,
 ) :
-    AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags),
+    AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     FileLoweringPass,
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -379,15 +379,15 @@ interface IrChangedBitMaskVariable : IrChangedBitMaskValue {
  */
 class ComposableFunctionBodyTransformer(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     private val collectSourceInformation: Boolean,
     private val traceMarkersEnabled: Boolean,
     targetRuntimeVersion: ComposeRuntimeVersion?,
     featureFlags: FeatureFlags,
+    irModule: IrModuleFragment,
 ) :
-    AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
+    AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
     FileLoweringPass,
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableFunctionBodyTransformer.kt
@@ -379,15 +379,15 @@ interface IrChangedBitMaskVariable : IrChangedBitMaskValue {
  */
 class ComposableFunctionBodyTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     private val collectSourceInformation: Boolean,
     private val traceMarkersEnabled: Boolean,
     targetRuntimeVersion: ComposeRuntimeVersion?,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
 ) :
-    AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
+    AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     FileLoweringPass,
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -48,10 +48,11 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  */
 class ComposableTargetAnnotationsTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags) {
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags) {
     private val ComposableTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableTarget)
     private val ComposableOpenTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableOpenTarget)
     private val ComposableInferredTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableInferredTarget)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -48,11 +48,11 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  */
 class ComposableTargetAnnotationsTransformer(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags) {
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule) {
     private val ComposableTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableTarget)
     private val ComposableOpenTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableOpenTarget)
     private val ComposableInferredTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableInferredTarget)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -48,11 +48,11 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  */
 class ComposableTargetAnnotationsTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule) {
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags) {
     private val ComposableTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableTarget)
     private val ComposableOpenTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableOpenTarget)
     private val ComposableInferredTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableInferredTarget)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -267,10 +267,11 @@ private class ClassContext(override val declaration: IrClass) : DeclarationConte
 
 class ComposerLambdaMemoization(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
 
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -267,11 +267,11 @@ private class ClassContext(override val declaration: IrClass) : DeclarationConte
 
 class ComposerLambdaMemoization(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
 
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -267,11 +267,11 @@ private class ClassContext(override val declaration: IrClass) : DeclarationConte
 
 class ComposerLambdaMemoization(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
 
     ModuleLoweringPass {
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
@@ -54,10 +54,11 @@ import kotlin.math.min
 
 class ComposerParamTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     stabilityInferencer: StabilityInferencer,
     metrics: ModuleMetrics,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     private var inlineLambdaInfo = ComposeInlineLambdaLocator(context)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
@@ -54,11 +54,11 @@ import kotlin.math.min
 
 class ComposerParamTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     stabilityInferencer: StabilityInferencer,
     metrics: ModuleMetrics,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     private var inlineLambdaInfo = ComposeInlineLambdaLocator(context)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
@@ -54,11 +54,11 @@ import kotlin.math.min
 
 class ComposerParamTransformer(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     stabilityInferencer: StabilityInferencer,
     metrics: ModuleMetrics,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
     ModuleLoweringPass {
 
     private var inlineLambdaInfo = ComposeInlineLambdaLocator(context)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableFunctionKeyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableFunctionKeyTransformer.kt
@@ -85,12 +85,14 @@ class KeyInfo(
  */
 class DurableFunctionKeyTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
 ) : DurableKeyTransformer(
     DurableKeyVisitor(),
     context,
+    irModule,
     stabilityInferencer,
     metrics,
     featureFlags,

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableFunctionKeyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableFunctionKeyTransformer.kt
@@ -85,17 +85,17 @@ class KeyInfo(
  */
 class DurableFunctionKeyTransformer(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
+    irModule: IrModuleFragment,
 ) : DurableKeyTransformer(
     DurableKeyVisitor(),
     context,
-    irModule,
     stabilityInferencer,
     metrics,
     featureFlags,
+    irModule,
 ) {
 
     fun realizeKeyMetaAnnotations(moduleFragment: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableFunctionKeyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableFunctionKeyTransformer.kt
@@ -85,17 +85,17 @@ class KeyInfo(
  */
 class DurableFunctionKeyTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
 ) : DurableKeyTransformer(
     DurableKeyVisitor(),
     context,
+    irModule,
     stabilityInferencer,
     metrics,
     featureFlags,
-    irModule,
 ) {
 
     fun realizeKeyMetaAnnotations(moduleFragment: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableKeyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableKeyTransformer.kt
@@ -43,10 +43,11 @@ import org.jetbrains.kotlin.name.Name
 open class DurableKeyTransformer(
     private val keyVisitor: DurableKeyVisitor,
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     stabilityInferencer: StabilityInferencer,
     metrics: ModuleMetrics,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableKeyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableKeyTransformer.kt
@@ -43,11 +43,11 @@ import org.jetbrains.kotlin.name.Name
 open class DurableKeyTransformer(
     private val keyVisitor: DurableKeyVisitor,
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     stabilityInferencer: StabilityInferencer,
     metrics: ModuleMetrics,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableKeyTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/DurableKeyTransformer.kt
@@ -43,11 +43,11 @@ import org.jetbrains.kotlin.name.Name
 open class DurableKeyTransformer(
     private val keyVisitor: DurableKeyVisitor,
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     stabilityInferencer: StabilityInferencer,
     metrics: ModuleMetrics,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/KlibAssignableParamTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/KlibAssignableParamTransformer.kt
@@ -62,14 +62,16 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  */
 class KlibAssignableParamTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
 ) : AbstractComposeLowering(
     context,
+    irModule,
     metrics,
     stabilityInferencer,
-    featureFlags
+    featureFlags,
 ), ModuleLoweringPass {
     override fun lower(irModule: IrModuleFragment) {
         irModule.transformChildrenVoid(this)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/KlibAssignableParamTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/KlibAssignableParamTransformer.kt
@@ -62,16 +62,16 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  */
 class KlibAssignableParamTransformer(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
 ) : AbstractComposeLowering(
     context,
+    irModule,
     metrics,
     stabilityInferencer,
     featureFlags,
-    irModule,
 ), ModuleLoweringPass {
     override fun lower(irModule: IrModuleFragment) {
         irModule.transformChildrenVoid(this)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/KlibAssignableParamTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/KlibAssignableParamTransformer.kt
@@ -62,16 +62,16 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  */
 class KlibAssignableParamTransformer(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
+    irModule: IrModuleFragment,
 ) : AbstractComposeLowering(
     context,
-    irModule,
     metrics,
     stabilityInferencer,
     featureFlags,
+    irModule,
 ), ModuleLoweringPass {
     override fun lower(irModule: IrModuleFragment) {
         irModule.transformChildrenVoid(this)

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/LiveLiteralTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/LiveLiteralTransformer.kt
@@ -99,10 +99,11 @@ open class LiveLiteralTransformer(
     private val usePerFileEnabledFlag: Boolean,
     private val keyVisitor: DurableKeyVisitor,
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/LiveLiteralTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/LiveLiteralTransformer.kt
@@ -99,11 +99,11 @@ open class LiveLiteralTransformer(
     private val usePerFileEnabledFlag: Boolean,
     private val keyVisitor: DurableKeyVisitor,
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
-) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
+) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/LiveLiteralTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/LiveLiteralTransformer.kt
@@ -99,11 +99,11 @@ open class LiveLiteralTransformer(
     private val usePerFileEnabledFlag: Boolean,
     private val keyVisitor: DurableKeyVisitor,
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags),
+    irModule: IrModuleFragment,
+) : AbstractComposeLowering(context, metrics, stabilityInferencer, featureFlags, irModule),
     ModuleLoweringPass {
 
     override fun lower(irModule: IrModuleFragment) {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/WrapJsComposableLambdaLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/WrapJsComposableLambdaLowering.kt
@@ -82,11 +82,13 @@ import org.jetbrains.kotlin.utils.IDEAPluginsCompatibilityAPI
  */
 class WrapJsComposableLambdaLowering(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
 ) : AbstractComposeLowering(
     context,
+    irModule,
     metrics,
     stabilityInferencer,
     featureFlags,
@@ -101,7 +103,7 @@ class WrapJsComposableLambdaLowering(
 
     private val rememberFunSymbol by lazy {
         val composerParamTransformer = ComposerParamTransformer(
-            context, stabilityInferencer, metrics, featureFlags
+            context, irModule, stabilityInferencer, metrics, featureFlags
         )
         getTopLevelFunctions(ComposeCallableIds.remember)
             .map {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/WrapJsComposableLambdaLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/WrapJsComposableLambdaLowering.kt
@@ -82,16 +82,16 @@ import org.jetbrains.kotlin.utils.IDEAPluginsCompatibilityAPI
  */
 class WrapJsComposableLambdaLowering(
     context: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
+    irModule: IrModuleFragment,
 ) : AbstractComposeLowering(
     context,
-    irModule,
     metrics,
     stabilityInferencer,
     featureFlags,
+    irModule,
 ) {
     private fun IrValueParameter.isArtificialComposeParameter(): Boolean =
         when {
@@ -103,7 +103,7 @@ class WrapJsComposableLambdaLowering(
 
     private val rememberFunSymbol by lazy {
         val composerParamTransformer = ComposerParamTransformer(
-            context, irModule, stabilityInferencer, metrics, featureFlags
+            context, stabilityInferencer, metrics, featureFlags, irModule
         )
         getTopLevelFunctions(ComposeCallableIds.remember)
             .map {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/WrapJsComposableLambdaLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/WrapJsComposableLambdaLowering.kt
@@ -82,16 +82,16 @@ import org.jetbrains.kotlin.utils.IDEAPluginsCompatibilityAPI
  */
 class WrapJsComposableLambdaLowering(
     context: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
 ) : AbstractComposeLowering(
     context,
+    irModule,
     metrics,
     stabilityInferencer,
     featureFlags,
-    irModule,
 ) {
     private fun IrValueParameter.isArtificialComposeParameter(): Boolean =
         when {
@@ -103,7 +103,7 @@ class WrapJsComposableLambdaLowering(
 
     private val rememberFunSymbol by lazy {
         val composerParamTransformer = ComposerParamTransformer(
-            context, stabilityInferencer, metrics, featureFlags, irModule
+            context, irModule, stabilityInferencer, metrics, featureFlags
         )
         getTopLevelFunctions(ComposeCallableIds.remember)
             .map {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
@@ -46,14 +46,16 @@ val hiddenFromObjCClassId = ClassId.fromString("kotlin/native/HiddenFromObjC")
  */
 class AddHiddenFromObjCLowering(
     private val pluginContext: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
 ) : AbstractComposeLowering(
     pluginContext,
+    irModule,
     metrics,
     stabilityInferencer,
-    featureFlags
+    featureFlags,
 ) {
 
     private val hiddenFromObjCAnnotation: IrClassSymbol by lazy {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
@@ -46,16 +46,16 @@ val hiddenFromObjCClassId = ClassId.fromString("kotlin/native/HiddenFromObjC")
  */
 class AddHiddenFromObjCLowering(
     private val pluginContext: IrPluginContext,
+    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
-    irModule: IrModuleFragment,
 ) : AbstractComposeLowering(
     pluginContext,
+    irModule,
     metrics,
     stabilityInferencer,
     featureFlags,
-    irModule,
 ) {
 
     private val hiddenFromObjCAnnotation: IrClassSymbol by lazy {

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
@@ -46,16 +46,16 @@ val hiddenFromObjCClassId = ClassId.fromString("kotlin/native/HiddenFromObjC")
  */
 class AddHiddenFromObjCLowering(
     private val pluginContext: IrPluginContext,
-    irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
     featureFlags: FeatureFlags,
+    irModule: IrModuleFragment,
 ) : AbstractComposeLowering(
     pluginContext,
-    irModule,
     metrics,
     stabilityInferencer,
     featureFlags,
+    irModule,
 ) {
 
     private val hiddenFromObjCAnnotation: IrClassSymbol by lazy {

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptLoweringExtension.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptLoweringExtension.kt
@@ -21,7 +21,7 @@ class ScriptLoweringExtension : IrGenerationExtension {
         when {
             platform.isJvm() -> {
                 val symbolsForScripting = JvmSymbolsForScripting(pluginContext, moduleFragment)
-                ScriptsToClassesLowering(pluginContext, symbolsForScripting).lower(moduleFragment)
+                ScriptsToClassesLowering(pluginContext, moduleFragment, symbolsForScripting).lower(moduleFragment)
             }
         }
     }

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptLoweringExtension.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptLoweringExtension.kt
@@ -21,7 +21,7 @@ class ScriptLoweringExtension : IrGenerationExtension {
         when {
             platform.isJvm() -> {
                 val symbolsForScripting = JvmSymbolsForScripting(pluginContext, moduleFragment)
-                ScriptsToClassesLowering(pluginContext, symbolsForScripting, moduleFragment).lower(moduleFragment)
+                ScriptsToClassesLowering(pluginContext, moduleFragment, symbolsForScripting).lower(moduleFragment)
             }
         }
     }

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptLoweringExtension.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptLoweringExtension.kt
@@ -21,7 +21,7 @@ class ScriptLoweringExtension : IrGenerationExtension {
         when {
             platform.isJvm() -> {
                 val symbolsForScripting = JvmSymbolsForScripting(pluginContext, moduleFragment)
-                ScriptsToClassesLowering(pluginContext, moduleFragment, symbolsForScripting).lower(moduleFragment)
+                ScriptsToClassesLowering(pluginContext, symbolsForScripting, moduleFragment).lower(moduleFragment)
             }
         }
     }

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/ScriptLowering.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/ScriptLowering.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.*
@@ -46,7 +45,11 @@ import org.jetbrains.kotlin.util.OperatorNameConventions
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.utils.topologicalSort
 
-internal class ScriptsToClassesLowering(val context: IrPluginContext, val symbolsForScripting: JvmSymbolsForScripting) : ModuleLoweringPass {
+internal class ScriptsToClassesLowering(
+    val context: IrPluginContext,
+    private val irModuleFragment: IrModuleFragment,
+    val symbolsForScripting: JvmSymbolsForScripting,
+) : ModuleLoweringPass {
     override fun lower(irModule: IrModuleFragment) {
         val scripts = mutableListOf<IrScript>()
         val scriptDependencies = mutableMapOf<IrScript, List<IrScript>>()
@@ -309,9 +312,8 @@ internal class ScriptsToClassesLowering(val context: IrPluginContext, val symbol
             irConstructor.parent = irScript
         }
 
-    @OptIn(ObsoleteDescriptorBasedAPI::class)
     private val scriptingJvmPackage by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        createEmptyExternalPackageFragment(context.moduleDescriptor, FqName("kotlin.script.experimental.jvm"))
+        createEmptyExternalPackageFragment(irModuleFragment, FqName("kotlin.script.experimental.jvm"))
     }
 
     private fun IrClass.addScriptMainFun() {

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/ScriptLowering.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/ScriptLowering.kt
@@ -47,8 +47,8 @@ import org.jetbrains.kotlin.utils.topologicalSort
 
 internal class ScriptsToClassesLowering(
     val context: IrPluginContext,
-    private val irModuleFragment: IrModuleFragment,
     val symbolsForScripting: JvmSymbolsForScripting,
+    private val irModuleFragment: IrModuleFragment,
 ) : ModuleLoweringPass {
     override fun lower(irModule: IrModuleFragment) {
         val scripts = mutableListOf<IrScript>()

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/ScriptLowering.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/irLowerings/ScriptLowering.kt
@@ -47,8 +47,8 @@ import org.jetbrains.kotlin.utils.topologicalSort
 
 internal class ScriptsToClassesLowering(
     val context: IrPluginContext,
-    val symbolsForScripting: JvmSymbolsForScripting,
     private val irModuleFragment: IrModuleFragment,
+    val symbolsForScripting: JvmSymbolsForScripting,
 ) : ModuleLoweringPass {
     override fun lower(irModule: IrModuleFragment) {
         val scripts = mutableListOf<IrScript>()


### PR DESCRIPTION
Thanks to these changes, a proper `IrModuleFragment` will be in scope for all constructions of `IrExternalPackageFragment`


^KT-87300 Fixed