### PR TITLE
Generate libclangext for Linux

### DIFF
--- a/kotlin-native/libclangInterop/build.gradle.kts
+++ b/kotlin-native/libclangInterop/build.gradle.kts
@@ -73,6 +73,9 @@ nativeInteropPlugin {
                     "__ZN4llvm4hlsl7rootsig16dumpRootElementsERNS_11raw_ostreamENS_8ArrayRefINSt3__17variantIJNS_4dxbc9RootFlagsENS1_13RootConstantsENS1_14RootDescriptorENS1_15DescriptorTableENS1_21DescriptorTableClauseENS1_13StaticSamplerEEEEEE"
             ).mapTo(this) { "-Wl,-U,$it" }
             addAll(listOf("-lpthread", "-lz", "-lm", "-lcurses"))
+        } else if (PlatformInfo.isLinux()) {
+            add("-Wl,-z,noexecstack")
+            addAll(listOf("-lrt", "-ldl", "-lpthread", "-lz", "-lm"))
         }
     })
     additionalLinkedStaticLibraries.set(buildList {
@@ -82,7 +85,7 @@ nativeInteropPlugin {
             "lib/${System.mapLibraryName("clang")}"
         }
         add("${nativeDependencies.llvmPath}/$libclang")
-        if (PlatformInfo.isMac()) {
+        if (PlatformInfo.isMac() || PlatformInfo.isLinux()) {
             listOf(
                     "clangAST", "clangASTMatchers", "clangAnalysis", "clangBasic", "clangDriver", "clangEdit",
                     "clangFrontend", "clangFrontendTool", "clangLex", "clangParse", "clangSema",

--- a/kotlin-native/libclangInterop/build.gradle.kts
+++ b/kotlin-native/libclangInterop/build.gradle.kts
@@ -74,6 +74,8 @@ nativeInteropPlugin {
             ).mapTo(this) { "-Wl,-U,$it" }
             addAll(listOf("-lpthread", "-lz", "-lm", "-lcurses"))
         } else if (PlatformInfo.isLinux()) {
+            // Linux linkers (ld/lld) allow unresolved symbols by default when producing shared libraries, so '-Wl,-U' flags are not
+            // needed here.
             add("-Wl,-z,noexecstack")
             addAll(listOf("-lrt", "-ldl", "-lpthread", "-lz", "-lm"))
         }

--- a/kotlin-native/libclangext/build.gradle.kts
+++ b/kotlin-native/libclangext/build.gradle.kts
@@ -42,7 +42,7 @@ native {
             "-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1",
             *reproducibilityCompilerFlags,
     )
-    if (PlatformInfo.isMac()) {
+    if (PlatformInfo.isMac() || PlatformInfo.isLinux()) {
         cxxflags += "-DLIBCLANGEXT_ENABLE=1"
     }
     suffixes {

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CInteropHeaderModeValidationTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CInteropHeaderModeValidationTest.kt
@@ -6,12 +6,15 @@
 package org.jetbrains.kotlin.konan.test.blackbox
 
 import org.jetbrains.kotlin.konan.library.components.bitcode
+import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.test.blackbox.support.*
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.*
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationResult.Companion.assertSuccess
 import org.jetbrains.kotlin.library.isHeader
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.Settings
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
@@ -92,27 +95,79 @@ class CInteropHeaderModeValidationTest : AbstractNativeSimpleTest() {
         )
         assertTrue(dependentKlibSuccess.klibFile.exists())
 
-        // 3. Compile CInterop in Full Mode
-        val fullKlib = cinteropToLibrary(
-            defFile,
-            buildDir.resolve("fullModeOut").apply { mkdirs() },
-            TestCInteropArgs(includeArg)
-        ).assertSuccess().resultingArtifact
+        // Full-mode cinterop compilation and binary linking require running on the matching host platform
+        if (!targets.areDifferentTargets()) {
+            // 3. Compile cinterop in full mode
+            val fullKlib = cinteropToLibrary(
+                defFile,
+                buildDir.resolve("fullModeOut").apply { mkdirs() },
+                TestCInteropArgs(includeArg)
+            ).assertSuccess().resultingArtifact
 
-        val fullLibrary = KlibLoader { libraryPaths(fullKlib.klibFile.path) }.load().librariesStdlibFirst.single()
-        assertFalse(fullLibrary.isHeader) { "Expected full klib to not have header=true in manifest" }
+            val fullLibrary = KlibLoader { libraryPaths(fullKlib.klibFile.path) }.load().librariesStdlibFirst.single()
+            assertFalse(fullLibrary.isHeader) { "Expected full klib to not have header=true in manifest" }
 
-        // 4. Link the pre-compiled dependent KLIB with the Full-Mode KLIB (fails linking)
-        val linkTestCase = generateTestCaseWithSingleModule(null, TestCompilerArgs.EMPTY)
-        val result = compileToExecutableInOneStage(
-            linkTestCase,
-            dependentKlibSuccess.asLibraryDependency(),
-            fullKlib.asLibraryDependency()
+            // 4. Link the pre-compiled dependent KLIB with the Full-Mode KLIB (fails linking)
+            val linkTestCase = generateTestCaseWithSingleModule(null, TestCompilerArgs.EMPTY)
+            val result = compileToExecutableInOneStage(
+                linkTestCase,
+                dependentKlibSuccess.asLibraryDependency(),
+                fullKlib.asLibraryDependency()
+            )
+
+            // The linking step must fail because fullKlib is missing testInvalidBridge's bridge implementation
+            assertTrue(result is TestCompilationResult.CompilationToolFailure) {
+                "Expected link compilation to fail, but it succeeded! Result: $result"
+            }
+        }
+    }
+
+    @Test
+    fun testHeaderModeCrossCompilation() {
+        // Cross-targets supported on this host (e.g. Linux host supports linux_arm64, android_arm64, android_x64, mingw_x64)
+        val crossTargets = listOf(
+            KonanTarget.LINUX_ARM64,
+            KonanTarget.ANDROID_ARM64,
+            KonanTarget.ANDROID_X64,
+            KonanTarget.MINGW_X64,
         )
 
-        // The linking step must fail because fullKlib is missing testInvalidBridge's bridge implementation
-        assertTrue(result is TestCompilationResult.CompilationToolFailure) {
-            "Expected link compilation to fail, but it succeeded! Result: $result"
+        val includeArg = listOf("-compiler-option", "-I${headerFile.parentFile.canonicalPath}")
+
+        for (target in crossTargets) {
+            val targetSettings = object : Settings(
+                testRunSettings,
+                listOf(KotlinNativeTargets(target, targets.hostTarget))
+            ) {}
+
+            val targetBuildDir = buildDir.resolve("cross_${target.name}").apply { mkdirs() }
+
+            // 1. Cross-compile CInterop in Header Mode
+            val testCase = generateCInteropTestCaseFromSingleDefFile(defFile, TestCInteropArgs(includeArg + "-Xheader-mode"))
+            val headerKlib = CInteropCompilation(
+                settings = targetSettings,
+                freeCompilerArgs = TestCInteropArgs(includeArg + "-Xheader-mode"),
+                defFile = testCase.modules.single().files.single().location,
+                dependencies = emptyList(),
+                expectedArtifact = getLibraryArtifact(testCase, targetBuildDir.resolve("headerModeOut").apply { mkdirs() }, true),
+                noDefaultLibs = true
+            ).result.assertSuccess().resultingArtifact
+
+            val headerLibrary = KlibLoader { libraryPaths(headerKlib.klibFile.path) }.load().librariesStdlibFirst.single()
+            val bitcodeFiles = headerLibrary.bitcode(target)?.bitcodeFilePaths ?: emptyList()
+            assertTrue(bitcodeFiles.isEmpty()) { "Expected no bitcode in header klib for target $target, got: $bitcodeFiles" }
+
+            // 2. Cross-compile dependent Kotlin code against the Header-Mode KLIB
+            val dependentTestCase = generateTestCaseWithSingleModule(dependentKotlinDir, TestCompilerArgs.EMPTY)
+            val dependentKlibSuccess = LibraryCompilation(
+                settings = targetSettings,
+                freeCompilerArgs = TestCompilerArgs.EMPTY,
+                sourceModules = dependentTestCase.modules,
+                dependencies = listOf(headerKlib.asLibraryDependency()),
+                expectedArtifact = getLibraryArtifact(dependentTestCase, targetBuildDir.resolve("dependentHeaderSuccess").apply { mkdirs() }, true)
+            ).result.assertSuccess().resultingArtifact
+
+            assertTrue(dependentKlibSuccess.klibFile.exists()) { "Expected dependent KLIB to be generated for target $target" }
         }
     }
 }


### PR DESCRIPTION
Libclangext is required to run cinterop in header mode for cross-compilation of apple targets.