### PR TITLE
[Gradle] Attach Error to test nodes during process crash cleanup

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/testing/TCServiceMessagesClient.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/testing/TCServiceMessagesClient.kt
@@ -516,6 +516,21 @@ internal open class TCServiceMessagesClient(
     private fun pop() = leaf!!.also { leaf = it.parent }
 
     fun ensureNodesClosed(root: RootNode? = null, cause: Throwable? = null, throwError: Boolean = true): Error? {
+        fun createTestProcessCrashedError(currentTest: TestNode?, output: String): Error {
+            return Error(
+                buildString {
+                    append("Test running process exited unexpectedly.\n")
+                    if (currentTest != null) {
+                        append("Current test: ${currentTest.cleanName}\n")
+                    }
+                    if (output.isNotBlank()) {
+                        append("Process output:\n $output")
+                    }
+                },
+                cause
+            )
+        }
+
         val ts = System.currentTimeMillis()
 
         when (leaf) {
@@ -523,38 +538,28 @@ internal open class TCServiceMessagesClient(
             root -> close(ts, leaf!!.localId)
             else -> {
                 val output = StringBuilder()
-                var currentTest: TestNode? = null
+                var currentError: Error? = null
 
                 while (leaf != null) {
                     val currentLeaf = leaf!!
 
                     if (currentLeaf is TestNode) {
-                        currentTest = currentLeaf
                         output.append(currentLeaf.allOutput)
-                        currentLeaf.failure(TestFailed(currentLeaf.cleanName, null as Throwable?), false)
+                        currentError = createTestProcessCrashedError(currentLeaf, output.toString())
+                        currentLeaf.failure(TestFailed(currentLeaf.cleanName, currentError), false)
                     }
 
                     close(ts, currentLeaf.localId)
                 }
 
-                @Suppress("ThrowableNotThrown")
-                val error = Error(
-                    buildString {
-                        append("Test running process exited unexpectedly.\n")
-                        if (currentTest != null) {
-                            append("Current test: ${currentTest.cleanName}\n")
-                        }
-                        if (output.toString().isNotBlank()) {
-                            append("Process output:\n $output")
-                        }
-                    },
-                    cause
-                )
+                if (currentError == null) {
+                    currentError = createTestProcessCrashedError(currentTest = null, output.toString())
+                }
 
                 if (throwError) {
-                    throw error
+                    throw currentError
                 } else {
-                    return error
+                    return currentError
                 }
             }
         }


### PR DESCRIPTION
If node cleanup, done by TCServiceMessagesClient.ensureNodesClosed, is triggered by test process crash, attach the synthetic Error produced by that method to all TestNodes on the stack, so it properly displays in the IDE output.

KTIJ-39225, which this change resolves, is triggered as follows:

1. TCServiceMessagesTestExecutor launches the test process and listens to the process' output stream.
2. Test process crash closes the stream without publishing the expected "testFinished" message.
3. Stream closure leads to TCServiceMessageOutputStreamHandler getting closed as well.
4. Now that the test run is considered completed, TCServiceMessagesClient performs cleanup, and executes ensureNodesClosed.
5. ensureNodesClosed closes all nodes in the client's stack. TestNodes are marked as failure, with no attached Throwable.
6. ensureNodesClosed then creates a synthetic Error and throws it.
7. The Error is caught by TCServiceMessagesTestExecutor, which triggers another call to ensureNodesClosed in the client, which would now attach the Error to any test nodes on the stack. However, at that point there's nothing to clean up.

This change attaches the synthetic Error to all TestNodes during cleanup, to ensure there are no failure TestNodes without an attached Throwable. Throwable is what's used by the IDE to display useful feedback, so it's important that it's present.

^KTIJ-39225 Verification Pending

---

Before

<img width="2180" height="468" alt="Screenshot 2026-07-09 at 13 20 04" src="https://github.com/user-attachments/assets/115adb0c-3779-4beb-b8a7-e67d817a8f8a" />

After

<img width="2177" height="351" alt="Screenshot 2026-07-09 at 13 10 45" src="https://github.com/user-attachments/assets/f5b49be0-7bc9-47d0-aaad-b2468ff9a86f" />