### PR TITLE
Incremental compilation: fixed stale external caches problem

### DIFF
--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
@@ -32,6 +32,7 @@ object NativeConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.ko
     val CACHED_LIBRARIES by key<Map<String, String>>("Mapping from library paths to cache paths.")
     val FILES_TO_CACHE by key<List<String>>("Which files should be compiled to cache.")
     val MAKE_PER_FILE_CACHE by key<Boolean>()
+    val CACHED_LIBRARY_DEPENDENCIES_FINGERPRINT by key<String>("Combined fingerprint of external cached dependencies of the library being cached.")
     val FRAMEWORK_IMPORT_HEADERS by key<List<String>>()
     val KONAN_FRIEND_LIBRARIES by key<List<String>>()
     val KONAN_REFINES_MODULES by key<List<String>>()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -157,14 +157,21 @@ class CacheBuilder(
         // This happens when a dependency is changed to an already-cached version, e.g. rolled back to the version it had before
         // an update (KT-87194). Each cache records the fingerprint of such dependencies, so force a full rebuild whenever
         // it doesn't match the current dependencies.
+        // Caches produced by compilers older than 2.2.20 don't have the metadata at all; rebuild them as well (KT-87202).
         val currentCompilerFingerprint = config.distribution.compilerFingerprint
         val staleCacheLibraries = icedLibraries.filter { library ->
             // All files of a per-file cache are produced against the same compiler and dependencies,
             // so any file's metadata identifies the fingerprints of the whole cache.
             val cache = caches[library] as? CachedLibraries.Cache.PerFile ?: return@filter false
             val anyCachedFile = File(cache.path).listFiles.firstOrNull()?.name ?: return@filter false
-            val metadata = cache.getMetadata(anyCachedFile)
+            val metadata = cache.getMetadataOrNull(anyCachedFile)
             when {
+                metadata == null -> {
+                    configuration.reportLog(
+                            "Incremental cache for ${library.path} has no metadata" +
+                                    " (it was produced by a compiler older than 2.2.20); rebuilding it")
+                    true
+                }
                 metadata.compilerFingerprint != currentCompilerFingerprint -> {
                     configuration.reportLog(
                             "Incremental cache for ${library.path} was produced by a different compiler version; rebuilding it")
@@ -214,7 +221,8 @@ class CacheBuilder(
                 } else {
                     actualFiles.remove(cachedFile)
                     val actualContentHash = SerializedIrFileFingerprint(library, fileIndex).fileFingerprint
-                    val previousContentHash = cache.getMetadata(cachedFile).hash
+                    // Missing metadata (a cache produced by a compiler older than 2.2.20) means the file has to be rebuilt.
+                    val previousContentHash = cache.getMetadataOrNull(cachedFile)?.hash
                     if (previousContentHash != actualContentHash)
                         changedFiles.add(libraryFile)
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -99,6 +99,18 @@ class CacheBuilder(
             return autoCacheableFrom.any { libraryCanonicalPath.startsWith(Path(it.canonicalPath)) }
         }
 
+    private val KotlinLibrary.isSubjectOfIC: Boolean
+        get() = isExplicitlySpecifiedByUserInCLIArgument && !isExternal && !isNativeStdlib
+
+    // Only auto-cached external libraries contribute to the fingerprint: changes in the per-file cached dependencies are tracked
+    // by the dirty-file analysis, and the distribution libraries only change together with the compiler fingerprint.
+    private fun computeDependenciesFingerprint(library: KotlinLibrary): FingerprintHash {
+        val externalCachedDependencies = library.getAllTransitiveDependencies(uniqueNameToLibrary).filter {
+            !it.isSubjectOfIC && !it.isImplicitlyLoadedFromKotlinNativeDistribution && !it.isNativeStdlib
+        }
+        return CachedLibraries.computeDependenciesFingerprint(externalCachedDependencies, uniqueNameToHash)
+    }
+
     fun build() {
         val externalLibrariesToCache = mutableListOf<KotlinLibrary>()
         val icedLibraries = mutableListOf<KotlinLibrary>()
@@ -109,7 +121,7 @@ class CacheBuilder(
             if (config.target == KonanTarget.MINGW_X64 && !library.isNativeStdlib) {
                 return@forEach
             }
-            val isSubjectOfIC = library.isExplicitlySpecifiedByUserInCLIArgument && !library.isExternal && !library.isNativeStdlib
+            val isSubjectOfIC = library.isSubjectOfIC
             val cache = config.cachedLibraries.getLibraryCache(library, allowIncomplete = isSubjectOfIC)
             cache?.let {
                 caches[library] = it
@@ -141,20 +153,34 @@ class CacheBuilder(
         // leading to linkage/runtime errors. Each cache records the producing compiler's fingerprint, so force a full rebuild
         // of any cached library whose fingerprint does not match the current compiler. (Distribution/auto caches live inside
         // the compiler distribution directory so they are naturally rebuilt with each compiler version.)
+        // Similarly, the dirty-file check doesn't notice changes in external cached dependencies if their caches already exist.
+        // This happens when a dependency is changed to an already-cached version, e.g. rolled back to the version it had before
+        // an update (KT-87194). Each cache records the fingerprint of such dependencies, so force a full rebuild whenever
+        // it doesn't match the current dependencies.
         val currentCompilerFingerprint = config.distribution.compilerFingerprint
-        val staleCompilerCacheLibraries = icedLibraries.filter { library ->
-            // All files of a per-file cache are produced by the same compiler, so any file's metadata
-            // identifies the fingerprint of the whole cache.
+        val staleCacheLibraries = icedLibraries.filter { library ->
+            // All files of a per-file cache are produced against the same compiler and dependencies,
+            // so any file's metadata identifies the fingerprints of the whole cache.
             val cache = caches[library] as? CachedLibraries.Cache.PerFile ?: return@filter false
             val anyCachedFile = File(cache.path).listFiles.firstOrNull()?.name ?: return@filter false
-            (cache.getMetadata(anyCachedFile).compilerFingerprint != currentCompilerFingerprint).also { stale ->
-                if (stale) configuration.reportLog(
-                        "Incremental cache for ${library.path} was produced by a different compiler version; rebuilding it")
+            val metadata = cache.getMetadata(anyCachedFile)
+            when {
+                metadata.compilerFingerprint != currentCompilerFingerprint -> {
+                    configuration.reportLog(
+                            "Incremental cache for ${library.path} was produced by a different compiler version; rebuilding it")
+                    true
+                }
+                metadata.dependenciesFingerprint != computeDependenciesFingerprint(library) -> {
+                    configuration.reportLog(
+                            "Incremental cache for ${library.path} was produced against different dependencies; rebuilding it")
+                    true
+                }
+                else -> false
             }
         }
 
         // Every library dependable on one of the changed external libraries needs its cache to be fully rebuilt.
-        val needFullRebuild = findAllDependable(externalLibrariesToCache) + staleCompilerCacheLibraries
+        val needFullRebuild = findAllDependable(externalLibrariesToCache) + staleCacheLibraries
 
         val libraryFilesWithFqNames = mutableMapOf<KotlinLibrary, List<FileWithFqName>>()
 
@@ -495,6 +521,8 @@ class CacheBuilder(
             this.cachedLibraries = cachedLibraries
             cacheDirectories = listOf(libraryCacheDirectory.absolutePath)
             this.makePerFileCache = makePerFileCache
+            if (makePerFileCache)
+                cachedLibraryDependenciesFingerprint = computeDependenciesFingerprint(library).toString()
             if (filesToCache.isNotEmpty())
                 this.filesToCache = filesToCache
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheStorage.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheStorage.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan
 
+import org.jetbrains.kotlin.backend.common.serialization.FingerprintHash
 import org.jetbrains.kotlin.backend.konan.serialization.CacheMetadata
 import org.jetbrains.kotlin.backend.konan.serialization.CacheMetadataSerializer
 import org.jetbrains.kotlin.backend.konan.serialization.ClassFieldsSerializer
@@ -13,6 +14,7 @@ import org.jetbrains.kotlin.backend.konan.serialization.InlineFunctionBodyRefere
 import org.jetbrains.kotlin.backend.konan.serialization.TrivialGettersSerializer
 import org.jetbrains.kotlin.backend.konan.util.compilerFingerprint
 import org.jetbrains.kotlin.backend.konan.util.runtimeFingerprint
+import org.jetbrains.kotlin.konan.config.cachedLibraryDependenciesFingerprint
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.library.javaFile
 import org.jetbrains.kotlin.konan.target.HostManager
@@ -31,6 +33,7 @@ private fun NativeGenerationState.generateCacheMetadata(): CacheMetadata {
             target = config.target,
             compilerFingerprint = config.distribution.compilerFingerprint,
             runtimeFingerprint = runtimeFingerprint,
+            dependenciesFingerprint = config.configuration.cachedLibraryDependenciesFingerprint?.let { FingerprintHash.fromString(it) },
     )
 }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CachedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CachedLibraries.kt
@@ -128,8 +128,13 @@ class CachedLibraries(
                         it.absolutePath
                     }
 
-            fun getMetadata(file: String) = File(path).child(file).child(METADATA_FILE_NAME).bufferedReader().use {
-                CacheMetadataSerializer.deserialize(it)
+            // Returns null when the metadata file is absent, which is the case for caches produced by compilers older than 2.2.20 (KT-87202).
+            fun getMetadataOrNull(file: String): CacheMetadata? {
+                val metadataFile = File(path).child(file).child(METADATA_FILE_NAME)
+                if (!metadataFile.exists) return null
+                return metadataFile.bufferedReader().use {
+                    CacheMetadataSerializer.deserialize(it)
+                }
             }
 
             override fun computeBitcodeDependencies() = perFileBitcodeDependencies.values.flatten()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CachedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CachedLibraries.kt
@@ -281,6 +281,17 @@ class CachedLibraries(
                     hashComputer.digest()
                 }
 
+        fun computeDependenciesFingerprint(
+                dependencies: List<KotlinLibrary>,
+                librariesHashes: MutableMap<String, FingerprintHash>,
+        ): FingerprintHash {
+            val hashComputer = LibraryHashComputer()
+            dependencies.sortedBy { it.uniqueName }.forEach {
+                hashComputer.update(computeLibraryHash(it, librariesHashes))
+            }
+            return hashComputer.digest()
+        }
+
         fun computeLibraryCacheDirectory(
                 baseCacheDirectory: File,
                 library: KotlinLibrary,
@@ -288,14 +299,8 @@ class CachedLibraries(
                 librariesHashes: MutableMap<String, FingerprintHash>,
         ): File {
             val dependencies = library.getAllTransitiveDependencies(allLibraries)
-            val hashComputer = LibraryHashComputer()
-            hashComputer.update(computeLibraryHash(library, librariesHashes))
-            dependencies.sortedBy { it.uniqueName }.forEach {
-                hashComputer.update(computeLibraryHash(it, librariesHashes))
-            }
-
-            val hashString = hashComputer.digest().toString()
-            return baseCacheDirectory.child(library.uniqueName).child(hashString)
+            val fingerprintHash = computeDependenciesFingerprint(listOf(library) + dependencies, librariesHashes)
+            return baseCacheDirectory.child(library.uniqueName).child(fingerprintHash.toString())
         }
 
         const val PER_FILE_CACHE_IR_LEVEL_DIR_NAME = "ir"

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/CacheSerializationSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/CacheSerializationSupport.kt
@@ -600,6 +600,8 @@ class CacheMetadata(
         val target: KonanTarget,
         val compilerFingerprint: String,
         val runtimeFingerprint: String?, // only present in caches using the runtime (i.e. for stdlib)
+        // Combined fingerprint of auto-cached external libraries the cache was built against.
+        val dependenciesFingerprint: FingerprintHash?,
 )
 
 object CacheMetadataSerializer {
@@ -612,6 +614,7 @@ object CacheMetadataSerializer {
                 "target" to metadata.target.toString(),
                 "compilerFingerprint" to metadata.compilerFingerprint,
                 metadata.runtimeFingerprint?.let { "runtimeFingerprint" to it },
+                metadata.dependenciesFingerprint?.let { "dependenciesFingerprint" to it.toString() },
         ).forEach { [key, value] ->
             writer.appendLine("$key=$value")
         }
@@ -626,6 +629,7 @@ object CacheMetadataSerializer {
                     target = KonanTarget.predefinedTargets[this["target"] as String]!!,
                     compilerFingerprint = this["compilerFingerprint"] as String,
                     runtimeFingerprint = this["runtimeFingerprint"] as String?,
+                    dependenciesFingerprint = (this["dependenciesFingerprint"] as String?)?.let { FingerprintHash.fromString(it) },
             )
         }
     }

--- a/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
+++ b/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
@@ -86,6 +86,10 @@ object NativeConfigurationKeys {
     @JvmField
     val MAKE_PER_FILE_CACHE = CompilerConfigurationKey.create<Boolean>("MAKE_PER_FILE_CACHE")
 
+    // Combined fingerprint of external cached dependencies of the library being cached.
+    @JvmField
+    val CACHED_LIBRARY_DEPENDENCIES_FINGERPRINT = CompilerConfigurationKey.create<String>("CACHED_LIBRARY_DEPENDENCIES_FINGERPRINT")
+
     @JvmField
     val FRAMEWORK_IMPORT_HEADERS = CompilerConfigurationKey.create<List<String>>("FRAMEWORK_IMPORT_HEADERS")
 
@@ -351,6 +355,10 @@ var CompilerConfiguration.filesToCache: List<String>
 var CompilerConfiguration.makePerFileCache: Boolean
     get() = getBoolean(NativeConfigurationKeys.MAKE_PER_FILE_CACHE)
     set(value) { put(NativeConfigurationKeys.MAKE_PER_FILE_CACHE, value) }
+
+var CompilerConfiguration.cachedLibraryDependenciesFingerprint: String?
+    get() = get(NativeConfigurationKeys.CACHED_LIBRARY_DEPENDENCIES_FINGERPRINT)
+    set(value) { put(NativeConfigurationKeys.CACHED_LIBRARY_DEPENDENCIES_FINGERPRINT, requireNotNull(value) { "nullable values are not allowed" }) }
 
 var CompilerConfiguration.frameworkImportHeaders: List<String>
     get() = getList(NativeConfigurationKeys.FRAMEWORK_IMPORT_HEADERS)

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/file1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/file1.kt
@@ -1,0 +1,3 @@
+package external
+
+fun foo() = 42

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/file2.1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/file2.1.kt
@@ -1,0 +1,3 @@
+package external
+
+inline fun foo2() = 128

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/file2.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/file2.kt
@@ -1,0 +1,3 @@
+package external
+
+inline fun foo2() = 117

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/externalLib/module.info
@@ -1,0 +1,13 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+
+STEP 1:
+    modifications:
+        U : file2.1.kt -> file2.kt
+
+// Roll the library back to the same content as at step 0, so that its auto-cache from step 0 is reused (KT-87194).
+STEP 2:
+    modifications:
+        U : file2.kt -> file2.kt

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/main.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/main.kt
@@ -1,0 +1,6 @@
+import kotlin.test.*
+
+@Test
+fun doTest() {
+    assertEquals(42, bar())
+}

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/main2.1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/main2.1.kt
@@ -1,0 +1,6 @@
+import kotlin.test.*
+
+@Test
+fun doTest2() {
+    assertEquals(128, bar2())
+}

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/main2.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/main2.kt
@@ -1,0 +1,6 @@
+import kotlin.test.*
+
+@Test
+fun doTest2() {
+    assertEquals(117, bar2())
+}

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/main/module.info
@@ -1,0 +1,15 @@
+STEP 0:
+    dependencies: externalLib, userLib
+    modifications:
+        U : main.kt -> main.kt
+        U : main2.kt -> main2.kt
+
+STEP 1:
+    dependencies: externalLib, userLib
+    modifications:
+        U : main2.1.kt -> main2.kt
+
+STEP 2:
+    dependencies: externalLib, userLib
+    modifications:
+        U : main2.kt -> main2.kt

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/project.info
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/project.info
@@ -1,0 +1,11 @@
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: externalLib, userLib, main
+
+STEP 0:
+    libs: externalLib, userLib, main
+
+STEP 1:
+    libs: externalLib, userLib, main
+
+STEP 2:
+    libs: externalLib, userLib, main

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/userLib/file1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/userLib/file1.kt
@@ -1,0 +1,1 @@
+fun bar() = external.foo()

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/userLib/file2.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/userLib/file2.kt
@@ -1,0 +1,1 @@
+fun bar2() = external.foo2()

--- a/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/userLib/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/rolledBackExternalDependency/userLib/module.info
@@ -1,0 +1,17 @@
+STEP 0:
+    dependencies: externalLib
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+    added cache: file1.kt, file2.kt
+
+STEP 1:
+    dependencies: externalLib
+    modified cache: file1.kt, file2.kt
+
+// KT-87194: the external library is rolled back to a version whose auto-cache already exists,
+// so the library files themselves don't change, but the caches still must be rebuilt:
+// file2.kt has the body of the external inline function baked in.
+STEP 2:
+    dependencies: externalLib
+    modified cache: file1.kt, file2.kt


### PR DESCRIPTION
There were no check if an external library was changed (only existance of its cache). This might lead to stale caches being used (e.g. when a dependency was changed to an earlier version, for which the cache was already built). This PR fixes the problem by storing the hash of all transitive external dependencies of a library, and comping it with an actual during cache building.