### PR TITLE
[Test] Do not use '$' symbol in temporary directory path

### DIFF
--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/impl/TemporaryDirectoryManagerImpl.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/impl/TemporaryDirectoryManagerImpl.kt
@@ -21,7 +21,7 @@ class TemporaryDirectoryManagerImpl(testServices: TestServices) : TemporaryDirec
         val className = testInfo.className
         val methodName = testInfo.methodName
         if (!onWindows && className.length + methodName.length < 255) {
-            return@lazy KtTestUtil.tmpDirForTest(className, methodName)
+            return@lazy KtTestUtil.tmpDirForTest(className.stripDollarSymbols(), methodName)
         }
 
         // This code will simplify directory name for windows. This is needed because there can occur errors due to long name
@@ -50,7 +50,11 @@ class TemporaryDirectoryManagerImpl(testServices: TestServices) : TemporaryDirec
         private val onWindows: Boolean = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("windows")
 
         private fun String.getOnlyUpperCaseSymbols(): String {
-            return this.filter { it.isUpperCase() || it == '$' }.toList().joinToString(separator = "")
+            return this.stripDollarSymbols().filter { it.isUpperCase() }
+        }
+
+        private fun String.stripDollarSymbols(): String {
+            return this.replace('$', '_')
         }
     }
 }


### PR DESCRIPTION
This complicates debugging on the local machine if you need to copy the path and insert it into Linux/macOS terminal, which immediately starts interpreting '$' symbols in the path as if they were prefixes of environment variables.