### PR TITLE
Update Browser JS Test DSL after DM for 2.4.20-Beta2

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-annotations/api/kotlin-gradle-plugin-annotations.api
+++ b/libraries/tools/kotlin-gradle-plugin-annotations/api/kotlin-gradle-plugin-annotations.api
@@ -1,6 +1,16 @@
 public abstract interface annotation class org/jetbrains/kotlin/gradle/ComposeKotlinGradlePluginApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi : java/lang/annotation/Annotation {
+	public abstract fun kind ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApiKind {
+	public static final field INSTANCE Lorg/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApiKind;
+	public static final field REPLACES_DEFAULTS Ljava/lang/String;
+	public static final field REQUIRES_KNOWLEDGE Ljava/lang/String;
+}
+
 public abstract interface annotation class org/jetbrains/kotlin/gradle/ExperimentalJsTestDsl : java/lang/annotation/Annotation {
 }
 

--- a/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
+++ b/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+/**
+ * General annotation to mark delicate Kotlin Gradle Plugin API.
+ * API marked with this annotation most likely is not suitable for everyday use.
+ * Yet it is useful and covers some corner cases that may be required by a small number of users.
+ *
+ * Delicate doesn't mean unstable.
+ * Stable delicate API will have to go through the same deprecation cycle as any other stable API.
+ * Though delicate API can also be experimental, and can be changed without notice.
+ *
+ * If you're unsure about using this API, feel free to ask in [Kotlin Community](https://kotl.in/build-tools-slack) or [Kotlin issue tracker](https://kotl.in/issue).
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This is delicate Kotlin Gradle Plugin API." +
+            " Make sure you fully understand the use case, applicability area and read documentation about this API."
+)
+annotation class DelicateKotlinGradlePluginApi(val kind: String)
+
+object DelicateKotlinGradlePluginApiKind {
+    /**
+     * API allows replacing the default behavior or component of KGP.
+     * And can break integration with other components. Leading to incorrect or failed builds.
+     */
+    const val REPLACES_DEFAULTS = "DELICATE_KOTLIN_GRADLE_PLUGIN_API_REPLACES_DEFAULTS"
+
+    /**
+     * API is not intuitive and requires a deep understanding of its functionality.
+     * User of the API should read related documentation.
+     */
+    const val REQUIRES_KNOWLEDGE = "DELICATE_KOTLIN_GRADLE_PLUGIN_API_REQUIRES_KNOWLEDGE"
+}

--- a/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
+++ b/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
@@ -14,7 +14,7 @@ package org.jetbrains.kotlin.gradle
  * Stable delicate API will have to go through the same deprecation cycle as any other stable API.
  * Though delicate API can also be experimental, and can be changed without notice.
  *
- * If you're unsure about using this API, feel free to ask in Kotlin Slack or Kotlin issue tracker.
+ * If you're unsure about using this API, feel free to ask in [Kotlin Community](https://kotl.in/build-tools-slack) or [Kotlin issue tracker](https://kotl.in/issue).
  */
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,

--- a/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
+++ b/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
@@ -10,6 +10,10 @@ package org.jetbrains.kotlin.gradle
  * API marked with this annotation most likely is not suitable for everyday use.
  * Yet it is useful and covers some corner cases that may be required by a small number of users.
  *
+ * Delicate doesn't mean unstable.
+ * Stable delicate API will have to go through the same deprecation cycle as any other stable API.
+ * Though delicate API can also be experimental, and can be changed without notice.
+ *
  * If you're unsure about using this API, feel free to ask in Kotlin Slack or Kotlin issue tracker.
  */
 @RequiresOptIn(

--- a/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
+++ b/libraries/tools/kotlin-gradle-plugin-annotations/src/main/kotlin/org/jetbrains/kotlin/gradle/DelicateKotlinGradlePluginApi.kt
@@ -10,11 +10,7 @@ package org.jetbrains.kotlin.gradle
  * API marked with this annotation most likely is not suitable for everyday use.
  * Yet it is useful and covers some corner cases that may be required by a small number of users.
  *
- * Delicate doesn't mean unstable.
- * Stable delicate API will have to go through the same deprecation cycle as any other stable API.
- * Though delicate API can also be experimental, and can be changed without notice.
- *
- * If you're unsure about using this API, feel free to ask in [Kotlin Community](https://kotl.in/build-tools-slack) or [Kotlin issue tracker](https://kotl.in/issue).
+ * If you're unsure about using this API, feel free to ask in Kotlin Slack or Kotlin issue tracker.
  */
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.DisplayName
 import kotlin.test.Ignore
 import kotlin.test.assertContains
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.toJavaDuration
 
 @JsBrowserGradlePluginTests
 class JsBrowserTestsIT : KGPBaseTest() {
@@ -225,7 +224,6 @@ class JsBrowserTestsIT : KGPBaseTest() {
 
     @DisplayName("KT-86958: Unclear error for js test failure on timeout")
     @GradleTest
-    @Ignore("Currently fails due to missing infra on CI, see KTI-3326")
     fun `prints clear error message when a test times out`(gradleVersion: GradleVersion) {
         project("empty", gradleVersion = gradleVersion) {
             plugins {
@@ -239,7 +237,7 @@ class JsBrowserTestsIT : KGPBaseTest() {
                             @OptIn(ExperimentalJsTestDsl::class)
                             with(test) {
                                 chromium {
-                                    it.timeout.set(1234.milliseconds.toJavaDuration())
+                                    it.timeout.set(1234.milliseconds)
                                 }
                             }
                         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBrowserTestDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTestsLocation
@@ -117,7 +118,8 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
                     it.newBundleLocation.set(project.layout.buildDirectory.dir("post-processed-test-bundle"))
                 }
 
-                jsTarget.browser.test.browserDefaults.testsLocation.set(postProcess.map { it.kotlinJsTestsLocation })
+                @OptIn(DelicateKotlinGradlePluginApi::class)
+                jsTarget.browser.test.testsLocation.set(postProcess.map { it.kotlinJsTestsLocation })
             }
 
 
@@ -438,6 +440,7 @@ private class MyLocalFileLocation(
     @get:Input
     override val testHtmlFileName: Provider<String>,
 ) : KotlinJsTestsLocation {
+    @OptIn(DelicateKotlinGradlePluginApi::class)
     @get:Internal
     override val url: Provider<URI> = bundleLocation.map { it.asFile.resolve(testHtmlFileName.get()).toURI() }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -107,7 +107,7 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
             // replace default tests location with post-processed one
             buildScriptInjection {
                 val jsTarget = kotlinMultiplatform.targets.filterIsInstance<KotlinJsIrTarget>().single()
-                val defaultTestsLocation = jsTarget.browser.test.defaultTestsLocation
+                val defaultTestsLocation = jsTarget.browser.test.defaultTestsLocationProvider
 
                 val postProcess = project.tasks.register(
                     "postProcessTestBundle",

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -2589,7 +2589,6 @@ public final class org/jetbrains/kotlin/gradle/targets/js/d8/D8RootExtension$Com
 
 public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerTopLevelConfigDsl {
 	public abstract fun getHeadless ()Lorg/gradle/api/provider/Property;
-	public abstract fun getLaunchEnvironmentVariables ()Lorg/gradle/api/provider/MapProperty;
 	public abstract fun getTestsLocation ()Lorg/gradle/api/provider/Property;
 	public abstract fun getTimeout ()Lorg/gradle/api/provider/Property;
 }
@@ -2614,6 +2613,7 @@ public abstract interface annotation class org/jetbrains/kotlin/gradle/targets/j
 public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinBrowserTestRunnerDsl : org/gradle/api/Named, org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerTopLevelConfigDsl {
 	public abstract fun getCustomBrowserExecutable ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getLaunchArgs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getLaunchEnvironmentVariables ()Lorg/gradle/api/provider/MapProperty;
 }
 
 public final class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBinaryMode : java/lang/Enum {

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -2587,10 +2587,8 @@ public final class org/jetbrains/kotlin/gradle/targets/js/d8/D8RootExtension$Com
 	public fun getPlatformDisambiguator ()Ljava/lang/String;
 }
 
-public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerConfigDsl {
-	public abstract fun getCustomBrowserExecutable ()Lorg/gradle/api/file/RegularFileProperty;
+public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerTopLevelConfigDsl {
 	public abstract fun getHeadless ()Lorg/gradle/api/provider/Property;
-	public abstract fun getLaunchArgs ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getLaunchEnvironmentVariables ()Lorg/gradle/api/provider/MapProperty;
 	public abstract fun getTestsLocation ()Lorg/gradle/api/provider/Property;
 	public abstract fun getTimeout ()Lorg/gradle/api/provider/Property;
@@ -2613,7 +2611,9 @@ public abstract interface annotation class org/jetbrains/kotlin/gradle/targets/j
 public abstract interface annotation class org/jetbrains/kotlin/gradle/targets/js/dsl/ExperimentalMainFunctionArgumentsDsl : java/lang/annotation/Annotation {
 }
 
-public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinBrowserTestRunnerDsl : org/gradle/api/Named, org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerConfigDsl {
+public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinBrowserTestRunnerDsl : org/gradle/api/Named, org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerTopLevelConfigDsl {
+	public abstract fun getCustomBrowserExecutable ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getLaunchArgs ()Lorg/gradle/api/provider/ListProperty;
 }
 
 public final class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBinaryMode : java/lang/Enum {
@@ -2631,14 +2631,12 @@ public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/Kotli
 	public abstract fun webpackTask (Lorg/gradle/api/Action;)V
 }
 
-public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl {
-	public abstract fun browserDefaults (Lorg/gradle/api/Action;)Lorg/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerConfigDsl;
+public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl : org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerTopLevelConfigDsl {
 	public abstract fun chromium (Ljava/lang/String;)V
 	public abstract fun chromium (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun firefox (Ljava/lang/String;)V
 	public abstract fun firefox (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun getAllBrowserRunners ()Lorg/gradle/api/provider/Provider;
-	public abstract fun getBrowserDefaults ()Lorg/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerConfigDsl;
 	public abstract fun getDefaultTestsLocationProvider ()Lorg/gradle/api/provider/Provider;
 	public abstract fun webkit (Ljava/lang/String;)V
 	public abstract fun webkit (Ljava/lang/String;Lorg/gradle/api/Action;)V

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -2639,7 +2639,7 @@ public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/Kotli
 	public abstract fun firefox (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun getAllBrowserRunners ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getBrowserDefaults ()Lorg/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerConfigDsl;
-	public abstract fun getDefaultTestsLocation ()Lorg/gradle/api/provider/Provider;
+	public abstract fun getDefaultTestsLocationProvider ()Lorg/gradle/api/provider/Provider;
 	public abstract fun webkit (Ljava/lang/String;)V
 	public abstract fun webkit (Ljava/lang/String;Lorg/gradle/api/Action;)V
 }

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -2589,6 +2589,7 @@ public final class org/jetbrains/kotlin/gradle/targets/js/d8/D8RootExtension$Com
 
 public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerTopLevelConfigDsl {
 	public abstract fun getHeadless ()Lorg/gradle/api/provider/Property;
+	public abstract fun getLaunchEnvironmentVariables ()Lorg/gradle/api/provider/MapProperty;
 	public abstract fun getTestsLocation ()Lorg/gradle/api/provider/Property;
 	public abstract fun getTimeout ()Lorg/gradle/api/provider/Property;
 }
@@ -2613,7 +2614,6 @@ public abstract interface annotation class org/jetbrains/kotlin/gradle/targets/j
 public abstract interface class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinBrowserTestRunnerDsl : org/gradle/api/Named, org/jetbrains/kotlin/gradle/targets/js/dsl/BrowserTestRunnerTopLevelConfigDsl {
 	public abstract fun getCustomBrowserExecutable ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getLaunchArgs ()Lorg/gradle/api/provider/ListProperty;
-	public abstract fun getLaunchEnvironmentVariables ()Lorg/gradle/api/provider/MapProperty;
 }
 
 public final class org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBinaryMode : java/lang/Enum {

--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
                 "org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl",
                 "org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation",
                 "org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl",
+                "org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApi",
             )
         )
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl
 import org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApiKind
 import java.net.URI
-import java.time.Duration
+import kotlin.time.Duration
 
 /**
  * Represents common configuration that is applicable to all Kotlin Browser Test Runners.

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
@@ -41,7 +41,7 @@ interface BrowserTestRunnerTopLevelConfigDsl {
      * Configure global timeout for how long tests allow to run.
      * On timeout browser will be closed, and the test run should finish with an error.
      *
-     * Default is 2 seconds.
+     * Default is 30 seconds.
      */
     val timeout: Property<Duration>
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
@@ -29,7 +29,7 @@ interface BrowserTestRunnerConfigDsl {
     /**
      * Input location pointing to a prepared JS bundle with tests and HTML page that can be opened in a browser.
      *
-     * Normally configured to use [KotlinJsBrowserTestDsl.defaultTestsLocation]
+     * Normally configured to use [KotlinJsBrowserTestDsl.defaultTestsLocationProvider]
      *
      * Change it to a custom location to run tests from there.
      * The bundle location must be compatible with underlying browser test runners.
@@ -122,9 +122,14 @@ interface KotlinJsBrowserTestDsl {
 
     /**
      * Default location of bundled and ready to execute JS tests produced from Kotlin JS test compilation.
-     * The output of this task is set to [BrowserTestRunnerConfigDsl.testsLocation].
+     * Note that this is read-only [Provider], that Kotlin Gradle Plugin offers as default.
+     * To use different test location for tests use [BrowserTestRunnerConfigDsl.testsLocation].
+     *
+     * The intended use case when this provider should be consumed by user code is to post-process default test bundle
+     * or replace some parts of it in a different task and producing new instance of [KotlinJsTestsLocation].
+     * The new location instance should be later set via [BrowserTestRunnerConfigDsl.testsLocation].
      */
-    val defaultTestsLocation: Provider<out KotlinJsTestsLocation>
+    val defaultTestsLocationProvider: Provider<out KotlinJsTestsLocation>
 
     /** Chromium-specific browser test runner config */
     interface ChromiumTestRunnerDsl : KotlinBrowserTestRunnerDsl

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
@@ -21,8 +21,29 @@ import kotlin.time.Duration
 
 /**
  * Represents common configuration that is applicable to all Kotlin Browser Test Runners.
- * Available at top level [browser.test][KotlinJsBrowserTestDsl] DSL block.
- * But can be overridden at [runner-level][KotlinBrowserTestRunnerDsl] for specific browser runner.
+ *
+ * This configuration DSL is available as part of [top-level block][KotlinJsBrowserTestDsl].
+ * And can be overridden by a concrete browser [runner][KotlinBrowserTestRunnerDsl]
+ * Sample:
+ *
+ *     kotlin {
+ *       js {
+ *         browser {
+ *           test {
+ *             // override default timeout on top-level
+ *             timeout = 20.seconds
+ *             chromium {
+ *                 // override default timeout to 25 seconds
+ *                 // specifically for this test runner
+ *                 timeout = 25.seconds
+ *             }
+ *             firefox {
+ *                // inherits timeout of 20 seconds from top-level block
+ *             }
+ *           }
+ *         }
+ *       }
+ *     }
  */
 @ExperimentalJsTestDsl
 interface BrowserTestRunnerTopLevelConfigDsl {
@@ -94,6 +115,24 @@ interface KotlinJsTestsLocation {
 /**
  * Represents browser runner (e.g. [browser.test.chromium][KotlinJsBrowserTestDsl.ChromiumTestRunnerDsl]) DSL block.
  * Interface shared between all browser runners, and its members are not available at [top-level][BrowserTestRunnerTopLevelConfigDsl].
+ *
+ * Sample:
+ *
+ *     kotlin {
+ *       js {
+ *         browser {
+ *           test {
+ *             // no launchArgs at top-level
+ *             chromium {
+ *                launchArgs = listOf("--no-sandbox")
+ *             }
+ *             firefox {
+ *                launchArgs = listOf("-devtools")
+ *             }
+ *           }
+ *         }
+ *       }
+ *     }
  */
 @ExperimentalJsTestDsl
 interface KotlinBrowserTestRunnerDsl : BrowserTestRunnerTopLevelConfigDsl, Named {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
@@ -13,7 +13,9 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl
+import org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApiKind
 import java.net.URI
 import java.time.Duration
 
@@ -32,6 +34,7 @@ interface BrowserTestRunnerConfigDsl {
      * Change it to a custom location to run tests from there.
      * The bundle location must be compatible with underlying browser test runners.
      */
+    @DelicateKotlinGradlePluginApi(kind = DelicateKotlinGradlePluginApiKind.REPLACES_DEFAULTS)
     val testsLocation: Property<KotlinJsTestsLocation>
 
     /**
@@ -65,6 +68,7 @@ interface BrowserTestRunnerConfigDsl {
      * Should not be used to get the default browser executable path.
      * Default is empty, meaning that the toolchain's default browser will be used.
      */
+    @DelicateKotlinGradlePluginApi(kind = DelicateKotlinGradlePluginApiKind.REPLACES_DEFAULTS)
     val customBrowserExecutable: RegularFileProperty
 }
 
@@ -89,7 +93,15 @@ interface KotlinJsTestsLocation {
     /**
      * Access prepared JS tests via http web server.
      * Already points to [testHtmlFileName].
+     *
+     * *Delicate API*:
+     * By default, URL points to the internal oversimplified web server launched by KGP as Shared Gradle Build Service.
+     * This web server is suitable for serving static files only for tests execution in browsers.
+     * The port is random and the host is localhost.
+     * It is not recommended to use this property outside the Test task.
+     * This URL is also used to attach the IDE debugger.
      */
+    @DelicateKotlinGradlePluginApi(kind = DelicateKotlinGradlePluginApiKind.REQUIRES_KNOWLEDGE)
     val url: Provider<URI>
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/dsl/KotlinJsBrowserTestDsl.kt
@@ -19,13 +19,13 @@ import org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApiKind
 import java.net.URI
 import java.time.Duration
 
-@ExperimentalJsTestDsl
 /**
- * Represents browser runner configuration.
- * This interface is extended by top-level [KotlinBrowserTestRunnerDsl]
- * as well as in browser-specific configurations (i.e. [KotlinJsBrowserTestDsl.ChromiumTestRunnerDsl])
+ * Represents common configuration that is applicable to all Kotlin Browser Test Runners.
+ * Available at top level [browser.test][KotlinJsBrowserTestDsl] DSL block.
+ * But can be overridden at [runner-level][KotlinBrowserTestRunnerDsl] for specific browser runner.
  */
-interface BrowserTestRunnerConfigDsl {
+@ExperimentalJsTestDsl
+interface BrowserTestRunnerTopLevelConfigDsl {
     /**
      * Input location pointing to a prepared JS bundle with tests and HTML page that can be opened in a browser.
      *
@@ -53,23 +53,9 @@ interface BrowserTestRunnerConfigDsl {
     val headless: Property<Boolean>
 
     /**
-     * Configure additional command line arguments to launch the browser.
-     */
-    val launchArgs: ListProperty<String>
-
-    /**
      * Configure environment variables that will be passed to the browser instance.
      */
     val launchEnvironmentVariables: MapProperty<String, String>
-
-    /**
-     * Set to configure a custom path to the browser executable.
-     *
-     * Should not be used to get the default browser executable path.
-     * Default is empty, meaning that the toolchain's default browser will be used.
-     */
-    @DelicateKotlinGradlePluginApi(kind = DelicateKotlinGradlePluginApiKind.REPLACES_DEFAULTS)
-    val customBrowserExecutable: RegularFileProperty
 }
 
 /**
@@ -105,29 +91,40 @@ interface KotlinJsTestsLocation {
     val url: Provider<URI>
 }
 
+/**
+ * Represents browser runner (e.g. [browser.test.chromium][KotlinJsBrowserTestDsl.ChromiumTestRunnerDsl]) DSL block.
+ * Interface shared between all browser runners, and its members are not available at [top-level][BrowserTestRunnerTopLevelConfigDsl].
+ */
 @ExperimentalJsTestDsl
-interface KotlinBrowserTestRunnerDsl : BrowserTestRunnerConfigDsl, Named
+interface KotlinBrowserTestRunnerDsl : BrowserTestRunnerTopLevelConfigDsl, Named {
+    /**
+     * Configure additional command line arguments to launch the browser.
+     */
+    val launchArgs: ListProperty<String>
+
+    /**
+     * Set to configure a custom path to the browser executable.
+     *
+     * Should not be used to get the default browser executable path.
+     * Default is empty, meaning that the toolchain's default browser will be used.
+     */
+    @DelicateKotlinGradlePluginApi(kind = DelicateKotlinGradlePluginApiKind.REPLACES_DEFAULTS)
+    val customBrowserExecutable: RegularFileProperty
+}
 
 /**
  * DSL Interface to configure multiple browser test runners for Kotlin/JS.
  */
 @ExperimentalJsTestDsl
-interface KotlinJsBrowserTestDsl {
-    /**
-     * Represents a default configuration for all browser test runners.
-     * Defaults can be overridden in the individual browser test runner configuration.
-     */
-    val browserDefaults: BrowserTestRunnerConfigDsl
-    fun browserDefaults(configure: Action<BrowserTestRunnerConfigDsl>): BrowserTestRunnerConfigDsl
-
+interface KotlinJsBrowserTestDsl : BrowserTestRunnerTopLevelConfigDsl {
     /**
      * Default location of bundled and ready to execute JS tests produced from Kotlin JS test compilation.
      * Note that this is read-only [Provider], that Kotlin Gradle Plugin offers as default.
-     * To use different test location for tests use [BrowserTestRunnerConfigDsl.testsLocation].
+     * To use different test location for tests use [KotlinBrowserTestRunnerDsl.testsLocation].
      *
      * The intended use case when this provider should be consumed by user code is to post-process default test bundle
      * or replace some parts of it in a different task and producing new instance of [KotlinJsTestsLocation].
-     * The new location instance should be later set via [BrowserTestRunnerConfigDsl.testsLocation].
+     * The new location instance should be later set via [KotlinBrowserTestRunnerDsl.testsLocation].
      */
     val defaultTestsLocationProvider: Provider<out KotlinJsTestsLocation>
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinBrowserTestRunnerDsl
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
 import org.jetbrains.kotlin.gradle.tasks.registerTask
+import kotlin.time.toJavaDuration
 
 internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { target ->
     if (target !is KotlinJsIrTarget) return@KotlinTargetSideEffect
@@ -92,7 +93,9 @@ private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
 ) {
     name.convention(runner.name)
     testsLocation.convention(runner.testsLocation)
-    timeout.convention(runner.timeout)
+    // map to java duration is necessary because Gradle Task fingerprints doesn't work with kotlin.time.Duration
+    // https://github.com/gradle/gradle/issues/38444
+    timeout.convention(runner.timeout.map { it.toJavaDuration() })
     headless.convention(runner.headless)
     launchArgs.convention(runner.launchArgs)
     launchEnvironmentVariables.convention(runner.launchEnvironmentVariables)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -94,7 +94,6 @@ private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
     name.convention(runner.name)
     testsLocation.convention(runner.testsLocation)
     // map to java duration is necessary because Gradle Task fingerprints doesn't work with kotlin.time.Duration
-    // https://github.com/gradle/gradle/issues/38444
     timeout.convention(runner.timeout.map { it.toJavaDuration() })
     headless.convention(runner.headless)
     launchArgs.convention(runner.launchArgs)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -94,6 +94,7 @@ private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
     name.convention(runner.name)
     testsLocation.convention(runner.testsLocation)
     // map to java duration is necessary because Gradle Task fingerprints doesn't work with kotlin.time.Duration
+    // https://github.com/gradle/gradle/issues/38444
     timeout.convention(runner.timeout.map { it.toJavaDuration() })
     headless.convention(runner.headless)
     launchArgs.convention(runner.launchArgs)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
@@ -120,7 +120,7 @@ internal abstract class KotlinJsBrowserTestImpl
 
     override val headless: Property<Boolean> = objects.propertyWithConvention<Boolean>(true)
 
-    override val timeout: Property<Duration> = objects.propertyWithConvention<Duration>(2L.seconds)
+    override val timeout: Property<Duration> = objects.propertyWithConvention<Duration>(30L.seconds)
 
     private fun connectTopLevelConfigDslWithBrowserTestDsl(browserLevelDsl: KotlinBrowserTestRunnerDsl) {
         browserLevelDsl.testsLocation.convention(testsLocation)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
@@ -22,8 +22,9 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.locateOrRegisterBrowserTes
 import org.jetbrains.kotlin.gradle.utils.listProperty
 import org.jetbrains.kotlin.gradle.utils.property
 import org.jetbrains.kotlin.gradle.utils.propertyWithConvention
-import java.time.Duration
 import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 internal abstract class KotlinBrowserTestRunner(
     private val name: String,
@@ -119,7 +120,7 @@ internal abstract class KotlinJsBrowserTestImpl
 
     override val headless: Property<Boolean> = objects.propertyWithConvention<Boolean>(true)
 
-    override val timeout: Property<Duration> = objects.propertyWithConvention<Duration>(Duration.ofSeconds(2))
+    override val timeout: Property<Duration> = objects.propertyWithConvention<Duration>(2L.seconds)
 
     private fun connectTopLevelConfigDslWithBrowserTestDsl(browserLevelDsl: KotlinBrowserTestRunnerDsl) {
         browserLevelDsl.testsLocation.convention(testsLocation)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
@@ -69,7 +69,7 @@ internal abstract class KotlinJsBrowserTestImpl
         chromiumRunners + firefoxRunners + webkitRunners
     }
 
-    override val defaultTestsLocation: Provider<KotlinDefaultJsTestLocation> = testCompilation
+    override val defaultTestsLocationProvider: Provider<KotlinDefaultJsTestLocation> = testCompilation
         .locateOrRegisterBrowserTestBundleTask {
             // enabled when at least one browser runner is enabled. So the user has an intention to test via the browser pipeline.
             browserRunnersDeclared.set(allBrowserRunners.map { it.isNotEmpty() })
@@ -117,7 +117,7 @@ internal abstract class KotlinJsBrowserTestImpl
     override val browserDefaults: BrowserTestRunnerConfigDsl = objects
         .newInstance(BrowserTestRunnerConfigDsl::class.java)
         .apply {
-            testsLocation.convention(defaultTestsLocation)
+            testsLocation.convention(defaultTestsLocationProvider)
             headless.convention(true)
             timeout.convention(Duration.ofSeconds(2))
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsBrowserTestImpl.kt
@@ -14,7 +14,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.kotlin.dsl.mapProperty
-import org.jetbrains.kotlin.gradle.targets.js.dsl.BrowserTestRunnerConfigDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinBrowserTestRunnerDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBrowserTestDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTestsLocation
@@ -22,6 +21,7 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinDefaultJsTestLocatio
 import org.jetbrains.kotlin.gradle.targets.js.testing.locateOrRegisterBrowserTestBundleTask
 import org.jetbrains.kotlin.gradle.utils.listProperty
 import org.jetbrains.kotlin.gradle.utils.property
+import org.jetbrains.kotlin.gradle.utils.propertyWithConvention
 import java.time.Duration
 import javax.inject.Inject
 
@@ -114,25 +114,17 @@ internal abstract class KotlinJsBrowserTestImpl
         body.execute(runner)
     }
 
-    override val browserDefaults: BrowserTestRunnerConfigDsl = objects
-        .newInstance(BrowserTestRunnerConfigDsl::class.java)
-        .apply {
-            testsLocation.convention(defaultTestsLocationProvider)
-            headless.convention(true)
-            timeout.convention(Duration.ofSeconds(2))
-        }
+    override val testsLocation: Property<KotlinJsTestsLocation> =
+        objects.propertyWithConvention<KotlinJsTestsLocation>(defaultTestsLocationProvider)
 
-    override fun browserDefaults(configure: Action<BrowserTestRunnerConfigDsl>) =
-        browserDefaults.also { configure.execute(it) }
+    override val headless: Property<Boolean> = objects.propertyWithConvention<Boolean>(true)
+
+    override val timeout: Property<Duration> = objects.propertyWithConvention<Duration>(Duration.ofSeconds(2))
 
     private fun connectTopLevelConfigDslWithBrowserTestDsl(browserLevelDsl: KotlinBrowserTestRunnerDsl) {
-        with(browserDefaults) {
-            browserLevelDsl.testsLocation.convention(testsLocation)
-            browserLevelDsl.headless.convention(headless)
-            browserLevelDsl.timeout.convention(timeout)
-            browserLevelDsl.launchArgs.convention(launchArgs)
-            browserLevelDsl.customBrowserExecutable.convention(customBrowserExecutable)
-            browserLevelDsl.launchEnvironmentVariables.convention(launchEnvironmentVariables)
-        }
+        browserLevelDsl.testsLocation.convention(testsLocation)
+        browserLevelDsl.headless.convention(headless)
+        browserLevelDsl.timeout.convention(timeout)
+        browserLevelDsl.launchEnvironmentVariables.convention(launchEnvironmentVariables)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -80,10 +80,10 @@ internal class KotlinPlaywrightJsTestFramework(
         abstract val name: Property<String>
 
         @get:Input
-        val timeout: Property<Duration> = objects.property<Duration>().convention(Duration.ofMinutes(1))
+        val timeout: Property<Duration> = objects.property<Duration>()
 
         @get:Input
-        val headless: Property<Boolean> = objects.property<Boolean>().convention(true)
+        val headless: Property<Boolean> = objects.property<Boolean>()
 
         @get:Input
         val launchArgs: ListProperty<String> = objects.listProperty()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/providerApiUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/providerApiUtils.kt
@@ -60,7 +60,7 @@ internal inline fun <reified T : Any?> ObjectFactory.setPropertyWithLazyValue(
 ) = setPropertyWithValue(providerWithLazyConvention(lazyValue))
 
 internal inline fun <reified T : Any?> ObjectFactory.propertyWithConvention(
-    conventionValue: Provider<T>
+    conventionValue: Provider<out T>
 ) = property<T>().convention(conventionValue)
 
 internal inline fun <reified T : Any?> ObjectFactory.propertyWithConvention(

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinHttpServerForBrowserJsTestsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinHttpServerForBrowserJsTestsTest.kt
@@ -56,7 +56,7 @@ class KotlinHttpServerForBrowserJsTestsTest {
                     browser {
                         test {
                             // accessing to default tests location should trigger registration of http server service
-                            it.defaultTestsLocation.get()
+                            it.defaultTestsLocationProvider.get()
                         }
                     }
                 }
@@ -84,7 +84,7 @@ class KotlinHttpServerForBrowserJsTestsTest {
 
 
         // create directory simulating that bundle task got executed, so http server can safely start
-        val defaultTestLocation = jsIrTarget.browser.test.defaultTestsLocation.get()
+        val defaultTestLocation = jsIrTarget.browser.test.defaultTestsLocationProvider.get()
         defaultTestLocation.bundleLocation.get().asFile.mkdirs()
 
         try {
@@ -104,7 +104,7 @@ class KotlinHttpServerForBrowserJsTestsTest {
                     browser {
                         test {
                             // accessing to default tests location should trigger registration of http server service
-                            it.defaultTestsLocation.get()
+                            it.defaultTestsLocationProvider.get()
                         }
                     }
                 }
@@ -131,7 +131,7 @@ class KotlinHttpServerForBrowserJsTestsTest {
                     browser {
                         test {
                             // accessing to default tests location should trigger registration of http server service
-                            it.defaultTestsLocation.get()
+                            it.defaultTestsLocationProvider.get()
                         }
                     }
                 }
@@ -144,7 +144,7 @@ class KotlinHttpServerForBrowserJsTestsTest {
         assertNotNull(service, "Build service should be registered")
 
         // create directory simulating that bundle task got executed, so http server can safely start
-        val defaultTestLocation = jsIrTarget.browser.test.defaultTestsLocation.get()
+        val defaultTestLocation = jsIrTarget.browser.test.defaultTestsLocationProvider.get()
         val bundleDir = defaultTestLocation.bundleLocation.get()
         bundleDir.asFile.mkdirs()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
@@ -38,81 +38,106 @@ class KotlinJsBrowserTestDslTest {
 
         val bundle = test.defaultBundleDirectory
         assertEquals(
-            mapOf(
+            expected = mapOf(
                 "chromium" to RunnerDump(
-                    KotlinChromiumTestRunner::class,
-                    Duration.ofSeconds(2),
-                    true,
-                    emptyList(),
-                    bundle
+                    type = KotlinChromiumTestRunner::class,
+                    timeout = Duration.ofSeconds(2),
+                    headless = true,
+                    launchArgs = emptyList(),
+                    launchEnvironmentVariables = mapOf(),
+                    testsLocation = bundle
                 ),
                 "custom-chromium" to RunnerDump(
-                    KotlinChromiumTestRunner::class,
-                    Duration.ofSeconds(30),
-                    false,
-                    listOf("--lang=fi-FI"),
-                    bundle,
+                    type = KotlinChromiumTestRunner::class,
+                    timeout = Duration.ofSeconds(30),
+                    headless = false,
+                    launchArgs = listOf("--lang=fi-FI"),
+                    launchEnvironmentVariables = mapOf(),
+                    testsLocation = bundle,
                 ),
                 "firefox" to RunnerDump(
-                    KotlinFirefoxTestRunner::class,
-                    Duration.ofSeconds(2),
-                    true,
-                    emptyList(),
-                    bundle
+                    type = KotlinFirefoxTestRunner::class,
+                    timeout = Duration.ofSeconds(2),
+                    headless = true,
+                    launchArgs = emptyList(),
+                    launchEnvironmentVariables = mapOf(),
+                    testsLocation = bundle
                 ),
                 "webkit" to RunnerDump(
-                    KotlinWebkitTestRunner::class,
-                    Duration.ofSeconds(2),
-                    true,
-                    emptyList(),
-                    bundle
+                    type = KotlinWebkitTestRunner::class,
+                    timeout = Duration.ofSeconds(2),
+                    headless = true,
+                    launchArgs = emptyList(),
+                    launchEnvironmentVariables = mapOf(),
+                    testsLocation = bundle
                 ),
                 "extra-webkit" to RunnerDump(
-                    KotlinWebkitTestRunner::class,
-                    Duration.ofSeconds(2),
-                    true,
-                    emptyList(),
-                    bundle
+                    type = KotlinWebkitTestRunner::class,
+                    timeout = Duration.ofSeconds(2),
+                    headless = true,
+                    launchArgs = emptyList(),
+                    launchEnvironmentVariables = mapOf(),
+                    testsLocation = bundle
                 ),
             ),
-            test.dumpRunners(),
+            actual = test.dumpRunners(),
         )
     }
 
     @Test
     fun `top-level configuration propagates to runners unless overridden`() {
         val test = configureBrowserTest {
-            browserDefaults.apply {
-                timeout.set(Duration.ofSeconds(10))
-                headless.set(false)
-                launchArgs.set(listOf("--global"))
+            timeout.set(Duration.ofSeconds(10))
+            headless.set(false)
+            launchEnvironmentVariables.put("A", "1")
+            // launchArgs is not available on top level
+
+            firefox()
+
+            chromium {
+                it.launchArgs.set(listOf("--global"))
+                // this should override convention,
+                // i.e. it will create new list instead of appending
+                it.launchEnvironmentVariables.put("B", "2")
             }
 
-            chromium()
             webkit("override") {
                 it.headless.set(true)
                 it.timeout.set(Duration.ofSeconds(42))
                 it.launchArgs.set(listOf("--no-sandbox"))
+                it.launchEnvironmentVariables.set(mapOf("C" to "3"))
             }
         }
 
         val bundle = test.defaultBundleDirectory
         assertEquals(
-            mapOf(
+            expected = mapOf(
                 "chromium" to RunnerDump(
-                    KotlinChromiumTestRunner::class,
-                    Duration.ofSeconds(10),
-                    false, listOf("--global"),
-                    bundle
+                    type = KotlinChromiumTestRunner::class,
+                    timeout = Duration.ofSeconds(10),
+                    headless = false,
+                    launchArgs = listOf("--global"),
+                    launchEnvironmentVariables = mapOf("B" to "2"),
+                    testsLocation = bundle
+                ),
+                "firefox" to RunnerDump(
+                    type = KotlinFirefoxTestRunner::class,
+                    timeout = Duration.ofSeconds(10),
+                    headless = false,
+                    launchArgs = listOf(),
+                    launchEnvironmentVariables = mapOf("A" to "1"),
+                    testsLocation = bundle
                 ),
                 "override" to RunnerDump(
-                    KotlinWebkitTestRunner::class,
-                    Duration.ofSeconds(42),
-                    true, listOf("--no-sandbox"),
-                    bundle
+                    type = KotlinWebkitTestRunner::class,
+                    timeout = Duration.ofSeconds(42),
+                    headless = true,
+                    launchArgs = listOf("--no-sandbox"),
+                    launchEnvironmentVariables = mapOf("C" to "3"),
+                    testsLocation = bundle
                 ),
             ),
-            test.dumpRunners(),
+            actual = test.dumpRunners(),
         )
     }
 
@@ -140,11 +165,12 @@ class KotlinJsBrowserTestDslTest {
         assertEquals(
             mapOf(
                 "repeated" to RunnerDump(
-                    KotlinChromiumTestRunner::class,
-                    Duration.ofSeconds(2),
-                    false,
-                    listOf("--flag"),
-                    test.defaultBundleDirectory,
+                    type = KotlinChromiumTestRunner::class,
+                    timeout = Duration.ofSeconds(2),
+                    headless = false,
+                    launchArgs = listOf("--flag"),
+                    launchEnvironmentVariables = mapOf(),
+                    testsLocation = test.defaultBundleDirectory,
                 ),
             ),
             test.dumpRunners(),
@@ -174,6 +200,7 @@ internal data class RunnerDump(
     val timeout: Duration,
     val headless: Boolean,
     val launchArgs: List<String>,
+    val launchEnvironmentVariables: Map<String, String>,
     val testsLocation: Directory,
 )
 
@@ -185,6 +212,7 @@ internal fun KotlinJsBrowserTestDsl.dumpRunners(): Map<String, RunnerDump> =
             headless = runner.headless.get(),
             launchArgs = runner.launchArgs.get(),
             testsLocation = runner.testsLocation.get().bundleLocation.get(),
+            launchEnvironmentVariables = runner.launchEnvironmentVariables.get(),
         )
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
@@ -15,10 +15,11 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinChromiumTestRunner
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinFirefoxTestRunner
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinWebkitTestRunner
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
-import java.time.Duration
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class KotlinJsBrowserTestDslTest {
 
@@ -27,7 +28,7 @@ class KotlinJsBrowserTestDslTest {
         val test = configureBrowserTest {
             chromium()
             chromium("custom-chromium") {
-                it.timeout.set(Duration.ofSeconds(30))
+                it.timeout.set(31L.seconds)
                 it.headless.set(false)
                 it.launchArgs.set(listOf("--lang=fi-FI"))
             }
@@ -41,7 +42,7 @@ class KotlinJsBrowserTestDslTest {
             expected = mapOf(
                 "chromium" to RunnerDump(
                     type = KotlinChromiumTestRunner::class,
-                    timeout = Duration.ofSeconds(2),
+                    timeout = 2L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -49,7 +50,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "custom-chromium" to RunnerDump(
                     type = KotlinChromiumTestRunner::class,
-                    timeout = Duration.ofSeconds(30),
+                    timeout = 31L.seconds,
                     headless = false,
                     launchArgs = listOf("--lang=fi-FI"),
                     launchEnvironmentVariables = mapOf(),
@@ -57,7 +58,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "firefox" to RunnerDump(
                     type = KotlinFirefoxTestRunner::class,
-                    timeout = Duration.ofSeconds(2),
+                    timeout = 2L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -65,7 +66,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "webkit" to RunnerDump(
                     type = KotlinWebkitTestRunner::class,
-                    timeout = Duration.ofSeconds(2),
+                    timeout = 2L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -73,7 +74,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "extra-webkit" to RunnerDump(
                     type = KotlinWebkitTestRunner::class,
-                    timeout = Duration.ofSeconds(2),
+                    timeout = 2L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -87,7 +88,7 @@ class KotlinJsBrowserTestDslTest {
     @Test
     fun `top-level configuration propagates to runners unless overridden`() {
         val test = configureBrowserTest {
-            timeout.set(Duration.ofSeconds(10))
+            timeout.set(10L.seconds)
             headless.set(false)
             launchEnvironmentVariables.put("A", "1")
             // launchArgs is not available on top level
@@ -103,7 +104,7 @@ class KotlinJsBrowserTestDslTest {
 
             webkit("override") {
                 it.headless.set(true)
-                it.timeout.set(Duration.ofSeconds(42))
+                it.timeout.set(42L.seconds)
                 it.launchArgs.set(listOf("--no-sandbox"))
                 it.launchEnvironmentVariables.set(mapOf("C" to "3"))
             }
@@ -114,7 +115,7 @@ class KotlinJsBrowserTestDslTest {
             expected = mapOf(
                 "chromium" to RunnerDump(
                     type = KotlinChromiumTestRunner::class,
-                    timeout = Duration.ofSeconds(10),
+                    timeout = 10L.seconds,
                     headless = false,
                     launchArgs = listOf("--global"),
                     launchEnvironmentVariables = mapOf("B" to "2"),
@@ -122,7 +123,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "firefox" to RunnerDump(
                     type = KotlinFirefoxTestRunner::class,
-                    timeout = Duration.ofSeconds(10),
+                    timeout = 10L.seconds,
                     headless = false,
                     launchArgs = listOf(),
                     launchEnvironmentVariables = mapOf("A" to "1"),
@@ -130,7 +131,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "override" to RunnerDump(
                     type = KotlinWebkitTestRunner::class,
-                    timeout = Duration.ofSeconds(42),
+                    timeout = 42L.seconds,
                     headless = true,
                     launchArgs = listOf("--no-sandbox"),
                     launchEnvironmentVariables = mapOf("C" to "3"),
@@ -166,7 +167,7 @@ class KotlinJsBrowserTestDslTest {
             mapOf(
                 "repeated" to RunnerDump(
                     type = KotlinChromiumTestRunner::class,
-                    timeout = Duration.ofSeconds(2),
+                    timeout = 2L.seconds,
                     headless = false,
                     launchArgs = listOf("--flag"),
                     launchEnvironmentVariables = mapOf(),

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
@@ -122,7 +122,7 @@ class KotlinJsBrowserTestDslTest {
             webkit()
         }
 
-        val expectedDefault = test.defaultTestsLocation.flatMap { it.bundleLocation }.get()
+        val expectedDefault = test.defaultTestsLocationProvider.flatMap { it.bundleLocation }.get()
         assertEquals(expectedDefault, test.allBrowserRunners.get().getValue("webkit").testsLocation.get().bundleLocation.get())
     }
 
@@ -189,4 +189,4 @@ internal fun KotlinJsBrowserTestDsl.dumpRunners(): Map<String, RunnerDump> =
     }
 
 internal val KotlinJsBrowserTestDsl.defaultBundleDirectory: Directory
-    get() = defaultTestsLocation.flatMap { it.bundleLocation }.get()
+    get() = defaultTestsLocationProvider.flatMap { it.bundleLocation }.get()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
@@ -42,7 +42,7 @@ class KotlinJsBrowserTestDslTest {
             expected = mapOf(
                 "chromium" to RunnerDump(
                     type = KotlinChromiumTestRunner::class,
-                    timeout = 2L.seconds,
+                    timeout = 30L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -58,7 +58,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "firefox" to RunnerDump(
                     type = KotlinFirefoxTestRunner::class,
-                    timeout = 2L.seconds,
+                    timeout = 30L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -66,7 +66,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "webkit" to RunnerDump(
                     type = KotlinWebkitTestRunner::class,
-                    timeout = 2L.seconds,
+                    timeout = 30L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -74,7 +74,7 @@ class KotlinJsBrowserTestDslTest {
                 ),
                 "extra-webkit" to RunnerDump(
                     type = KotlinWebkitTestRunner::class,
-                    timeout = 2L.seconds,
+                    timeout = 30L.seconds,
                     headless = true,
                     launchArgs = emptyList(),
                     launchEnvironmentVariables = mapOf(),
@@ -167,7 +167,7 @@ class KotlinJsBrowserTestDslTest {
             mapOf(
                 "repeated" to RunnerDump(
                     type = KotlinChromiumTestRunner::class,
-                    timeout = 2L.seconds,
+                    timeout = 30L.seconds,
                     headless = false,
                     launchArgs = listOf("--flag"),
                     launchEnvironmentVariables = mapOf(),

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -34,6 +34,9 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
 
 class KotlinPlaywrightTestFrameworkWiringTest {
 
@@ -181,13 +184,13 @@ class KotlinPlaywrightTestFrameworkWiringTest {
 
         val setup = buildBrowserTestProject {
             testsLocation.set(mockLocation1)
-            timeout.set(Duration.ofHours(72))
+            timeout.set(72L.hours)
             launchEnvironmentVariables.set(mapOf("FOO" to "BAR"))
 
             chromium("myChrome") {
                 it.headless.set(false)
                 it.launchArgs.set(listOf("--no-sandbox"))
-                it.timeout.set(Duration.ofDays(42))
+                it.timeout.set(42L.days)
                 it.customBrowserExecutable.set(customChromeExecutable)
             }
             firefox {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -180,9 +180,9 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val customChromeExecutable = File("custom-chrome-executable.txt").absoluteFile
 
         val setup = buildBrowserTestProject {
-            browserDefaults.testsLocation.set(mockLocation1)
-            browserDefaults.timeout.set(Duration.ofHours(72))
-            browserDefaults.launchEnvironmentVariables.set(mapOf("FOO" to "BAR"))
+            testsLocation.set(mockLocation1)
+            timeout.set(Duration.ofHours(72))
+            launchEnvironmentVariables.set(mapOf("FOO" to "BAR"))
 
             chromium("myChrome") {
                 it.headless.set(false)


### PR DESCRIPTION
This is about https://youtrack.jetbrains.com/issue/KT-87484/Update-Browser-JS-Test-DSL-after-DM-for-2.4.20-Beta2

* introduce DelicateApi opt-in
* defaults are moved to top-level as we agreed on last DM
* timeout type was replaced from java.duration to kotlin.duration
* default timeout value was set to 30s 