### PR TITLE
[Tests][JS] Don't use codegen helpers for JS diagnostic tests

### DIFF
--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsBlackBoxCodegenTestBase.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsBlackBoxCodegenTestBase.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.js.test.runners
 
-import org.jetbrains.kotlin.js.test.JsAdditionalSourceProvider
 import org.jetbrains.kotlin.js.test.converters.*
 import org.jetbrains.kotlin.js.test.converters.incremental.RecompileModuleJsIrBackendFacade
 import org.jetbrains.kotlin.js.test.handlers.*
@@ -33,7 +32,6 @@ import org.jetbrains.kotlin.test.services.configuration.CommonEnvironmentConfigu
 import org.jetbrains.kotlin.test.services.configuration.JsFirstStageEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.configuration.JsSecondStageEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.sourceProviders.AdditionalDiagnosticsSourceFilesProvider
-import org.jetbrains.kotlin.test.services.sourceProviders.CoroutineHelpersSourceFilesProvider
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import org.jetbrains.kotlin.utils.bind
 import java.lang.Boolean.getBoolean
@@ -230,8 +228,6 @@ fun TestConfigurationBuilder.commonServicesConfigurationForJsCodegenTest(
     }
 
     useAdditionalSourceProviders(
-        ::JsAdditionalSourceProvider,
-        ::CoroutineHelpersSourceFilesProvider,
         ::AdditionalDiagnosticsSourceFilesProvider,
     )
 }

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsES6Test.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsES6Test.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.js.test.runners
 
+import org.jetbrains.kotlin.js.test.JsAdditionalSourceProvider
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.TargetBackend
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
@@ -15,6 +16,7 @@ import org.jetbrains.kotlin.test.configuration.commonIrHandlersForCodegenTest
 import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.frontend.fir.FirMetaInfoDiffSuppressor
 import org.jetbrains.kotlin.test.services.configuration.JsEnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.sourceProviders.CoroutineHelpersSourceFilesProvider
 
 abstract class AbstractJsES6Test(
     pathToTestDir: String = "${JsEnvironmentConfigurator.TEST_DATA_DIR_PATH}/box/",
@@ -32,17 +34,21 @@ abstract class AbstractJsES6Test(
 }
 
 
-abstract class AbstractJsES6BoxTest : AbstractJsES6Test(
+abstract class AbstractJsES6BoxTest : AbstractJsES6CodegenBoxTest(
     pathToTestDir = "${JsEnvironmentConfigurator.TEST_DATA_DIR_PATH}/box/",
     testGroupOutputDirPrefix = "es6Box/"
 )
 
-abstract class AbstractJsES6CodegenBoxTest : AbstractJsES6Test(
-    pathToTestDir = "compiler/testData/codegen/box/",
-    testGroupOutputDirPrefix = "codegen/es6Box/"
-) {
+abstract class AbstractJsES6CodegenBoxTest(
+    pathToTestDir : String = "compiler/testData/codegen/box/",
+    testGroupOutputDirPrefix : String = "codegen/es6Box/"
+) : AbstractJsES6Test(pathToTestDir, testGroupOutputDirPrefix) {
     override fun configure(builder: TestConfigurationBuilder) {
         super.configure(builder)
+        builder.useAdditionalSourceProviders(
+            ::JsAdditionalSourceProvider,
+            ::CoroutineHelpersSourceFilesProvider,
+        )
         builder.configureFirHandlersStep {
             commonFirHandlersForCodegenTest()
         }
@@ -57,12 +63,12 @@ abstract class AbstractJsES6CodegenBoxTest : AbstractJsES6Test(
     }
 }
 
-abstract class AbstractJsES6CodegenInlineTest : AbstractJsES6Test(
+abstract class AbstractJsES6CodegenInlineTest : AbstractJsES6CodegenBoxTest(
     pathToTestDir = "compiler/testData/codegen/boxInline/",
     testGroupOutputDirPrefix = "codegen/es6BoxInline/"
 )
 
-abstract class AbstractJsES6CodegenWasmJsInteropTest : AbstractJsES6Test(
+abstract class AbstractJsES6CodegenWasmJsInteropTest : AbstractJsES6CodegenBoxTest(
     pathToTestDir = "compiler/testData/codegen/boxWasmJsInterop",
     testGroupOutputDirPrefix = "codegen/boxWasmJsInteropEs6",
 )

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.js.test.runners
 
 import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.js.test.JsAdditionalSourceProvider
 import org.jetbrains.kotlin.js.test.handlers.JsIrRecompiledArtifactsIdentityHandler
 import org.jetbrains.kotlin.js.test.handlers.JsLineNumberHandler
 import org.jetbrains.kotlin.js.test.handlers.JsSizeHandler
@@ -42,6 +43,7 @@ import org.jetbrains.kotlin.test.frontend.fir.handlers.FirResolvedTypesVerifier
 import org.jetbrains.kotlin.test.services.SplittingModuleTransformerForBoxTests
 import org.jetbrains.kotlin.test.services.SplittingTestConfigurator
 import org.jetbrains.kotlin.test.services.configuration.JsEnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.sourceProviders.CoroutineHelpersSourceFilesProvider
 import java.lang.Boolean.getBoolean
 
 
@@ -107,6 +109,10 @@ abstract class AbstractJsCodegenBoxTestBase(
 ) : AbstractJsTest(pathToTestDir, testGroupOutputDirPrefix) {
     override fun configure(builder: TestConfigurationBuilder) {
         super.configure(builder)
+        builder.useAdditionalSourceProviders(
+            ::JsAdditionalSourceProvider,
+            ::CoroutineHelpersSourceFilesProvider,
+        )
         builder.configureFirHandlersStep {
             commonFirHandlersForCodegenTest()
         }

--- a/js/js.translator/testData/box/esModules/kotlin.test/_common.kt
+++ b/js/js.translator/testData/box/esModules/kotlin.test/_common.kt
@@ -15,7 +15,7 @@ fun raise(name: String): Nothing {
 }
 
 // Adapter should be initialized eagerly
-@Suppress("INVISIBLE_MEMBER")
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 @OptIn(kotlin.ExperimentalStdlibApi::class)
 @EagerInitialization
 private val underscore = kotlin.test.setAdapter(object : FrameworkAdapter {

--- a/js/js.translator/testData/box/kotlin.test/_common.kt
+++ b/js/js.translator/testData/box/kotlin.test/_common.kt
@@ -15,7 +15,7 @@ fun raise(name: String): Nothing {
 }
 
 // Adapter should be initialized eagerly
-@Suppress("INVISIBLE_MEMBER")
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 @OptIn(kotlin.ExperimentalStdlibApi::class)
 @EagerInitialization
 private val underscore = kotlin.test.setAdapter(object : FrameworkAdapter {


### PR DESCRIPTION
Don't use codegen helpers for JS diagnostic tests,
otherwise, KOTLIN_PACKAGE_USAGE error diagnostic will be raised for helpers `fail.kt`, `asserts.kt`, `arrayAsserts.kt`, which contain line `package kotlin`, which is
- recently prohibited in ^KT-85764
- not needed for diagnostic tests

Rationale: in master, `JsDiagnosticsWithIrInlinerTestGenerated`, `LightTreeJsKlibDiagnosticsTestGenerated` and `PsiJsKlibDiagnosticsTestGenerated` are red with messages
```
KOTLIN_PACKAGE_USAGE: Only the Kotlin standard library is allowed to use the 'kotlin' package. at fail.kt:(0,14)
```
It isn't shown in Aggregate CI, due to exclusion of JS ES5 tests from Aggregate CI, in scope of 
[KTI-3244 Duty (18 May - 24 May)](https://youtrack.jetbrains.com/issue/KTI-3244) . 
See 
- [JSCompilerTestsES5_LINUX are in Quarantine](https://jetbrains.team/p/kti/repositories/kotlin-infrastructure/files/7a3dae8ab0a79393ea92b9f0b236b9dc24b78d45/.teamcity/Quarantine.kt?tab=source&line=15&lines-count=1) 
- [no ES5 tests at all in current aggregate](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_Aggregate/994365609?buildTab=dependencies&name=testPropertyDifferentPackages&type=snapshot&mode=list&page=1&build-name-pattern=js), even for Windows 

Due to absence in Aggregate, these testrunners were overlooked in scope of ^KT-85764.
This PR fixes them by removing the following codegen helpers from JS diagnostic tests, and adding them only to JS codegen tests:
- `JsAdditionalSourceProvider`
- `CoroutineHelpersSourceFilesProvider`

On the way, abstract classes for ES6 codegen tests were streamlined

Note: As next steps, it worth returning ES5 testrunners to Aggregate CI, due to upcoming 2.4.20-Beta2 branching.

^KT-85764