### PR TITLE
[Wasm] Companion blocks static initializers fix

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/WebStaticInitializersDeclarationLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/WebStaticInitializersDeclarationLowering.kt
@@ -47,7 +47,6 @@ import org.jetbrains.kotlin.ir.util.isEffectivelyExternal
 import org.jetbrains.kotlin.ir.util.isInterface
 import org.jetbrains.kotlin.ir.util.isReal
 import org.jetbrains.kotlin.ir.util.setDeclarationsParent
-import org.jetbrains.kotlin.ir.util.superClass
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
@@ -144,9 +143,10 @@ class WebStaticInitializersDeclarationLowering(private val context: JsCommonBack
 
         val hasStaticFieldInitializer = container.declarations.any {
             when (it) {
-                is IrEnumEntry -> it.correspondingField?.isStatic == true && it.initializerExpression != null
-                is IrField -> it.isStatic && it.initializer != null
-                is IrProperty -> it.backingField?.isStatic == true && it.backingField?.initializer != null
+                is IrEnumEntry -> it.correspondingField?.isStatic == true
+                is IrField -> it.isStatic && it.origin != IrDeclarationOrigin.FIELD_FOR_OBJECT_INSTANCE &&
+                        it.correspondingPropertySymbol?.owner?.isLateinit == false
+                is IrProperty -> it.backingField?.isStatic == true && !it.isLateinit
                 else -> false
             }
         }
@@ -240,7 +240,7 @@ class WebStaticInitializersDeclarationLowering(private val context: JsCommonBack
             endOffset = UNDEFINED_OFFSET
             this.origin = origin
             name = Name.identifier(STATIC_INIT_FUNCTION_NAME)
-            visibility = DescriptorVisibilities.PRIVATE
+            visibility = DescriptorVisibilities.PUBLIC
             returnType = context.irBuiltIns.unitType
         }
         return initFunction.apply {

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInParentInAnotherModule.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersInParentInAnotherModule.kt
@@ -1,6 +1,5 @@
 // LANGUAGE: +CompanionBlocksAndExtensions
 // IGNORE_IR_DESERIALIZATION_TEST: JS_IR, NATIVE
-// WASM_IGNORE_FOR: mode=multi-module
 // ^^^ KT-86953 K2: Fake overrides are generated for inherited companion-block static members
 
 // MODULE: lib

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersSequenceInParentVersusChild.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/initializersSequenceInParentVersusChild.kt
@@ -1,0 +1,35 @@
+// LANGUAGE: +CompanionBlocksAndExtensions
+
+// MODULE: lib
+// FILE: lib.kt
+var initLog = ""
+
+open class Parent {
+    companion {
+        val parentValue = run {
+            initLog += "P"
+            "parent"
+        }
+    }
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+class Child : Parent() {
+    companion {
+        val childValue = run {
+            initLog += "C"
+            "child"
+        }
+    }
+}
+
+fun box(): String {
+    if (Child.childValue != "child") return "FAIL child"
+    if (initLog != "PC") return "FAIL order: $initLog"
+    if (Parent.parentValue != "parent") return "FAIL parent"
+
+    if (initLog != "PC") return "FAIL order: $initLog"
+
+    return "OK"
+}

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib1/l1.0.kt
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib1/l1.0.kt
@@ -1,0 +1,5 @@
+var staticInitParent = false
+
+open class Parent {
+    val someField: Int = 0
+}

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib1/l1.1.kt
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib1/l1.1.kt
@@ -1,0 +1,11 @@
+var staticInitParent = false
+
+open class Parent {
+    val someField: Int = 0
+    companion {
+        val parentValue: Unit = run {
+            staticInitParent = true
+            Unit
+        }
+    }
+}

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib1/module.info
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib1/module.info
@@ -1,0 +1,8 @@
+STEP 0:
+    modifications:
+        U : l1.0.kt -> l1.kt
+    added file: l1.kt
+STEP 1:
+    modifications:
+        U : l1.1.kt -> l1.kt
+    modified ir: l1.kt

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib2/l2.0.kt
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib2/l2.0.kt
@@ -1,0 +1,7 @@
+var staticInitChild = false
+
+class Child : Parent() {
+    companion {
+        val someGet: Int = 0
+    }
+}

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib2/module.info
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/lib2/module.info
@@ -1,0 +1,8 @@
+STEP 0:
+    dependencies: lib1
+    modifications:
+        U : l2.0.kt -> l2.kt
+    added file: l2.kt
+STEP 1:
+    dependencies: lib1
+    updated imports <wasm>: l2.kt

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/main/m.kt
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/main/m.kt
@@ -1,0 +1,13 @@
+fun box(stepId: Int, isWasm: Boolean): String {
+    if (!isWasm) return "OK"
+
+    if (Child.someGet != 0) return "Expected 0 found ${Child.someGet}"
+
+    when (stepId) {
+        0 -> if (staticInitParent) return "Expected uninitialized super class"
+        1 -> if (!staticInitParent) return "Expected initialized super class"
+        else -> return  "Unknown"
+    }
+
+    return "OK"
+}

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/main/module.info
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/main/module.info
@@ -1,0 +1,5 @@
+STEP 0:
+    dependencies: lib1, lib2
+    added file: m.kt
+STEP 1:
+    dependencies: lib1, lib2

--- a/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/project.info
+++ b/js/js.translator/testData/incremental/invalidation/addCompanionBlockToParent/project.info
@@ -1,0 +1,12 @@
+MODULES: lib1, lib2, main
+
+STEP 0:
+    language: +CompanionBlocksAndExtensions
+    libs: lib1, lib2, main
+    dirty js modules: lib1, lib2, main
+    dirty js files:   lib1/l1, lib2/l2, main/m, main/m.export, main
+STEP 1:
+    language: +CompanionBlocksAndExtensions
+    libs: lib1, lib2, main
+    dirty js modules: lib1
+    dirty js files:   lib1/l1

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib1/l1.0.kt
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib1/l1.0.kt
@@ -1,0 +1,10 @@
+var staticInitParent = false
+
+open class Parent {
+    companion {
+        val parentValue: Unit = run {
+            staticInitParent = true
+            Unit
+        }
+    }
+}

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib1/module.info
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib1/module.info
@@ -1,0 +1,5 @@
+STEP 0:
+    modifications:
+        U : l1.0.kt -> l1.kt
+    added file: l1.kt
+STEP 1:

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib2/l2.0.kt
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib2/l2.0.kt
@@ -1,0 +1,7 @@
+var staticInitChild = false
+
+class Child : Parent() {
+    companion {
+        val someGet: Int = 0
+    }
+}

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib2/l2.1.kt
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib2/l2.1.kt
@@ -1,0 +1,7 @@
+var staticInitChild = false
+
+class Child : Parent() {
+    companion {
+        val someGet: Int = 1
+    }
+}

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib2/module.info
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/lib2/module.info
@@ -1,0 +1,10 @@
+STEP 0:
+    dependencies: lib1
+    modifications:
+        U : l2.0.kt -> l2.kt
+    added file: l2.kt
+STEP 1:
+    dependencies: lib1
+    modifications:
+        U : l2.1.kt -> l2.kt
+    modified ir: l2.kt

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/main/m.kt
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/main/m.kt
@@ -1,0 +1,5 @@
+fun box(stepId: Int, isWasm: Boolean): String {
+    if (Child.someGet != stepId) return "Expected $stepId found ${Child.someGet}"
+    if (!staticInitParent) return "Expected initialized super class"
+    return "OK"
+}

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/main/module.info
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/main/module.info
@@ -1,0 +1,5 @@
+STEP 0:
+    dependencies: lib1, lib2
+    added file: m.kt
+STEP 1:
+    dependencies: lib1, lib2

--- a/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/project.info
+++ b/js/js.translator/testData/incremental/invalidation/changeCompanionBlockChild/project.info
@@ -1,0 +1,12 @@
+MODULES: lib1, lib2, main
+
+STEP 0:
+    language: +CompanionBlocksAndExtensions
+    libs: lib1, lib2, main
+    dirty js modules: lib1, lib2, main
+    dirty js files:   lib1/l1, lib2/l2, main/m, main/m.export, main
+STEP 1:
+    language: +CompanionBlocksAndExtensions
+    libs: lib1, lib2, main
+    dirty js modules: lib2
+    dirty js files:   lib2/l2


### PR DESCRIPTION
When multimodule or incremental wasm compilation is applied then the declarations are being loaded without bodies, so WebStaticInitializersDeclarationLowering should not rely on bodies, when static initializer should created.

Fixed KT-87109 KT-87329