### PR TITLE
[KLIB] Fix detection of compiler DEV version when it ends with '-dev'

### DIFF
--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
@@ -27,7 +27,7 @@ abstract class LibrarySpecialCompatibilityChecker {
         override fun hashCode() = comparableVersion.hashCode()
 
         // TODO (KT-83853): Find a reliable way to detect dev compiler versions.
-        val isDevVersion: Boolean = "-dev-" in rawVersion || rawVersion.endsWith("-SNAPSHOT")
+        val isDevVersion: Boolean = "-dev-" in rawVersion || rawVersion.endsWith("-dev") || rawVersion.endsWith("-SNAPSHOT")
 
         override fun toString() = rawVersion
         fun toComparableVersionString() = comparableVersion.toString()

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
@@ -17,7 +17,7 @@ import kotlin.io.path.readBytes
 
 /** See KT-68322 for details. */
 abstract class LibrarySpecialCompatibilityChecker {
-    protected class Version(
+    class Version(
         private val comparableVersion: MavenComparableVersion,
         private val languageVersion: LanguageVersion,
         private val rawVersion: String

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/diagnostics/LibrarySpecialCompatibilityChecker.kt
@@ -69,7 +69,7 @@ abstract class LibrarySpecialCompatibilityChecker {
         // It might happen that the compiler has already got a new major version (N.M+1.0), but there is still the old bootstrap compiler
         // version (N.M,*) used to compile stdlib & kotlin-test libraries. As a result, these libraries still have `abi_version=N.M.0`
         // in their manifest files. And the compatibility check, if it were applied, would fail.
-        val useRelaxedCompatibilityCheckForDevCompilerVersion = true // TODO(KT-87548) revert to after bootstrap isLatestKlibAbiCompatibilityLevel && compilerVersion.isDevVersion
+        val useRelaxedCompatibilityCheckForDevCompilerVersion = isLatestKlibAbiCompatibilityLevel && compilerVersion.isDevVersion
 
         for (library in libraries) {
             val checkedLibrary = library.toCheckedLibrary() ?: continue

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/compatibility/LibrarySpecialCompatibilityChecksTest.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/compatibility/LibrarySpecialCompatibilityChecksTest.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.backend.common.diagnostics.LibrarySpecialCompatibili
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.messages.MessageCollectorImpl
 import org.jetbrains.kotlin.config.KlibAbiCompatibilityLevel
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.io.readProperties
 import org.jetbrains.kotlin.io.unzipTo
@@ -18,7 +19,10 @@ import org.jetbrains.kotlin.io.writeProperties
 import org.jetbrains.kotlin.io.zipDirAs
 import org.jetbrains.kotlin.library.KLIB_PROPERTY_ABI_VERSION
 import org.jetbrains.kotlin.library.KotlinAbiVersion
+import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.parallel.Isolated
 import java.nio.file.Files.createTempDirectory
@@ -122,9 +126,32 @@ abstract class LibrarySpecialCompatibilityChecksTest : DummyLibraryCompiler {
 
     @Test
     fun testEitherVersionIsMissing() {
-        listOf(
+        // TODO (KT-83853): Use KotlinToolingVersion here!
+        fun getKotlinVersion(rawKotlinVersion: String): KotlinVersion {
+            val versionNumbers = rawKotlinVersion.substringBefore('-').split('.').map { it.toInt() }
+
+            return when (versionNumbers.size) {
+                2 -> KotlinVersion(versionNumbers[0], versionNumbers[1])
+                3 -> KotlinVersion(versionNumbers[0], versionNumbers[1], versionNumbers[2])
+                else -> fail { "Malformed Kotlin version: $$rawKotlinVersion" }
+            }
+        }
+
+        val compilerVersionUsedToBuildOriginalLibrary: KotlinVersion = KlibLoader { libraryPaths(originalLibraryPath) }.load().run {
+            assertFalse(hasProblems)
+            assertEquals(1, librariesStdlibFirst.size)
+
+            val compilerVersionInManifest = librariesStdlibFirst.single().versions.compilerVersion
+                ?: fail { "No compiler version in manifest of the library: $originalLibraryPath" }
+
+            getKotlinVersion(compilerVersionInManifest)
+        }
+
+        val currentCompilerVersion: KotlinVersion? = KotlinCompilerVersion.getVersion()?.let(::getKotlinVersion)
+
+        listOfNotNull(
             TestVersion(2, 0, 0) to null,
-            null to TestVersion(2, 0, 0),
+            (null to TestVersion(2, 0, 0)).takeIf { compilerVersionUsedToBuildOriginalLibrary == currentCompilerVersion },
         ).forEach { [libraryVersion, compilerVersion] ->
             compileDummyLibrary(
                 libraryVersion = libraryVersion,

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/compatibility/StdlibSpecialCompatibilityChecksTest.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/compatibility/StdlibSpecialCompatibilityChecksTest.kt
@@ -47,7 +47,7 @@ interface StdlibSpecialCompatibilityChecksTest : DummyLibraryCompiler {
         listOf(
             "2.5.0" to false,
             "2.5.0-Beta1" to false,
-            "2.5.0-dev" to false, // TODO(KT-83853): this should be a DEV version
+            "2.5.0-dev" to true,
             "2.5.0-dev1" to false,
             "2.5.0-dev-123" to true,
             "2.5.0-SNAPSHOT" to true,

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/compatibility/StdlibSpecialCompatibilityChecksTest.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/klib/compatibility/StdlibSpecialCompatibilityChecksTest.kt
@@ -5,8 +5,11 @@
 
 package org.jetbrains.kotlin.test.klib.compatibility
 
+import org.jetbrains.kotlin.backend.common.diagnostics.LibrarySpecialCompatibilityChecker
 import org.jetbrains.kotlin.test.klib.compatibility.LibrarySpecialCompatibilityChecksTest.Companion.SORTED_TEST_COMPILER_VERSION_GROUPS
 import org.jetbrains.kotlin.test.klib.compatibility.LibrarySpecialCompatibilityChecksTest.Companion.SORTED_TEST_OLD_LIBRARY_VERSION_GROUPS
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
 interface StdlibSpecialCompatibilityChecksTest : DummyLibraryCompiler {
@@ -34,6 +37,26 @@ interface StdlibSpecialCompatibilityChecksTest : DummyLibraryCompiler {
                     expectedWarningStatus = WarningStatus.TOO_NEW_LIBRARY_WARNING,
                     exportKlibToOlderAbiVersion = true,
                 )
+            }
+        }
+    }
+
+    // TODO (KT-83853): Find a reliable way to detect dev compiler versions.
+    @Test
+    fun `check compiler DEV version is properly detected`() {
+        listOf(
+            "2.5.0" to false,
+            "2.5.0-Beta1" to false,
+            "2.5.0-dev" to false, // TODO(KT-83853): this should be a DEV version
+            "2.5.0-dev1" to false,
+            "2.5.0-dev-123" to true,
+            "2.5.0-SNAPSHOT" to true,
+        ).forEach { [rawVersion, shouldBeDevVersion] ->
+            val parsedVersion = LibrarySpecialCompatibilityChecker.Version.parseVersion(rawVersion)
+                ?: fail("Compiler version cannot be parsed: $rawVersion")
+
+            assertEquals(shouldBeDevVersion, parsedVersion.isDevVersion) {
+                "Compiler version $rawVersion is not detected as a DEV version"
             }
         }
     }


### PR DESCRIPTION
^KT-83853

Pending advancing LV to 2.5.