### PR TITLE
[K/N] Hide companion blocks and extensions from C Export

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterGenerator.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.descriptors.konan.allParameters
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.util.referenceFunction
+import org.jetbrains.kotlin.metadata.deserialization.hasCompanionExtensionReceiver
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.isChildOf
@@ -24,6 +25,8 @@ import org.jetbrains.kotlin.resolve.annotations.argumentValue
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.isEffectivelyPublicApi
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
+import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedPropertyDescriptor
+import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 
@@ -51,6 +54,7 @@ private enum class Direction {
     C_TO_KOTLIN
 }
 
+@OptIn(K1Deprecation::class)
 private fun isExportedFunction(descriptor: FunctionDescriptor): Boolean {
     if (!descriptor.isEffectivelyPublicApi || !descriptor.kind.isReal || descriptor.isExpect)
         return false
@@ -58,7 +62,22 @@ private fun isExportedFunction(descriptor: FunctionDescriptor): Boolean {
         return false
     if (descriptor.contextReceiverParameters.any())
         return false
-    return !descriptor.typeParameters.any()
+    if (descriptor.typeParameters.any())
+        return false
+    when (descriptor) {
+        is SimpleFunctionDescriptor -> {
+            val proto = (descriptor as DeserializedSimpleFunctionDescriptor).proto
+            return !proto.hasCompanionExtensionReceiver()
+        }
+        is PropertyAccessorDescriptor -> {
+            val proto = (descriptor.correspondingProperty as DeserializedPropertyDescriptor).proto
+            return !proto.hasCompanionExtensionReceiver()
+        }
+        is ConstructorDescriptor -> return true
+        else -> {
+            error("Unexpected FunctionDescriptor: $descriptor")
+        }
+    }
 }
 
 private fun isExportedClass(descriptor: ClassDescriptor): Boolean {

--- a/native/native.tests/testData/CExport/InterfaceV1HeaderTests/smoke.h
+++ b/native/native.tests/testData/CExport/InterfaceV1HeaderTests/smoke.h
@@ -111,6 +111,15 @@ typedef struct {
 typedef struct {
   smoke_KNativePtr pinned;
 } smoke_kref_tests_native_CtxClass;
+typedef struct {
+  smoke_KNativePtr pinned;
+} smoke_kref_tests_native_WithCompanionObject;
+typedef struct {
+  smoke_KNativePtr pinned;
+} smoke_kref_tests_native_WithCompanionObject_Companion;
+typedef struct {
+  smoke_KNativePtr pinned;
+} smoke_kref_tests_native_WithCompanionBlock;
 
 
 typedef struct {
@@ -214,6 +223,25 @@ typedef struct {
             smoke_KType* (*_type)(void);
             smoke_kref_tests_native_CtxClass (*CtxClass)();
           } CtxClass;
+          struct {
+            struct {
+              smoke_KType* (*_type)(void);
+              smoke_kref_tests_native_WithCompanionObject_Companion (*_instance)();
+              smoke_KInt (*get_xVal)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              smoke_KInt (*get_xVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              void (*set_xVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz, smoke_KInt set);
+              smoke_KInt (*get_yVal)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              smoke_KInt (*get_yVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              void (*set_yVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz, smoke_KInt value);
+              void (*f)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+            } Companion;
+            smoke_KType* (*_type)(void);
+            smoke_kref_tests_native_WithCompanionObject (*WithCompanionObject)();
+          } WithCompanionObject;
+          struct {
+            smoke_KType* (*_type)(void);
+            smoke_kref_tests_native_WithCompanionBlock (*WithCompanionBlock)();
+          } WithCompanionBlock;
           smoke_KDouble (*get_constDouble)();
           smoke_KFloat (*get_constFloat)();
           smoke_KInt (*get_constInt)();

--- a/native/native.tests/testData/CExport/InterfaceV1HeaderTests/smoke.kt
+++ b/native/native.tests/testData/CExport/InterfaceV1HeaderTests/smoke.kt
@@ -79,3 +79,38 @@ class CtxClass {
         get() = if (c) 1 else 0
         set(v) {}
 }
+
+class WithCompanionObject {
+    companion object {
+        val xVal = 0
+        var xVar = 0
+        val yVal
+            get() = 0
+        var yVar
+            get() = 0
+            set(value) {}
+        fun f() {}
+    }
+}
+
+class WithCompanionBlock {
+    companion {
+        val xVal = 0
+        var xVar = 0
+        val yVal
+            get() = 0
+        var yVar
+            get() = 0
+            set(value) {}
+        fun f() {}
+    }
+}
+
+companion val SimpleClass.xVal = 0
+companion var SimpleClass.xVar = 0
+companion val SimpleClass.yVal
+    get() = 0
+companion var SimpleClass.yVar
+    get() = 0
+    set(value) {}
+companion fun SimpleClass.f() {}

--- a/native/native.tests/testData/CExport/InterfaceV1HeaderTests/smoke.mingw_x64.h
+++ b/native/native.tests/testData/CExport/InterfaceV1HeaderTests/smoke.mingw_x64.h
@@ -116,6 +116,15 @@ typedef struct {
 typedef struct {
   smoke_KNativePtr pinned;
 } smoke_kref_tests_native_CtxClass;
+typedef struct {
+  smoke_KNativePtr pinned;
+} smoke_kref_tests_native_WithCompanionObject;
+typedef struct {
+  smoke_KNativePtr pinned;
+} smoke_kref_tests_native_WithCompanionObject_Companion;
+typedef struct {
+  smoke_KNativePtr pinned;
+} smoke_kref_tests_native_WithCompanionBlock;
 
 
 typedef struct {
@@ -219,6 +228,25 @@ typedef struct {
             smoke_KType* (*_type)(void);
             smoke_kref_tests_native_CtxClass (*CtxClass)();
           } CtxClass;
+          struct {
+            struct {
+              smoke_KType* (*_type)(void);
+              smoke_kref_tests_native_WithCompanionObject_Companion (*_instance)();
+              smoke_KInt (*get_xVal)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              smoke_KInt (*get_xVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              void (*set_xVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz, smoke_KInt set);
+              smoke_KInt (*get_yVal)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              smoke_KInt (*get_yVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+              void (*set_yVar)(smoke_kref_tests_native_WithCompanionObject_Companion thiz, smoke_KInt value);
+              void (*f)(smoke_kref_tests_native_WithCompanionObject_Companion thiz);
+            } Companion;
+            smoke_KType* (*_type)(void);
+            smoke_kref_tests_native_WithCompanionObject (*WithCompanionObject)();
+          } WithCompanionObject;
+          struct {
+            smoke_KType* (*_type)(void);
+            smoke_kref_tests_native_WithCompanionBlock (*WithCompanionBlock)();
+          } WithCompanionBlock;
           smoke_KDouble (*get_constDouble)();
           smoke_KFloat (*get_constFloat)();
           smoke_KInt (*get_constInt)();

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCExportInterfaceV1HeaderTest.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCExportInterfaceV1HeaderTest.kt
@@ -41,6 +41,7 @@ abstract class AbstractNativeCExportInterfaceV1HeaderTest() : AbstractNativeSimp
                 "-opt-in", "kotlinx.cinterop.ExperimentalForeignApi",
                 "-opt-in", "kotlin.native.internal.InternalForKotlinNative",
                 "-opt-in", "kotlin.experimental.ExperimentalObjCRefinement",
+                "-XXLanguage:+CompanionBlocksAndExtensions",
                 "-Xbinary=cInterfaceMode=v1",
             )),
             nominalPackageName = PackageName(moduleName),


### PR DESCRIPTION
The new companion blocks and extensions can be represented as top-level declarations, but their names should be mangled. The mangling scheme should be designed separately, this commit just omits these new entities in the C Export header.

^KT-87538