### PR TITLE
[KMP] Hash source file path for unique JVM metadata fragment filenames

### DIFF
--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmMetadataComponentWriter.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmMetadataComponentWriter.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.cli.pipeline.jvm.metadata
 
+import org.jetbrains.kotlin.backend.common.serialization.cityHash64String
 import org.jetbrains.kotlin.incremental.components.ICFileMappingTracker
 import org.jetbrains.kotlin.library.SerializedFirMetadata
 import org.jetbrains.kotlin.library.components.KlibMetadataComponentLayout
@@ -29,17 +30,34 @@ internal class JvmMetadataComponentWriter(
             layout.getPackageFragmentsDir(packageFqName).createDirectories()
 
             metadata.fragments[index].forEach { packageFragmentPart ->
-                val sourceFile = packageFragmentPart.path?.let { Path(it) }
-                val sourceFileName = packageFragmentPart.name
+                val sourceFileName = getMetadataFileName(packageFragmentPart.name, packageFragmentPart.path)
 
                 val packageFragmentFile = layout.getPackageFragmentFile(packageFqName = packageFqName, partName = sourceFileName)
                 // Such duplications are not allowed in JVM compilation
                 check(packageFragmentFile.exists().not()) { "Duplicate package fragment name '${packageFragmentFile.pathString}'" }
                 packageFragmentFile.writeBytes(packageFragmentPart.content)
 
-                fragmentTracker?.recordSourceFile(sourceFile, packageFragmentFile)
+                fragmentTracker?.recordSourceFile(packageFragmentPart.path?.let { Path(it) }, packageFragmentFile)
             }
         }
+    }
+
+    // TODO(KT-87183): Switch to filename-based naming for KLIB package fragment files.
+    // Until then the source file path is kept absolute and hashed into a per-file suffix that
+    // disambiguate same-named files within a package. This is a temporary solution that is safe
+    // for JVM incremental compilation: IC records the source-to-output mapping and, on a change,
+    // deletes exactly the previously recorded output(s) and re-records the freshly produced one
+    // (InputsCache.removeOutputForSourceFiles) — it never recomputes this fragment name from the
+    // source path. IC stores that mapping with relative (relocatable) paths when project/build
+    // dirs are supplied and absolute paths otherwise, but it round-trips per machine either way,
+    // so the absolute path here is just an opaque, per-machine-deterministic token.
+    private fun getMetadataFileName(firFileName: String, sourceFilePath: String?): String {
+        val fileNameWithoutExtension = Path(firFileName).nameWithoutExtension
+        if (sourceFilePath == null) {
+            return fileNameWithoutExtension
+        }
+
+        return fileNameWithoutExtension.plus("_${sourceFilePath.cityHash64String()}")
     }
 
     private fun ICFileMappingTracker.recordSourceFile(sourceFile: Path?, packageFragmentFile: Path) {

--- a/compiler/cli/cli-jvm/test/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmMetadataComponentWriterTest.kt
+++ b/compiler/cli/cli-jvm/test/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmMetadataComponentWriterTest.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.cli.pipeline.jvm.metadata
 
+import org.jetbrains.kotlin.backend.common.serialization.cityHash64String
 import org.jetbrains.kotlin.incremental.components.ICFileMappingTracker
 import org.jetbrains.kotlin.library.SerializedFirFile
 import org.jetbrains.kotlin.library.SerializedFirMetadata
@@ -61,7 +62,10 @@ internal class JvmMetadataComponentWriterTest {
 
         val layout = KlibMetadataComponentLayout(root)
         val expectedMappings = listOf(
-            File("/src/a.kt") to layout.getPackageFragmentFile(packageFqName = "", partName = "a").toFile(),
+            File("/src/a.kt") to layout.getPackageFragmentFile(
+                packageFqName = "",
+                partName = "a_${"/src/a.kt".cityHash64String()}",
+            ).toFile(),
             null to layout.getPackageFragmentFile(packageFqName = "", partName = "0_").toFile(),
             null to layout.getPackageFragmentFile(packageFqName = "foo.bar", partName = "0_bar").toFile(),
         )
@@ -69,7 +73,33 @@ internal class JvmMetadataComponentWriterTest {
     }
 
     @Test
-    @DisplayName("Writing two fragments with the same name in one package fails with a duplicate-fragment error")
+    @DisplayName("Two fragments with the same name but different source paths get distinct file names")
+    fun disambiguateSameNamedFragmentsByPath(@TempDir klibDir: File) {
+        val tracker = RecordingFileMappingTracker()
+        val content = ByteArray(10)
+        val root = klibDir.toPath()
+
+        JvmMetadataComponentWriter(
+            SerializedFirMetadata(
+                module = content,
+                fragments = listOf(
+                    listOf(
+                        SerializedFirFile(name = "a", content = content, path = "/src/x/a.kt"),
+                        SerializedFirFile(name = "a", content = content, path = "/src/y/a.kt"),
+                    ),
+                ),
+                fragmentNames = listOf("foo.bar"),
+                metadataVersion = MetadataVersion.INSTANCE.toArray(),
+            ),
+            tracker,
+        ).writeTo(root)
+
+        val outputFiles = tracker.recordedMappings.map { it.second }
+        assertEquals(2, outputFiles.toSet().size, "Same-named sources with different paths must produce distinct fragment files")
+    }
+
+    @Test
+    @DisplayName("Writing two fragments with the same name and no source path in one package fails with a duplicate-fragment error")
     fun failsOnDuplicateFragmentNamesWithinPackage(@TempDir klibDir: File) {
         val content = ByteArray(10)
         val root = klibDir.toPath()
@@ -80,8 +110,8 @@ internal class JvmMetadataComponentWriterTest {
                     module = content,
                     fragments = listOf(
                         listOf(
-                            SerializedFirFile(name = "a", content = content, path = "/src/x/a.kt"),
-                            SerializedFirFile(name = "a", content = content, path = "/src/y/a.kt"),
+                            SerializedFirFile(name = "a", content = content, path = null),
+                            SerializedFirFile(name = "a", content = content, path = null),
                         ),
                     ),
                     fragmentNames = listOf("foo.bar"),


### PR DESCRIPTION
Introduce a temporary mechanism to disambiguate same-named source files within a package by hashing the absolute source file path. This ensures compatibility with incremental compilation while avoiding duplicate fragment names.

^KT-87110 Verification Pending