### PR TITLE
[Gradle] Throw error if new JS test DSL is used with Wasm

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2377,6 +2377,20 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
+    internal object NewJsTestDslNotSupportedForWasmError : ToolingDiagnosticFactory(
+        predefinedSeverity = ERROR,
+        predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
+    ) {
+        operator fun invoke() = build {
+            title { "The new test {} DSL is currently not supported for wasmJs targets" }
+                .description {
+                    "At the moment the new test {} DSL is not supported for wasmJs targets, support will be added in a future release."
+                }
+                .solution { "For now, please use the old DSL with wasmJs targets" }
+                .documentationLink(URI("https://kotl.in/new-js-browser-test-dsl"))
+        }
+    }
+
     internal object SwiftPMLinkagePackageNotIntegratedInXcodeProject : ToolingDiagnosticFactory(
         FATAL,
         DiagnosticGroup.Kgp.Misconfiguration,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.gradle.targets.KotlinTargetSideEffect
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinBrowserTestRunnerDsl
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
+import org.jetbrains.kotlin.gradle.targets.wasm.internal.isWasm
 import org.jetbrains.kotlin.gradle.tasks.registerTask
 import kotlin.time.toJavaDuration
 
@@ -23,12 +24,18 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
 
     val project = target.project
 
+
     project.launchInStage(KotlinPluginLifecycle.Stage.AfterEvaluateBuildscript) {
         val browser = target.subTargets.filterIsInstance<KotlinBrowserJsIr>().singleOrNull() ?: return@launchInStage
 
         val browserTestDsl = browser.test as KotlinJsBrowserTestImpl
         if (browserTestDsl.allBrowserRunners.get().isEmpty()) {
             project.logger.debug("No browser runners configured. Skipping kotlin js test task configuration")
+            return@launchInStage
+        }
+
+        if (target.isWasm) {
+            project.reportDiagnostic(KotlinToolingDiagnostics.NewJsTestDslNotSupportedForWasmError())
             return@launchInStage
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJsBrowserTestDslTest.kt
@@ -9,11 +9,14 @@ package org.jetbrains.kotlin.gradle.unitTests
 
 import org.gradle.api.file.Directory
 import org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBrowserTestDsl
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinChromiumTestRunner
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinFirefoxTestRunner
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinWebkitTestRunner
+import org.jetbrains.kotlin.gradle.util.assertContainsDiagnostic
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
 import kotlin.reflect.KClass
 import kotlin.test.Test
@@ -176,6 +179,26 @@ class KotlinJsBrowserTestDslTest {
             ),
             test.dumpRunners(),
         )
+    }
+
+    @Test
+    fun `using new test DSL in wasmJs target throws an error`() {
+        val project = buildProjectWithMPP {
+            with(multiplatformExtension) {
+                @OptIn(ExperimentalWasmDsl::class)
+                wasmJs {
+                    browser {
+                        test {
+                            it.chromium()
+                        }
+                    }
+                }
+            }
+        }
+
+        project.evaluate()
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.NewJsTestDslNotSupportedForWasmError)
     }
 }
 


### PR DESCRIPTION
The new test DSL currently can't be used with Wasm. This change catches attempts to use the new DSL early, preventing downstream failures.

^KT-87501 Verification Pending