### PR TITLE
Ignore implicit context parameter offsets when building IR call

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/utils/OffsetUtils.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/utils/OffsetUtils.kt
@@ -137,7 +137,7 @@ internal inline fun <T : IrElement> FirStatement.convertWithOffsets(
 ): T {
     val startOffset: Int
     val endOffset: Int
-    if (isCompiledElement(psi)) {
+    if (isCompiledElement(psi) || calleeReference.source?.kind == KtFakeSourceElementKind.ImplicitContextParameterArgument) {
         startOffset = UNDEFINED_OFFSET
         endOffset = UNDEFINED_OFFSET
     } else {

--- a/compiler/testData/debug/stepping/contextParameters.kt
+++ b/compiler/testData/debug/stepping/contextParameters.kt
@@ -1,0 +1,47 @@
+
+// WITH_STDLIB
+// FILE: test.kt
+
+private class Context1(val id: Int)
+private class Context2(val id: Int)
+
+private object Container {
+    context(context1: Context1, context2: Context2)
+    fun caller(value: Int) {
+        target(value)
+    }
+
+    context(context1: Context1, context2: Context2)
+    private fun target(value: Int) {
+        println(context1.id + context2.id + value)
+    }
+}
+
+fun box() {
+    context(Context1(1), Context2(2)) {
+        Container.caller(3)
+    }
+}
+
+// EXPECTATIONS JVM_IR
+// test.kt:21 box
+// test.kt:5 <init>
+// test.kt:21 box
+// test.kt:6 <init>
+// test.kt:21 box
+// test.kt:22 box
+// test.kt:21 box
+// test.kt:22 box
+// test.kt:11 caller
+// test.kt:9 caller
+// test.kt:11 caller
+// test.kt:16 target
+// test.kt:5 getId
+// test.kt:16 target
+// test.kt:6 getId
+// test.kt:16 target
+// test.kt:17 target
+// test.kt:12 caller
+// test.kt:23 box
+// test.kt:21 box
+// test.kt:24 box

--- a/compiler/testData/debug/stepping/contextParameters.kt
+++ b/compiler/testData/debug/stepping/contextParameters.kt
@@ -30,10 +30,6 @@ fun box() {
 // test.kt:6 <init>
 // test.kt:21 box
 // test.kt:22 box
-// test.kt:21 box
-// test.kt:22 box
-// test.kt:11 caller
-// test.kt:9 caller
 // test.kt:11 caller
 // test.kt:16 target
 // test.kt:5 getId


### PR DESCRIPTION
KT-87335