### PR TITLE
[Test] Fix JS KLIB compatibility tests by adding missing source providers

### DIFF
--- a/compiler/testData/codegen/box/coroutines/featureIntersection/suspendFunctionIsAs.kt
+++ b/compiler/testData/codegen/box/coroutines/featureIntersection/suspendFunctionIsAs.kt
@@ -3,6 +3,9 @@
 // WITH_COROUTINES
 // NO_CHECK_LAMBDA_INLINING
 
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.3,2.4
+// ^^^ KT-78040 is available in 2.4.20-Beta2
+
 // FILE: lib.kt
 import kotlin.coroutines.*
 

--- a/compiler/testData/codegen/box/coroutines/functionReference_Function_SuspendFunction_casts.kt
+++ b/compiler/testData/codegen/box/coroutines/functionReference_Function_SuspendFunction_casts.kt
@@ -13,6 +13,9 @@
 // fixed after KT-78040 (AddFunctionSupertypeToSuspendFunctionLowering was modified
 // and moved into backend.common to we used by Wasm as well)
 
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.3,2.4
+// ^^^ KT-78040 is available in 2.4.20-Beta2
+
 import kotlin.reflect.KFunction2
 import kotlin.reflect.KSuspendFunction1
 import kotlin.test.*

--- a/compiler/testData/codegen/box/coroutines/functionReference_invokeAsFunction.kt
+++ b/compiler/testData/codegen/box/coroutines/functionReference_invokeAsFunction.kt
@@ -7,6 +7,9 @@
 // AssertionError: Expected <159>, actual <[object Generator]>.
 // KT-82349: ClassCastException
 
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.3,2.4
+// ^^^ KT-78040 is available in 2.4.20-Beta2
+
 import kotlin.test.*
 
 import kotlin.coroutines.*

--- a/compiler/testData/codegen/box/inlineClasses/unboxParameterOfSuspendLambdaBeforeInvoke.kt
+++ b/compiler/testData/codegen/box/inlineClasses/unboxParameterOfSuspendLambdaBeforeInvoke.kt
@@ -5,6 +5,9 @@
 // WITH_STDLIB
 // WORKS_WHEN_VALUE_CLASS
 
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.3,2.4
+// ^^^ KT-78040 is available in 2.4.20-Beta2
+
 import helpers.*
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*

--- a/compiler/testData/codegen/box/inlineClasses/unboxParameterOfSuspendLambdaBeforeInvokeGeneric.kt
+++ b/compiler/testData/codegen/box/inlineClasses/unboxParameterOfSuspendLambdaBeforeInvokeGeneric.kt
@@ -5,6 +5,9 @@
 // WITH_STDLIB
 // WORKS_WHEN_VALUE_CLASS
 
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.3,2.4
+// ^^^ KT-78040 is available in 2.4.20-Beta2
+
 import helpers.*
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*

--- a/js/js.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/js/test/klib/AbstractCustomJsCompilerFirstStageTest.kt
+++ b/js/js.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/js/test/klib/AbstractCustomJsCompilerFirstStageTest.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.js.test.klib
 
+import org.jetbrains.kotlin.js.test.JsAdditionalSourceProvider
 import org.jetbrains.kotlin.js.test.runners.AbstractJsBlackBoxCodegenTestBase.JsBackendFacades
 import org.jetbrains.kotlin.js.test.runners.commonConfigurationForJsBackendSecondStageTest
 import org.jetbrains.kotlin.js.test.runners.configureJsBoxHandlers
@@ -62,6 +63,7 @@ open class AbstractCustomJsCompilerFirstStageTest(val testDataRoot: String = "co
 
         useAdditionalSourceProviders(
             ::CoroutineHelpersSourceFilesProvider,
+            ::JsAdditionalSourceProvider,
             ::AdditionalDiagnosticsSourceFilesProvider,
         )
 

--- a/js/js.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/js/test/klib/AbstractCustomJsCompilerSecondStageTest.kt
+++ b/js/js.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/js/test/klib/AbstractCustomJsCompilerSecondStageTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.js.test.klib
 
 import org.jetbrains.kotlin.config.LanguageVersion
+import org.jetbrains.kotlin.js.test.JsAdditionalSourceProvider
 import org.jetbrains.kotlin.js.test.preprocessors.JsExportBoxPreprocessor
 import org.jetbrains.kotlin.js.test.runners.commonConfigurationForJsTest
 import org.jetbrains.kotlin.js.test.runners.configureJsBoxHandlers
@@ -25,6 +26,7 @@ import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerWithTargetBackend
 import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
 import org.jetbrains.kotlin.test.services.StandardLibrariesPathProviderForKotlinProject
 import org.jetbrains.kotlin.test.services.configuration.UnsupportedFeaturesTestConfigurator
+import org.jetbrains.kotlin.test.services.sourceProviders.CoroutineHelpersSourceFilesProvider
 import org.jetbrains.kotlin.utils.bind
 import org.junit.jupiter.api.Tag
 import java.io.File
@@ -80,6 +82,11 @@ open class AbstractCustomJsCompilerSecondStageTest : AbstractKotlinCompilerWithT
             // Suppress failed tests having `// IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_SECOND_STAGE: X.Y.Z`,
             // where `X.Y.Z` matches to `customJsCompilerSettings.version`
             ::CustomKlibCompilerSecondStageTestSuppressor.bind(customJsCompilerSettings.defaultLanguageVersion),
+        )
+
+        useAdditionalSourceProviders(
+            ::JsAdditionalSourceProvider,
+            ::CoroutineHelpersSourceFilesProvider,
         )
     }
 }

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/klib/CustomJsCompilerSecondStageFacade.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/klib/CustomJsCompilerSecondStageFacade.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.test.services.CompilationStage
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.configuration.JsEnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.configuration.finalizePath
-import org.jetbrains.kotlin.test.utils.withExtension
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -51,18 +50,14 @@ class CustomJsCompilerSecondStageFacade(
         regularDependencies: Set<String>,
         friendDependencies: Set<String>,
     ): BinaryArtifacts.Js {
-        val jsArtifactFile = File(
-            JsEnvironmentConfigurator.getJsModuleArtifactPath(testServices, module.name).finalizePath(
-                JsEnvironmentConfigurator.getModuleKind(
-                    testServices,
-                    module
-                )
-            )
-        )
+        val moduleKind = JsEnvironmentConfigurator.getModuleKind(testServices, module)
+
+        val finalJsArtifactFile = File(JsEnvironmentConfigurator.getJsModuleArtifactPath(testServices, module.name).finalizePath(moduleKind))
+        val outputDir: File = finalJsArtifactFile.parentFile
+        val tempJsArtifactFile = outputDir.resolve(module.name.finalizePath(moduleKind))
 
         val compilerXmlOutput = ByteArrayOutputStream()
 
-        val outputDir = jsArtifactFile.parentFile
         val exitCode = PrintStream(compilerXmlOutput).use { printStream ->
             val regularAndFriendDependencies = regularDependencies + friendDependencies
             customJsCompilerSettings.customKlibCompiler.callCompiler(
@@ -73,8 +68,9 @@ class CustomJsCompilerSecondStageFacade(
                     K2JSCompilerArguments::sourceMapEmbedSources.cliArgument(SOURCE_MAP_SOURCE_CONTENT_NEVER),
                     K2JSCompilerArguments::includes.cliArgument(mainLibrary),
 
+                    K2JSCompilerArguments::moduleKind.cliArgument, moduleKind.type,
                     K2JSCompilerArguments::outputDir.cliArgument, outputDir.path,
-                    K2JSCompilerArguments::moduleName.cliArgument, module.name,
+                    K2JSCompilerArguments::moduleName.cliArgument, tempJsArtifactFile.nameWithoutExtension,
                     CommonCompilerArguments::disableDefaultScriptingPlugin.cliArgument,
                 ),
                 runIf(regularAndFriendDependencies.isNotEmpty()) {
@@ -92,25 +88,24 @@ class CustomJsCompilerSecondStageFacade(
 
         if (exitCode == ExitCode.OK) {
             // Successfully compiled. Return the artifact.
-            File(outputDir.path, module.name + ".js")
-                .renameFollowingTestInfraConvention(jsArtifactFile)
+            tempJsArtifactFile.renameTo(finalJsArtifactFile)
 
             return JsIrArtifact(
-                outputFile = jsArtifactFile,
+                outputFile = finalJsArtifactFile,
                 compilerResult = CompilerResult(
                     listOf(
                         CompilationOutputsBuilt(
                             artifactConfiguration = WebArtifactConfiguration(
-                                moduleKind = ModuleKind.PLAIN,
+                                moduleKind = moduleKind,
                                 moduleName = module.name,
                                 outputDirectory = outputDir,
-                                outputName = module.name,
+                                outputName = finalJsArtifactFile.nameWithoutExtension,
                                 granularity = JsGenerationGranularity.WHOLE_PROGRAM,
                                 tsCompilationStrategy = TsCompilationStrategy.NONE,
                                 production = false,
                                 minimizedMemberNames = false,
                             ),
-                            rawJsCode = jsArtifactFile.readText(),
+                            rawJsCode = finalJsArtifactFile.readText(),
                             sourceMap = null,
                             tsDefinitions = null,
                             jsProgram = null,
@@ -121,25 +116,6 @@ class CustomJsCompilerSecondStageFacade(
         } else {
             // Throw an exception to abort further test execution.
             throw CustomKlibCompilerException(exitCode, compilerXmlOutput.toString(Charsets.UTF_8.name()))
-        }
-    }
-
-    // CLI compilation creates an output file of different name than testInfra usually does.
-    // A rename is needed, in order the testInfra runner can use its usual logic to run the test script.
-    private fun File.renameFollowingTestInfraConvention(outputFile: File) {
-        require(exists()) {
-            "Internal testinfra error: Couldn't find expected generated js script ${absolutePath}"
-        }
-
-        renameTo(outputFile)
-
-        // Move SourceMap file as well
-        with(withExtension(".js.map")) {
-            require(exists()) {
-                "Internal testinfra error: Couldn't find expected generated js source map ${absolutePath}"
-            }
-
-            renameTo(outputFile.withExtension(".js.map"))
         }
     }
 }


### PR DESCRIPTION
These providers have been removed accidentally in
commit d4eb7c89706a96b90c44faae6d2cd16870bb1879.