### PR TITLE
[K/N] Don't use K1 implementation of special bridges data

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/SpecialBridgeMethods.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/SpecialBridgeMethods.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.common.lower
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.builtins.StandardNames
+import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -34,7 +35,8 @@ class BuiltInWithDifferentJvmName(
     val isOverriding: Boolean = true
 )
 
-class SpecialBridgeMethods(val context: CommonBackendContext) {
+class SpecialBridgeMethods(val irBuiltIns: IrBuiltIns) {
+    constructor(context: CommonBackendContext): this(context.irBuiltIns)
     private data class SpecialMethodDescription(val kotlinFqClassName: FqName?, val name: Name, val arity: Int)
 
     private fun makeDescription(classFqName: FqName, funName: String, arity: Int = 0): SpecialMethodDescription =
@@ -55,15 +57,15 @@ class SpecialBridgeMethods(val context: CommonBackendContext) {
 
     @Suppress("UNUSED_PARAMETER")
     private fun constFalse(bridge: IrSimpleFunction) =
-        IrConstImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, context.irBuiltIns.booleanType, IrConstKind.Boolean, false)
+        IrConstImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, irBuiltIns.booleanType, IrConstKind.Boolean, false)
 
     @Suppress("UNUSED_PARAMETER")
     private fun constNull(bridge: IrSimpleFunction) =
-        IrConstImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, context.irBuiltIns.anyNType, IrConstKind.Null, null)
+        IrConstImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, irBuiltIns.anyNType, IrConstKind.Null, null)
 
     @Suppress("UNUSED_PARAMETER")
     private fun constMinusOne(bridge: IrSimpleFunction) =
-        IrConstImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, context.irBuiltIns.intType, IrConstKind.Int, -1)
+        IrConstImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, irBuiltIns.intType, IrConstKind.Int, -1)
 
     private fun getSecondArg(bridge: IrSimpleFunction) =
         IrGetValueImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, bridge.parameters[2].symbol)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -9,6 +9,7 @@ import llvm.LLVMTypeRef
 import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.config.LoggingContext
 import org.jetbrains.kotlin.backend.common.linkage.partial.createPartialLinkageSupportForLowerings
+import org.jetbrains.kotlin.backend.common.lower.SpecialBridgeMethods
 import org.jetbrains.kotlin.backend.konan.cexport.CAdapterExportedElements
 import org.jetbrains.kotlin.backend.konan.ir.*
 import org.jetbrains.kotlin.backend.konan.llvm.KonanMetadata
@@ -60,6 +61,7 @@ internal class Context(
     val bridgesSupport by lazy { BridgesSupport(irBuiltIns, symbols, irFactory) }
     val enumsSupport by lazy { EnumsSupport(irBuiltIns, irFactory) }
     val cachesAbiSupport by lazy { CachesAbiSupport(irFactory) }
+    val specialBridgeMethods by lazy { SpecialBridgeMethods(irBuiltIns) }
 
     val moduleDeserializerProvider by lazy {
         ModuleDeserializerProvider(config.libraryToCache, config.cachedLibraries, irLinker)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -21,8 +21,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.computeFunctionName
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.K1Deprecation
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
+import org.jetbrains.kotlin.backend.common.lower.SpecialMethodWithDefaultInfo
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
@@ -40,14 +39,12 @@ import org.jetbrains.kotlin.ir.types.isNullableAny
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
-import org.jetbrains.kotlin.load.java.BuiltinMethodsWithSpecialGenericSignature
-import org.jetbrains.kotlin.load.java.SpecialGenericSignatures
 import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 
+private fun IrSimpleFunction.getSpecialBridgeInfoByOverrides(context: Context): SpecialMethodWithDefaultInfo? {
+    return context.specialBridgeMethods.findSpecialWithOverride(this, includeSelf = true)?.second
+}
 private var IrFunction.bridges: MutableMap<BridgeDirections, IrSimpleFunction>? by irAttribute(copyByDefault = false)
-
-@OptIn(ObsoleteDescriptorBasedAPI::class, K1Deprecation::class)
-internal fun IrFunction.getDefaultValueForOverriddenBuiltinFunction() = BuiltinMethodsWithSpecialGenericSignature.getDefaultValueForOverriddenBuiltinFunction(descriptor)
 
 internal class BridgesSupport(val irBuiltIns: IrBuiltIns, val symbols: BackendNativeSymbols, val irFactory: IrFactory) {
     fun getBridge(overriddenFunction: OverriddenFunctionInfo): IrSimpleFunction {
@@ -217,14 +214,14 @@ internal class BridgesBuilding(val context: Context) : ClassLoweringPass {
                 return declaration
             }
 
-            override fun visitFunction(declaration: IrFunction): IrStatement {
+            override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
                 declaration.transformChildrenVoid(this)
 
                 val body = declaration.body ?: return declaration
 
-                val typeSafeBarrierDescription = declaration.getDefaultValueForOverriddenBuiltinFunction()
-                if (typeSafeBarrierDescription == null || builtBridges.contains(declaration))
-                    return declaration
+                if (builtBridges.contains(declaration)) return declaration
+
+                val typeSafeBarrierDescription = declaration.getSpecialBridgeInfoByOverrides(context) ?: return declaration
 
                 val irBuilder = context.createIrBuilder(declaration.symbol, declaration.startOffset, declaration.endOffset)
                 declaration.body = irBuilder.irBlockBody(declaration) {
@@ -264,23 +261,12 @@ private fun IrBuilderWithScope.returnIfBadType(value: IrExpression,
                                                returnValueOnFail: IrExpression)
         = irIfThen(irNotIs(value, type), irReturn(returnValueOnFail))
 
-private fun IrBuilderWithScope.irConst(value: Any?) = when (value) {
-    null       -> irNull()
-    is Int     -> irInt(value)
-    is Boolean -> if (value) irTrue() else irFalse()
-    else       -> TODO()
-}
-
-private fun IrBlockBodyBuilder.buildTypeSafeBarrier(function: IrFunction,
-                                                    originalFunction: IrFunction,
-                                                    typeSafeBarrierDescription: SpecialGenericSignatures.TypeSafeBarrierDescription) {
-    val parameters = function.nonDispatchParameters
-    val originalParameters = originalFunction.nonDispatchParameters
-    for (i in parameters.indices) {
-        if (!typeSafeBarrierDescription.checkParameter(i))
-            continue
-
-        val type = originalParameters[i].type.eraseTypeParameters()
+private fun IrBlockBodyBuilder.buildTypeSafeBarrier(bridgeFunction: IrSimpleFunction,
+                                                    targetFunction: IrSimpleFunction,
+                                                    typeSafeBarrierDescription: SpecialMethodWithDefaultInfo) {
+    // skip dispatch receiver, and than check required number of first parameters
+    for (i in bridgeFunction.parameters.indices.drop(1).take(typeSafeBarrierDescription.argumentsToCheck)) {
+        val type = targetFunction.parameters[i].type.eraseTypeParameters()
         // Note: erasing to single type is not entirely correct if type parameter has multiple upper bounds.
         // In this case the compiler could generate multiple type checks, one for each upper bound.
         // But let's keep it simple here for now; JVM backend doesn't do this anyway.
@@ -288,10 +274,8 @@ private fun IrBlockBodyBuilder.buildTypeSafeBarrier(function: IrFunction,
         if (!type.isNullableAny()) {
             // Here, we can't trust value parameter type until we check it, because of @UnsafeVariance
             // So we add implicit cast to avoid type check optimization
-            +returnIfBadType(irImplicitCast(irGet(parameters[i]), context.irBuiltIns.anyNType), type,
-                    if (typeSafeBarrierDescription == SpecialGenericSignatures.TypeSafeBarrierDescription.MAP_GET_OR_DEFAULT)
-                        irGet(parameters[1])
-                    else irConst(typeSafeBarrierDescription.defaultValue)
+            +returnIfBadType(irImplicitCast(irGet(bridgeFunction.parameters[i]), context.irBuiltIns.anyNType), type,
+                    typeSafeBarrierDescription.defaultValueGenerator(bridgeFunction)
             )
         }
     }
@@ -309,9 +293,9 @@ private fun Context.buildBridge(startOffset: Int, endOffset: Int,
 
     val irBuilder = createIrBuilder(bridge.symbol, startOffset, endOffset)
     bridge.body = irBuilder.irBlockBody(bridge) {
-        val typeSafeBarrierDescription = overriddenFunction.overriddenFunction.getDefaultValueForOverriddenBuiltinFunction()
-        typeSafeBarrierDescription?.let { buildTypeSafeBarrier(bridge, overriddenFunction.function, it) }
-
+        target.getSpecialBridgeInfoByOverrides(this@buildBridge)?.let {
+            buildTypeSafeBarrier(bridge, target, it)
+        }
         val delegatingCall = IrCallImpl.fromSymbolOwner(
                 startOffset,
                 endOffset,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DataFlowIR.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DataFlowIR.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.backend.konan.llvm.isExported
 import org.jetbrains.kotlin.backend.konan.llvm.localHash
 import org.jetbrains.kotlin.backend.konan.lower.DECLARATION_ORIGIN_BRIDGE_METHOD
 import org.jetbrains.kotlin.backend.konan.lower.bridgeTarget
-import org.jetbrains.kotlin.backend.konan.lower.getDefaultValueForOverriddenBuiltinFunction
 import org.jetbrains.kotlin.backend.konan.lower.isEagerStaticInitializer
 import org.jetbrains.kotlin.backend.konan.util.CustomBitSet
 import org.jetbrains.kotlin.descriptors.Modality
@@ -28,6 +27,7 @@ import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrGetField
+import org.jetbrains.kotlin.ir.expressions.IrReturn
 import org.jetbrains.kotlin.ir.objcinterop.getExternalObjCMethodInfo
 import org.jetbrains.kotlin.ir.objcinterop.isObjCClass
 import org.jetbrains.kotlin.ir.types.IrType
@@ -662,11 +662,10 @@ internal object DataFlowIR {
                 else -> {
                     val isAbstract = it.modality == Modality.ABSTRACT
                     val irClass = it.parent as? IrClass
-                    val bridgeTarget = it.bridgeTarget
-                    val isSpecialBridge = bridgeTarget.let {
-                        it != null && it.getDefaultValueForOverriddenBuiltinFunction() != null
-                    }
-                    val bridgeTargetSymbol = if (isSpecialBridge || bridgeTarget == null) null else mapFunction(bridgeTarget)
+                    // Don't inline bridge, if it's more complicated that just returning
+                    // This can happen around special builtins
+                    val bridgeTarget = if (it.body?.statements?.getOrNull(0) is IrReturn) it.bridgeTarget else null
+                    val bridgeTargetSymbol = if (bridgeTarget == null) null else mapFunction(bridgeTarget)
                     val placeToFunctionsTable = !isAbstract && irClass != null
                             && (it.isOverridableOrOverrides || bridgeTarget != null || function.isSpecial || !irClass.isFinalClass)
                     val symbolTableIndex = if (placeToFunctionsTable) module.numberOfFunctions++ else -1


### PR DESCRIPTION
Compiler has both K1 and frontend-agnostic storage of special bridges. This MR switches from first to second in K/N as part of "remove K1" effort. 