### PR TITLE
Fix Wasm IC build for the case when gradle cleans output directory

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -11172,6 +11172,49 @@
                                                 }
                                             },
                                             {
+                                                "name": "Xwasm-IC-generate-unchanged-modules",
+                                                "shortName": null,
+                                                "deprecatedName": null,
+                                                "description": {
+                                                    "current": "Regenerate unchanged modules in multimodule IC.",
+                                                    "valueInVersions": []
+                                                },
+                                                "delimiter": null,
+                                                "affectsCompilationOutcome": true,
+                                                "valueType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "valueDescription": {
+                                                    "current": null,
+                                                    "valueInVersions": []
+                                                },
+                                                "releaseVersionsMetadata": {
+                                                    "introducedVersion": "2.4.0",
+                                                    "stabilizedVersion": null,
+                                                    "deprecatedVersion": null,
+                                                    "removedVersion": null
+                                                },
+                                                "argumentType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                }
+                                            },
+                                            {
                                                 "name": "Xwasm-debug-friendly",
                                                 "shortName": null,
                                                 "deprecatedName": null,
@@ -12962,6 +13005,49 @@
                                                     "introducedVersion": "2.1.20",
                                                     "stabilizedVersion": null,
                                                     "deprecatedVersion": "2.4.0",
+                                                    "removedVersion": null
+                                                },
+                                                "argumentType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "name": "Xwasm-IC-generate-unchanged-modules",
+                                                "shortName": null,
+                                                "deprecatedName": null,
+                                                "description": {
+                                                    "current": "Regenerate unchanged modules in multimodule IC.",
+                                                    "valueInVersions": []
+                                                },
+                                                "delimiter": null,
+                                                "affectsCompilationOutcome": true,
+                                                "valueType": {
+                                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                                    "isNullable": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    },
+                                                    "defaultValue": {
+                                                        "current": false,
+                                                        "valueInVersions": []
+                                                    }
+                                                },
+                                                "valueDescription": {
+                                                    "current": null,
+                                                    "valueInVersions": []
+                                                },
+                                                "releaseVersionsMetadata": {
+                                                    "introducedVersion": "2.4.0",
+                                                    "stabilizedVersion": null,
+                                                    "deprecatedVersion": null,
                                                     "removedVersion": null
                                                 },
                                                 "argumentType": {

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/WasmCompilerArguments.kt
@@ -66,6 +66,17 @@ val actualWasmArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames.wa
     }
 
     compilerArgument {
+        name = "Xwasm-IC-generate-unchanged-modules"
+        compilerName = "regenerateUnchangedModules"
+        description = "Regenerate unchanged modules in multimodule IC.".asReleaseDependent()
+        valueType = BooleanType.defaultFalse
+
+        lifecycle(
+            introducedVersion = KotlinReleaseVersion.v2_4_0,
+        )
+    }
+
+    compilerArgument {
         name = "Xwasm-included-module-only"
         description = "Compile only a module passed using `-include` option.".asReleaseDependent()
         valueType = BooleanType.defaultFalse

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JSCompilerArgumentsToKotlinWasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JSCompilerArgumentsToKotlinWasmCompilerArgumentsCopyGenerated.kt
@@ -16,6 +16,7 @@ fun copyK2JSCompilerArguments(from: K2JSCompilerArguments, to: KotlinWasmCompile
     to.includeUnavailableSourcesIntoSourceMap = from.includeUnavailableSourcesIntoSourceMap
     to.irDceDumpDeclarationIrSizesToFile = from.irDceDumpDeclarationIrSizesToFile
     to.irDceDumpReachabilityInfoToFile = from.irDceDumpReachabilityInfoToFile
+    to.regenerateUnchangedModules = from.regenerateUnchangedModules
     @Suppress("DEPRECATION")
     to.wasm = from.wasm
     to.wasmDebug = from.wasmDebug

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArguments.kt
@@ -44,6 +44,16 @@ sealed class K2WasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         }
 
     @Argument(
+        value = "-Xwasm-IC-generate-unchanged-modules",
+        description = "Regenerate unchanged modules in multimodule IC.",
+    )
+    var regenerateUnchangedModules: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xwasm-debug-friendly",
         description = "Avoid optimizations that can break debugging.",
     )

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2WasmCompilerArgumentsCopyGenerated.kt
@@ -17,6 +17,7 @@ fun copyK2WasmCompilerArguments(from: K2WasmCompilerArguments, to: K2WasmCompile
     to.includeUnavailableSourcesIntoSourceMap = from.includeUnavailableSourcesIntoSourceMap
     to.irDceDumpDeclarationIrSizesToFile = from.irDceDumpDeclarationIrSizesToFile
     to.irDceDumpReachabilityInfoToFile = from.irDceDumpReachabilityInfoToFile
+    to.regenerateUnchangedModules = from.regenerateUnchangedModules
     @Suppress("DEPRECATION")
     to.wasm = from.wasm
     to.wasmDebug = from.wasmDebug

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArguments.kt
@@ -45,6 +45,16 @@ class KotlinWasmCompilerArguments : CommonJsAndWasmCompilerArguments() {
         }
 
     @Argument(
+        value = "-Xwasm-IC-generate-unchanged-modules",
+        description = "Regenerate unchanged modules in multimodule IC.",
+    )
+    var regenerateUnchangedModules: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xwasm-debug-friendly",
         description = "Avoid optimizations that can break debugging.",
     )

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/KotlinWasmCompilerArgumentsCopyGenerated.kt
@@ -16,6 +16,7 @@ fun copyKotlinWasmCompilerArguments(from: KotlinWasmCompilerArguments, to: Kotli
     to.includeUnavailableSourcesIntoSourceMap = from.includeUnavailableSourcesIntoSourceMap
     to.irDceDumpDeclarationIrSizesToFile = from.irDceDumpDeclarationIrSizesToFile
     to.irDceDumpReachabilityInfoToFile = from.irDceDumpReachabilityInfoToFile
+    to.regenerateUnchangedModules = from.regenerateUnchangedModules
     @Suppress("DEPRECATION")
     to.wasm = from.wasm
     to.wasmDebug = from.wasmDebug

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/KotlinIr2WasmIrCompilerIC.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/KotlinIr2WasmIrCompilerIC.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.config.moduleName
 import org.jetbrains.kotlin.ir.backend.js.ic.ModuleArtifact
 import org.jetbrains.kotlin.js.config.outputName
 import org.jetbrains.kotlin.wasm.config.wasmGenerateClosedWorldMultimodule
+import org.jetbrains.kotlin.wasm.config.wasmIcGenerateUnchangedModules
 import org.jetbrains.kotlin.wasm.config.wasmIncludedModuleOnly
 import kotlin.collections.mutableSetOf
 import kotlin.collections.set
@@ -198,7 +199,7 @@ fun compileIncrementallyMultimodule(
     val kotlinTestArtifact = artifacts.firstOrNull { it.moduleName == "<kotlin-test>" }
 
     val (toRecompile, toDependency) = artifacts.partition { artifact ->
-        artifact.fileArtifacts.any { it.isModified() }
+        configuration.wasmIcGenerateUnchangedModules || artifact.fileArtifacts.any { it.isModified() }
     }
 
     val builtInFragments = mutableListOf<WasmIrProgramFragmentsMultimodule>()

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmConfigurationUpdater.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/WasmConfigurationUpdater.kt
@@ -47,6 +47,7 @@ object WasmConfigurationUpdater : ConfigurationUpdater<KotlinWasmCompilerArgumen
         configuration.put(WasmConfigurationKeys.WASM_ENABLE_ASSERTS, arguments.wasmEnableAsserts)
         configuration.put(WasmConfigurationKeys.WASM_GENERATE_WAT, arguments.wasmGenerateWat)
         configuration.put(WasmConfigurationKeys.WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS, arguments.wasmUseTrapsInsteadOfExceptions)
+        configuration.put(WasmConfigurationKeys.WASM_IC_GENERATE_UNCHANGED_MODULES, arguments.regenerateUnchangedModules)
 
         val wasmTarget = arguments.wasmTarget?.let(WasmTarget::fromName)
 

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/WasmConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/WasmConfigurationKeysContainer.kt
@@ -15,6 +15,7 @@ object WasmConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.wasm
     val WASM_GENERATE_WAT by key<Boolean>()
     val WASM_TARGET by key<WasmTarget>(defaultValue = "WasmTarget.JS")
     val WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS by key<Boolean>()
+    val WASM_IC_GENERATE_UNCHANGED_MODULES by key<Boolean>()
     val WASM_USE_NEW_EXCEPTION_PROPOSAL by key<Boolean>()
     val WASM_NO_JS_TAG by key<Boolean>("Don't use WebAssembly.JSTag for throwing and catching exceptions")
     val WASM_DEBUG by key<Boolean>()

--- a/compiler/testData/cli/js/jsExtraHelp.out
+++ b/compiler/testData/cli/js/jsExtraHelp.out
@@ -29,6 +29,8 @@ where advanced options include:
   -Xir-dump-declaration-ir-sizes-to-file=<path>
                              Dump the IR size of each declaration into a file. The format will be chosen automatically depending on the file extension. Supported output formats include JSON for .json, a JS const initialized with a plain object containing information for .js, and plain text for all other file types.
   -Xwasm                     Use the WebAssembly compiler backend.
+  -Xwasm-IC-generate-unchanged-modules
+                             Regenerate unchanged modules in multimodule IC.
   -Xwasm-debug-friendly      Avoid optimizations that can break debugging.
   -Xwasm-debug-info          Add debug info to the compiled WebAssembly module.
   -Xwasm-debugger-custom-formatters

--- a/compiler/testData/cli/wasm/wasmExtraHelp.out
+++ b/compiler/testData/cli/wasm/wasmExtraHelp.out
@@ -5,6 +5,8 @@ where advanced options include:
   -Xir-dump-declaration-ir-sizes-to-file=<path>
                              Dump the IR size of each declaration into a file. The format will be chosen automatically depending on the file extension. Supported output formats include JSON for .json, a JS const initialized with a plain object containing information for .js, and plain text for all other file types.
   -Xwasm                     Use the WebAssembly compiler backend.
+  -Xwasm-IC-generate-unchanged-modules
+                             Regenerate unchanged modules in multimodule IC.
   -Xwasm-debug-friendly      Avoid optimizations that can break debugging.
   -Xwasm-debug-info          Add debug info to the compiled WebAssembly module.
   -Xwasm-debugger-custom-formatters

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.gradle
 
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.withType
-import org.gradle.kotlin.dsl.withType
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.targets.js.dsl.Distribution
@@ -203,6 +202,47 @@ class KotlinWasmGradlePluginIT : AbstractKotlinWasmGradlePluginIT() {
                 assertTasksExecuted(":app:wasmJsD8ProductionRun")
                 assertOutputContains("Hello from Lib, App!")
                 assertOutputContains("v2: [cube, sphere, light]")
+            }
+        }
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    @DisplayName("Check js target with per-module closed world incremental build with rerun tasks")
+    @GradleTest
+    fun jsTargetPerModuleClosedWorldWithRerunTasks(gradleVersion: GradleVersion) {
+        project("new-mpp-wasm-js", gradleVersion) {
+            buildGradleKts.modify {
+                it.replace("<JsEngine>", "d8")
+            }
+
+            buildScriptInjection {
+                kotlinMultiplatform.wasmJs {
+                    binaries.executable().forEach {
+                        it.linkTask.configure {
+                            compilerOptions.freeCompilerArgs.add("-Xwasm-generate-closed-world-multimodule")
+                        }
+                    }
+                }
+            }
+
+            build(
+                ":compileDevelopmentExecutableKotlinWasmJs",
+            ) {
+                assertTasksExecuted(":compileDevelopmentExecutableKotlinWasmJs")
+
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/redefined-wasm-module-name.wasm")
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/kotlin-kotlin-stdlib.wasm")
+            }
+
+            build(
+                ":compileDevelopmentExecutableKotlinWasmJs",
+                *rerunTask(":compileDevelopmentExecutableKotlinWasmJs"),
+            ) {
+                assertTasksExecuted(":compileDevelopmentExecutableKotlinWasmJs")
+
+                // Incremental build should not remove unchanged files
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/redefined-wasm-module-name.wasm")
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/kotlin-kotlin-stdlib.wasm")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -3076,6 +3076,7 @@ public final class org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrCompilati
 
 public abstract class org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrLink : org/jetbrains/kotlin/gradle/tasks/Kotlin2JsCompile, org/jetbrains/kotlin/gradle/plugin/statistics/UsesBuildFusService {
 	public fun <init> (Lorg/gradle/api/Project;Lorg/jetbrains/kotlin/gradle/plugin/KotlinPlatformType;Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/workers/WorkerExecutor;)V
+	public synthetic fun callCompilerAsync$kotlin_gradle_plugin_common (Lorg/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments;Lorg/gradle/work/InputChanges;Lorg/jetbrains/kotlin/gradle/tasks/TaskOutputsBackup;)V
 	protected fun cleanOutputsAndLocalState (Ljava/lang/String;)V
 	protected fun contributeAdditionalCompilerArguments (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilerArgumentsProducer$ContributeCompilerArgumentsContext;)V
 	public final fun getIncrementalJsIr ()Z

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrLink.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrLink.kt
@@ -11,6 +11,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.work.InputChanges
 import org.gradle.work.NormalizeLineEndings
 import org.gradle.workers.WorkerExecutor
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
@@ -26,6 +27,7 @@ import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBinaryMode
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBinaryMode.DEVELOPMENT
 import org.jetbrains.kotlin.gradle.tasks.K2MultiplatformStructure
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+import org.jetbrains.kotlin.gradle.tasks.TaskOutputsBackup
 import org.jetbrains.kotlin.gradle.utils.KotlinJsCompilerOptionsDefault
 import org.jetbrains.kotlin.platform.js.JsPlatforms
 import javax.inject.Inject
@@ -106,6 +108,18 @@ abstract class KotlinJsIrLink @Inject constructor(
     }
 
     override fun isIncrementalCompilationEnabled(): Boolean = false
+
+    override fun callCompilerAsync(
+        args: K2JSCompilerArguments,
+        inputChanges: InputChanges,
+        taskOutputsBackup: TaskOutputsBackup?,
+    ) {
+        if (!inputChanges.isIncremental && isWasmPlatform) {
+            args.regenerateUnchangedModules = true
+        }
+
+        super.callCompilerAsync(args, inputChanges, taskOutputsBackup)
+    }
 
     override fun contributeAdditionalCompilerArguments(context: ContributeCompilerArgumentsContext<K2JSCompilerArguments>) {
         context.primitive { args ->

--- a/wasm/wasm.frontend/gen/org/jetbrains/kotlin/wasm/config/WasmConfigurationKeys.kt
+++ b/wasm/wasm.frontend/gen/org/jetbrains/kotlin/wasm/config/WasmConfigurationKeys.kt
@@ -33,6 +33,9 @@ object WasmConfigurationKeys {
     val WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS = CompilerConfigurationKey.create<Boolean>("WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS")
 
     @JvmField
+    val WASM_IC_GENERATE_UNCHANGED_MODULES = CompilerConfigurationKey.create<Boolean>("WASM_IC_GENERATE_UNCHANGED_MODULES")
+
+    @JvmField
     val WASM_USE_NEW_EXCEPTION_PROPOSAL = CompilerConfigurationKey.create<Boolean>("WASM_USE_NEW_EXCEPTION_PROPOSAL")
 
     // Don't use WebAssembly.JSTag for throwing and catching exceptions
@@ -95,6 +98,10 @@ var CompilerConfiguration.wasmTarget: WasmTarget
 var CompilerConfiguration.wasmUseTrapsInsteadOfExceptions: Boolean
     get() = getBoolean(WasmConfigurationKeys.WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS)
     set(value) { put(WasmConfigurationKeys.WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS, value) }
+
+var CompilerConfiguration.wasmIcGenerateUnchangedModules: Boolean
+    get() = getBoolean(WasmConfigurationKeys.WASM_IC_GENERATE_UNCHANGED_MODULES)
+    set(value) { put(WasmConfigurationKeys.WASM_IC_GENERATE_UNCHANGED_MODULES, value) }
 
 var CompilerConfiguration.wasmUseNewExceptionProposal: Boolean
     get() = getBoolean(WasmConfigurationKeys.WASM_USE_NEW_EXCEPTION_PROPOSAL)


### PR DESCRIPTION
Running gradle with --rerun-tasks cleans output directory which cause lack of wasm files in Wasm IC build step. This is because the IC does not make files for a modules, that did not change.

Fixed [KT-87066](https://youtrack.jetbrains.com/issue/KT-87066)

Original MR: https://github.com/JetBrains/kotlin/pull/6504