### PR TITLE
Temporary skip JsBrowserGradlePluginTests on Windows

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.gradle.util.isTeamCityRun
 import kotlin.io.path.moveTo
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.DisplayName
-import kotlin.test.Ignore
+import org.junit.jupiter.api.condition.OS
 import kotlin.test.assertContains
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -224,6 +224,9 @@ class JsBrowserTestsIT : KGPBaseTest() {
 
     @DisplayName("KT-86958: Unclear error for js test failure on timeout")
     @GradleTest
+    @OsCondition(
+        supportedOn = [OS.LINUX, OS.MAC, OS.WINDOWS],
+        enabledOnCI = [OS.LINUX, OS.MAC])
     fun `prints clear error message when a test times out`(gradleVersion: GradleVersion) {
         project("empty", gradleVersion = gradleVersion) {
             plugins {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -28,12 +28,16 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.testbase.BuildOptions.ConfigurationCacheValue
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
+import org.junit.jupiter.api.condition.OS
 import java.net.URI
 import javax.inject.Inject
 import kotlin.io.path.writeText
 import kotlin.test.Ignore
 
 @OptIn(ExperimentalJsTestDsl::class)
+@OsCondition(
+    supportedOn = [OS.LINUX, OS.MAC, OS.WINDOWS],
+    enabledOnCI = [OS.LINUX, OS.MAC])
 @JsBrowserGradlePluginTests
 class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
     override val defaultBuildOptions: BuildOptions


### PR DESCRIPTION
Ignore JsBrowserGradlePluginTests tests on windows 