### PR TITLE
[K/N] Port kotlin-calls-checker-module to C++

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
@@ -188,10 +188,6 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
     }
 }
 
-private const val functionListGlobal = "Kotlin_callsCheckerKnownFunctions"
-private const val functionListSizesGlobal = "Kotlin_callsCheckerKnownFunctionsCounts"
-private const val functionListSizesSizeGlobal = "Kotlin_callsCheckerKnownFunctionsCountsCount"
-
 internal fun checkLlvmModuleExternalCalls(generationState: NativeGenerationState) {
     val llvm = generationState.llvm
     val staticData = llvm.staticData
@@ -217,80 +213,5 @@ internal fun checkLlvmModuleExternalCalls(generationState: NativeGenerationState
     getFunctions(llvm.module)
             .filter { !it.isExternalFunction() && it !in ignoredFunctions }
             .forEach(checker::processFunction)
-    // otherwise optimiser can inline it
-    staticData.getGlobal(functionListGlobal)?.setExternallyInitialized(true)
-    staticData.getGlobal(functionListSizesGlobal)?.setExternallyInitialized(true)
-    staticData.getGlobal(functionListSizesSizeGlobal)?.setExternallyInitialized(true)
     verifyModule(llvm.module)
 }
-
-// this should be a separate pass, to handle DCE correctly
-internal fun addFunctionsListSymbolForChecker(generationState: NativeGenerationState) {
-    val llvm = generationState.llvm
-    val staticData = llvm.staticData
-    val context = generationState.context
-
-    val functions = getFunctions(llvm.module)
-            .filter { !it.isExternalFunction() }
-            .map { constPointer(it) }
-            .toList()
-
-    val libName = context.config.libraryToCache?.klib?.uniqueName ?: context.config.moduleId
-    // The function-list global must be unique per object file. When a per-file cache is produced, every file becomes
-    // a separate object, so the file id has to be a part of the symbol name; otherwise these objects would clash with
-    // a "duplicate symbol" linker error once several of them are linked together.
-    // Note: checking for CacheDeserializationStrategy.MultipleFiles is not needed, as it will split into single files
-    // by TopLevelPhases.kt->runBackend->splitIntoFragments.
-    val cacheKey = (generationState.cacheDeserializationStrategy as? CacheDeserializationStrategy.SingleFile)
-            ?.let { perFileCheckerCacheKey(libName, CacheSupport.cacheFileId(it.fqName, it.filePath)) }
-            ?: libName
-
-    staticData.placeGlobalConstArray(cacheKey.knownFunctionsGlobalName, llvm.pointerType, functions, isExported = true)
-    staticData.placeGlobal(cacheKey.knownFunctionsCountGlobalName, llvm.constInt32(functions.size), isExported = true)
-
-    if (generationState.config.isFinalBinary) {
-        // Reference the function-list globals of exactly the caches that are linked into the binary. This must mirror
-        // the binary selection in [resolveCacheBinaries]: a monolithic cache contributes a single library-keyed global,
-        // while a per-file cache contributes one global per linked file (keyed by [CacheSupport.cacheFileId]).
-        // Note that the dependency kind alone is not enough: a monolithic cache may still be referenced via CertainFiles.
-        val cacheKeys = generationState.dependenciesTracker.allCachedBitcodeDependencies.flatMap { dependency ->
-            val library = dependency.library
-            when (val cache = context.config.cachedLibraries.getLibraryCache(library)) {
-                null -> error("Library ${library.path} is expected to be cached")
-
-                is CachedLibraries.Cache.Monolithic -> listOf(library.uniqueName)
-
-                is CachedLibraries.Cache.PerFile -> {
-                    (dependency.kind as? DependenciesTracker.DependencyKind.CertainFiles)?.files
-                            ?.map { perFileCheckerCacheKey(library.uniqueName, it.name) }
-                            ?: cache.fileIds.map { perFileCheckerCacheKey(library.uniqueName, it) }
-                }
-            }
-        } + cacheKey
-
-        val allFunctionListsArray = llvm.exportedGlobalPointerArray(staticData, cacheKeys.map { it.knownFunctionsGlobalName })
-        val allFunctionSizesListsArray = llvm.exportedGlobalPointerArray(staticData, cacheKeys.map { it.knownFunctionsCountGlobalName })
-
-        staticData.getOrCreateExportedGlobal(llvm.pointerType, functionListGlobal).setInitializer(allFunctionListsArray)
-        staticData.getOrCreateExportedGlobal(llvm.pointerType, functionListSizesGlobal).setInitializer(allFunctionSizesListsArray)
-        staticData.getOrCreateExportedGlobal(llvm.int32Type, functionListSizesSizeGlobal).setInitializer(llvm.constInt32(cacheKeys.size))
-    }
-    verifyModule(llvm.module)
-}
-
-
-private val String.knownFunctionsGlobalName
-    get() = "_Konan_callsCheckerKnownFunctions_${this}"
-
-private val String.knownFunctionsCountGlobalName
-    get() = "_Konan_callsCheckerKnownFunctionsCount_${this}"
-
-private fun perFileCheckerCacheKey(libName: String, cacheFileId: String): String = "${libName}_$cacheFileId"
-
-private fun KotlinStaticData.getOrCreateExportedGlobal(type: LLVMTypeRef, name: String) =
-        staticData.getGlobal(name) ?: staticData.createGlobal(type, name, isExported = true)
-
-private fun CodegenLlvmHelpers.exportedGlobalPointerArray(staticData: KotlinStaticData, values: List<String>) =
-        staticData.placeGlobalConstArray("", pointerType, values.map {
-            staticData.getOrCreateExportedGlobal(pointerType, it).pointer
-        })

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
@@ -414,6 +414,12 @@ class RemoveRedundantSafepointsPipeline(config: LlvmPipelineConfig, performanceM
     }
 }
 
+class ModuleCallsCheckerPipeline(config: LlvmPipelineConfig, performanceManager: PerformanceManager?, logger: LoggingContext? = null) :
+        LlvmOptimizationPipeline(config, performanceManager, logger) {
+    override val pipelineName = "llvm-calls-checker-module"
+    override val passes = listOf("kotlin-calls-checker-module")
+}
+
 internal fun RelocationModeFlags.currentRelocationMode(context: NativeBackendPhaseContext): RelocationModeFlags.Mode =
         when (determineLinkerOutput(context)) {
             LinkerOutputKind.DYNAMIC_LIBRARY -> dynamicLibraryRelocationMode

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
@@ -67,15 +67,10 @@ internal val CheckExternalCallsPhase = createSimpleNamedCompilerPhase<NativeGene
     checkLlvmModuleExternalCalls(context)
 }
 
-/**
- * Rewrites globals for external calls checker after optimizer run.
- */
-internal val RewriteExternalCallsCheckerGlobals = createSimpleNamedCompilerPhase<NativeGenerationState, Unit>(
-        name = "RewriteExternalCallsCheckerGlobals",
-        postactions = getDefaultLlvmModuleActions(),
-) { context, _ ->
-    addFunctionsListSymbolForChecker(context)
-}
+internal val ModuleCallsChecker = optimizationPipelinePass(
+        name = "ModuleCallsChecker",
+        pipeline = ::ModuleCallsCheckerPipeline
+)
 
 internal class OptimizationState(
         config: NativeSecondStageCompilationConfig,
@@ -198,6 +193,9 @@ internal fun <T : BitcodePostProcessingContext> PhaseEngine<T>.runBitcodePostPro
         }
         if (!context.config.runLLVMPassesInCompiler) {
             it.runAndMeasurePhase(RemoveRedundantSafepointsPhaseInLLVM, module)
+        }
+        if (context.config.checkStateAtExternalCalls) {
+            it.runAndMeasurePhase(ModuleCallsChecker, module)
         }
     }
     if (context.config.runLLVMPassesInCompiler) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -412,9 +412,6 @@ internal fun PhaseEngine<NativeGenerationState>.runPostCodegen() {
         runAndMeasurePhase(CheckExternalCallsPhase)
     }
     newEngine(context as BitcodePostProcessingContext) { it.runBitcodePostProcessing() }
-    if (checkExternalCalls) {
-        runAndMeasurePhase(RewriteExternalCallsCheckerGlobals)
-    }
     if (context.config.produce.isFullCache) {
         runAndMeasurePhase(SaveAdditionalCacheInfoPhase)
     }

--- a/kotlin-native/libllvmext/README.md
+++ b/kotlin-native/libllvmext/README.md
@@ -40,3 +40,4 @@ Custom LLVM passes live in the [Passes](src/main/cpp/Passes) directory:
 - `RemoveRedundantSafepointsPass` (`kotlin-remove-sp`): function pass, that removes unnecessary prologue
   safepoints from functions; useful, when run after LLVM inlining; can be configured as
   `kotlin-remove-sp<inline>` to additionally inline the remaining safepoints.
+- `ModuleCallsCheckerPass` (`kotlin-calls-checker-module`): module pass for external calls checker instrumentation; creates module contructor; should be run after DCE

--- a/kotlin-native/libllvmext/src/main/cpp/KotlinPlugin.cpp
+++ b/kotlin-native/libllvmext/src/main/cpp/KotlinPlugin.cpp
@@ -4,6 +4,7 @@
 
 #include "KotlinPlugin.h"
 
+#include "Passes/CallsChecker.h"
 #include "Passes/HideSymbols.h"
 #include "Passes/PrepareStackProtector.h"
 #include "Passes/PrepareThreadSanitizer.h"
@@ -72,6 +73,10 @@ PassPluginLibraryInfo getKotlinPluginInfo() {
                    ArrayRef<PassBuilder::PipelineElement>) {
                   if (parsePass(Name, "kotlin-hide-symbols")) {
                     PM.addPass(HideSymbolsPass());
+                    return true;
+                  }
+                  if (parsePass(Name, "kotlin-calls-checker-module")) {
+                    PM.addPass(ModuleCallsCheckerPass());
                     return true;
                   }
                   return false;

--- a/kotlin-native/libllvmext/src/main/cpp/Passes/CallsChecker.cpp
+++ b/kotlin-native/libllvmext/src/main/cpp/Passes/CallsChecker.cpp
@@ -1,0 +1,65 @@
+// Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language
+// contributors. Use of this source code is governed by the Apache 2.0 license
+// that can be found in the license/LICENSE.txt file.
+
+#include "CallsChecker.h"
+
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Transforms/Utils/Instrumentation.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+
+using namespace llvm;
+using namespace llvm::kotlin;
+
+static bool isAKnownFunction(Function &F) {
+  // Just treat all defined functions as known functions (i.e. allowed to be
+  // called in the runnable state). This also applies to the entire K/N runtime.
+  return !F.isDeclaration();
+}
+
+PreservedAnalyses ModuleCallsCheckerPass::run(Module &M,
+                                              ModuleAnalysisManager &) {
+  if (!run(M))
+    return PreservedAnalyses::all();
+  return PreservedAnalyses::none();
+}
+
+bool ModuleCallsCheckerPass::run(Module &M) {
+  if (checkIfAlreadyInstrumented(M, "no_external_calls_check"))
+    return false;
+
+  SmallVector<Constant *> KnownFunctions;
+  for (auto &F : M) {
+    if (isAKnownFunction(F)) {
+      KnownFunctions.push_back(&F);
+    }
+  }
+
+  // If there are no known functions, no need to register this module with the
+  // runtime.
+  if (KnownFunctions.empty())
+    return false;
+
+  auto &Ctx = M.getContext();
+
+  auto *KnownFunctionsArrValue = ConstantArray::get(
+      ArrayType::get(PointerType::getUnqual(Ctx), KnownFunctions.size()),
+      KnownFunctions);
+  auto *KnownFunctionsArr = new GlobalVariable(
+      M, KnownFunctionsArrValue->getType(), true, GlobalValue::PrivateLinkage,
+      KnownFunctionsArrValue, "kotlin.callsChecker.knownFunctions");
+
+  auto *KnownFunctionsSize =
+      ConstantInt::get(Type::getInt64Ty(Ctx), KnownFunctions.size());
+
+  getOrCreateSanitizerCtorAndInitFunctions(
+      M, "kotlin.callsChecker.module_ctor", "Kotlin_callsChecker_init",
+      {PointerType::getUnqual(Ctx), KnownFunctionsSize->getType()},
+      {KnownFunctionsArr, KnownFunctionsSize},
+      [&](Function *Ctor, FunctionCallee) { appendToGlobalCtors(M, Ctor, 0); });
+  // Technically, we need to handle the destructor as well: the module may go
+  // away and a new one could get placed in the same address space. But for
+  // simplicity we will avoid this usecase for now.
+  return true;
+}

--- a/kotlin-native/libllvmext/src/main/cpp/Passes/CallsChecker.h
+++ b/kotlin-native/libllvmext/src/main/cpp/Passes/CallsChecker.h
@@ -1,0 +1,24 @@
+// Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language
+// contributors. Use of this source code is governed by the Apache 2.0 license
+// that can be found in the license/LICENSE.txt file.
+
+#pragma once
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm::kotlin {
+
+/// A module pass for external calls checker instrumentation.
+///
+/// Creates module constructor. Should be run after DCE: it saves all defined
+/// functions in a global, preventing DCE from removing unused ones
+class ModuleCallsCheckerPass : public PassInfoMixin<ModuleCallsCheckerPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+
+  bool run(Module &M);
+
+private:
+};
+
+} // namespace llvm::kotlin

--- a/kotlin-native/libllvmext/testData/fileCheck/moduleCallsChecker.ll
+++ b/kotlin-native/libllvmext/testData/fileCheck/moduleCallsChecker.ll
@@ -1,0 +1,19 @@
+; OPT: --passes=kotlin-calls-checker-module
+
+; CHECK: @kotlin.callsChecker.knownFunctions = private constant [2 x ptr] [ptr @f_defined1, ptr @f_defined2]
+; CHECK: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @kotlin.callsChecker.module_ctor, ptr null }]
+
+; CHECK: define internal void @kotlin.callsChecker.module_ctor() {{.*}} {
+; CHECK-NEXT: call void @Kotlin_callsChecker_init(ptr @kotlin.callsChecker.knownFunctions, i64 2)
+; CHECK-NEXT: ret void
+; CHECK-NEXT: }
+
+define void @f_defined1() {
+  ret void
+}
+
+define void @f_defined2() {
+  ret void
+}
+
+declare void @f_declared()

--- a/kotlin-native/libllvmext/testData/fileCheck/moduleCallsCheckerEmpty.ll
+++ b/kotlin-native/libllvmext/testData/fileCheck/moduleCallsCheckerEmpty.ll
@@ -1,0 +1,8 @@
+; OPT: --passes=kotlin-calls-checker-module
+
+; CHECK-NOT: @kotlin.callsChecker.knownFunctions
+; CHECK-NOT: @llvm.global_ctors
+; CHECK-NOT: @kotlin.callsChecker.module_ctor
+
+declare void @f_declared1()
+declare void @f_declared2()

--- a/kotlin-native/runtime/src/externalCallsChecker/common/cpp/CallsChecker.hpp
+++ b/kotlin-native/runtime/src/externalCallsChecker/common/cpp/CallsChecker.hpp
@@ -21,4 +21,10 @@ public:
     ALWAYS_INLINE ~CallsCheckerIgnoreGuard();
 };
 
+class CallsChecker : private Pinned {
+public:
+    CallsChecker() noexcept;
+    ~CallsChecker();
+};
+
 } // namespace kotlin

--- a/kotlin-native/runtime/src/externalCallsChecker/impl/cpp/CallsChecker.cpp
+++ b/kotlin-native/runtime/src/externalCallsChecker/impl/cpp/CallsChecker.cpp
@@ -5,6 +5,7 @@
 
 #include "CallsChecker.hpp"
 
+#include <atomic>
 #include <string_view>
 #include <cstring>
 #include <unordered_set>
@@ -15,13 +16,9 @@
 #include "StackTrace.hpp"
 #include "ThreadData.hpp"
 #include "ExecFormat.h"
+#include "concurrent/Mutex.hpp"
 
 using namespace kotlin;
-
-// this values will be substituted by compiler
-extern "C" const void*** Kotlin_callsCheckerKnownFunctions;
-extern "C" const int** Kotlin_callsCheckerKnownFunctionsCounts;
-extern "C" const int Kotlin_callsCheckerKnownFunctionsCountsCount;
 
 extern "C" const char* Kotlin_callsCheckerGoodFunctionNames[] = {
         "\x01_mprotect",
@@ -297,21 +294,26 @@ extern "C" const char* Kotlin_callsCheckerGoodFunctionNames[] = {
 
 namespace {
 
-class KnownFunctionChecker {
+class KnownFunctionChecker : private Pinned {
 public:
     KnownFunctionChecker() {
-        for (int i = 0; i < Kotlin_callsCheckerKnownFunctionsCountsCount; i++) {
-            for (int j = 0; j < *Kotlin_callsCheckerKnownFunctionsCounts[i]; j++) {
-                known_functions_.insert(Kotlin_callsCheckerKnownFunctions[i][j]);
-            }
-        }
         std::copy(
                 std::begin(Kotlin_callsCheckerGoodFunctionNames), std::end(Kotlin_callsCheckerGoodFunctionNames),
                 std::begin(good_names_copy_));
         std::sort(std::begin(good_names_copy_), std::end(good_names_copy_));
     }
 
-    bool isKnown(const void* fun) const noexcept { return known_functions_.find(fun) != known_functions_.end(); }
+    ~KnownFunctionChecker() = delete;
+
+    bool isKnown(const void* fun) const noexcept {
+        // This is a hot path, but we have already tried to read another atomic, so this
+        // shouldn't add too much overhead.
+        if (!sealed_.load(std::memory_order_relaxed)) {
+            PrintStackTraceStderr();
+            RuntimeFail("isKnown is called before the checker is sealed");
+        }
+        return known_functions_.find(fun) != known_functions_.end();
+    }
 
     bool isSafeByName(std::string_view name) const noexcept {
         auto it = std::lower_bound(std::begin(good_names_copy_), std::end(good_names_copy_), name);
@@ -330,14 +332,38 @@ public:
         return false;
     }
 
-    ~KnownFunctionChecker() = delete;
+    void insert(std_support::span<const void*> knownFunctions) noexcept {
+        std::unique_lock guard(initLock_);
+        if (sealed_.load(std::memory_order_relaxed)) {
+            PrintStackTraceStderr();
+            RuntimeFail(
+                    "Using CallsChecker with dynamically loaded modules is unsupported: all known functions must be registered before "
+                    "GlobalData is created.");
+        }
+        known_functions_.insert(knownFunctions.begin(), knownFunctions.end());
+    }
+
+    void seal() noexcept {
+        std::unique_lock guard(initLock_);
+        sealed_.store(true, std::memory_order_relaxed);
+    }
 
 private:
+    SpinLock initLock_; // may be used very early on the start, safer to use a simple spin lock.
+    std::atomic<bool> sealed_ = false;
     std::unordered_set<const void*> known_functions_;
     std::string_view good_names_copy_[sizeof(Kotlin_callsCheckerGoodFunctionNames) / sizeof(Kotlin_callsCheckerGoodFunctionNames[0])];
 };
 
-[[clang::no_destroy]] const KnownFunctionChecker checker;
+// This can't be just a part of `GlobalData`, because this may be called very early from
+// global constructors.
+// For the same reason, it can't just be a simple global: if some global constructor
+// used this global before the global initialized, we have UB. Using lazy initialization
+// avoid this problem.
+static KnownFunctionChecker& knownFunctionChecker() noexcept {
+    [[clang::no_destroy]] static KnownFunctionChecker instance;
+    return instance;
+}
 
 constexpr int MSG_SEND_TO_NULL = -1;
 constexpr int CALLED_LLVM_BUILTIN = -2;
@@ -368,6 +394,8 @@ extern "C" RUNTIME_NOTHROW RUNTIME_NODEBUG void Kotlin_mm_checkStateAtExternalFu
     if (actualState == ThreadState::kNative) {
         return;
     }
+
+    auto& checker = knownFunctionChecker();
     if (reinterpret_cast<int64_t>(calleePtr) != CALLED_LLVM_BUILTIN && checker.isKnown(calleePtr)) {
         return;
     }
@@ -390,9 +418,20 @@ extern "C" RUNTIME_NOTHROW RUNTIME_NODEBUG void Kotlin_mm_checkStateAtExternalFu
     RuntimeFail("Expected kNative thread state at call of function %s by function %s", callee, caller);
 }
 
+// Called from global constructors.
+extern "C" RUNTIME_NOTHROW RUNTIME_EXPORT void Kotlin_callsChecker_init(const void** knownFunctions, uint64_t knownFunctionsCount) {
+    knownFunctionChecker().insert({knownFunctions, static_cast<size_t>(knownFunctionsCount)});
+}
+
 ALWAYS_INLINE CallsCheckerIgnoreGuard::CallsCheckerIgnoreGuard() noexcept {
     ++ignoreGuardsCount;
 }
 ALWAYS_INLINE CallsCheckerIgnoreGuard::~CallsCheckerIgnoreGuard() {
     --ignoreGuardsCount;
 }
+
+CallsChecker::CallsChecker() noexcept {
+    knownFunctionChecker().seal();
+}
+
+CallsChecker::~CallsChecker() = default;

--- a/kotlin-native/runtime/src/externalCallsChecker/noop/cpp/CallsChecker.cpp
+++ b/kotlin-native/runtime/src/externalCallsChecker/noop/cpp/CallsChecker.cpp
@@ -9,3 +9,6 @@ using namespace kotlin;
 
 CallsCheckerIgnoreGuard::CallsCheckerIgnoreGuard() noexcept = default;
 CallsCheckerIgnoreGuard::~CallsCheckerIgnoreGuard() = default;
+
+CallsChecker::CallsChecker() noexcept = default;
+CallsChecker::~CallsChecker() = default;

--- a/kotlin-native/runtime/src/mm/cpp/GlobalData.hpp
+++ b/kotlin-native/runtime/src/mm/cpp/GlobalData.hpp
@@ -8,6 +8,7 @@
 
 #include "Allocator.hpp"
 #include "AppStateTracking.hpp"
+#include "CallsChecker.hpp"
 #include "GC.hpp"
 #include "GCScheduler.hpp"
 #include "GlobalsRegistry.hpp"
@@ -43,6 +44,7 @@ private:
     GlobalData() noexcept;
     ~GlobalData() = delete;
 
+    [[no_unique_address]] CallsChecker callsChecker_;
     ThreadRegistry threadRegistry_;
     AppStateTracking appStateTracking_;
     GlobalsRegistry globalsRegistry_;


### PR DESCRIPTION
kotlin-calls-checker-module collects all known functions and registers them with the K/N runtime via module constructors.

This follows standard LLVM sanitizers.

^KT-87596