### PR TITLE
[Gradle] KT-87600 Make outputDir internal in PlaywrightBrowserInstall

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -62,6 +62,9 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
             val objects = project.objects
             val inputs = KotlinPlaywrightJsTestFramework.createInputs(objects)
 
+            // dependsOn is required because outputDir is internal and doesn't carry task dependencies
+            // FIXME: KT-87599 Design host-wide toolchain management
+            testTask.dependsOn(playwrightBrowserInstallTask)
             inputs.playwrightBrowsersDirectory.set(playwrightBrowserInstallTask.flatMap { it.outputDir })
 
             inputs.chromiumRunners.set(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightBrowserInstall.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightBrowserInstall.kt
@@ -13,7 +13,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
@@ -64,7 +63,9 @@ internal abstract class PlaywrightBrowserInstall @Inject constructor(
     @get:Internal
     internal val npmToolingEnvDir: DirectoryProperty = objects.directoryProperty().convention(compilation.npmToolingDir())
 
-    @get:OutputDirectory
+    // this is intentional to prevent gradle warnings about tasks writing to the same location
+    // FIXME: KT-87599 Design host-wide toolchain management
+    @get:Internal
     internal val outputDir: DirectoryProperty = objects.directoryProperty().fileProvider(
         PropertiesProvider(project).playwrightBrowsersPath
             .orElse(providers.environmentVariable("PLAYWRIGHT_BROWSERS_PATH"))


### PR DESCRIPTION
This helps from problem when two subprojects executes this task and writes to the same location (at least partially). then consuming tasks (KotlinJsTest with PW runner) would fail by gradle because they will attempt to read from location that was written by task from another subproject.
this is not good and will be fixed here:
 KT-87599 Design host-wide toolchain management

In the meantime, I added this hack that marks output dir as internal so that tasks can safely work further.