### PR TITLE
[Swift Export] KTI-3419: Unify cancellation approach between async swift invocations

### DIFF
--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/SirBridgeProviderImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/SirBridgeProviderImpl.kt
@@ -384,6 +384,7 @@ private class BridgeFunctionDescriptor(
                 )
                 addAll(continuation.helperBridges(typeNamer))
                 addAll(exception.helperBridges(typeNamer))
+                addAll(cancellation.helperBridges(typeNamer))
             }.distinct()
         }
 
@@ -505,19 +506,21 @@ private class BridgeFunctionDescriptor(
             val shadowedName = "__${param.name}".kotlinIdentifier
             val converted = bridge.inKotlinSources.kotlinToSwift(typeNamer, paramName)
             if (converted != paramName) {
-                shadowDeclarations.add("    val $shadowedName = $converted")
+                shadowDeclarations.add("val $shadowedName = $converted")
                 shadowedName
             } else {
                 paramName
             }
         }
 
-        val shadowDeclarationLines = shadowDeclarations.joinToString("") { "$it\n" }
+        val asyncBlock = renderKotlinSuspendSwiftCoroutine(
+            typeNamer,
+            Triple(continuation, exception, cancellation),
+        ) { continuationArg, exceptionArg, cancellationArg ->
+            "$swiftBridgeName(${(callArgs + listOf(continuationArg, exceptionArg, cancellationArg)).joinToString()})"
+        }
 
-        val continuationKotlinType = typeNamer.kotlinFqName(continuation.swiftType, SirTypeNamer.KotlinNameType.PARAMETRIZED)
-        val exceptionKotlinType = typeNamer.kotlinFqName(exception.swiftType, SirTypeNamer.KotlinNameType.PARAMETRIZED)
-
-        val swiftBridgeArgs = (callArgs + listOf("__continuationPtr", "__exceptionPtr", "__cancellationPtr")).joinToString()
+        val functionBody = (shadowDeclarations + "return $asyncBlock").joinToString("\n")
 
         val kotlinSource = """
             |@$importAnnotation("$swiftBridgeName")
@@ -525,14 +528,7 @@ private class BridgeFunctionDescriptor(
             |
             |@$reverseBridgeAnnotation($targetClassFqName::class, "$targetMethodName")
             |public suspend fun $cBridgeName($trampolineParams): $trampolineReturnType {
-            |${shadowDeclarationLines}    return awaitSwiftCoroutine { __resume, __cancellation ->
-            |        val __continuation: $continuationKotlinType = { _result -> __resume(kotlin.Result.success(_result)) }
-            |        val __exception: $exceptionKotlinType = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-            |        val __continuationPtr = ${continuation.inKotlinSources.kotlinToSwift(typeNamer, "__continuation")}
-            |        val __exceptionPtr = ${exception.inKotlinSources.kotlinToSwift(typeNamer, "__exception")}
-            |        val __cancellationPtr = ${cancellation.inKotlinSources.kotlinToSwift(typeNamer, "__cancellation")}
-            |        $swiftBridgeName($swiftBridgeArgs)
-            |    }
+            |${functionBody.prependIndent("    ")}
             |}
         """.trimMargin()
 

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
@@ -47,7 +47,7 @@ internal fun asyncContinuationBridges(
     // continuation
     AsCovariantBlock(parameters = listOf(resultBridge), returnType = AsVoid),
     // exception
-    // A `null` exception is used to signal a cancellation, see `suspendSwiftCoroutine`/`awaitSwiftCoroutine`.
+    // A `null` exception is used to signal a cancellation, see `suspendSwiftCoroutine`.
     AsCovariantBlock(
         parameters = listOf(AsObjCBridged(SirSwiftModule.error.nominalType().optional(), CType.NSError.nullable)),
         returnType = AsVoid,
@@ -59,6 +59,29 @@ internal fun asyncContinuationBridges(
         cType = CType.Object,
     ),
 )
+
+context(session: SirSession)
+internal fun renderKotlinSuspendSwiftCoroutine(
+    typeNamer: SirTypeNamer,
+    async: Triple<KotlinToSwiftBridge, KotlinToSwiftBridge, KotlinToSwiftBridge>,
+    prelude: String = "",
+    call: (continuation: String, exception: String, cancellation: String) -> String,
+): String {
+    val args = listOf(
+        "continuation" to async.first,
+        "exception" to async.second,
+        "cancellation" to async.third,
+    )
+    val defineArgs = args.joinToString(prefix = " ", postfix = " ->") {
+        "${it.first}: ${typeNamer.kotlinFqName(it.second.swiftType, SirTypeNamer.KotlinNameType.PARAMETRIZED)}"
+    }
+    val lines = buildList {
+        if (prelude.isNotEmpty()) add(prelude)
+        args.forEach { add("val _${it.first} = ${it.second.inKotlinSources.kotlinToSwift(typeNamer, it.first)}") }
+        add(call("_continuation", "_exception", "_cancellation"))
+    }
+    return "suspendSwiftCoroutine {$defineArgs\n${lines.joinToString("\n").prependIndent("    ")}\n}"
+}
 
 context(session: SirSession)
 private fun bridgeTypeForVariadicParameter(type: SirType): Bridge =
@@ -999,32 +1022,25 @@ internal sealed interface Bridge {
                     addAll(contextParameters.mapIndexed { idx, el -> "ctx${idx}" to el })
                     addAll(parameters.mapIndexed { idx, el -> "arg${idx}" to el })
                 }.takeIf { it.isNotEmpty() }
-                val asyncArgs = asyncParameters?.let {
-                    buildList {
-                        add("continuation" to it.first)
-                        add("exception" to it.second)
-                        add("cancellation" to it.third)
-                    }
-                }
-                val allArgs = buildList {
-                    argsInClosure?.let(::addAll)
-                    asyncArgs?.let(::addAll)
-                }
-                val mappedArgs = allArgs.takeIf { it.isNotEmpty() }?.joinToString(separator = "\n", postfix = "\n") { [name, bridge] ->
+                val regularConversions = argsInClosure.orEmpty().joinToString(separator = "\n") { [name, bridge] ->
                     "val _$name = ${bridge.inKotlinSources.kotlinToSwift(typeNamer, name)}"
-                } ?: ""
-                val callArgs = allArgs.joinToString { [name, _] -> "_$name" }
-                var body = mappedArgs + "val _result = kotlinFun($callArgs)\n${
-                    returnType.inKotlinSources.swiftToKotlin(typeNamer, "_result")
-                }"
-                if (asyncArgs != null) {
-                    body = """suspendSwiftCoroutine {${asyncArgs.defineArgs(typeNamer)}
-                    ${body.prependIndent("|    ")}
-                    |}""".trimMargin()
                 }
+                val regularCallArgs = argsInClosure.orEmpty().map { [name, _] -> "_$name" }
+
+                val body = asyncParameters?.let { async ->
+                    renderKotlinSuspendSwiftCoroutine(typeNamer, async, prelude = regularConversions) { continuation, exception, cancellation ->
+                        "val _result = kotlinFun(${(regularCallArgs + listOf(continuation, exception, cancellation)).joinToString()})\n" +
+                                returnType.inKotlinSources.swiftToKotlin(typeNamer, "_result")
+                    }
+                } ?: run {
+                    val mappedArgs = regularConversions.takeIf { it.isNotEmpty() }?.let { "$it\n" } ?: ""
+                    mappedArgs + "val _result = kotlinFun(${regularCallArgs.joinToString()})\n" +
+                            returnType.inKotlinSources.swiftToKotlin(typeNamer, "_result")
+                }
+
                 return """run {
                 |    val kotlinFun = convertBlockPtrToKotlinFunction<$kotlinFunctionTypeRendered>($valueExpression);
-                |    ${asyncArgs?.let { "suspend " } ?: ""}{${argsInClosure.defineArgs(typeNamer)}
+                |    ${asyncParameters?.let { "suspend " } ?: ""}{${argsInClosure.defineArgs(typeNamer)}
                 ${body.prependIndent("|        ")}
                 |    }
                 |}""".trimMargin()

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/inheritance/inheritance.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/inheritance/inheritance.swift
@@ -270,6 +270,61 @@ func swiftSuspendOverrideRunsCleanupOnCancellation() async throws {
     #expect(result == .failure(CancellationError()))
 }
 
+// Swift's cancellation is advisory: a Swift override may observe cancellation, decline to rethrow it, and still
+// return a value. That value must propagate to the Kotlin caller (Swift semantics) instead of being replaced by a
+// CancellationError. Under the old eager reverse bridge the Kotlin caller resumed on cancellation and this value was
+// discarded; the honest bridge awaits the override and delivers what it actually produced.
+@Test
+func swiftSuspendOverrideValueSurvivesCancellation() async throws {
+    final class UncooperativeDerived: AsyncBase, @unchecked Sendable {
+        override func greet(name: String) async throws -> String {
+            try? await Task.sleep(nanoseconds: 10_000_000_000) // cancellation aborts the sleep but is swallowed
+            return "Swift: \(name)"
+        }
+    }
+
+    let derived = UncooperativeDerived()
+    let task = Task<String, any Error>.detached {
+        try await callGreet(base: derived, name: "X")
+    }
+    DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+        task.cancel()
+    }
+
+    let result = await task.result
+    #expect(task.isCancelled)
+    #expect(result == .success("Swift: X"), "a value returned by the override after cancellation must reach the Kotlin caller")
+}
+
+// Same as above, but the non-cooperative override throws its OWN error after cancellation instead of returning; the
+// custom error (its message) must survive to the Kotlin caller rather than being replaced by a CancellationError.
+@Test
+func swiftSuspendOverrideCustomErrorSurvivesCancellation() async throws {
+    final class UncooperativeThrower: AsyncBase, @unchecked Sendable {
+        override func greet(name: String) async throws -> String {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            throw NSError(domain: "swift.test", code: 5, userInfo: [NSLocalizedDescriptionKey: "uncooperative-boom"])
+        }
+    }
+
+    let derived = UncooperativeThrower()
+    let task = Task<String, any Error>.detached {
+        try await callGreet(base: derived, name: "X")
+    }
+    DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+        task.cancel()
+    }
+
+    let result = await task.result
+    #expect(task.isCancelled)
+    if case let .failure(e) = result {
+        #expect(!(e is CancellationError), "the override's own error must survive, not be replaced by cancellation")
+        #expect(String(describing: e).contains("uncooperative-boom"))
+    } else {
+        Issue.record("expected the override's custom error to propagate, got \(result)")
+    }
+}
+
 func ==<T>(_ lhs: Result<T, any Error>, _ rhs: Result<T, any Error>) -> Bool where T: Equatable {
     switch (lhs, rhs) {
     case (.success(let l), .success(let r)): l == r

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/KotlinxCoroutinesCore/KotlinxCoroutinesCore.kt
@@ -24,13 +24,11 @@ internal external fun kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArgumen
 public suspend fun kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.FlowCollector<kotlin.Any?>, value: kotlin.Any?): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<Unit, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_FlowCollector_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value, _continuation, _exception, _cancellation)
     }
 }
 
@@ -41,13 +39,11 @@ internal external fun kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArg
 public suspend fun kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse(self: kotlinx.coroutines.flow.MutableSharedFlow<kotlin.Any?>, value: kotlin.Any?): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __value = if (value == null) kotlin.native.internal.NativePtr.NULL else kotlin.native.internal.ref.createRetainedExternalRCRef(value)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<Unit, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        kotlinx_coroutines_flow_MutableSharedFlow_emit__TypesOfArguments__Swift_Optional_anyU20KotlinRuntimeSupport__KotlinBridgeable_____reverse_swift(__self, __value, _continuation, _exception, _cancellation)
     }
 }
 

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/main/main.kt
@@ -19,13 +19,11 @@ internal external fun FunctionalInterfaceWithSuspendFunction_emit__reverse_swift
 @BindReverseBridgeToMethod(FunctionalInterfaceWithSuspendFunction::class, "emit")
 public suspend fun FunctionalInterfaceWithSuspendFunction_emit__reverse(self: FunctionalInterfaceWithSuspendFunction): Unit {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<Unit, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        FunctionalInterfaceWithSuspendFunction_emit__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<Unit, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        FunctionalInterfaceWithSuspendFunction_emit__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/crossLanguageInheritance/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/crossLanguageInheritance/golden_result/main/main.kt
@@ -22,13 +22,11 @@ internal external fun AsyncAbstractBase_abstractGreet__reverse_swift(self: kotli
 @BindReverseBridgeToMethod(AsyncAbstractBase::class, "abstractGreet")
 public suspend fun AsyncAbstractBase_abstractGreet__reverse(self: AsyncAbstractBase): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncAbstractBase_abstractGreet__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncAbstractBase_abstractGreet__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 
@@ -38,13 +36,11 @@ internal external fun AsyncAbstractBase_concreteGreet__reverse_swift(self: kotli
 @BindReverseBridgeToMethod(AsyncAbstractBase::class, "concreteGreet")
 public suspend fun AsyncAbstractBase_concreteGreet__reverse(self: AsyncAbstractBase): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncAbstractBase_concreteGreet__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncAbstractBase_concreteGreet__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 
@@ -54,13 +50,11 @@ internal external fun AsyncBase_count__reverse_swift(self: kotlin.native.interna
 @BindReverseBridgeToMethod(AsyncBase::class, "count")
 public suspend fun AsyncBase_count__reverse(self: AsyncBase): Int {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<Int, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncBase_count__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<Int, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncBase_count__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 
@@ -71,13 +65,11 @@ internal external fun AsyncBase_greet__TypesOfArguments__Swift_String____reverse
 public suspend fun AsyncBase_greet__TypesOfArguments__Swift_String____reverse(self: AsyncBase, name: kotlin.String): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __name = name.objcPtr()
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncBase_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncBase_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name, _continuation, _exception, _cancellation)
     }
 }
 
@@ -98,13 +90,11 @@ internal external fun AsyncDefaulter_describe__reverse_swift(self: kotlin.native
 @BindReverseBridgeToMethod(AsyncDefaulter::class, "describe")
 public suspend fun AsyncDefaulter_describe__reverse(self: AsyncDefaulter): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncDefaulter_describe__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncDefaulter_describe__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 
@@ -114,13 +104,11 @@ internal external fun AsyncDefaulter_tag__reverse_swift(self: kotlin.native.inte
 @BindReverseBridgeToMethod(AsyncDefaulter::class, "tag")
 public suspend fun AsyncDefaulter_tag__reverse(self: AsyncDefaulter): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncDefaulter_tag__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncDefaulter_tag__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 
@@ -131,13 +119,11 @@ internal external fun AsyncGreeterBase_greet__TypesOfArguments__Swift_String____
 public suspend fun AsyncGreeterBase_greet__TypesOfArguments__Swift_String____reverse(self: AsyncGreeterBase, name: kotlin.String): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __name = name.objcPtr()
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncGreeterBase_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncGreeterBase_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name, _continuation, _exception, _cancellation)
     }
 }
 
@@ -147,13 +133,11 @@ internal external fun AsyncGreeterBase_salutation__reverse_swift(self: kotlin.na
 @BindReverseBridgeToMethod(AsyncGreeterBase::class, "salutation")
 public suspend fun AsyncGreeterBase_salutation__reverse(self: AsyncGreeterBase): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncGreeterBase_salutation__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncGreeterBase_salutation__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 
@@ -164,13 +148,11 @@ internal external fun AsyncGreeter_greet__TypesOfArguments__Swift_String____reve
 public suspend fun AsyncGreeter_greet__TypesOfArguments__Swift_String____reverse(self: AsyncGreeter, name: kotlin.String): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
     val __name = name.objcPtr()
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncGreeter_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncGreeter_greet__TypesOfArguments__Swift_String____reverse_swift(__self, __name, _continuation, _exception, _cancellation)
     }
 }
 
@@ -180,13 +162,11 @@ internal external fun AsyncGreeter_salutation__reverse_swift(self: kotlin.native
 @BindReverseBridgeToMethod(AsyncGreeter::class, "salutation")
 public suspend fun AsyncGreeter_salutation__reverse(self: AsyncGreeter): kotlin.String {
     val __self = kotlin.native.internal.ref.createRetainedExternalRCRef(self)
-    return awaitSwiftCoroutine { __resume, __cancellation ->
-        val __continuation: Function1<kotlin.String, Unit> = { _result -> __resume(kotlin.Result.success(_result)) }
-        val __exception: Function1<platform.Foundation.NSError?, Unit> = { _error -> __resume(kotlin.Result.failure(_error?.let(::SwiftException) ?: kotlinx.coroutines.CancellationException("Cancelled using CancellationError in Swift"))) }
-        val __continuationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__continuation)
-        val __exceptionPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__exception)
-        val __cancellationPtr = kotlin.native.internal.ref.createRetainedExternalRCRef(__cancellation)
-        AsyncGreeter_salutation__reverse_swift(__self, __continuationPtr, __exceptionPtr, __cancellationPtr)
+    return suspendSwiftCoroutine { continuation: Function1<kotlin.String, Unit>, exception: Function1<platform.Foundation.NSError?, Unit>, cancellation: SwiftJob ->
+        val _continuation = kotlin.native.internal.ref.createRetainedExternalRCRef(continuation)
+        val _exception = kotlin.native.internal.ref.createRetainedExternalRCRef(exception)
+        val _cancellation = kotlin.native.internal.ref.createRetainedExternalRCRef(cancellation)
+        AsyncGreeter_salutation__reverse_swift(__self, _continuation, _exception, _cancellation)
     }
 }
 

--- a/native/swift/swift-export-standalone/resources/swift/KotlinCoroutineSupport.kt
+++ b/native/swift/swift-export-standalone/resources/swift/KotlinCoroutineSupport.kt
@@ -85,15 +85,6 @@ public suspend fun <T> suspendSwiftCoroutine(
     }
 }
 
-public suspend fun <T> awaitSwiftCoroutine(
-    block: (resume: (Result<T>) -> Unit, cancellation: SwiftJob) -> Unit,
-): T {
-    val cancellation = SwiftJob(coroutineContext.job)
-    return suspendCancellableCoroutine { cont ->
-        block({ result -> if (cont.isActive) cont.resumeWith(result) }, cancellation)
-    }
-}
-
 @ExportedBridge("__root___SwiftJob_init_allocate")
 public fun __root___SwiftJob_init_allocate(): kotlin.native.internal.NativePtr {
     val instance = kotlin.native.internal.createUninitializedInstance<SwiftJob>()


### PR DESCRIPTION
Before this MR async reverse bridges incidentally used a different approach to cancellation than contravariant async closures (which take precedence): an async call into swift made via a reverse bridge (i.e. in cross-language sub typing) used to un-block the caller as soon as cancellation was received, letting the rest of the caller and the rest of the callee to execute in parallel.