### PR TITLE
[ABI Validation] Add negative tests for android multiplatform library plugin

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationAndroidKmpIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationAndroidKmpIT.kt
@@ -3,22 +3,32 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
+@file:OptIn(ExperimentalAbiValidation::class)
+
 package org.jetbrains.kotlin.gradle.abi
 
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.abi.utils.AbiValidationTestDumps.assertDumpsEqual
 import org.jetbrains.kotlin.gradle.abi.utils.abiValidation
 import org.jetbrains.kotlin.gradle.abi.utils.androidKmpLibraryProject
+import org.jetbrains.kotlin.gradle.abi.utils.androidLibrary
+import org.jetbrains.kotlin.gradle.abi.utils.referenceKlibDumpFile
 import org.jetbrains.kotlin.gradle.abi.utils.referenceMixedAndroidDumpFile
 import org.jetbrains.kotlin.gradle.abi.utils.referenceMixedJvmDumpFile
+import org.jetbrains.kotlin.gradle.dsl.abi.BinariesSource
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 import org.jetbrains.kotlin.gradle.testbase.AndroidGradlePluginTests
 import org.jetbrains.kotlin.gradle.testbase.AndroidTestVersions
 import org.jetbrains.kotlin.gradle.testbase.GradleAndroidTest
 import org.jetbrains.kotlin.gradle.testbase.JdkVersions
 import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
 import org.jetbrains.kotlin.gradle.testbase.TestVersions
+import org.jetbrains.kotlin.gradle.testbase.assertFileContains
 import org.jetbrains.kotlin.gradle.testbase.assertFileExists
+import org.jetbrains.kotlin.gradle.testbase.assertOutputContains
+import org.jetbrains.kotlin.gradle.testbase.assertTasksFailed
 import org.jetbrains.kotlin.gradle.testbase.build
+import org.jetbrains.kotlin.gradle.testbase.buildAndFail
 import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
 import org.jetbrains.kotlin.gradle.testbase.source
 
@@ -111,6 +121,188 @@ class AbiValidationAndroidKmpIT : KGPBaseTest() {
 
             """.trimIndent()
             assertDumpsEqual(expectedJvmDump, jvmDumpFile)
+        }
+    }
+
+    @AndroidTestVersions(minVersion = TestVersions.AGP.AGP_88, additionalVersions = [TestVersions.AGP.AGP_811])
+    @GradleAndroidTest
+    fun testCheckFailsOnAndroidAbiChange(
+        gradleVersion: GradleVersion,
+        agpVersion: String,
+        jdkVersion: JdkVersions.ProvidedJdk,
+    ) {
+        androidKmpLibraryProject(gradleVersion, agpVersion, jdkVersion) {
+            abiValidation()
+
+            kotlinSourcesDir("commonMain").source("CommonClass.kt") { "class CommonClass" }
+            kotlinSourcesDir("androidMain").source("AndroidClass.kt") { "class AndroidClass" }
+
+            build("updateKotlinAbi")
+            assertFileExists(referenceMixedAndroidDumpFile())
+            build("checkKotlinAbi")
+
+            kotlinSourcesDir("androidMain").source("AndroidClass.kt") {
+                "class AndroidClass {\n    fun newApi(): Int = 42\n}"
+            }
+            buildAndFail("checkKotlinAbi") {
+                assertTasksFailed(":checkKotlinAbi")
+                assertOutputContains("public final fun newApi ()I")
+            }
+        }
+    }
+
+    @AndroidTestVersions(minVersion = TestVersions.AGP.AGP_88, additionalVersions = [TestVersions.AGP.AGP_811])
+    @GradleAndroidTest
+    fun testMavenPublicationsRejectedForAndroidTarget(
+        gradleVersion: GradleVersion,
+        agpVersion: String,
+        jdkVersion: JdkVersions.ProvidedJdk,
+    ) {
+        androidKmpLibraryProject(gradleVersion, agpVersion, jdkVersion) {
+            buildScriptInjection {
+                project.plugins.apply("maven-publish")
+            }
+            abiValidation {
+                binariesSource.set(BinariesSource.MAVEN_PUBLICATIONS)
+            }
+
+            kotlinSourcesDir("commonMain").source("CommonClass.kt") { "class CommonClass" }
+            kotlinSourcesDir("androidMain").source("AndroidClass.kt") { "class AndroidClass" }
+
+            buildAndFail("updateKotlinAbi") {
+                assertOutputContains("ABI Validation: Android target unsupported with Maven binary sources mode")
+            }
+        }
+    }
+
+    @AndroidTestVersions(minVersion = TestVersions.AGP.AGP_88, additionalVersions = [TestVersions.AGP.AGP_811])
+    @GradleAndroidTest
+    fun testAndroidWithNativeTarget(
+        gradleVersion: GradleVersion,
+        agpVersion: String,
+        jdkVersion: JdkVersions.ProvidedJdk,
+    ) {
+        androidKmpLibraryProject(gradleVersion, agpVersion, jdkVersion) {
+            abiValidation()
+            buildScriptInjection {
+                with(kotlinMultiplatform) {
+                    linuxX64()
+                }
+            }
+
+            kotlinSourcesDir("commonMain").source("CommonClass.kt") { "class CommonClass" }
+            kotlinSourcesDir("androidMain").source("AndroidClass.kt") { "class AndroidClass" }
+
+            build("updateKotlinAbi")
+
+            // The android multiplatform library target (JVM-kind) is dumped through the dedicated
+            // Android branch into api/android/, including commonMain + androidMain declarations.
+            val androidDumpFile = referenceMixedAndroidDumpFile()
+            assertFileExists(androidDumpFile)
+            assertFileContains(
+                androidDumpFile.toPath(),
+                "public final class AndroidClass",
+                "public final class CommonClass",
+            )
+
+            // The native target is processed independently as a klib ABI dump; it contains the
+            // shared commonMain declarations but not the android-only ones.
+            val klibDumpFile = referenceKlibDumpFile()
+            assertFileExists(klibDumpFile)
+            assertFileContains(klibDumpFile.toPath(), "CommonClass")
+        }
+    }
+
+    @AndroidTestVersions(minVersion = TestVersions.AGP.AGP_88, additionalVersions = [TestVersions.AGP.AGP_811])
+    @GradleAndroidTest
+    fun testNonTestCompilationsExcludeTestSources(
+        gradleVersion: GradleVersion,
+        agpVersion: String,
+        jdkVersion: JdkVersions.ProvidedJdk,
+    ) {
+        androidKmpLibraryProject(gradleVersion, agpVersion, jdkVersion) {
+            abiValidation {
+                binariesSource.set(BinariesSource.NON_TEST_COMPILATIONS)
+            }
+            // Test compilations are disabled by default in com.android.kotlin.multiplatform.library,
+            // so enable them explicitly to verify they are excluded from the ABI dump.
+            buildScriptInjection {
+                kotlinMultiplatform.androidLibrary {
+                    withHostTest {}
+                    withDeviceTest {}
+                }
+                kotlinMultiplatform.apply {
+                    val customMain = sourceSets.create("customMain").apply {
+                        dependsOn(sourceSets.getByName("commonMain"))
+                    }
+                    sourceSets.getByName("androidMain").dependsOn(customMain)
+                }
+            }
+
+            // Non-test source sets that feed the main compilation - all must appear in the dump.
+            kotlinSourcesDir("commonMain").source("CommonClass.kt") { "class CommonClass" }
+            kotlinSourcesDir("customMain").source("CustomClass.kt") { "class CustomClass" }
+            kotlinSourcesDir("androidMain").source("AndroidClass.kt") { "class AndroidClass" }
+            // Public declarations in the test compilations - none must appear in the dump.
+            kotlinSourcesDir("androidHostTest").source("HostTestClass.kt") { "class HostTestClass" }
+            kotlinSourcesDir("androidDeviceTest").source("DeviceTestClass.kt") { "class DeviceTestClass" }
+
+            build("updateKotlinAbi")
+
+            val dumpFile = referenceMixedAndroidDumpFile()
+            assertFileExists(dumpFile)
+
+            // The dump contains only the non-test declarations (commonMain + customMain + androidMain);
+            // both the host-test and device-test compilations are excluded.
+            val tab = "\t"
+            val expectedDump = """
+                public final class AndroidClass {
+                ${tab}public fun <init> ()V
+                }
+
+                public final class CommonClass {
+                ${tab}public fun <init> ()V
+                }
+
+                public final class CustomClass {
+                ${tab}public fun <init> ()V
+                }
+
+
+            """.trimIndent()
+            assertDumpsEqual(expectedDump, dumpFile)
+        }
+    }
+
+    @AndroidTestVersions(minVersion = TestVersions.AGP.AGP_88, additionalVersions = [TestVersions.AGP.AGP_811])
+    @GradleAndroidTest
+    fun testJavaSourcesInAndroidTarget(
+        gradleVersion: GradleVersion,
+        agpVersion: String,
+        jdkVersion: JdkVersions.ProvidedJdk,
+    ) {
+        androidKmpLibraryProject(gradleVersion, agpVersion, jdkVersion) {
+            abiValidation()
+            buildScriptInjection {
+                kotlinMultiplatform.androidLibrary {
+                    withJava()
+                }
+            }
+
+            kotlinSourcesDir("commonMain").source("CommonClass.kt") { "class CommonClass" }
+            kotlinSourcesDir("androidMain").source("AndroidClass.kt") { "class AndroidClass" }
+            javaSourcesDir("androidMain").source("JavaClass.java") { "public class JavaClass {}" }
+
+            build("updateKotlinAbi")
+
+            val dumpFile = referenceMixedAndroidDumpFile()
+            assertFileExists(dumpFile)
+            assertFileContains(
+                dumpFile.toPath(),
+                "public final class AndroidClass",
+                "public final class CommonClass",
+                "public class JavaClass",
+            )
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationAndroidKmpIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationAndroidKmpIT.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.gradle.testbase.assertTasksFailed
 import org.jetbrains.kotlin.gradle.testbase.build
 import org.jetbrains.kotlin.gradle.testbase.buildAndFail
 import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
+import org.jetbrains.kotlin.gradle.testbase.makeSnapshotTo
 import org.jetbrains.kotlin.gradle.testbase.source
 
 @AndroidGradlePluginTests
@@ -273,4 +274,5 @@ class AbiValidationAndroidKmpIT : KGPBaseTest() {
             assertDumpsEqual(expectedDump, dumpFile)
         }
     }
+
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationAndroidKmpIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/AbiValidationAndroidKmpIT.kt
@@ -273,37 +273,4 @@ class AbiValidationAndroidKmpIT : KGPBaseTest() {
             assertDumpsEqual(expectedDump, dumpFile)
         }
     }
-
-    @AndroidTestVersions(minVersion = TestVersions.AGP.AGP_88, additionalVersions = [TestVersions.AGP.AGP_811])
-    @GradleAndroidTest
-    fun testJavaSourcesInAndroidTarget(
-        gradleVersion: GradleVersion,
-        agpVersion: String,
-        jdkVersion: JdkVersions.ProvidedJdk,
-    ) {
-        androidKmpLibraryProject(gradleVersion, agpVersion, jdkVersion) {
-            abiValidation()
-            buildScriptInjection {
-                kotlinMultiplatform.androidLibrary {
-                    withJava()
-                }
-            }
-
-            kotlinSourcesDir("commonMain").source("CommonClass.kt") { "class CommonClass" }
-            kotlinSourcesDir("androidMain").source("AndroidClass.kt") { "class AndroidClass" }
-            javaSourcesDir("androidMain").source("JavaClass.java") { "public class JavaClass {}" }
-
-            build("updateKotlinAbi")
-
-            val dumpFile = referenceMixedAndroidDumpFile()
-            assertFileExists(dumpFile)
-            assertFileContains(
-                dumpFile.toPath(),
-                "public final class AndroidClass",
-                "public final class CommonClass",
-                "public class JavaClass",
-            )
-        }
-    }
-
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/utils/AbiValidationProjects.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/abi/utils/AbiValidationProjects.kt
@@ -138,7 +138,7 @@ internal fun KGPBaseTest.jvmProject(
     project.configuration()
 }
 
-private fun KotlinMultiplatformExtension.androidLibrary(
+internal fun KotlinMultiplatformExtension.androidLibrary(
     action: KotlinMultiplatformAndroidLibraryTarget.() -> Unit
 ) {
     (this as ExtensionAware).extensions.findByType(


### PR DESCRIPTION
## Summary
- `testCheckFailsOnAndroidAbiChange` — verifies `checkKotlinAbi` actually fails when the Android target's public API changes (existing tests only assert `updateKotlinAbi` dump content, never the enforcement path).
- `testMavenPublicationsRejectedForAndroidTarget` — verifies `updateKotlinAbi` fails with a clear diagnostic when `binariesSource = MAVEN_PUBLICATIONS` is used with `com.android.kotlin.multiplatform.library`. This diagnostic was already tested for the old-style `androidTarget()` in `AbiValidationKmpMavenPublicationsIT`, but untested for the new plugin.
- `testAndroidWithNativeTarget` — verifies the android target and a native (`linuxX64`) target coexist, each producing its own dump (`api/android/` and the klib ABI dump) without interfering.
- `testNonTestCompilationsExcludeTestSources` — verifies that with `binariesSource = NON_TEST_COMPILATIONS` and test compilations enabled (`withHostTest`/`withDeviceTest`, which are off by default in this plugin), declarations from test compilations are excluded from the dump.

#KT-85950