### PR TITLE
[Build] Read `kotlinApiVersionForProjectsDependingOnStableStdlib` from GradleProperties instead of rootProject.extra

### DIFF
--- a/libraries/tools/ide-plugin-dependencies-validator/build.gradle.kts
+++ b/libraries/tools/ide-plugin-dependencies-validator/build.gradle.kts
@@ -41,7 +41,7 @@ application {
 }
 
 val projectsDependingOnStableStdlib: Array<String> = CompilerModules.projectsDependingOnStableStdlib
-val kotlinApiVersionForProjectsDependingOnStableStdlib: String by rootProject.extra
+val kotlinApiVersionForProjectsDependingOnStableStdlib: String = project.providers.gradleProperty("kotlinApiVersionForProjectsDependingOnStableStdlib").get()
 
 tasks.withType<JavaExec> {
     notCompatibleWithConfigurationCache("Uses project in task action")

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
@@ -105,7 +105,7 @@ fun Project.configureJavaCompile() {
     }
 }
 
-val kotlinApiVersionForProjectsDependingOnStableStdlib: String by rootProject.extra
+val kotlinApiVersionForProjectsDependingOnStableStdlib: Provider<String> = project.providers.gradleProperty("kotlinApiVersionForProjectsDependingOnStableStdlib")
 
 fun Project.configureKotlinCompilationOptions() {
     plugins.withType<KotlinBasePluginWrapper> {
@@ -142,7 +142,7 @@ fun Project.configureKotlinCompilationOptions() {
                 freeCompilerArgs.add("-Xskip-prerelease-check")
 
                 if (project.path in CompilerModules.projectsDependingOnStableStdlib) {
-                    apiVersion.set(KotlinVersion.fromVersion(kotlinApiVersionForProjectsDependingOnStableStdlib))
+                    apiVersion.set(kotlinApiVersionForProjectsDependingOnStableStdlib.map { KotlinVersion.fromVersion(it) })
                 }
             }
 

--- a/repo/gradle-build-conventions/gradle-plugins-common/src/main/kotlin/LanguageLevelLimitations.kt
+++ b/repo/gradle-build-conventions/gradle-plugins-common/src/main/kotlin/LanguageLevelLimitations.kt
@@ -4,20 +4,19 @@
  */
 
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.extra
-import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 internal fun Project.limitLanguageAndApiVersions(version: KotlinVersion) {
     val projectsDependingOnStableStdlib: Array<String> = CompilerModules.projectsDependingOnStableStdlib
-    val kotlinApiVersionForProjectsDependingOnStableStdlib: String by rootProject.extra
+    val kotlinApiVersionForProjectsDependingOnStableStdlib: Provider<String> = project.providers.gradleProperty("kotlinApiVersionForProjectsDependingOnStableStdlib")
 
     tasks.withType<KotlinJvmCompile>().configureEach {
         compilerOptions {
             if (project.path !in projectsDependingOnStableStdlib ||
-                KotlinVersion.fromVersion(kotlinApiVersionForProjectsDependingOnStableStdlib) > version
+                KotlinVersion.fromVersion(kotlinApiVersionForProjectsDependingOnStableStdlib.get()) > version
             ) {
                 // check the `configureKotlinCompilationOptions` in `common-configurations.gradle.kts` out
                 apiVersion.set(version)

--- a/repo/gradle-build-conventions/gradle-plugins-common/src/test/kotlin/GradlePluginTests.kt
+++ b/repo/gradle-build-conventions/gradle-plugins-common/src/test/kotlin/GradlePluginTests.kt
@@ -207,13 +207,13 @@ class GradlePluginTests {
         workingDir.resolve("gradle.properties").writeText(
             """
             build.number=1.0
+            kotlinApiVersionForProjectsDependingOnStableStdlib=
             """.trimIndent()
         )
         val root = ProjectBuilder.builder().also {
             it.withProjectDir(workingDir)
         }.build()
         root.extraProperties.set("projectsDependingOnStableStdlib", emptyArray<String>())
-        root.extraProperties.set("kotlinApiVersionForProjectsDependingOnStableStdlib", emptyArray<String>())
         root.tasks.register("mvnInstall")
 
         createKotlinSubproject("kotlin-gradle-plugin-api", root).also {


### PR DESCRIPTION
Required for Isolated Projects