### PR TITLE
[Gradle] Append Playwright runner name to test name in IDE

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -229,8 +229,8 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
                             <results>
                               <testsuite name="jsBrowserTest.chromium.FailingTest" tests="2" skipped="0" failures="1" errors="0" timestamp="..." hostname="..." time="...">
                                 <properties />
-                                <testcase name="passing[js, browser]" classname="jsBrowserTest.chromium.FailingTest" time="..." />
-                                <testcase name="failing[js, browser]" classname="jsBrowserTest.chromium.FailingTest" time="...">
+                                <testcase name="passing[js, browser, chromium]" classname="jsBrowserTest.chromium.FailingTest" time="..." />
+                                <testcase name="failing[js, browser, chromium]" classname="jsBrowserTest.chromium.FailingTest" time="...">
                                   <failure message="..." type="AssertionError">...</failure>
                                 </testcase>
                                 <system-out>PASSED marker</system-out>
@@ -317,13 +317,13 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
                             <results>
                               <testsuite name="jsBrowserTest.first.DummyTest" tests="1" skipped="0" failures="0" errors="0" timestamp="..." hostname="..." time="...">
                                 <properties />
-                                <testcase name="dummy[js, browser]" classname="jsBrowserTest.first.DummyTest" time="..." />
+                                <testcase name="dummy[js, browser, first]" classname="jsBrowserTest.first.DummyTest" time="..." />
                                 <system-out>dummy test</system-out>
                                 <system-err />
                               </testsuite>
                               <testsuite name="jsBrowserTest.second.DummyTest" tests="1" skipped="0" failures="0" errors="0" timestamp="..." hostname="..." time="...">
                                 <properties />
-                                <testcase name="dummy[js, browser]" classname="jsBrowserTest.second.DummyTest" time="..." />
+                                <testcase name="dummy[js, browser, second]" classname="jsBrowserTest.second.DummyTest" time="..." />
                                 <system-out>dummy test</system-out>
                                 <system-err />
                               </testsuite>

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -152,7 +152,7 @@ internal class KotlinPlaywrightJsTestFramework(
         val modules = NpmProjectModules(npmToolingEnv)
 
         return PwExecutionSpec(
-            createClient = { processor, logger -> TCServiceMessagesClient(processor, clientSettings, logger) },
+            createClient = { processor, logger -> PlaywrightTCServiceMessagesClient(processor, clientSettings, logger) },
             runners = pwRunners,
             nodeExecutable = executable.get(),
             playwrightCli = modules.require("playwright-core/cli.js"),

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTCServiceMessagesClient.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTCServiceMessagesClient.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.targets.js.testing.playwright
+
+import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClient
+import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClientSettings
+import org.slf4j.Logger
+
+/**
+ * Lightweight implementation of [TCServiceMessagesClient] that allows appending [currentRunnerName] to [testNameSuffix].
+ */
+internal class PlaywrightTCServiceMessagesClient(
+    results: TestResultProcessor,
+    settings: TCServiceMessagesClientSettings,
+    log: Logger,
+) : TCServiceMessagesClient(results, settings, log) {
+    var currentRunnerName: String? = null
+
+    override val testNameSuffix: String?
+        get() = super.testNameSuffix.let { superTestNameSuffix ->
+            when {
+                currentRunnerName == null -> superTestNameSuffix
+                superTestNameSuffix == null -> currentRunnerName
+                else -> "$superTestNameSuffix, $currentRunnerName"
+            }
+        }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -31,7 +31,6 @@ import org.gradle.api.internal.tasks.testing.TestExecuter
 import org.gradle.api.internal.tasks.testing.TestExecutionSpec
 import org.gradle.api.internal.tasks.testing.TestResultProcessor
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessageOutputStreamHandler
-import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClient
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTestsLocation
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -76,7 +75,7 @@ internal class PwRunnerSpec(
  * within a single test task invocation.
  */
 internal class PwExecutionSpec(
-    val createClient: (TestResultProcessor, Logger) -> TCServiceMessagesClient,
+    val createClient: (TestResultProcessor, Logger) -> PlaywrightTCServiceMessagesClient,
     val runners: List<PwRunnerSpec>,
     val nodeExecutable: String,
     val playwrightCli: String,
@@ -108,10 +107,16 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
 
             playwright.use {
                 with(client) {
+                    // TODO: Ideally, we'd like to create a separate root for each runner, but this doesn't currently play well with
+                    // Gradle's test reporting API, which only supports one test report per root and overwrites previously created reports.
+                    // This will get easier once we split each runner into its own Gradle task (see KT-86706).
                     root {
                         for (runner in spec.runners) {
                             suite(id = runner.name) {
                                 try {
+                                    // TODO: It would be better to eventually make currentRunnerName the ID of the Root node when we have
+                                    // one root per runner - see comment above.
+                                    client.currentRunnerName = runner.name
                                     executeRunner(playwright, runner, handler)
                                 } catch (t: Throwable) {
                                     val tsEnd = System.currentTimeMillis()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -107,14 +107,14 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
 
             playwright.use {
                 with(client) {
-                    // TODO: Ideally, we'd like to create a separate root for each runner, but this doesn't currently play well with
+                    // TODO(KT-86706): Ideally, we'd like to create a separate root for each runner, but this doesn't currently play well with
                     // Gradle's test reporting API, which only supports one test report per root and overwrites previously created reports.
-                    // This will get easier once we split each runner into its own Gradle task (see KT-86706).
+                    // This will get easier once we split each runner into its own Gradle task.
                     root {
                         for (runner in spec.runners) {
                             suite(id = runner.name) {
                                 try {
-                                    // TODO: It would be better to eventually make currentRunnerName the ID of the Root node when we have
+                                    // TODO(KT-86706): It would be better to eventually make currentRunnerName the ID of the Root node when we have
                                     // one root per runner - see comment above.
                                     client.currentRunnerName = runner.name
                                     executeRunner(playwright, runner, handler)

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTCServiceMessagesClientTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTCServiceMessagesClientTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.targets.js.testing.playwright
+
+import jetbrains.buildServer.messages.serviceMessages.TestFinished
+import jetbrains.buildServer.messages.serviceMessages.TestStarted
+import jetbrains.buildServer.messages.serviceMessages.TestSuiteFinished
+import jetbrains.buildServer.messages.serviceMessages.TestSuiteStarted
+import org.jetbrains.kotlin.gradle.internal.testing.RecordingTestResultProcessor
+import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClientSettings
+import org.slf4j.LoggerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaywrightTCServiceMessagesClientTest {
+    @Test
+    fun `no test name suffix or current runner name provided`() {
+        assertClientProducesOutput(
+            expectedOutput = """
+            STARTED SUITE root // root
+              STARTED SUITE  // root/
+                STARTED TEST displayName: Test, classDisplayName: , className: , name: Test // root//Test
+                COMPLETED SUCCESS // root//Test
+              COMPLETED SUCCESS // root/
+            COMPLETED SUCCESS // root
+            """
+        )
+    }
+
+    @Test
+    fun `no current runner name provided`() {
+        assertClientProducesOutput(
+            testNameSuffix = "defaultSuffix",
+            expectedOutput = """
+            STARTED SUITE root // root
+              STARTED SUITE  // root/
+                STARTED TEST displayName: Test[defaultSuffix], classDisplayName: , className: , name: Test // root//Test
+                COMPLETED SUCCESS // root//Test
+              COMPLETED SUCCESS // root/
+            COMPLETED SUCCESS // root
+            """
+        )
+    }
+
+    @Test
+    fun `no default test name suffix provided`() {
+        assertClientProducesOutput(
+            currentRunnerName = "browser",
+            expectedOutput = """
+            STARTED SUITE root // root
+              STARTED SUITE  // root/
+                STARTED TEST displayName: Test[browser], classDisplayName: , className: , name: Test // root//Test
+                COMPLETED SUCCESS // root//Test
+              COMPLETED SUCCESS // root/
+            COMPLETED SUCCESS // root
+            """
+        )
+    }
+
+    @Test
+    fun `default test name suffix and current runner name provided`() {
+        assertClientProducesOutput(
+            testNameSuffix = "defaultSuffix",
+            currentRunnerName = "browser",
+            expectedOutput = """
+            STARTED SUITE root // root
+              STARTED SUITE  // root/
+                STARTED TEST displayName: Test[defaultSuffix, browser], classDisplayName: , className: , name: Test // root//Test
+                COMPLETED SUCCESS // root//Test
+              COMPLETED SUCCESS // root/
+            COMPLETED SUCCESS // root
+            """
+        )
+    }
+
+    private fun assertClientProducesOutput(
+        testNameSuffix: String? = null,
+        currentRunnerName: String? = null,
+        expectedOutput: String
+    ) {
+        val results = RecordingTestResultProcessor()
+        val client = PlaywrightTCServiceMessagesClient(
+            results = results,
+            settings = TCServiceMessagesClientSettings(
+                rootNodeName = "root",
+                testNameSuffix = testNameSuffix,
+            ),
+            log = LoggerFactory.getLogger("test"),
+        )
+
+        client.root {
+            client.currentRunnerName = currentRunnerName
+            client.serviceMessage(TestSuiteStarted(""))
+            client.serviceMessage(TestStarted("Test", false, null))
+            client.serviceMessage(TestFinished("Test", 0))
+            client.serviceMessage(TestSuiteFinished(""))
+        }
+
+        assertEquals(
+            expectedOutput.trimIndent(),
+            results.output.toString().trim()
+        )
+    }
+}


### PR DESCRIPTION
This change fixes PlaywrightTestExecutor to match the behaviour of the Karma executor, where the information about the browser and OS a test is running on is appended to the test name for reporting. In case of Playwright, the runner name, as specified in the DSL, is appended instead. So for an unnamed Chromium runner, Karma would report the test name as follows:

test[js, browser, Chrome150.0.0.0, MacOS10.15.7]

whereas Playwright reports the following:

test[js, browser, chromium]

^KT-86799 Verification Pending

---

Here's the screenshot of what this looks like in the IDE:

<img width="453" height="605" alt="Screenshot 2026-07-08 at 15 27 01" src="https://github.com/user-attachments/assets/d80415b2-8822-42a2-a98f-d87e19de32b0" />