### PR TITLE
JVM: Stub default arguments of non-exposed constructor stub

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmInlineClassLowering.kt
@@ -29,11 +29,13 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
+import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueSymbol
 import org.jetbrains.kotlin.ir.transformStatement
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.ir.visitors.IrTransformer
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.name.JvmStandardClassIds
@@ -791,7 +793,32 @@ internal class JvmInlineClassLowering(private val context: JvmBackendContext) : 
                 parameters.any { it.type.isInlineClassType() } &&
                 !constructedClass.isInlineClass
 
+    // Copy real defaults only when lowering the non-exposed constructor itself, fixing up the stub.
+    private fun IrConstructor.copyDefaultValuesFromOriginalConstructorReplacingStubs(original: IrConstructor) {
+        val typeParameterSubstitution = original.typeParameters.zip(typeParameters).toMap()
+        val valueParameterSubstitution = original.parameters.zip(parameters).associate { [originalParameter, replacementParameter] ->
+            originalParameter.symbol to replacementParameter
+        }
+
+        for ([originalParameter, replacementParameter] in original.parameters.zip(parameters)) {
+            val originalDefault = originalParameter.defaultValue
+            replacementParameter.defaultValue = if (originalDefault == null) {
+                null
+            } else {
+                factory.createExpressionBody(
+                    startOffset = originalDefault.startOffset,
+                    endOffset = originalDefault.endOffset,
+                    expression = originalDefault.expression.deepCopyWithSymbols(
+                        initialParent = this,
+                        createTypeRemapper = { IrTypeParameterRemapper(typeParameterSubstitution) },
+                    ).transform(DefaultValueParameterRemapper, valueParameterSubstitution),
+                )
+            }
+        }
+    }
+
     private fun transformFlattenedConstructor(function: IrConstructor, replacement: IrConstructor): List<IrDeclaration> {
+        replacement.copyDefaultValuesFromOriginalConstructorReplacingStubs(function)
         replacement.parameters.forEach {
             it.defaultValue?.patchDeclarationParents(replacement)
             it.transformChildrenVoid()
@@ -960,5 +987,12 @@ internal class JvmInlineClassLowering(private val context: JvmBackendContext) : 
         val replacement = getReflectionReplacement() ?: return super.visitRawFunctionReference(expression)
         expression.symbol = replacement.symbol
         return super.visitRawFunctionReference(expression)
+    }
+}
+
+private object DefaultValueParameterRemapper : IrTransformer<Map<IrValueParameterSymbol, IrValueParameter>>() {
+    override fun visitGetValue(expression: IrGetValue, data: Map<IrValueParameterSymbol, IrValueParameter>): IrExpression {
+        val newParameter = data[expression.symbol] ?: return expression
+        return IrGetValueImpl(expression.startOffset, expression.endOffset, newParameter.type, newParameter.symbol, expression.origin)
     }
 }

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/MemoizedInlineClassReplacements.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrAnnotation
 import org.jetbrains.kotlin.ir.expressions.impl.IrAnnotationImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrErrorExpressionImpl
 import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
 import org.jetbrains.kotlin.ir.irAttribute
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -364,6 +365,19 @@ class MemoizedInlineClassReplacements(
         name = InlineClassAbi.mangledNameFor(function, mangleReturnTypes, useOldManglingScheme)
     }
 
+    private fun IrConstructor.replaceCopiedDefaultValuesWithStubsFrom(source: IrConstructor) {
+        for ([sourceParameter, replacementParameter] in source.parameters.zip(parameters)) {
+            val sourceDefault = sourceParameter.defaultValue ?: continue
+            // The replacement can be requested from another file before the source default expression is lowered.
+            // Keep the parameter defaultable, but do not keep the early deep copy made by copyFunctionSignatureFrom.
+            replacementParameter.defaultValue = factory.createExpressionBody(
+                IrErrorExpressionImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, replacementParameter.type, "Default Stub").apply {
+                    attributeOwnerId = sourceDefault.expression
+                }
+            )
+        }
+    }
+
     // When we expose regular class constructors, we add another constructor with BoxingMarker parameter
     // to be called from Kotlin, while original constructor is to be called from Java.
     fun getReplacementForRegularClassConstructor(constructor: IrConstructor): IrConstructor? {
@@ -395,6 +409,7 @@ class MemoizedInlineClassReplacements(
                 }
             }
             copyFunctionSignatureFrom(constructor)
+            replaceCopiedDefaultValuesWithStubsFrom(constructor)
             annotations = constructor.annotations.withoutJvmExposeBoxedAnnotation()
             body = constructor.body?.patchDeclarationParents(this)
 

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/kt87466.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/kt87466.kt
@@ -1,0 +1,22 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+// JVM_EXPOSE_BOXED
+
+// FILE: 2.kt
+
+package repro
+
+internal fun make(v: V): C = C(v)
+
+fun box(): String {
+    make(V(1L))
+    return "OK"
+}
+
+// FILE: 1.kt
+package repro
+
+@JvmInline
+internal value class V(val value: Long)
+
+internal class C(v: V, f: () -> Unit = {})

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/kt87466.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/kt87466.kt
@@ -1,0 +1,24 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// FILE: 2.kt
+
+package repro
+
+internal fun make(v: V): C = C(v)
+
+fun box(): String {
+    make(V(1L))
+    return "OK"
+}
+
+// FILE: 1.kt
+
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package repro
+
+@JvmInline
+internal value class V(val value: Long)
+
+internal class C @JvmExposeBoxed constructor(v: V, f: () -> Unit = {})


### PR DESCRIPTION
We generate a stub for non-exposed constructor of ordinary class, so, if a caller is lowered before the class itself, the caller will point to the stub instead of unlowered constructor.

Previously, the default arguments were copied to the stub. Which is incorrect, since the stub's default arguments won't be lowered.

The fix is to put a stub is a stub, so the caller will not depend on the order of lowerings while not depending on the order of lowerings.
 #KT-87466 Fixed