### PR TITLE
[Gradle] Fix file assertion in KotlinWebpackUpToDateIT

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/web/KotlinWebpackUpToDateIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/web/KotlinWebpackUpToDateIT.kt
@@ -124,16 +124,9 @@ sealed class KotlinWebpackUpToDateIT(
                             .trim()
                     }
 
-                val expectedFileBasedDepPath = projectPath.toRealPath().absolutePathString() + "/sp2/foo-npm-dep"
+                val expectedFileBasedDepPath = projectPath.absolute().resolve("sp2/foo-npm-dep").pathString
                 assertEquals(
-                    buildString {
-                        append(buildTaskPath)
-                        append(" doNotCacheIf=true.")
-                        append(" Task depends on file-based NPM dependencies: [")
-                        append(expectedFileBasedDepPath)
-                        append("].")
-                        append(" See KT-86309.")
-                    },
+                    "$buildTaskPath doNotCacheIf=true. Task depends on file-based NPM dependencies: [$expectedFileBasedDepPath]. See KT-86309.",
                     fileBasedNpmDepsLogLines,
                 )
             }


### PR DESCRIPTION
The test fails on Windows because of different path separators.

Also, fix a few other things.
- `toRealPath()` is redundant, remove it.
- Replace `buildString {}` with regular string - it's easier to view.