### PR TITLE
[K/N] Special backend checks: tolerate missing intrinsics

### DIFF
--- a/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/checkers/EscapeAnalysisChecker.kt
+++ b/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/checkers/EscapeAnalysisChecker.kt
@@ -31,6 +31,20 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.NativeRuntimeNames
 
+/**
+ * Same as [tryGetIntrinsicType], but treats an intrinsic `kind` that isn't a value in this compiler's [IntrinsicType] enum
+ * as "unknown" (returns `null`) instead of propagating [IllegalArgumentException] from [Enum.valueOf].
+ *
+ * Reserved for the stdlib-build traversal: the stdlib is compiled by a pinned bootstrap K/N distribution whose
+ * `IntrinsicType` enum may lag behind the current source. Without this tolerance, adding new `@TypedIntrinsic` kind
+ * to the runtime would require a bootstrap bump before the runtime can actually use it.
+ */
+private fun tryGetIntrinsicTypeIgnoringUnknown(function: IrFunction): IntrinsicType? = try {
+    tryGetIntrinsicType(function)
+} catch (_: IllegalArgumentException) {
+    null
+}
+
 class EscapeAnalysisChecker(
     private val context: NativePhaseContext,
     private val irFile: IrFile,
@@ -90,7 +104,7 @@ class EscapeAnalysisChecker(
                 && !startsWith(kotlinPackageFqn.child(Name.identifier("native")).child(Name.identifier("concurrent")))
 
     private val IrFunction.isLoweredIntrinsic: Boolean
-        get() = tryGetIntrinsicType(this)?.mustBeLowered == true
+        get() = tryGetIntrinsicTypeIgnoringUnknown(this)?.mustBeLowered == true
 
     private val IrType.cannotEscape: Boolean
         get() = isUnit() || isNothing() || computeBinaryType() is BinaryType.Primitive

--- a/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialBackendChecksTraversal.kt
+++ b/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialBackendChecksTraversal.kt
@@ -45,6 +45,20 @@ import org.jetbrains.kotlin.utils.fileUtils.descendantRelativeTo
 import java.io.File
 
 /**
+ * Same as [tryGetIntrinsicType], but treats an intrinsic `kind` that isn't a value in this compiler's [IntrinsicType] enum
+ * as "unknown" (returns `null`) instead of propagating [IllegalArgumentException] from [Enum.valueOf].
+ *
+ * Reserved for the stdlib-build traversal: the stdlib is compiled by a pinned bootstrap K/N distribution whose
+ * `IntrinsicType` enum may lag behind the current source. Without this tolerance, adding new `@TypedIntrinsic` kind
+ * to the runtime would require a bootstrap bump before the runtime can actually use it.
+ */
+private fun tryGetIntrinsicTypeIgnoringUnknown(function: IrFunction): IntrinsicType? = try {
+    tryGetIntrinsicType(function)
+} catch (_: IllegalArgumentException) {
+    null
+}
+
+/**
  * Kotlin/Native-specific language checks. Most importantly, it checks C/Objective-C interop restrictions.
  * TODO: Should be moved to compiler frontend after K2.
  */
@@ -452,7 +466,7 @@ private class BackendChecker(
         if (callee.isCFunctionOrGlobalAccessor())
             checkCanGenerateCFunctionCallOrGlobalAccess(expression, isInvoke = false)
 
-        when (val intrinsicType = tryGetIntrinsicType(expression)) {
+        when (val intrinsicType = tryGetIntrinsicTypeIgnoringUnknown(callee)) {
             IntrinsicType.INTEROP_STATIC_C_FUNCTION -> {
                 (val target = function, val captures) = getUnboundReferencedFunction(expression.arguments[0]!!)
 


### PR DESCRIPTION
Adding new intrinsic type now is annoying: if it ought to be used in runtime, this needs to be done in three steps - first, add the intrinsic type; second, bump the bootstrap compiler; and finally, use it in the runtime. This is because stdlib is being compiled using the bootstrap compiler.

This commit workarounds that irritable problem by ignoring missing intrinsic types instead of throwing an exception.