### PR TITLE
fix: cold build

### DIFF
--- a/repo/kotlin-build-helpers/settings.gradle.kts
+++ b/repo/kotlin-build-helpers/settings.gradle.kts
@@ -4,4 +4,8 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "kotlin-build-helpers"


### PR DESCRIPTION
I couldn't build the compiler after cloning the repo on a fresh Windows machine. Gradle was complaining that it couldn't find a matching JDK (version 17, while I have JDK 26 installed on the system) and couldn't download it on its own due to lacking config. This patch fixed the issue by adding the toolchain autoresolver plugin to `kotlin-build-helpers` project. Other subprojects have it too, so I figured this is the way to go.