### PR TITLE
Initialize `cleanableStoreProvider` for CleanDataTask

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NodeJsGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/NodeJsGradlePluginIT.kt
@@ -136,4 +136,18 @@ class NodeJsGradlePluginIT : KGPBaseTest() {
             build(":kotlinNodeJsSetup")
         }
     }
+
+    @DisplayName("error warning for deprecated clean task")
+    @GradleTest
+    @TestMetadata("subprojects-nodejs-setup")
+    fun testDeprecatedCleanTask(gradleVersion: GradleVersion) {
+        project(
+            "subprojects-nodejs-setup",
+            gradleVersion
+        ) {
+            buildAndFail("nodeKotlinClean") {
+                assertOutputContains("The task ':nodeKotlinClean' is deprecated. Scheduled for removal in Kotlin 2.4.")
+            }
+        }
+    }
 }

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -5960,7 +5960,6 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/CInteropProcess : org/gr
 public class org/jetbrains/kotlin/gradle/tasks/CleanDataTask : org/gradle/api/DefaultTask {
 	public static final field Companion Lorg/jetbrains/kotlin/gradle/tasks/CleanDataTask$Companion;
 	public static final field NAME_SUFFIX Ljava/lang/String;
-	public field cleanableStoreProvider Lorg/gradle/api/provider/Provider;
 	public fun <init> ()V
 	public final fun exec ()V
 	public final fun getCleanableStoreProvider ()Lorg/gradle/api/provider/Provider;

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/CleanDataTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/CleanDataTask.kt
@@ -11,6 +11,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.utils.property
+import java.time.Instant
 
 /**
  * Task to clean all old unused loaded files from [storeProvider].
@@ -26,7 +28,8 @@ open class CleanDataTask : DefaultTask() {
     @Suppress("DEPRECATION_ERROR")
     @Deprecated("Scheduled for removal in Kotlin 2.4", level = DeprecationLevel.ERROR)
     @Input
-    lateinit var cleanableStoreProvider: Provider<org.jetbrains.kotlin.gradle.tasks.internal.CleanableStore>
+    var cleanableStoreProvider: Provider<org.jetbrains.kotlin.gradle.tasks.internal.CleanableStore> =
+        project.objects.property(CleanableStoreObject)
 
     /**
      * Time to live in days
@@ -47,6 +50,22 @@ open class CleanDataTask : DefaultTask() {
 
         @InternalKotlinGradlePluginApi
         fun deprecationMessage(taskPath: String) = "The task '$taskPath' is deprecated. Scheduled for removal in Kotlin 2.4."
-    }
 
+        @Suppress("DEPRECATION_ERROR")
+        private object CleanableStoreObject : org.jetbrains.kotlin.gradle.tasks.internal.CleanableStore {
+            private fun readResolve(): Any = CleanableStoreObject
+            override fun cleanDir(expirationDate: Instant) {
+                throw UnsupportedOperationException("CleanableStore is scheduled for removal in Kotlin 2.4")
+            }
+
+            override fun get(fileName: String): org.jetbrains.kotlin.gradle.tasks.internal.DownloadedFile {
+                throw UnsupportedOperationException("CleanableStore is scheduled for removal in Kotlin 2.4")
+            }
+
+            override fun markUsed() {
+                throw UnsupportedOperationException("CleanableStore is scheduled for removal in Kotlin 2.4")
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
All CleanDataTask parameters should be initialized to be able to receive a deprecation message

^KT-87241: Fixed