### PR TITLE
Incremental compilation: fixed stale cinterop library caches

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.konan
 import org.jetbrains.kotlin.analyzer.CompilationErrorException
 import org.jetbrains.kotlin.backend.common.serialization.FingerprintHash
 import org.jetbrains.kotlin.backend.common.serialization.SerializedIrFileFingerprint
+import org.jetbrains.kotlin.backend.common.serialization.SerializedKlibFingerprint
 import org.jetbrains.kotlin.backend.konan.util.compilerFingerprint
 import org.jetbrains.kotlin.backend.konan.util.reportCompilationErrorAndThrow
 import org.jetbrains.kotlin.cli.reportLog
@@ -102,13 +103,45 @@ class CacheBuilder(
     private val KotlinLibrary.isSubjectOfIC: Boolean
         get() = isExplicitlySpecifiedByUserInCLIArgument && !isExternal && !isNativeStdlib
 
-    // Only auto-cached external libraries contribute to the fingerprint: changes in the per-file cached dependencies are tracked
-    // by the dirty-file analysis, and the distribution libraries only change together with the compiler fingerprint.
+    // Among the IC'ed libraries only the cinterop ones are cached monolithically (see buildLibraryCache).
+    private val KotlinLibrary.isCachedPerFile: Boolean
+        get() = isSubjectOfIC && !isCInteropLibrary()
+
+    // Only monolithically cached non-distribution dependencies (auto-cached external libraries and IC'ed cinterop libraries)
+    // contribute to the fingerprint: changes in the per-file cached dependencies are tracked by the dirty-file analysis,
+    // and the distribution libraries only change together with the compiler fingerprint (they live in compiler's dist directory).
     private fun computeDependenciesFingerprint(library: KotlinLibrary): FingerprintHash {
-        val externalCachedDependencies = library.getAllTransitiveDependencies(uniqueNameToLibrary).filter {
-            !it.isSubjectOfIC && !it.isImplicitlyLoadedFromKotlinNativeDistribution && !it.isNativeStdlib
+        val monolithicallyCachedDependencies = library.getAllTransitiveDependencies(uniqueNameToLibrary).filter {
+            !it.isCachedPerFile && !it.isImplicitlyLoadedFromKotlinNativeDistribution && !it.isNativeStdlib
         }
-        return CachedLibraries.computeDependenciesFingerprint(externalCachedDependencies, uniqueNameToHash)
+        return CachedLibraries.computeDependenciesFingerprint(monolithicallyCachedDependencies, uniqueNameToHash)
+    }
+
+    private val currentCompilerFingerprint by lazy { config.distribution.compilerFingerprint }
+
+    // Returns a human-readable reason if the cache of an IC'ed library cannot be reused, or null if it is up to date.
+    private fun staleCacheReason(library: KotlinLibrary, cache: CachedLibraries.Cache): String? {
+        val metadata = when (cache) {
+            is CachedLibraries.Cache.Monolithic -> cache.getMetadataOrNull() // A cinterop library.
+            is CachedLibraries.Cache.PerFile -> {
+                // All files of a per-file cache are produced against the same compiler and dependencies,
+                // so any file's metadata identifies the fingerprints of the whole cache.
+                val anyCachedFile = File(cache.path).listFiles.firstOrNull()?.name ?: return null
+                cache.getMetadataOrNull(anyCachedFile)
+            }
+        }
+        return when {
+            metadata == null ->
+                "has no metadata (it was produced by a compiler older than 2.2.20)"
+            metadata.compilerFingerprint != currentCompilerFingerprint ->
+                "was produced by a different compiler version"
+            metadata.dependenciesFingerprint != computeDependenciesFingerprint(library) ->
+                "was produced against different dependencies"
+            cache is CachedLibraries.Cache.Monolithic
+                    && metadata.hash != SerializedKlibFingerprint(library.path.toFile()).klibFingerprint ->
+                "does not match the current content of the library"
+            else -> null
+        }
     }
 
     fun build() {
@@ -157,37 +190,28 @@ class CacheBuilder(
         // This happens when a dependency is changed to an already-cached version, e.g. rolled back to the version it had before
         // an update (KT-87194). Each cache records the fingerprint of such dependencies, so force a full rebuild whenever
         // it doesn't match the current dependencies.
+        // The dirty-file check doesn't cover the monolithically cached cinterop libraries either: their caches are looked up
+        // by the library name, so a changed library would silently reuse the stale cache (KT-87273). Each cache records
+        // the fingerprint of its library, so force a rebuild whenever it doesn't match the current library.
         // Caches produced by compilers older than 2.2.20 don't have the metadata at all; rebuild them as well (KT-87202).
-        val currentCompilerFingerprint = config.distribution.compilerFingerprint
-        val staleCacheLibraries = icedLibraries.filter { library ->
-            // All files of a per-file cache are produced against the same compiler and dependencies,
-            // so any file's metadata identifies the fingerprints of the whole cache.
-            val cache = caches[library] as? CachedLibraries.Cache.PerFile ?: return@filter false
-            val anyCachedFile = File(cache.path).listFiles.firstOrNull()?.name ?: return@filter false
-            val metadata = cache.getMetadataOrNull(anyCachedFile)
-            when {
-                metadata == null -> {
-                    configuration.reportLog(
-                            "Incremental cache for ${library.path} has no metadata" +
-                                    " (it was produced by a compiler older than 2.2.20); rebuilding it")
-                    true
-                }
-                metadata.compilerFingerprint != currentCompilerFingerprint -> {
-                    configuration.reportLog(
-                            "Incremental cache for ${library.path} was produced by a different compiler version; rebuilding it")
-                    true
-                }
-                metadata.dependenciesFingerprint != computeDependenciesFingerprint(library) -> {
-                    configuration.reportLog(
-                            "Incremental cache for ${library.path} was produced against different dependencies; rebuilding it")
-                    true
-                }
-                else -> false
+        val staleCaches = icedLibraries.mapNotNull { library ->
+            val cache = caches[library] ?: return@mapNotNull null
+            staleCacheReason(library, cache)?.let { reason ->
+                configuration.reportLog("Incremental cache for ${library.path} $reason; rebuilding it")
+                library to cache
             }
         }
 
+        // Unlike per-file caches, which are rebuilt in place file by file, a stale monolithic cache is deleted and rebuilt
+        // right away: the dependent cache builds spawned below read it at its fixed name-keyed location.
+        val [staleMonolithicCaches, stalePerFileCaches] = staleCaches.partition { it.second is CachedLibraries.Cache.Monolithic }
+        staleMonolithicCaches.forEach { [library, cache] ->
+            File(cache.rootDirectory).deleteRecursively()
+            lastRebuiltArchives.addAll(buildLibraryCache(library, false, emptyList()))
+        }
+
         // Every library dependable on one of the changed external libraries needs its cache to be fully rebuilt.
-        val needFullRebuild = findAllDependable(externalLibrariesToCache) + staleCacheLibraries
+        val needFullRebuild = findAllDependable(externalLibrariesToCache) + stalePerFileCaches.map { it.first }
 
         val libraryFilesWithFqNames = mutableMapOf<KotlinLibrary, List<FileWithFqName>>()
 
@@ -535,7 +559,7 @@ class CacheBuilder(
             this.cachedLibraries = cachedLibraries
             cacheDirectories = listOf(libraryCacheDirectory.absolutePath)
             this.makePerFileCache = makePerFileCache
-            if (makePerFileCache)
+            if (library.isSubjectOfIC)
                 cachedLibraryDependenciesFingerprint = computeDependenciesFingerprint(library).toString()
             if (filesToCache.isNotEmpty())
                 this.filesToCache = filesToCache

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CachedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CachedLibraries.kt
@@ -71,9 +71,20 @@ class CachedLibraries(
             Kind.HEADER -> CompilerOutputKind.HEADER_CACHE
         }
 
+        // Returns null when the metadata file is absent, which is the case for caches produced by compilers older than 2.2.20 (KT-87202).
+        protected fun readMetadataOrNull(directory: File): CacheMetadata? {
+            val metadataFile = directory.child(METADATA_FILE_NAME)
+            if (!metadataFile.exists) return null
+            return metadataFile.bufferedReader().use {
+                CacheMetadataSerializer.deserialize(it)
+            }
+        }
+
         class Monolithic(target: KonanTarget, kind: Kind, path: String)
             : Cache(target, kind, path, File(path).parentFile.parentFile.absolutePath)
         {
+            fun getMetadataOrNull(): CacheMetadata? = readMetadataOrNull(File(rootDirectory))
+
             override fun computeBitcodeDependencies(): List<DependenciesTracker.UnresolvedDependency> {
                 val directory = File(path).absoluteFile.parentFile
                 val data = directory.child(BITCODE_DEPENDENCIES_FILE_NAME).readStrings()
@@ -130,14 +141,7 @@ class CachedLibraries(
                         it.absolutePath
                     }
 
-            // Returns null when the metadata file is absent, which is the case for caches produced by compilers older than 2.2.20 (KT-87202).
-            fun getMetadataOrNull(file: String): CacheMetadata? {
-                val metadataFile = File(path).child(file).child(METADATA_FILE_NAME)
-                if (!metadataFile.exists) return null
-                return metadataFile.bufferedReader().use {
-                    CacheMetadataSerializer.deserialize(it)
-                }
-            }
+            fun getMetadataOrNull(file: String): CacheMetadata? = readMetadataOrNull(File(path).child(file))
 
             override fun computeBitcodeDependencies() = perFileBitcodeDependencies.values.flatten()
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/CacheBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/CacheBuilding.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.driver.phases
 
 import org.jetbrains.kotlin.backend.common.phaser.createSimpleNamedCompilerPhase
+import org.jetbrains.kotlin.backend.common.serialization.SerializedKlibFingerprint
 import org.jetbrains.kotlin.backend.konan.CacheStorage
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.OutputFiles
@@ -30,6 +31,9 @@ internal val BuildAdditionalCacheInfoPhase = createSimpleNamedCompilerPhase<Nati
     val moduleDeserializer = parent.moduleDeserializerProvider.getDeserializerOrNull(module.descriptor.kotlinLibrary)
     if (moduleDeserializer == null) {
         require(module.descriptor.isFromCInteropLibrary()) { "No module deserializer for ${module.descriptor}" }
+        // C-interop libraries have no deserialized IR, so CacheInfoBuilder is not run for them. Still record
+        // the library fingerprint, so that the cache staleness check can detect a changed library (KT-87273).
+        context.klibHash = SerializedKlibFingerprint(module.descriptor.kotlinLibrary.path.toFile()).klibFingerprint
     } else {
         CacheInfoBuilder(context, moduleDeserializer, module).build()
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/CacheSerializationSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/CacheSerializationSupport.kt
@@ -600,7 +600,8 @@ class CacheMetadata(
         val target: KonanTarget,
         val compilerFingerprint: String,
         val runtimeFingerprint: String?, // only present in caches using the runtime (i.e. for stdlib)
-        // Combined fingerprint of auto-cached external libraries the cache was built against.
+        // Combined fingerprint of the monolithically cached dependencies (auto-cached external libraries
+        // and IC'ed cinterop libraries) the cache was built against.
         val dependenciesFingerprint: FingerprintHash?,
 )
 

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/cinterop/cinterop.1.def
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/cinterop/cinterop.1.def
@@ -1,0 +1,4 @@
+package = cstubs
+---
+static int answer(void) { return 45; }
+static int answerTwice(void) { return 2 * answer(); }

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/cinterop/cinterop.def
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/cinterop/cinterop.def
@@ -1,0 +1,3 @@
+package = cstubs
+---
+static int answer(void) { return 40; }

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/cinterop/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/cinterop/module.info
@@ -1,0 +1,14 @@
+STEP 0:
+    modifications:
+        U : cinterop.def -> cinterop.def
+    added cache: cinterop.def
+
+// KT-87273: the custom declarations in the def file change, so the monolithic cinterop cache must be rebuilt.
+STEP 1:
+    modifications:
+        U : cinterop.1.def -> cinterop.def
+    modified cache: cinterop.def
+
+// Nothing changes: the cache must be reused as is.
+STEP 2:
+    unchanged cache: cinterop.def

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/check.1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/check.1.kt
@@ -1,0 +1,4 @@
+fun checkAnswers() {
+    kotlin.test.assertEquals(45, bar())
+    kotlin.test.assertEquals(90, barTwice())
+}

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/check.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/check.kt
@@ -1,0 +1,3 @@
+fun checkAnswers() {
+    kotlin.test.assertEquals(40, bar())
+}

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/main.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/main.kt
@@ -1,0 +1,6 @@
+import kotlin.test.*
+
+@Test
+fun doTest() {
+    checkAnswers()
+}

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/main/module.info
@@ -1,0 +1,13 @@
+STEP 0:
+    dependencies: cinterop, userLib
+    modifications:
+        U : main.kt -> main.kt
+        U : check.kt -> check.kt
+
+STEP 1:
+    dependencies: cinterop, userLib
+    modifications:
+        U : check.1.kt -> check.kt
+
+STEP 2:
+    dependencies: cinterop, userLib

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/project.info
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/project.info
@@ -1,0 +1,11 @@
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: cinterop, userLib, main
+
+STEP 0:
+    libs: cinterop, userLib, main
+
+STEP 1:
+    libs: cinterop, userLib, main
+
+STEP 2:
+    libs: cinterop, userLib, main

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/userLib/file1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/userLib/file1.kt
@@ -1,0 +1,1 @@
+fun bar() = cstubs.answer()

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/userLib/file2.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/userLib/file2.kt
@@ -1,0 +1,1 @@
+fun barTwice() = cstubs.answerTwice()

--- a/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/userLib/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/changedCInteropDependency/userLib/module.info
@@ -1,0 +1,22 @@
+STEP 0:
+    dependencies: cinterop
+    arguments: -opt-in=kotlinx.cinterop.ExperimentalForeignApi
+    modifications:
+        U : file1.kt -> file1.kt
+    added cache: file1.kt
+
+// KT-87273: the cinterop dependency has changed, so the caches must be fully rebuilt even though
+// the sources are untouched: the compiled binaries reference symbols of the changed library.
+STEP 1:
+    dependencies: cinterop
+    arguments: -opt-in=kotlinx.cinterop.ExperimentalForeignApi
+    modifications:
+        U : file2.kt -> file2.kt
+    modified cache: file1.kt
+    added cache: file2.kt
+
+// Nothing changes: the caches must be reused as is.
+STEP 2:
+    dependencies: cinterop
+    arguments: -opt-in=kotlinx.cinterop.ExperimentalForeignApi
+    unchanged cache: file1.kt, file2.kt

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeIncrementalCompilationTest.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeIncrementalCompilationTest.kt
@@ -9,8 +9,10 @@ import com.intellij.testFramework.TestDataFile
 import org.jetbrains.kotlin.codegen.*
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestCompilerArgs
 import org.jetbrains.kotlin.konan.test.blackbox.support.TestDirectives
+import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.CInteropCompilation
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact.KLIB
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationDependency
+import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationResult.Companion.assertSuccess
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UsePartialLinkage
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.isDisabledNative
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.isIgnoredTarget
@@ -135,17 +137,31 @@ abstract class AbstractNativeIncrementalCompilationTest : AbstractNativeSimpleTe
                 val module = testStructure.modules.getValue(moduleName)
                 val moduleStep = module.getStep(step.id)
                     ?: fail("Module '$moduleName' is in step ${step.id} order but has no module-info entry")
-                producedLibraries[moduleName] = compileToLibrary(
-                    module.sourceDir,
-                    outputDir(moduleName),
-                    freeCompilerArgs = TestCompilerArgs(
-                        // otherwise, it might shadow some problems with inline functions.
-                        listOf("-XXLanguage:-IrIntraModuleInlinerBeforeKlibSerialization") + moduleStep.cliArguments
-                    ),
-                    dependencies = moduleStep.dependencies.toCompilationDependencies(),
-                )
+                val defFile = module.sourceDir.listFiles()?.singleOrNull { it.extension == "def" }
+                producedLibraries[moduleName] = if (defFile != null) {
+                    compileCInteropLibrary(moduleName, defFile)
+                } else {
+                    compileToLibrary(
+                        module.sourceDir,
+                        outputDir(moduleName),
+                        freeCompilerArgs = TestCompilerArgs(
+                            // otherwise, it might shadow some problems with inline functions.
+                            listOf("-XXLanguage:-IrIntraModuleInlinerBeforeKlibSerialization") + moduleStep.cliArguments
+                        ),
+                        dependencies = moduleStep.dependencies.toCompilationDependencies(),
+                    )
+                }
             }
         }
+
+        private fun compileCInteropLibrary(moduleName: String, defFile: File): KLIB =
+            CInteropCompilation(
+                settings = testRunSettings,
+                freeCompilerArgs = TestCompilerArgs.EMPTY,
+                defFile = defFile,
+                dependencies = emptyList(),
+                expectedArtifact = KLIB(outputDir(moduleName).resolve("$moduleName.klib")),
+            ).result.assertSuccess().resultingArtifact
 
         // Compile test, NOT respecting possible `mode=TWO_STAGE_MULTI_MODULE`: don't add intermediate LibraryCompilation(kt->klib).
         // KT-66014: Extract this test from usual Native test run, and run it in scope of new test module
@@ -184,6 +200,8 @@ abstract class AbstractNativeIncrementalCompilationTest : AbstractNativeSimpleTe
                     val key = CacheKey(moduleName, relativePath)
                     val sourceFile = module.sourceDir.resolve(relativePath)
                     val cacheDir = when {
+                        // C-interop libraries are cached monolithically, so a def file maps to the whole-library cache.
+                        relativePath.endsWith(".def") -> monolithicLibraryCache(moduleName)
                         sourceFile.exists() -> libraryFileCache(moduleName, relativePath, sourceFile.packageFqName())
                         else -> previousSnapshot[key]?.cacheDir
                             ?: fail("No previous cache entry data for removed source file $moduleName/$relativePath at step $stepId")
@@ -295,6 +313,9 @@ abstract class AbstractNativeIncrementalCompilationTest : AbstractNativeSimpleTe
 
     private fun archivePath(cacheDir: File): String =
         Path(cacheDir.absolutePath, "bin", "lib${cacheDir.name}.a").toString()
+
+    private fun monolithicLibraryCache(libName: String): File =
+        icCacheDir.resolve(cacheFlavor).resolve("$libName-cache")
 
     private fun libraryFileCache(libName: String, libFileRelativePath: String, fqName: String): File {
         val libCacheDir = icCacheDir.resolve(cacheFlavor).resolve("$libName-per-file-cache")


### PR DESCRIPTION
Changes in IC'ed cinterop libraries (not external and not from distribution) didn't lead to dependencies recompilation. This led to stale caches being used during incremental compilation. This PR fixes the problem by handling them in the same way as for external dependencies (computing a hash of all transitive dependencies and checking it at caches built time).