### PR TITLE
[KLIB API] Replace usage of `KotlinLibrary.libraryFile` by `path` in JKlib backend

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -50,7 +50,6 @@ import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.util.ExternalDependenciesGenerator
 import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.SymbolTable
-import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isJklibStdlib
 import org.jetbrains.kotlin.library.loader.KlibLoader
@@ -71,6 +70,8 @@ import org.jetbrains.kotlin.resolve.jvm.multiplatform.OptionalAnnotationPackageF
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactory
 import org.jetbrains.kotlin.storage.StorageManager
 import org.jetbrains.kotlin.types.KotlinType
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
 object JKlibIrCompilationPhase :
@@ -81,11 +82,11 @@ object JKlibIrCompilationPhase :
 
     override fun executePhase(input: JKlibSerializationArtifact): JKlibIrCompilationArtifact {
         val configuration = input.configuration
-        val klib = File(input.outputKlibPath)
+        val klib = Path(input.outputKlibPath)
 
         val projectEnvironment = input.projectEnvironment
 
-        val klibFiles = configuration.getList(JVMConfigurationKeys.KLIB_PATHS) + klib.absolutePath
+        val klibFiles = configuration.getList(JVMConfigurationKeys.KLIB_PATHS) + klib.absolutePathString()
         val projectContext = ProjectContext(projectEnvironment.project, "TopDownAnalyzer for JKlib")
         val storageManager = projectContext.storageManager
         val builtIns = JvmBuiltIns(projectContext.storageManager, JvmBuiltIns.Kind.FROM_DEPENDENCIES)
@@ -103,7 +104,7 @@ object JKlibIrCompilationPhase :
         val allDescriptors = dependencyDescriptorsByKlib.values + jarDepsModuleDescriptor
         dependencyDescriptorsByKlib.values.forEach { it.setDependencies(allDescriptors) }
 
-        val mainModule = dependencyDescriptorsByKlib.getValue(sortedDependencies.single { it.libraryFile == klib })
+        val mainModule = dependencyDescriptorsByKlib.getValue(sortedDependencies.single { it.path == klib })
 
         val trace = BindingTraceContext(projectContext.project)
         val mangler = JKlibDescriptorMangler(

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
@@ -63,6 +63,7 @@ import org.jetbrains.kotlin.utils.PathUtil
 import java.io.File
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.pathString
 
 object JKlibConfigurationPhase : AbstractConfigurationPhase<K2JKlibCompilerArguments>(
@@ -223,7 +224,7 @@ object JKlibFrontendPipelinePhase : PipelinePhase<ConfigurationPipelineArtifact,
         val libraryList = DependencyListForCliModule.build(Name.identifier(moduleName)) {
             dependencies(configuration.jvmClasspathRoots.map { it.absolutePath })
             dependencies(configuration.jvmModularRoots.map { it.absolutePath })
-            dependencies(resolvedLibraries.map { it.libraryFile.absolutePath })
+            dependencies(resolvedLibraries.map { it.path.absolutePathString() })
             friendDependencies(configuration.friendPaths)
         }
 


### PR DESCRIPTION
^KT-87104