### PR TITLE
[K/N] Implement new class initialization order.

### DIFF
--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersBlocksAndObject.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersBlocksAndObject.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JVM, JVM_IR, NATIVE
+// IGNORE_BACKEND: JVM, JVM_IR
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersEnumImplementingInterfaceWithDefaultMember.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersEnumImplementingInterfaceWithDefaultMember.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JVM_IR, NATIVE
+// IGNORE_BACKEND: JVM_IR
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritance.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritance.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: NATIVE
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMixedWithObject.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMixedWithObject.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JVM, JVM_IR, NATIVE
+// IGNORE_BACKEND: JVM, JVM_IR
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultiLevel.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultiLevel.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: NATIVE
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultipleSupertypes.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultipleSupertypes.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JVM_IR, NATIVE
+// IGNORE_BACKEND: JVM_IR
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultipleSupertypesMixedOrder.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInheritanceMultipleSupertypesMixedOrder.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JVM_IR, NATIVE
+// IGNORE_BACKEND: JVM_IR
 
 // This test is essentially the same one as initializersInheritanceMultipleSupertypes,
 // but with different super type kinds order (interface, class, interface)

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersTriggeredByObject.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersTriggeredByObject.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
-// IGNORE_BACKEND: JVM, JVM_IR, NATIVE
+// IGNORE_BACKEND: JVM, JVM_IR
 
 var initOrder = ""
 

--- a/compiler/testData/codegen/box/objects/companionObjectAccess/companionInitOrderWithSuperclassCrossModule.kt
+++ b/compiler/testData/codegen/box/objects/companionObjectAccess/companionInitOrderWithSuperclassCrossModule.kt
@@ -1,5 +1,8 @@
-// ISSUE: KT-86521 Native: init order of companion objects is different from JVM
-// IGNORE_BACKEND: NATIVE
+// ISSUE: KT-76655 Kotlin/Native: Native test infrastructure does not support per-module directives
+// LANGUAGE: +CompanionBlocksAndExtensions
+// ^ On Native `CompanionBlocksAndExtensions` language feature enables the JVM-like initialization.
+//   See nativeCompanionInitOrderCrossModuleLegacy for Native behavior without the language feature.
+//   Native also needs tests when some modules are built with the feature enabled, and some with it disabled.
 // ISSUE: KT-84267 K/Wasm: init order of companion objects is different from JVM
 // ISSUE: KT-86640 K/Wasm: cross-module signature mismatch for parent companion getInstance
 // IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: JS,Wasm-js:2.3,2.4

--- a/compiler/testData/codegen/box/objects/companionObjectAccess/companionObjectInitOrderWithSuperinterface.kt
+++ b/compiler/testData/codegen/box/objects/companionObjectAccess/companionObjectInitOrderWithSuperinterface.kt
@@ -1,0 +1,82 @@
+// LANGUAGE: +CompanionBlocksAndExtensions
+// ^ On Native `CompanionBlocksAndExtensions` language feature enables the JVM-like initialization.
+//   See nativeCompanionInitOrderLegacy for Native behavior without the language feature.
+// ISSUE: KT-87516 [K/JS, K/Wasm] Companion objects coming from super interfaces are not initialized
+// IGNORE_BACKEND: JS_IR, JS_IR_ES6, WASM_JS, WASM_WASI
+
+var l = ""
+private fun log(t: String) {
+    l += t + "\n"
+}
+
+// Each test uses its own class hierarchy so companions are initialized fresh.
+
+// multiple interface inheritance
+interface I1 {
+    fun i() {}
+    companion object { init { log("I1.Companion") } }
+}
+interface J1 {
+    fun j() {}
+    companion object { init { log("J1.Companion") } }
+}
+interface K1 : I1 {
+    fun k() {}
+    companion object { init { log("K1.Companion") } }
+}
+interface L1 : J1 {
+    fun l() {}
+    companion object { init { log("L1.Companion") } }
+}
+interface M1 {
+    companion object { init { log("M1.Companion") } }
+}
+open class B1 : J1, K1 {
+    companion object { init { log("B1.Companion") } }
+}
+class A1: B1(), L1, M1 {
+    companion object { init { log("A1.Companion") } }
+}
+
+// multiple interface inheritance; with instance creation
+interface I2 {
+    fun i() {}
+    companion object { init { log("I2.Companion") } }
+}
+interface J2 {
+    fun j() {}
+    companion object { init { log("J2.Companion") } }
+}
+interface K2 : I2 {
+    fun k() {}
+    companion object { init { log("K2.Companion") } }
+}
+interface L2 : J2 {
+    fun l() {}
+    companion object { init { log("L2.Companion") } }
+}
+interface M2 {
+    companion object { init { log("M2.Companion") } }
+}
+open class B2 : J2, K2 {
+    init { log("B2.init") }
+    companion object { init { log("B2.Companion") } }
+}
+class A2: B2(), L2, M2 {
+    init { log("A2.init") }
+    companion object { init { log("A2.Companion") } }
+}
+
+fun box(): String {
+    l = ""
+    A1
+    val r1 = l
+    if (r1 != "J1.Companion\nI1.Companion\nK1.Companion\nB1.Companion\nL1.Companion\nA1.Companion\n") return "fail test1: '$r1'"
+
+    l = ""
+    A2()
+    val r2 = l
+    if (r2 != "J2.Companion\nI2.Companion\nK2.Companion\nB2.Companion\nL2.Companion\nA2.Companion\nB2.init\nA2.init\n") return "fail test2: '$r2'"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/objects/companionObjectAccess/nativeCompanionInitOrderCrossModuleLegacy.kt
+++ b/compiler/testData/codegen/box/objects/companionObjectAccess/nativeCompanionInitOrderCrossModuleLegacy.kt
@@ -1,0 +1,38 @@
+// See companionInitOrderWithSuperclassCrossModule for the common treatment
+// TARGET_BACKEND: NATIVE
+// LANGUAGE: -CompanionBlocksAndExtensions
+// Without this language feature, the initialization order on Native does not include recursive initialization of superclasses and superinterfaces.
+
+// MODULE: lib
+// FILE: lib.kt
+
+package lib
+
+var initLog = ""
+
+fun log(t: String) {
+    initLog += t + "\n"
+}
+
+open class Root {
+    companion object { init { log("Root.Companion") } }
+}
+
+open class Middle : Root()
+
+// MODULE: main(lib)
+// FILE: main.kt
+
+import lib.Middle
+import lib.initLog
+
+class Leaf : Middle() {
+    companion object { init { lib.log("Leaf.Companion") } }
+}
+
+fun box(): String {
+    initLog = ""
+    Leaf
+    val result = initLog
+    return if (result == "Leaf.Companion\n") "OK" else "fail: '$result'"
+}

--- a/compiler/testData/codegen/box/objects/companionObjectAccess/nativeCompanionInitOrderLegacy.kt
+++ b/compiler/testData/codegen/box/objects/companionObjectAccess/nativeCompanionInitOrderLegacy.kt
@@ -1,10 +1,7 @@
-// LANGUAGE: +CompanionBlocksAndExtensions
-// ^ On Native `CompanionBlocksAndExtensions` language feature enables the JVM-like initialization.
-//   See nativeCompanionInitOrderLegacy for Native behavior without the language feature.
-// ISSUE: KT-84267 K/Wasm: init order of companion objects is different from JVM
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: JS,Wasm-js:2.3,2.4
-// ^^^KT-84267 is fixed in 2.4.20-beta1 for WASM
-// ^^^KT-40768 is fixed in 2.4.20-beta1 for JS
+// See companionInitOrderWithSuperclass and companionInitOrderWithSuperinterface for the common treatment.
+// TARGET_BACKEND: NATIVE
+// LANGUAGE: -CompanionBlocksAndExtensions
+// Without this language feature, the initialization order on Native does not include recursive initialization of superclasses and superinterfaces.
 
 var l = ""
 private fun log(t: String) {
@@ -191,50 +188,106 @@ class A16 : B16<String>() {
     companion object { init { log("A16.Companion") } }
 }
 
+// multiple interface inheritance
+interface I17 {
+    fun i() {}
+    companion object { init { log("I17.Companion") } }
+}
+interface J17 {
+    fun j() {}
+    companion object { init { log("J17.Companion") } }
+}
+interface K17 : I17 {
+    fun k() {}
+    companion object { init { log("K17.Companion") } }
+}
+interface L17 : J17 {
+    fun l() {}
+    companion object { init { log("L17.Companion") } }
+}
+interface M17 {
+    companion object { init { log("M17.Companion") } }
+}
+open class B17 : J17, K17 {
+    companion object { init { log("B17.Companion") } }
+}
+class A17: B17(), L17, M17 {
+    companion object { init { log("A17.Companion") } }
+}
+
+// multiple interface inheritance; with instance creation
+interface I18 {
+    fun i() {}
+    companion object { init { log("I18.Companion") } }
+}
+interface J18 {
+    fun j() {}
+    companion object { init { log("J18.Companion") } }
+}
+interface K18 : I18 {
+    fun k() {}
+    companion object { init { log("K18.Companion") } }
+}
+interface L18 : J18 {
+    fun l() {}
+    companion object { init { log("L18.Companion") } }
+}
+interface M18 {
+    companion object { init { log("M18.Companion") } }
+}
+open class B18 : J18, K18 {
+    init { log("B18.init") }
+    companion object { init { log("B18.Companion") } }
+}
+class A18: B18(), L18, M18 {
+    init { log("A18.init") }
+    companion object { init { log("A18.Companion") } }
+}
+
 fun box(): String {
     l = ""
     A1
     val r1 = l
-    if (r1 != "B1.Companion\nA1.Companion\n") return "fail test1: '$r1'"
+    if (r1 != "A1.Companion\n") return "fail test1: '$r1'"
 
     l = ""
     A2()
     val r2 = l
-    if (r2 != "B2.Companion\nA2.Companion\nB2.init#1\nB2.init#2\nA2.init#1\nA2.init#2\n") return "fail test2: '$r2'"
+    if (r2 != "A2.Companion\nB2.Companion\nB2.init#1\nB2.init#2\nA2.init#1\nA2.init#2\n") return "fail test2: '$r2'"
 
     l = ""
     A3
     log("--")
     A3()
     val r3 = l
-    if (r3 != "B3.Companion\nA3.Companion\n--\nB3.init#1\nB3.init#2\nA3.init#1\nA3.init#2\n") return "fail test3: '$r3'"
+    if (r3 != "A3.Companion\n--\nB3.Companion\nB3.init#1\nB3.init#2\nA3.init#1\nA3.init#2\n") return "fail test3: '$r3'"
 
     l = ""
     A4()
     log("--")
     A4
     val r4 = l
-    if (r4 != "B4.Companion\nA4.Companion\nB4.init#1\nB4.init#2\nA4.init#1\nA4.init#2\n--\n") return "fail test4: '$r4'"
+    if (r4 != "A4.Companion\nB4.Companion\nB4.init#1\nB4.init#2\nA4.init#1\nA4.init#2\n--\n") return "fail test4: '$r4'"
 
     l = ""
     A5
     val r5 = l
-    if (r5 != "C5.Companion\nB5.Companion\nA5.Companion\n") return "fail test5: '$r5'"
+    if (r5 != "A5.Companion\n") return "fail test5: '$r5'"
 
     l = ""
     A6()
     val r6 = l
-    if (r6 != "C6.Companion\nB6.Companion\nA6.Companion\nC6.init\nB6.init\nA6.init\n") return "fail test6: '$r6'"
+    if (r6 != "A6.Companion\nB6.Companion\nC6.Companion\nC6.init\nB6.init\nA6.init\n") return "fail test6: '$r6'"
 
     l = ""
     A7
     val r7 = l
-    if (r7 != "C7.Companion\nA7.Companion\n") return "fail test7: '$r7'"
+    if (r7 != "A7.Companion\n") return "fail test7: '$r7'"
 
     l = ""
     A8()
     val r8 = l
-    if (r8 != "C8.Companion\nA8.Companion\nC8.init\nA8.init\n") return "fail test8: '$r8'"
+    if (r8 != "A8.Companion\nC8.Companion\nC8.init\nA8.init\n") return "fail test8: '$r8'"
 
     l = ""
     B9
@@ -247,7 +300,7 @@ fun box(): String {
     l = ""
     A10
     val r10 = l
-    if (r10 != "B10.Parent\nA10.Child\n") return "fail test10: '$r10'"
+    if (r10 != "A10.Child\n") return "fail test10: '$r10'"
 
     l = ""
     if (A11.value != "B11.Companion/A11.Companion") return "fail test11 value: '${A11.value}'"
@@ -262,24 +315,34 @@ fun box(): String {
     l = ""
     A13
     val r13 = l
-    if (r13 != "B13.Companion\nCompanionBase13.init\nA13.Companion\n") return "fail test13: '$r13'"
+    if (r13 != "CompanionBase13.init\nA13.Companion\n") return "fail test13: '$r13'"
 
     l = ""
     A14
     val r14 = l
-    if (r14 != "C14.Companion\nA14.Companion\n") return "fail test14: '$r14'"
+    if (r14 != "A14.Companion\n") return "fail test14: '$r14'"
 
     l = ""
     A15
     log("--")
     if (I15.marker != "I15.Companion") return "fail test15 marker"
     val r15 = l
-    if (r15 != "B15.Companion\nA15.Companion\n--\nI15.Companion\n") return "fail test15: '$r15'"
+    if (r15 != "A15.Companion\n--\nI15.Companion\n") return "fail test15: '$r15'"
 
     l = ""
     A16
     val r16 = l
-    if (r16 != "B16.Companion\nA16.Companion\n") return "fail test16: '$r16'"
+    if (r16 != "A16.Companion\n") return "fail test16: '$r16'"
+
+    l = ""
+    A17
+    val r17 = l
+    if (r17 != "A17.Companion\n") return "fail test17: '$r17'"
+
+    l = ""
+    A18()
+    val r18 = l
+    if (r18 != "A18.Companion\nB18.Companion\nB18.init\nA18.init\n") return "fail test18: '$r18'"
 
     return "OK"
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ObjectClassLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ObjectClassLowering.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
 import org.jetbrains.kotlin.backend.konan.ir.isUnit
+import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.*
 import org.jetbrains.kotlin.ir.declarations.*
@@ -22,6 +23,7 @@ import org.jetbrains.kotlin.ir.irAttribute
 import org.jetbrains.kotlin.ir.objcinterop.*
 import org.jetbrains.kotlin.ir.types.isAny
 import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.library.newCompanionInitializationEnabled
 import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 
 private var IrClass.objectClassInstanceFunction: IrSimpleFunction? by irAttribute(copyByDefault = false)
@@ -77,11 +79,18 @@ internal class ObjectClassLowering(val generationState: NativeGenerationState) :
                             declaration
                     )
                 }
-                declaration.declarations.singleOrNull { (it as? IrClass)?.isCompanion == true }?.let {
-                    processObjectClass(
-                            it as IrClass,
-                            declaration
-                    )
+                val companionIndex = declaration.declarations.indexOfFirst { (it as? IrClass)?.isCompanion == true }
+                if (companionIndex != -1) {
+                    val companionDeclaration = declaration.declarations[companionIndex] as IrClass
+                    val addAtIndex = if (declaration.konanLibrary?.newCompanionInitializationEnabled == true) {
+                        // With the initialization order, the `companion object` and `companion` blocks should be initialized
+                        // following the program order. So, the field holding `companion object` instance should be placed
+                        // next to the `companion object` to preserve the program order.
+                        companionIndex + 1
+                    } else {
+                        -1
+                    }
+                    processObjectClass(companionDeclaration, declaration, addAtIndex)
                 }
                 return declaration
             }
@@ -106,11 +115,16 @@ internal class ObjectClassLowering(val generationState: NativeGenerationState) :
 
     fun processObjectClass(
             declaration: IrClass,
-            classToAdd: IrClass
+            classToAdd: IrClass,
+            addAtIndex: Int = -1,
     ) {
         val function = context.getObjectClassInstanceFunction(declaration)
         val property = function.correspondingPropertySymbol!!.owner
-        classToAdd.declarations.add(property)
+        if (addAtIndex == -1) {
+            classToAdd.declarations.add(property)
+        } else {
+            classToAdd.declarations.add(addAtIndex, property)
+        }
 
         property.addBackingField {
             isFinal = true

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
@@ -9,9 +9,12 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.binaryTypeIsReference
+import org.jetbrains.kotlin.backend.konan.ir.getSuperClassNotAny
+import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.llvm.FieldStorageKind
 import org.jetbrains.kotlin.backend.konan.llvm.storageKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
@@ -20,11 +23,17 @@ import org.jetbrains.kotlin.ir.builders.irNull
 import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.irAttribute
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.classOrFail
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
+import org.jetbrains.kotlin.library.newCompanionInitializationEnabled
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
 internal object StaticInitializersOrigins {
@@ -60,6 +69,8 @@ internal fun ConfigChecks.shouldBeInitializedEagerly(irField: IrField): Boolean 
     return annotations.hasAnnotation(KonanFqNames.eagerInitialization)
 }
 
+internal var IrClass.clinitTriggerFunction: IrSimpleFunctionSymbol? by irAttribute(copyByDefault = false)
+
 internal class StaticInitializersLowering(val context: Context) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         irFile.acceptVoid(object : IrVisitorVoid() {
@@ -71,10 +82,26 @@ internal class StaticInitializersLowering(val context: Context) : FileLoweringPa
                 declaration.acceptChildrenVoid(this)
             }
             override fun visitClass(declaration: IrClass) {
+                declaration.addChild(declaration.getClinitTriggerFunction().owner.apply {
+                    body = context.irFactory.createBlockBody(SYNTHETIC_OFFSET, SYNTHETIC_OFFSET)
+                })
                 processDeclarationContainter(declaration)
                 declaration.acceptChildrenVoid(this)
             }
         })
+    }
+
+    // An internal static method to trigger class initialization:
+    // * the regular rules of this lowering will insert calls to the actual initializers inside the body
+    // * initializers of other classes will emit calls to this trigger, when needed
+    private fun IrClass.getClinitTriggerFunction() = ::clinitTriggerFunction.getOrSetIfNull {
+        context.irFactory.buildFun {
+            name = Name.identifier($$"$clinit_trigger")
+            visibility = DescriptorVisibilities.PUBLIC
+            returnType = context.irBuiltIns.unitType
+        }.apply {
+            parent = this@getClinitTriggerFunction
+        }.symbol
     }
 
     private fun IrStatement.isConst(): Boolean = when (this) {
@@ -98,6 +125,52 @@ internal class StaticInitializersLowering(val context: Context) : FileLoweringPa
         val eagerGlobalInitializers = mutableListOf<IrExpression>()
 
         val builder = context.irBuiltIns.createIrBuilder((container as IrSymbolOwner).symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET)
+
+        if (container is IrClass && !container.isInterface && container.konanLibrary?.newCompanionInitializationEnabled == true) {
+            // Implemented as defined in
+            // https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-5.html#jvms-5.5
+            // Next, if C is a class rather than an interface, then let SC be its superclass and let SI1, ..., SIn be all
+            // superinterfaces of C (whether direct or indirect) that declare at least one non-abstract, non-static method.
+            // The order of superinterfaces is given by a recursive enumeration over the superinterface hierarchy of each interface
+            // directly implemented by C. For each interface I directly implemented by C (in the order of the interfaces array of C),
+            // the enumeration recurs on I's superinterfaces (in the order of the interfaces array of I) before returning I.
+            // For each S in the list [ SC, SI1, ..., SIn ], if S has not yet been initialized, then recursively perform this entire
+            // procedure for S. If necessary, verify and prepare S first.
+
+            val superClassesToInitialize = buildList {
+                container.getSuperClassNotAny()?.let { add(it) }
+                fun IrDeclaration.triggersInterfaceInitialization(): Boolean {
+                    if (this !is IrOverridableDeclaration<*>) return false
+                    if (isFakeOverride) return false
+                    if (modality == Modality.ABSTRACT) return false
+                    if (this is IrSimpleFunction && !isStatic) return true
+                    if (this is IrProperty && (getter?.isStatic ?: backingField?.isStatic) != true) return true
+                    return false
+                }
+
+                fun IrClass.needsInitializationAsInterface() = isInterface && declarations.any { it.triggersInterfaceInitialization() }
+                val seen = mutableSetOf<IrClassSymbol>()
+                fun IrClass.collectSuperInterfacesToInitialize() {
+                    if (!seen.add(symbol))
+                        return
+                    for (superType in superTypes) {
+                        val superClass = superType.classOrFail.owner
+                        if (superClass.isInterface) {
+                            superClass.collectSuperInterfacesToInitialize()
+                        }
+                    }
+                    if (needsInitializationAsInterface()) {
+                        add(this)
+                    }
+                }
+                container.collectSuperInterfacesToInitialize()
+            }
+            for (superClass in superClassesToInitialize) {
+                val trigger = superClass.getClinitTriggerFunction()
+                globalInitializers.add(builder.irCall(trigger))
+                threadLocalInitializers.add(builder.irCall(trigger))
+            }
+        }
 
         for (declaration in container.declarations) {
             val irField = (declaration as? IrField) ?: (declaration as? IrProperty)?.backingField


### PR DESCRIPTION
When `CompanionBlocksAndExtensions` language feature is enabled, the classes should follow JVM-like initialization scheme:
- first, the superclass should be initialized
- next, all superinterfaces with at least one non-static non-abstract method should be (recursively) initialized in the declaration order
- initialization of `companion` blocks and `companion object` should follow program order

^KT-87412