### PR TITLE
[K/N] Fixed a bug with perf metrics when compilation is incremental

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -224,8 +224,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
             }
         }
 
-        val fragments = backendEngine.splitIntoFragments(irModule, performanceManager)
-        val fragmentsList = fragments.toList()
+        val fragmentsList = backendEngine.splitIntoFragments(irModule, performanceManager).toList()
         val generationStates = performanceManager.tryMeasurePhaseTime(PhaseType.IrLowering) {
             fragmentsList.runAllLowerings()
         }
@@ -265,7 +264,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
         }
 
         if (performanceManager != null) {
-            fragments.forEach {
+            fragmentsList.forEach {
                 performanceManager.addOtherUnitStats(it.performanceManager?.unitStats)
             }
         }


### PR DESCRIPTION
With incremental compilation on, the compilation performance metrics were off. That's because the backend is run in parallel, and there was a bug in results accumulation of subcompilations.