### PR TITLE
[CLI] Deprecate `Xuse-fir-ic` in Kotlin 2.4.20

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -6211,8 +6211,14 @@
                         "shortName": null,
                         "deprecatedName": null,
                         "description": {
-                            "current": "Compile using frontend IR internal incremental compilation.\nWarning: This feature is not yet production-ready.",
-                            "valueInVersions": []
+                            "current": "Compile using frontend IR internal incremental compilation.",
+                            "valueInVersions": [
+                                {
+                                    "minReleaseVersion": "1.7.0",
+                                    "maxReleaseVersion": "2.4.0",
+                                    "value": "Compile using frontend IR internal incremental compilation.\nWarning: This feature is not yet production-ready."
+                                }
+                            ]
                         },
                         "delimiter": null,
                         "affectsCompilationOutcome": true,
@@ -6235,7 +6241,7 @@
                         "releaseVersionsMetadata": {
                             "introducedVersion": "1.7.0",
                             "stabilizedVersion": null,
-                            "deprecatedVersion": null,
+                            "deprecatedVersion": "2.4.20",
                             "removedVersion": null
                         },
                         "argumentType": {

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonCompilerArguments.kt
@@ -618,12 +618,16 @@ val actualCommonCompilerArguments by compilerArgumentsLevel(CompilerArgumentsLev
     compilerArgument {
         name = "Xuse-fir-ic"
         compilerName = "useFirIC"
-        description =
-            "Compile using frontend IR internal incremental compilation.\nWarning: This feature is not yet production-ready.".asReleaseDependent()
+        val commonDescriptionPart = "Compile using frontend IR internal incremental compilation."
+        description = ReleaseDependent(
+            commonDescriptionPart,
+            KotlinReleaseVersion.v1_7_0..KotlinReleaseVersion.v2_4_0 to "$commonDescriptionPart\nWarning: This feature is not yet production-ready."
+        )
         valueType = BooleanType.defaultFalse
 
         lifecycle(
             introducedVersion = KotlinReleaseVersion.v1_7_0,
+            deprecatedVersion = KotlinReleaseVersion.v2_4_20,
         )
     }
 

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/util/scenarioUtil.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/util/scenarioUtil.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.buildtools.tests.compilation.util
 
+import org.jetbrains.kotlin.buildtools.api.DeprecatedCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration
@@ -22,7 +23,7 @@ fun Scenario<JvmCompilationOperation.Builder, JvmSnapshotBasedIncrementalCompila
     moduleName = moduleName,
     dependencies = dependencies,
     compilationConfigAction = {
-        it.compilerArguments[CommonCompilerArguments.X_USE_FIR_IC] = true
+        it.compilerArguments[@OptIn(DeprecatedCompilerArgument::class) CommonCompilerArguments.X_USE_FIR_IC] = true
         compilationOperationConfig(it)
     },
     icOptionsConfigAction = {

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testDefaultOptions/kotlin/ModuleNameCompilationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testDefaultOptions/kotlin/ModuleNameCompilationTest.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.buildtools.tests.defaults
 
+import org.jetbrains.kotlin.buildtools.api.DeprecatedCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments.Companion.MODULE_NAME
@@ -70,7 +71,7 @@ class ModuleNameCompilationTest : BaseCompilationTest() {
                 @Suppress("DEPRECATION_ERROR")
                 it[USE_FIR_RUNNER] = true
             }, compilationConfigAction = {
-                it.compilerArguments[CommonCompilerArguments.X_USE_FIR_IC] = true
+                it.compilerArguments[@OptIn(DeprecatedCompilerArgument::class) CommonCompilerArguments.X_USE_FIR_IC] = true
                 it.compilerArguments[MODULE_NAME] = EXPLICIT_NULL_MODULE_NAME_MARKER
             })
 

--- a/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/gen/org/jetbrains/kotlin/buildtools/api/arguments/CommonCompilerArguments.kt
@@ -798,12 +798,14 @@ public interface CommonCompilerArguments : CommonToolArguments {
 
     /**
      * Compile using frontend IR internal incremental compilation.
-     * Warning: This feature is not yet production-ready.
      *
      * WARNING: this option is EXPERIMENTAL and it may be changed in the future without notice or may be removed entirely.
+     *
+     * Deprecated in Kotlin version 2.4.20.
      */
     @JvmField
     @ExperimentalCompilerArgument
+    @DeprecatedCompilerArgument
     public val X_USE_FIR_IC: CommonCompilerArgument<Boolean> =
         CommonCompilerArgument("X_USE_FIR_IC", KotlinReleaseVersion(1, 7, 0))
 

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt
@@ -1067,10 +1067,11 @@ Warning: This is temporary solution (see KT-63712) intended to be used only for 
             field = value
         }
 
+    @all:Deprecated("")
     @Argument(
         value = "-Xuse-fir-ic",
-        description = """Compile using frontend IR internal incremental compilation.
-Warning: This feature is not yet production-ready.""",
+        description = "Compile using frontend IR internal incremental compilation.",
+        deprecatedVersion = "2.4.20",
     )
     var useFirIC: Boolean = false
         set(value) {

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsCopyGenerated.kt
@@ -112,6 +112,7 @@ fun copyCommonCompilerArguments(from: CommonCompilerArguments, to: CommonCompile
     to.unrestrictedBuilderInference = from.unrestrictedBuilderInference
     @Suppress("DEPRECATION")
     to.useFirExperimentalCheckers = from.useFirExperimentalCheckers
+    @Suppress("DEPRECATION")
     to.useFirIC = from.useFirIC
     @Suppress("DEPRECATION")
     to.useFirLT = from.useFirLT

--- a/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalJvmCompilerRunnerTest.kt
+++ b/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalJvmCompilerRunnerTest.kt
@@ -83,7 +83,10 @@ abstract class AbstractIncrementalJvmCompilerRunnerTest : AbstractIncrementalCom
             val k2Mode = (args.languageVersion ?: LanguageVersion.LATEST_STABLE.versionString) >= LanguageVersion.KOTLIN_2_0.versionString
 
             val compiler =
-                if (k2Mode && args.useFirIC && @Suppress("DEPRECATION") args.useFirLT /* TODO by @Ilya.Chernikov: move LT check into runner */) {
+                if (k2Mode &&
+                    @Suppress("DEPRECATION") args.useFirIC &&
+                    @Suppress("DEPRECATION") args.useFirLT // TODO by @Ilya.Chernikov: move LT check into runner
+                ) {
                     IncrementalFirJvmCompilerTestRunner(
                         cachesDir,
                         buildReporter,

--- a/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalK2FirICJvmCompilerRunnerTest.kt
+++ b/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalK2FirICJvmCompilerRunnerTest.kt
@@ -13,6 +13,7 @@ abstract class AbstractIncrementalK2FirICJvmCompilerRunnerTest : AbstractIncreme
     override fun createCompilerArguments(destinationDir: File, testDir: File): K2JVMCompilerArguments =
         super.createCompilerArguments(destinationDir, testDir).apply {
             languageVersion = "2.0"
+            @Suppress("DEPRECATION")
             useFirIC = true
         }
 

--- a/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalK2PsiJvmCompilerRunnerTest.kt
+++ b/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalK2PsiJvmCompilerRunnerTest.kt
@@ -13,7 +13,6 @@ abstract class AbstractIncrementalK2PsiJvmCompilerRunnerTest : AbstractIncrement
     override fun createCompilerArguments(destinationDir: File, testDir: File): K2JVMCompilerArguments =
         super.createCompilerArguments(destinationDir, testDir).apply {
             languageVersion = "2.0"
-            useFirIC = false
             @Suppress("DEPRECATION")
             useFirLT = false
         }

--- a/compiler/testData/cli/js/jsExtraHelp.out
+++ b/compiler/testData/cli/js/jsExtraHelp.out
@@ -263,7 +263,7 @@ where advanced options include:
                              Enable experimental frontend IR checkers that are not yet ready for production.
                              The option is deprecated since Kotlin 2.2.20. It will be removed in one of the future releases.
   -Xuse-fir-ic               Compile using frontend IR internal incremental compilation.
-                             Warning: This feature is not yet production-ready.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xuse-fir-lt               Compile using the LightTree parser with the frontend IR.
                              The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases. The light tree mode is enabled by default, and it will become the only available mode in one of the future releases.
   -Xverbose-phases           Be verbose while performing the given backend phases.

--- a/compiler/testData/cli/jvm/extraHelp.out
+++ b/compiler/testData/cli/jvm/extraHelp.out
@@ -298,7 +298,7 @@ where advanced options include:
                              Enable experimental frontend IR checkers that are not yet ready for production.
                              The option is deprecated since Kotlin 2.2.20. It will be removed in one of the future releases.
   -Xuse-fir-ic               Compile using frontend IR internal incremental compilation.
-                             Warning: This feature is not yet production-ready.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xuse-fir-lt               Compile using the LightTree parser with the frontend IR.
                              The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases. The light tree mode is enabled by default, and it will become the only available mode in one of the future releases.
   -Xverbose-phases           Be verbose while performing the given backend phases.

--- a/compiler/testData/cli/metadata/cliArgsNotRedundantWhenOverriding.args
+++ b/compiler/testData/cli/metadata/cliArgsNotRedundantWhenOverriding.args
@@ -6,8 +6,8 @@ $STDLIB_COMMON_PATH$
 -Xtarget-platform=JVM,JS
 -Xtarget-platform=WasmJs,WasmWasi,Native
 
--Xuse-fir-ic=false
--Xuse-fir-ic=true
+-progressive=false
+-progressive=true
 -kotlin-home=$TESTDATA_DIR$
 -kotlin-home=
 -Xannotation-default-target=param-property

--- a/compiler/testData/cli/metadata/cliArgsNotRedundantWhenOverriding.out
+++ b/compiler/testData/cli/metadata/cliArgsNotRedundantWhenOverriding.out
@@ -1,4 +1,4 @@
-warning: argument '-Xuse-fir-ic' is passed multiple times: 'false', 'true'. The last value will be used.
+warning: argument '-progressive' is passed multiple times: 'false', 'true'. The last value will be used.
 warning: argument '-kotlin-home' is passed multiple times: '$TESTDATA_DIR$', ''. The last value will be used.
 warning: argument '-Xannotation-default-target' is passed multiple times: 'param-property', 'first-only-warn'. The last value will be used.
 warning: the argument '-Xannotation-default-target=first-only-warn' disables a stable language feature for the current language version 2.4. Future support for this mode is not guaranteed.

--- a/compiler/testData/cli/metadata/cliArgsRedundant.args
+++ b/compiler/testData/cli/metadata/cliArgsRedundant.args
@@ -9,5 +9,4 @@ $STDLIB_COMMON_PATH$
 -Xwhen-guards
 -Xannotation-default-target=first-only-warn
 -Xrender-internal-diagnostic-names
--Xuse-fir-ic=false
 -Xexplicit-api=disable

--- a/compiler/testData/cli/wasm/wasmExtraHelp.out
+++ b/compiler/testData/cli/wasm/wasmExtraHelp.out
@@ -238,7 +238,7 @@ where advanced options include:
                              Enable experimental frontend IR checkers that are not yet ready for production.
                              The option is deprecated since Kotlin 2.2.20. It will be removed in one of the future releases.
   -Xuse-fir-ic               Compile using frontend IR internal incremental compilation.
-                             Warning: This feature is not yet production-ready.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xuse-fir-lt               Compile using the LightTree parser with the frontend IR.
                              The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases. The light tree mode is enabled by default, and it will become the only available mode in one of the future releases.
   -Xverbose-phases           Be verbose while performing the given backend phases.

--- a/jps/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalK2FirICLightTreeJvmJpsTest.kt
+++ b/jps/jps-plugin/jps-tests/test/org/jetbrains/kotlin/jps/build/AbstractIncrementalK2FirICLightTreeJvmJpsTest.kt
@@ -19,7 +19,7 @@ abstract class AbstractIncrementalK2FirICLightTreeJvmJpsTest(
             arguments.languageVersion = "2.0"
         }
         additionalCommandLineArguments = additionalCommandLineArguments + listOf(
-            K2JVMCompilerArguments::useFirIC.cliArgument,
+            @Suppress("DEPRECATION") K2JVMCompilerArguments::useFirIC.cliArgument,
             @Suppress("DEPRECATION") K2JVMCompilerArguments::useFirLT.cliArgument,
         )
         super.updateCommandLineArguments(arguments)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
@@ -247,6 +247,7 @@ abstract class KotlinCompile @Inject constructor(
                     )
                 }
 
+                @Suppress("DEPRECATION")
                 args.useFirIC = true
             }
 

--- a/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
+++ b/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
@@ -264,7 +264,7 @@ where advanced options include:
                              Enable experimental frontend IR checkers that are not yet ready for production.
                              The option is deprecated since Kotlin 2.2.20. It will be removed in one of the future releases.
   -Xuse-fir-ic               Compile using frontend IR internal incremental compilation.
-                             Warning: This feature is not yet production-ready.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xuse-fir-lt               Compile using the LightTree parser with the frontend IR.
                              The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases. The light tree mode is enabled by default, and it will become the only available mode in one of the future releases.
   -Xverbose-phases           Be verbose while performing the given backend phases.


### PR DESCRIPTION
KT-75879