### PR TITLE
KT-87277 [AFU] Enforce private visibility for atomic companion properties

### DIFF
--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuErrorMessages.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuErrorMessages.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -54,7 +54,7 @@ object AtomicfuErrorMessages : BaseDiagnosticRendererFactory() {
                 "public val a: T by _a \n" +
                 "```\n"
 
-    private const val ATOMIC_PROEPRTIES_SHOULD_BE_VAL_MESSAGE = "Consider declaring `''{0}''` as a private val or internal val.\n" +
+    private const val ATOMIC_PROPERTIES_SHOULD_BE_VAL_MESSAGE = "Consider declaring `''{0}''` as a private val or internal val.\n" +
             "If you need to declare a variable with accessors delegated to the atomic property value, you can use a delegated property declared within the same scope, e.g:\n" +
             "```\n" +
             "private val _a = atomic<T>(initial) \n" +
@@ -69,7 +69,7 @@ object AtomicfuErrorMessages : BaseDiagnosticRendererFactory() {
             AtomicfuErrors.PUBLISHED_API_ATOMICS_ARE_FORBIDDEN, PUBLIC_ATOMICS_ARE_FORBIDDEN_MESSAGE, Renderers.TO_STRING
         )
         map.put(
-            AtomicfuErrors.ATOMIC_PROPERTIES_SHOULD_BE_VAL, ATOMIC_PROEPRTIES_SHOULD_BE_VAL_MESSAGE, Renderers.TO_STRING
+            AtomicfuErrors.ATOMIC_PROPERTIES_SHOULD_BE_VAL, ATOMIC_PROPERTIES_SHOULD_BE_VAL_MESSAGE, Renderers.TO_STRING
         )
     }
 

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuErrorMessages.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuErrorMessages.kt
@@ -61,6 +61,10 @@ object AtomicfuErrorMessages : BaseDiagnosticRendererFactory() {
             "public var a: T by _a \n" +
             "```\n"
 
+    private const val NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN_MESSAGE =
+        "\nTo prevent atomic properties defined in companion blocks or as companion extensions " +
+                "from being referenced outside the current Kotlin file, they must be declared as private."
+
     override val MAP: KtDiagnosticFactoryToRendererMap by KtDiagnosticFactoryToRendererMap("Atomicfu Plugin") { map ->
         map.put(
             AtomicfuErrors.PUBLIC_ATOMICS_ARE_FORBIDDEN, PUBLIC_ATOMICS_ARE_FORBIDDEN_MESSAGE, Renderers.TO_STRING
@@ -70,6 +74,9 @@ object AtomicfuErrorMessages : BaseDiagnosticRendererFactory() {
         )
         map.put(
             AtomicfuErrors.ATOMIC_PROPERTIES_SHOULD_BE_VAL, ATOMIC_PROPERTIES_SHOULD_BE_VAL_MESSAGE, Renderers.TO_STRING
+        )
+        map.put(
+            AtomicfuErrors.NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN, NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN_MESSAGE, Renderers.TO_STRING
         )
     }
 

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuErrors.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuErrors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -15,6 +15,6 @@ object AtomicfuErrors : KtDiagnosticsContainer() {
     val PUBLIC_ATOMICS_ARE_FORBIDDEN by error1<KtProperty, String>(SourceElementPositioningStrategies.VISIBILITY_MODIFIER)
     val PUBLISHED_API_ATOMICS_ARE_FORBIDDEN by error1<KtProperty, String>(SourceElementPositioningStrategies.VISIBILITY_MODIFIER)
     val ATOMIC_PROPERTIES_SHOULD_BE_VAL by error1<KtProperty, String>(SourceElementPositioningStrategies.VAL_OR_VAR_NODE)
-
+    val NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN by error1<KtProperty, String>(SourceElementPositioningStrategies.VISIBILITY_MODIFIER)
     override fun getRendererFactory(): BaseDiagnosticRendererFactory = AtomicfuErrorMessages
 }

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuPropertyChecker.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuPropertyChecker.kt
@@ -1,58 +1,46 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.atomicfu.compiler.diagnostic
 
+import org.jetbrains.kotlin.descriptors.EffectiveVisibility
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirPropertyChecker
 import org.jetbrains.kotlin.fir.declarations.FirProperty
-import org.jetbrains.kotlin.fir.declarations.utils.visibility
-import org.jetbrains.kotlin.fir.expressions.FirAnnotation
-import org.jetbrains.kotlin.fir.resolve.toClassLikeSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
+import org.jetbrains.kotlin.fir.declarations.utils.effectiveVisibility
+import org.jetbrains.kotlin.fir.resolve.transformers.publishedApiEffectiveVisibility
 import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.text
 
 private const val KOTLINX_ATOMICFU = "kotlinx.atomicfu"
-private const val PUBLISHED_API = "kotlin.PublishedApi"
 
 private fun FirProperty.isKotlinxAtomicfu(): Boolean = returnTypeRef.coneType.classId?.packageFqName?.asString() == KOTLINX_ATOMICFU
 
-private fun FirProperty.isPublishedApi(): Boolean = annotations.any(::isMarkedWithPublishedApi)
-
-private fun FirClassLikeSymbol<*>.isPublishedApi(): Boolean = resolvedAnnotationsWithClassIds.any(::isMarkedWithPublishedApi)
-private fun FirClassLikeSymbol<*>.isPublic(): Boolean = resolvedStatus.visibility.isPublicAPI
-
-private fun isMarkedWithPublishedApi(a: FirAnnotation): Boolean =
-    a.annotationTypeRef.coneType.classId?.asFqNameString() == PUBLISHED_API
+private val FirProperty.resolvedVisibility: EffectiveVisibility
+    get() = publishedApiEffectiveVisibility ?: effectiveVisibility
 
 object AtomicfuPropertyChecker: FirPropertyChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirProperty) {
         if (!declaration.isKotlinxAtomicfu()) return
-        val containingClassSymbol = declaration.dispatchReceiverType?.toClassLikeSymbol()
-        if (declaration.visibility.isPublicAPI &&
-            (containingClassSymbol == null || containingClassSymbol.isPublic())) {
+        if (!declaration.effectiveVisibility.publicApi && declaration.resolvedVisibility.publicApi) {
+            reporter.reportOn(
+                declaration.source,
+                AtomicfuErrors.PUBLISHED_API_ATOMICS_ARE_FORBIDDEN,
+                declaration.source.text.toString()
+            )
+        } else if (declaration.resolvedVisibility.publicApi) {
             reporter.reportOn(
                 declaration.source,
                 AtomicfuErrors.PUBLIC_ATOMICS_ARE_FORBIDDEN,
                 declaration.source.text.toString()
             )
-        } else {
-            if ((declaration.visibility.isPublicAPI || declaration.isPublishedApi()) &&
-                (containingClassSymbol == null || containingClassSymbol.isPublic() || containingClassSymbol.isPublishedApi())) {
-                reporter.reportOn(
-                    declaration.source,
-                    AtomicfuErrors.PUBLISHED_API_ATOMICS_ARE_FORBIDDEN,
-                    declaration.source.text.toString()
-                )
-            }
         }
         if (declaration.isVar) {
             reporter.reportOn(

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuPropertyChecker.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/diagnostic/AtomicfuPropertyChecker.kt
@@ -13,6 +13,8 @@ import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirPropertyChecker
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.utils.effectiveVisibility
+import org.jetbrains.kotlin.fir.declarations.utils.isCompanionBlockMember
+import org.jetbrains.kotlin.fir.declarations.utils.isCompanionExtension
 import org.jetbrains.kotlin.fir.resolve.transformers.publishedApiEffectiveVisibility
 import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.coneType
@@ -25,11 +27,22 @@ private fun FirProperty.isKotlinxAtomicfu(): Boolean = returnTypeRef.coneType.cl
 private val FirProperty.resolvedVisibility: EffectiveVisibility
     get() = publishedApiEffectiveVisibility ?: effectiveVisibility
 
-object AtomicfuPropertyChecker: FirPropertyChecker(MppCheckerKind.Common) {
+object AtomicfuPropertyChecker : FirPropertyChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirProperty) {
         if (!declaration.isKotlinxAtomicfu()) return
-        if (!declaration.effectiveVisibility.publicApi && declaration.resolvedVisibility.publicApi) {
+        if (!declaration.resolvedVisibility.privateApi &&
+            (declaration.isCompanionBlockMember || declaration.isCompanionExtension)
+        ) {
+            // Companion block's properties and companion extension properties will be supported in the plugin
+            // at the same exact time they become available for our users,
+            // and it's a chance to make things right from the beginning and support only private properties.
+            reporter.reportOn(
+                declaration.source,
+                AtomicfuErrors.NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN,
+                declaration.source.text.toString()
+            )
+        } else if (!declaration.effectiveVisibility.publicApi && declaration.resolvedVisibility.publicApi) {
             reporter.reportOn(
                 declaration.source,
                 AtomicfuErrors.PUBLISHED_API_ATOMICS_ARE_FORBIDDEN,

--- a/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicCompanionExtensions.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicCompanionExtensions.kt
@@ -1,0 +1,34 @@
+// LANGUAGE: +CompanionExtensions
+
+import kotlinx.atomicfu.*
+
+public class PublicClass
+internal class InternalClass
+@PublishedApi internal class PublishedInternaClass
+private class PrivateClass
+
+<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val PublicClass.pa = atomic(0)
+internal companion val PublicClass.pi = atomic(0)
+@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val PublicClass.pip = atomic(0)
+private companion val PublicClass.pp = atomic(0)
+
+<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>InternalClass<!>.pa = atomic(0)
+internal companion val InternalClass.pi = atomic(0)
+@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val InternalClass.pip = atomic(0)
+private companion val InternalClass.pp = atomic(0)
+
+<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>PublishedInternaClass<!>.pa = atomic(0)
+internal companion val PublishedInternaClass.pi = atomic(0)
+@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val PublishedInternaClass.pip = atomic(0)
+private companion val PublishedInternaClass.pp = atomic(0)
+
+<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pa = atomic(0)
+internal companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pi = atomic(0)
+@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pip = atomic(0)
+private companion val PrivateClass.pp = atomic(0)
+
+private companion <!ATOMIC_PROPERTIES_SHOULD_BE_VAL!>var<!> PrivateClass.volatileAtomic = atomic(0)
+
+fun box(): String {
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicCompanionExtensions.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicCompanionExtensions.kt
@@ -7,24 +7,24 @@ internal class InternalClass
 @PublishedApi internal class PublishedInternaClass
 private class PrivateClass
 
-<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val PublicClass.pa = atomic(0)
-internal companion val PublicClass.pi = atomic(0)
-@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val PublicClass.pip = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>public<!> companion val PublicClass.pa = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val PublicClass.pi = atomic(0)
+@PublishedApi <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val PublicClass.pip = atomic(0)
 private companion val PublicClass.pp = atomic(0)
 
-<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>InternalClass<!>.pa = atomic(0)
-internal companion val InternalClass.pi = atomic(0)
-@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val InternalClass.pip = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>InternalClass<!>.pa = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val InternalClass.pi = atomic(0)
+@PublishedApi <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val InternalClass.pip = atomic(0)
 private companion val InternalClass.pp = atomic(0)
 
-<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>PublishedInternaClass<!>.pa = atomic(0)
-internal companion val PublishedInternaClass.pi = atomic(0)
-@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val PublishedInternaClass.pip = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>PublishedInternaClass<!>.pa = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val PublishedInternaClass.pi = atomic(0)
+@PublishedApi <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val PublishedInternaClass.pip = atomic(0)
 private companion val PublishedInternaClass.pp = atomic(0)
 
-<!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pa = atomic(0)
-internal companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pi = atomic(0)
-@PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pip = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>public<!> companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pa = atomic(0)
+<!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pi = atomic(0)
+@PublishedApi <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> companion val <!EXPOSED_RECEIVER_TYPE!>PrivateClass<!>.pip = atomic(0)
 private companion val PrivateClass.pp = atomic(0)
 
 private companion <!ATOMIC_PROPERTIES_SHOULD_BE_VAL!>var<!> PrivateClass.volatileAtomic = atomic(0)

--- a/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicsInCompanionBlocks.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicsInCompanionBlocks.kt
@@ -4,9 +4,9 @@ import kotlinx.atomicfu.*
 
 public class PublicComanionHolder {
     companion {
-        <!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
-        internal val pi = atomic(0)
-        @PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
+        <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
+        <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> val pi = atomic(0)
+        @PublishedApi <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
         private val pp = atomic(0)
 
         private <!ATOMIC_PROPERTIES_SHOULD_BE_VAL!>var<!> volatileAtomic = atomic(0)
@@ -15,9 +15,9 @@ public class PublicComanionHolder {
 
 internal class InternalComanionHolder {
     companion {
-        public val pa = atomic(0)
-        internal val pi = atomic(0)
-        @PublishedApi internal val pip = atomic(0)
+        <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
+        <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> val pi = atomic(0)
+        @PublishedApi <!NON_PRIVATE_ATOMIC_COMPANIONS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
         private val pp = atomic(0)
     }
 }

--- a/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicsInCompanionBlocks.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicsInCompanionBlocks.kt
@@ -1,0 +1,36 @@
+// LANGUAGE: +CompanionBlocks
+
+import kotlinx.atomicfu.*
+
+public class PublicComanionHolder {
+    companion {
+        <!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
+        internal val pi = atomic(0)
+        @PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
+        private val pp = atomic(0)
+
+        private <!ATOMIC_PROPERTIES_SHOULD_BE_VAL!>var<!> volatileAtomic = atomic(0)
+    }
+}
+
+internal class InternalComanionHolder {
+    companion {
+        <!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
+        internal val pi = atomic(0)
+        @PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
+        private val pp = atomic(0)
+    }
+}
+
+private class PrivateComanionHolder {
+    companion {
+        <!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
+        internal val pi = atomic(0)
+        @PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
+        private val pp = atomic(0)
+    }
+}
+
+fun box(): String {
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicsInCompanionBlocks.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/diagnostics/AtomicsInCompanionBlocks.kt
@@ -15,18 +15,18 @@ public class PublicComanionHolder {
 
 internal class InternalComanionHolder {
     companion {
-        <!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
+        public val pa = atomic(0)
         internal val pi = atomic(0)
-        @PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
+        @PublishedApi internal val pip = atomic(0)
         private val pp = atomic(0)
     }
 }
 
 private class PrivateComanionHolder {
     companion {
-        <!PUBLIC_ATOMICS_ARE_FORBIDDEN!>public<!> val pa = atomic(0)
+        public val pa = atomic(0)
         internal val pi = atomic(0)
-        @PublishedApi <!PUBLISHED_API_ATOMICS_ARE_FORBIDDEN!>internal<!> val pip = atomic(0)
+        @PublishedApi internal val pip = atomic(0)
         private val pp = atomic(0)
     }
 }

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuFirCheckerTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuFirCheckerTestGenerated.java
@@ -28,6 +28,18 @@ public class AtomicfuFirCheckerTestGenerated extends AbstractAtomicfuFirCheckerT
   }
 
   @Test
+  @TestMetadata("AtomicCompanionExtensions.kt")
+  public void testAtomicCompanionExtensions() {
+    run("AtomicCompanionExtensions.kt");
+  }
+
+  @Test
+  @TestMetadata("AtomicsInCompanionBlocks.kt")
+  public void testAtomicsInCompanionBlocks() {
+    run("AtomicsInCompanionBlocks.kt");
+  }
+
+  @Test
   @TestMetadata("CheckAtomicVisibilityTest.kt")
   public void testCheckAtomicVisibilityTest() {
     run("CheckAtomicVisibilityTest.kt");


### PR DESCRIPTION
AFU is a notorious headache as it generates code accessing private fields from different compilation modules (for example, see KT-86558). Original AFU design was too permissive and let declaring internal atomic properties.

While changing it for regular properties will break several projects, for companion properties we can start from scratch and allow only private atomic properties.

This PR fixes visibility checks to work with companion blocks and extensions and adds a new check verifying visibility of atomic properties defined in companion blocks or as companion extensions.

Fixes KT-87277