### PR TITLE
CastsOptimization: fixed a bug in control flow merging

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/CastsOptimization.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/CastsOptimization.kt
@@ -466,6 +466,8 @@ internal class CastsOptimization(val context: Context) : BodyLoweringPass {
             // Is it something like (a is A) | (b is A)? It's not clear and complicates the analysis a lot, so here we just
             // handle a simple but practical case when the phi node only has a single value.
             var phiNodeAlias: IrValueDeclaration? = null,
+            // True if a value not coming from a variable (e.g. a constant) has flowed into the phi node.
+            var phiNodeHasNonVariableValue: Boolean = false,
             var predicate: Predicate = Predicate.Empty,
             val variableAliases: MutableMap<IrVariable, IrValueDeclaration> = mutableMapOf(),
     )
@@ -507,6 +509,7 @@ internal class CastsOptimization(val context: Context) : BodyLoweringPass {
         val doWhileLoopForWhileLoops = mutableMapOf<IrWhileLoop, IrDoWhileLoop>()
 
         val multipleValuesMarker = createVariable("\$TheMarker", unitType)
+        val safeCallResultWhens = mutableSetOf<IrWhen>()
         val variableAliases = mutableMapOf<IrVariable, IrValueDeclaration>()
         val getValueMergedVariableAliases = mutableMapOf<IrVariable, IrValueDeclaration>()
         val returnableBlockCFMPInfos = mutableMapOf<IrReturnableBlock, ControlFlowMergePointInfo>()
@@ -551,7 +554,9 @@ internal class CastsOptimization(val context: Context) : BodyLoweringPass {
                     variableAliases[variable] = multipleValuesMarker
             }
             val resultVariable = result.variable
-            if (resultVariable != null) {
+            if (resultVariable == null) {
+                phiNodeHasNonVariableValue = true
+            } else {
                 if (phiNodeAlias == null)
                     phiNodeAlias = resultVariable
                 else if (phiNodeAlias != resultVariable)
@@ -597,7 +602,19 @@ internal class CastsOptimization(val context: Context) : BodyLoweringPass {
             }
             return VisitorResult(
                     Predicates.optimizeAwayComplexTerms(cfmpInfo.predicate, localComplexTermsMask),
-                    cfmpInfo.phiNodeAlias.takeIf { it != multipleValuesMarker }
+                    cfmpInfo.phiNodeAlias
+                            .takeIf { it != multipleValuesMarker }
+                            ?.takeIf {
+                                // Generally, a non-variable value flowing into a phi node forbids aliasing of the phi node to other
+                                // variable (KT-87261 fired before this fix).
+                                !cfmpInfo.phiNodeHasNonVariableValue
+                                        // The exception is a safe call `recv?.prop` (see visitBlock): its null value only
+                                        // flows when the receiver is null, while the phi alias (a property phantom variable
+                                        // of the receiver, which the registration in visitBlock guarantees) is only ever
+                                        // constrained on paths dereferencing the receiver, and the safe call's own nullability
+                                        // comes from matchSafeCall rather than this alias - so keeping it is consistent.
+                                        || irElement in safeCallResultWhens
+                            }
             )
         }
 
@@ -983,6 +1000,17 @@ internal class CastsOptimization(val context: Context) : BodyLoweringPass {
             val returnableBlock = expression as? IrReturnableBlock
             val statements = expression.statements
             if (returnableBlock == null) {
+                expression.matchSafeCall()?.let { [_, safeCallResult] ->
+                    // Only register a proper safe call `recv?.foo(..)` - one whose result is a call with recv as
+                    // the dispatch receiver, so that the phi alias (if any) can only be a property phantom variable of recv.
+                    // A safe call with an inlined lambda (`recv?.let { obj }`) can produce an arbitrary variable as its result,
+                    // for which keeping the phi alias would be unsound.
+                    var receiver = (safeCallResult as? IrCall)?.dispatchReceiver
+                    while (receiver is IrTypeOperatorCall && receiver.isCast())
+                        receiver = receiver.argument
+                    if ((receiver as? IrGetValue)?.symbol?.owner == statements[0])
+                        safeCallResultWhens.add(statements[1] as IrWhen)
+                }
                 var predicate = data
                 var resultVariable: IrValueDeclaration? = null
                 statements.forEachIndexed { index, statement ->

--- a/native/native.tests/testData/codegen/fileCheck/kt87261.kt
+++ b/native/native.tests/testData/codegen/fileCheck/kt87261.kt
@@ -1,0 +1,74 @@
+// TARGET_BACKEND: NATIVE
+// FILECHECK_STAGE: CStubs
+// FREE_COMPILER_ARGS: -Xbinary=genericSafeCasts=true
+
+open class RTObject
+class Glue : RTObject()
+class StringValue : RTObject()
+class Other
+
+// CHECK-LABEL: define {{i1|zeroext i1}} @"kfun:#reproduce(RTObject;kotlin.Any){}kotlin.Boolean"
+fun reproduce(obj: RTObject, o: Any): Boolean {
+    val glue = if (obj is Glue) obj else null
+    val text = if (obj is StringValue) obj else null
+    if (glue == null && text != null) {
+        // This block is reachable, so `o is Other` must be kept, not folded to a constant.
+// CHECK-DEBUG: @IsSubtype{{.*}}@"kclass:Other"
+// CHECK-OPT: {{call|call zeroext}} i1 @IsSubclassFast
+        return o is Other
+    }
+    return false
+// CHECK-LABEL: epilogue:
+}
+
+// CHECK-LABEL: define {{i1|zeroext i1}} @"kfun:#reproduce2(Glue?;kotlin.Any){}kotlin.Boolean"
+fun reproduce2(v: Glue?, o: Any): Boolean {
+    val x = if (v is Glue?) v else null
+    if (x == null) {
+        // Reachable when v == null, so `o is Other` must be kept, not folded to a constant.
+// CHECK-DEBUG: @IsSubtype{{.*}}@"kclass:Other"
+// CHECK-OPT: {{call|call zeroext}} i1 @IsSubclassFast
+        return o is Other
+    }
+    return false
+// CHECK-LABEL: epilogue:
+}
+
+// CHECK-LABEL: define {{i1|zeroext i1}} @"kfun:#reproduce3(RTObject;kotlin.Any){}kotlin.Boolean"
+fun reproduce3(obj: RTObject, o: Any): Boolean {
+    val glue = if (obj as? Glue != null) obj else null
+    val text = if (obj as? StringValue != null) obj else null
+    if (glue == null && text != null) {
+        // This block is reachable, so `o is Other` must be kept, not folded to a constant.
+// CHECK-DEBUG: @IsSubtype{{.*}}@"kclass:Other"
+// CHECK-OPT: {{call|call zeroext}} i1 @IsSubclassFast
+        return o is Other
+    }
+    return false
+// CHECK-LABEL: epilogue:
+}
+
+// CHECK-LABEL: define {{i1|zeroext i1}} @"kfun:#reproduce4(kotlin.Any;kotlin.Any?){}kotlin.Boolean"
+fun reproduce4(obj: Any, t: Any?): Boolean {
+// CHECK-DEBUG: @IsSubtype{{.*}}@"kclass:Other"
+    if (obj is Other) {
+        // Reachable with t == null, when the safe call evaluates to null, so the `is Other` check on
+        // its result must be kept, not folded to a constant despite the safe call's result aliasing
+        // to `obj`. The explicit type arguments keep the frontend from narrowing the safe call's type
+        // (which would legitimately reduce the check to a null check).
+// CHECK-DEBUG: @IsSubtype{{.*}}@"kclass:Other"
+// CHECK-OPT: {{call|call zeroext}} i1 @IsSubclassFast
+        return (t?.let<Any, Any> { obj }) is Other
+    }
+    return false
+// CHECK-LABEL: epilogue:
+}
+
+// CHECK-LABEL: define ptr @"kfun:#box(){}kotlin.String"
+fun box(): String {
+    if (reproduce(StringValue(), Any())) return "FAIL KT-87261 (type check): o is Other folded to true"
+    if (reproduce2(null, Any())) return "FAIL KT-87261 (nullable type operand): o is Other folded to true"
+    if (reproduce3(StringValue(), Any())) return "FAIL KT-87261 (safe type check): o is Other folded to true"
+    if (reproduce4(Other(), null)) return "FAIL KT-87261 (safe call with unrelated result): is Other folded to true"
+    return "OK"
+}


### PR DESCRIPTION
There was a problem with alias computation for control flow merge points (only variables were accounted for).