### PR TITLE
[Tests][JS] Ignore two tests with ES_MODULE in JS Klib forward compatibility testing.

### DIFF
--- a/compiler/testData/codegen/box/size/add.kt
+++ b/compiler/testData/codegen/box/size/add.kt
@@ -1,3 +1,4 @@
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: JS:*
 // IGNORE_BACKEND_K2_MULTI_MODULE: JS_IR, JS_IR_ES6
 // ^^^^^^
 // The Mutli Module tests are compiling the main module as a dependency module.

--- a/compiler/testData/codegen/box/size/helloWorldPromise.kt
+++ b/compiler/testData/codegen/box/size/helloWorldPromise.kt
@@ -1,3 +1,4 @@
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: JS:*
 // IGNORE_BACKEND_K2_MULTI_MODULE: JS_IR, JS_IR_ES6
 // ^^^^^^
 // The Mutli Module tests are compiling the main module as a dependency module.


### PR DESCRIPTION
In scope of [KT-75176 Add infrastructure for bundle size testing](https://youtrack.jetbrains.com/issue/KT-75176), the following tests were enabled for JS_IR using ES_MODULES:
- compiler/testData/codegen/box/size/helloWorldPromise.kt
- compiler/testData/codegen/box/size/add.kt

In presence of ES_MODULES test directive, JS testing fails in multi-module mode, which is highlighted by test directive and comment: 
```
// IGNORE_BACKEND_K2_MULTI_MODULE: JS_IR, JS_IR_ES6
// ^^^^^^
// The Mutli Module tests are compiling the main module as a dependency module.
// Since we use ES modules in those tests, there is no re-exports from the dependencies,
// so it's failing with a runtime error, that there is no expected exported function
```
Similarly, in Klib forward compatibility tests there is no re-exports from the dependencies, so it's failing with a runtime error, that there is no expected exported function.
These two failures are revealed in recent CI run https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KlibBackwardAndForwardCompatibilityTestsNightly/994159326

In this PR, these two tests are ignored for JS Klib forward compatibility tests