### PR TITLE
[Tests][JS] Don't use codegen helpers for JS diagnostic tests (Part 2)

### DIFF
--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsIrDeserializationTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsIrDeserializationTest.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
 package org.jetbrains.kotlin.js.test.runners
 
 import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.js.test.JsAdditionalSourceProvider
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.TargetBackend
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
@@ -15,6 +16,7 @@ import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.LANGUAGE
 import org.jetbrains.kotlin.test.directives.model.ValueDirective
 import org.jetbrains.kotlin.test.frontend.fir.FirMetaInfoDiffSuppressor
+import org.jetbrains.kotlin.test.services.sourceProviders.CoroutineHelpersSourceFilesProvider
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
 /**
@@ -49,6 +51,10 @@ abstract class AbstractJsIrDeserializationTest(
             }
             useFailureSuppressors(
                 ::FirMetaInfoDiffSuppressor
+            )
+            useAdditionalSourceProviders(
+                ::JsAdditionalSourceProvider,
+                ::CoroutineHelpersSourceFilesProvider,
             )
         }
     }

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsTest.kt
@@ -348,7 +348,7 @@ abstract class AbstractJsSteppingSplitWithInlinedFunInKlibTest : AbstractJsStepp
 
 abstract class AbstractJsCodegenWasmJsInteropTest(
     testGroupOutputDirPrefix: String = "codegen/boxWasmJsInteropJs/"
-) : AbstractJsTest(
+) : AbstractJsCodegenBoxTestBase(
     pathToTestDir = "compiler/testData/codegen/boxWasmJsInterop/",
     testGroupOutputDirPrefix = testGroupOutputDirPrefix
 )


### PR DESCRIPTION
^KT-85764