### PR TITLE
[CLI] Remove future "removedVersion" (2.5.0) for `Xklib-normalize-absolute-path` and `-Xworker-exception-handling`

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -10749,7 +10749,7 @@
                                     "introducedVersion": "2.0.20",
                                     "stabilizedVersion": null,
                                     "deprecatedVersion": "2.4.20",
-                                    "removedVersion": "2.5.0"
+                                    "removedVersion": null
                                 },
                                 "argumentType": {
                                     "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
@@ -18027,7 +18027,7 @@
                                             "introducedVersion": "1.6.0",
                                             "stabilizedVersion": null,
                                             "deprecatedVersion": "2.4.20",
-                                            "removedVersion": "2.5.0"
+                                            "removedVersion": null
                                         },
                                         "argumentType": {
                                             "type": "org.jetbrains.kotlin.arguments.dsl.types.StringType",

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonKlibBasedCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/CommonKlibBasedCompilerArguments.kt
@@ -48,7 +48,9 @@ Note: The prefixes are applied in the same order as they are passed in this CLI 
         lifecycle(
             introducedVersion = KotlinReleaseVersion.v2_0_20,
             deprecatedVersion = KotlinReleaseVersion.v2_4_20,
-            removedVersion = KotlinReleaseVersion.v2_5_0,
+            // The CLI arguments generation is broken if use a future `removedVersion`.
+            // TODO: uncomment after switching to 2.5 or after fixing of KT-87495
+            // removedVersion = KotlinReleaseVersion.v2_5_0,
         )
         restrictedToCompilerPhase = KotlinCompilerPhase.KLIB_COMPILATION
     }

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/NativeCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/NativeCompilerArguments.kt
@@ -892,7 +892,9 @@ The default value is 1.""".asReleaseDependent()
         lifecycle(
             introducedVersion = KotlinReleaseVersion.v1_6_0,
             deprecatedVersion = KotlinReleaseVersion.v2_4_20,
-            removedVersion = KotlinReleaseVersion.v2_5_0,
+            // The CLI arguments generation is broken if use a future `removedVersion`.
+            // TODO: uncomment after switching to 2.5 or after fixing of KT-87495
+            // removedVersion = KotlinReleaseVersion.v2_5_0,
         )
     }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonKlibBasedArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/CommonKlibBasedArgumentsImpl.kt
@@ -128,7 +128,7 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     if (X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY in this) { arguments.duplicatedUniqueNameStrategy = get(X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY)?.stringValue}
     if (X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS in this) { arguments.enableSignatureClashChecks = get(X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS)}
     if (X_KLIB_IR_INLINER in this) { arguments.irInlinerBeforeKlibSerialization = get(X_KLIB_IR_INLINER).stringValue}
-    try { if (X_KLIB_NORMALIZE_ABSOLUTE_PATH in this) { arguments.setUsingReflection("normalizeAbsolutePath", get(X_KLIB_NORMALIZE_ABSOLUTE_PATH))} } catch (e: NoSuchMethodError) { throw IllegalStateException("""Compiler parameter not recognized: X_KLIB_NORMALIZE_ABSOLUTE_PATH. Current compiler version is: $KC_VERSION, but the argument was removed in 2.5.0""").initCause(e) }
+    if (X_KLIB_NORMALIZE_ABSOLUTE_PATH in this) { arguments.normalizeAbsolutePath = get(X_KLIB_NORMALIZE_ABSOLUTE_PATH)}
     if (X_KLIB_RELATIVE_PATH_BASE in this) { arguments.relativePathBases = get(X_KLIB_RELATIVE_PATH_BASE).map { it.absolutePathStringOrThrow() }.also { list -> list.checkNoneContains(",") }.toTypedArray()}
     if (X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT in this) { arguments.klibZipFileAccessorCacheLimit = get(X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT).toString()}
     if (X_PARTIAL_LINKAGE in this) { arguments.partialLinkageMode = get(X_PARTIAL_LINKAGE)?.stringValue}
@@ -144,7 +144,7 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     try { this[X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY] = arguments.duplicatedUniqueNameStrategy?.let { DuplicatedUniqueNameStrategy.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::duplicatedUniqueNameStrategy, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xklib-duplicated-unique-name-strategy value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS] = arguments.enableSignatureClashChecks } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_IR_INLINER] = arguments.irInlinerBeforeKlibSerialization.let { KlibIrInlinerMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::irInlinerBeforeKlibSerialization, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xklib-ir-inliner value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
-    try { this[X_KLIB_NORMALIZE_ABSOLUTE_PATH] = arguments.getUsingReflection("normalizeAbsolutePath") } catch (_: NoSuchMethodError) {  }
+    try { this[X_KLIB_NORMALIZE_ABSOLUTE_PATH] = arguments.normalizeAbsolutePath } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_RELATIVE_PATH_BASE] = arguments.relativePathBases.mapOrEmpty { Path(it) } } catch (_: NoSuchMethodError) {  }
     try { this[X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT] = arguments.klibZipFileAccessorCacheLimit.let { it.toInt() } } catch (_: NoSuchMethodError) {  }
     try { this[X_PARTIAL_LINKAGE] = arguments.partialLinkageMode?.let { PartialLinkageMode.entries.firstOrNull { entry -> entry.stringValue.equals(it, true) }?.also { entry -> checkCaseMatches(_restrictedArgViolations, arguments::partialLinkageMode, entry.stringValue, it) } ?: throw CompilerArgumentsParseException("Unknown -Xpartial-linkage value: $it") } } catch (ex: CompilerArgumentsParseException) { _argumentValidationErrors.add(ex.message ?: "Error parsing compiler arguments") } catch (_: NoSuchMethodError) {  }
@@ -160,7 +160,7 @@ internal abstract class CommonKlibBasedArgumentsImpl(
     if (X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY in this) { arguments.duplicatedUniqueNameStrategy = get(X_KLIB_DUPLICATED_UNIQUE_NAME_STRATEGY)?.stringValue}
     if (X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS in this) { arguments.enableSignatureClashChecks = get(X_KLIB_ENABLE_SIGNATURE_CLASH_CHECKS)}
     if (X_KLIB_IR_INLINER in this) { arguments.irInlinerBeforeKlibSerialization = get(X_KLIB_IR_INLINER).stringValue}
-    try { if (X_KLIB_NORMALIZE_ABSOLUTE_PATH in this) { arguments.setUsingReflection("normalizeAbsolutePath", get(X_KLIB_NORMALIZE_ABSOLUTE_PATH))} } catch (e: NoSuchMethodError) { throw IllegalStateException("""Compiler parameter not recognized: X_KLIB_NORMALIZE_ABSOLUTE_PATH. Current compiler version is: $KC_VERSION, but the argument was removed in 2.5.0""").initCause(e) }
+    if (X_KLIB_NORMALIZE_ABSOLUTE_PATH in this) { arguments.normalizeAbsolutePath = get(X_KLIB_NORMALIZE_ABSOLUTE_PATH)}
     if (X_KLIB_RELATIVE_PATH_BASE in this) { arguments.relativePathBases = get(X_KLIB_RELATIVE_PATH_BASE).map { it.absolutePathStringOrThrow() }.also { list -> list.checkNoneContains(",") }.toTypedArray()}
     if (X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT in this) { arguments.klibZipFileAccessorCacheLimit = get(X_KLIB_ZIP_FILE_ACCESSOR_CACHE_LIMIT).toString()}
     if (X_PARTIAL_LINKAGE in this) { arguments.partialLinkageMode = get(X_PARTIAL_LINKAGE)?.stringValue}

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonKlibBasedCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/CommonKlibBasedCompilerArguments.kt
@@ -65,7 +65,6 @@ The only observable effect is that a custom ABI version is written to KLIB manif
         value = "-Xklib-normalize-absolute-path",
         description = "Normalize absolute paths in klibs.",
         deprecatedVersion = "2.4.20",
-        removedVersion = "2.5.0",
     )
     var normalizeAbsolutePath: Boolean = false
         set(value) {

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
@@ -646,7 +646,6 @@ This library must be one of the ones passed with '-library'.""",
         valueDescription = "<mode>",
         description = "Unhandled exception processing in 'Worker.executeAfter'. Possible values: 'legacy' and 'use-hook'. The default value is 'legacy' and for '-memory-model experimental', the default value is 'use-hook'.",
         deprecatedVersion = "2.4.20",
-        removedVersion = "2.5.0",
     )
     var workerExceptionHandling: String? = null
         set(value) {

--- a/compiler/testData/cli/js/jsExtraHelp.out
+++ b/compiler/testData/cli/js/jsExtraHelp.out
@@ -98,7 +98,7 @@ where advanced options include:
                              - `default` mode lets the IR inliner run in `intra-module`, `full` or `disabled` mode based on the current language version
 
   -Xklib-normalize-absolute-path Normalize absolute paths in klibs.
-                             The option is deprecated since Kotlin 2.4.20. It will be removed in $ABI_VERSION_NEXT$.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xklib-relative-path-base  Relativize all the paths stored in a klib using the given path prefixes.
                              The supplied prefixes should be absolute paths to the directories containing the source code files.
                              Note: The prefixes are applied in the same order as they are passed in this CLI argument.

--- a/compiler/testData/cli/wasm/wasmExtraHelp.out
+++ b/compiler/testData/cli/wasm/wasmExtraHelp.out
@@ -73,7 +73,7 @@ where advanced options include:
                              - `default` mode lets the IR inliner run in `intra-module`, `full` or `disabled` mode based on the current language version
 
   -Xklib-normalize-absolute-path Normalize absolute paths in klibs.
-                             The option is deprecated since Kotlin 2.4.20. It will be removed in $ABI_VERSION_NEXT$.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xklib-relative-path-base  Relativize all the paths stored in a klib using the given path prefixes.
                              The supplied prefixes should be absolute paths to the directories containing the source code files.
                              Note: The prefixes are applied in the same order as they are passed in this CLI argument.

--- a/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
+++ b/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
@@ -79,7 +79,7 @@ where advanced options include:
   -Xverify-compiler          Verify the compiler.
   -Xworker-exception-handling=<mode>
                              Unhandled exception processing in 'Worker.executeAfter'. Possible values: 'legacy' and 'use-hook'. The default value is 'legacy' and for '-memory-model experimental', the default value is 'use-hook'.
-                             The option is deprecated since Kotlin 2.4.20. It will be removed in $ABI_VERSION_NEXT$.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xwrite-dependencies-of-produced-klib-to=<path>
                              Write file containing the paths of dependencies used during klib compilation to the provided path
   -Xwrite-dependencies-to    Path for writing backend dependencies.
@@ -99,7 +99,7 @@ where advanced options include:
                              - `default` mode lets the IR inliner run in `intra-module`, `full` or `disabled` mode based on the current language version
 
   -Xklib-normalize-absolute-path Normalize absolute paths in klibs.
-                             The option is deprecated since Kotlin 2.4.20. It will be removed in $ABI_VERSION_NEXT$.
+                             The option is deprecated since Kotlin 2.4.20. It will be removed in one of the future releases.
   -Xklib-relative-path-base  Relativize all the paths stored in a klib using the given path prefixes.
                              The supplied prefixes should be absolute paths to the directories containing the source code files.
                              Note: The prefixes are applied in the same order as they are passed in this CLI argument.


### PR DESCRIPTION
KT-87495