### PR TITLE
[KT-87667] SwiftPM import can deadlock when joiner tasks submit blocking workers before owner start

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
@@ -9,14 +9,19 @@ package org.jetbrains.kotlin.gradle.apple
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.PackageResolvedSynchronization
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportTestExecutionKind
 import org.jetbrains.kotlin.gradle.testbase.GradleTest
+import org.jetbrains.kotlin.gradle.testbase.GradleTestVersions
 import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
 import org.jetbrains.kotlin.gradle.testbase.OsCondition
 import org.jetbrains.kotlin.gradle.testbase.SwiftPMImportGradlePluginTests
+import org.jetbrains.kotlin.gradle.testbase.TestVersions
 import org.jetbrains.kotlin.gradle.testbase.assertFileExists
+import org.jetbrains.kotlin.gradle.testbase.assertOutputContains
 import org.jetbrains.kotlin.gradle.testbase.assertOutputContainsExactlyTimes
 import org.jetbrains.kotlin.gradle.testbase.assertTasksExecuted
 import org.jetbrains.kotlin.gradle.testbase.build
+import org.jetbrains.kotlin.gradle.testbase.buildAndFail
 import org.jetbrains.kotlin.gradle.testbase.findTasksByPattern
 import org.jetbrains.kotlin.gradle.testbase.project
 import org.jetbrains.kotlin.gradle.util.runProcess
@@ -32,6 +37,74 @@ import kotlin.test.assertNotEquals
 )
 @SwiftPMImportGradlePluginTests
 class DumpXcodeBuildArgsTests : KGPBaseTest() {
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
+    fun `dump task - await worker can start before owner worker`(version: GradleVersion) {
+        val testBuildOptions = defaultBuildOptions.copy(
+            maxWorkers = 2,
+        )
+
+        project("empty", version, buildOptions = testBuildOptions) {
+            withLockFileFixture {
+                val sharedRepo = repoRef("SharedPackage").also { createRepo(it.name, listOf("1.0.0")) }
+                val ownerProjectName = "owner"
+                val joinerProjectName = "joiner"
+                val serviceName = "xcodebuild-worker-start-gate"
+
+                initSwiftPmProject(cacheDirFile) {}
+
+                val ownerProject = project("empty", version, buildOptions = testBuildOptions) {
+                    initSwiftPmProject(cacheDirFile) {
+                        configureSwiftImportTestExecution(
+                            serviceName,
+                            SwiftImportTestExecutionKind.XCODEBUILD,
+                            SwiftImportTestExecutionRole.OWNER,
+                        )
+                        swiftPMDependencies {
+                            packageResolvedSynchronization = PackageResolvedSynchronization.Identifier("sharedLock")
+                            swiftPackage(
+                                url = url(sharedRepo.url),
+                                version = exact("1.0.0"),
+                                products = listOf(product(sharedRepo.name)),
+                            )
+                        }
+                    }
+                }
+
+                val joinerProject = project("empty", version, buildOptions = testBuildOptions) {
+                    initSwiftPmProject(cacheDirFile) {
+                        configureSwiftImportTestExecution(
+                            serviceName,
+                            SwiftImportTestExecutionKind.XCODEBUILD,
+                            SwiftImportTestExecutionRole.JOINER,
+                        )
+                        swiftPMDependencies {
+                            packageResolvedSynchronization = PackageResolvedSynchronization.Identifier("sharedLock")
+                            swiftPackage(
+                                url = url(sharedRepo.url),
+                                version = exact("1.0.0"),
+                                products = listOf(product(sharedRepo.name)),
+                            )
+                        }
+                    }
+                }
+
+                include(ownerProject, ownerProjectName)
+                include(joinerProject, joinerProjectName)
+
+                buildAndFail(
+                    ":$ownerProjectName:dumpXcodebuildArgsIphoneos",
+                    ":$joinerProjectName:dumpXcodebuildArgsIphoneos",
+                    buildOptions = testBuildOptions,
+                ) {
+                    assertOutputContains(
+                        "Await worker started before the owner worker start hook timed out."
+                    )
+                }
+            }
+        }
+    }
 
     @GradleTest
     fun `smoke test - xcodebuild args are dumped into task output directory`(version: GradleVersion) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.testbase.TestVersions
 import org.jetbrains.kotlin.gradle.testbase.assertFileExists
 import org.jetbrains.kotlin.gradle.testbase.assertOutputContains
 import org.jetbrains.kotlin.gradle.testbase.assertOutputContainsExactlyTimes
+import org.jetbrains.kotlin.gradle.testbase.assertOutputDoesNotContain
 import org.jetbrains.kotlin.gradle.testbase.assertTasksExecuted
 import org.jetbrains.kotlin.gradle.testbase.build
 import org.jetbrains.kotlin.gradle.testbase.buildAndFail
@@ -93,12 +94,12 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
                 include(ownerProject, ownerProjectName)
                 include(joinerProject, joinerProjectName)
 
-                buildAndFail(
+                build(
                     ":$ownerProjectName:dumpXcodebuildArgsIphoneos",
                     ":$joinerProjectName:dumpXcodebuildArgsIphoneos",
                     buildOptions = testBuildOptions,
                 ) {
-                    assertOutputContains(
+                    assertOutputDoesNotContain(
                         "Await worker started before the owner worker start hook timed out."
                     )
                 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
@@ -17,13 +17,16 @@ import org.jetbrains.kotlin.gradle.dsl.createKotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FetchSyntheticImportProjectPackages
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject.Companion.SyntheticProductType
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.PackageResolvedSynchronization
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_CHECKOUT_DIR
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_SYNTHETIC_PACKAGE_DIR
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftPMDependency
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftPMDependencyIdentifier
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftPMImportMetadata
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportTestExecutionKind
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.TransitiveSwiftPMMetadata
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.locateOrRegisterSwiftPMDependenciesExtension
+import org.jetbrains.kotlin.gradle.testbase.BuildOptions
 import org.jetbrains.kotlin.gradle.testbase.GradleTest
 import org.jetbrains.kotlin.gradle.testbase.GradleTestVersions
 import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
@@ -38,6 +41,7 @@ import org.jetbrains.kotlin.gradle.testbase.assertOutputContains
 import org.jetbrains.kotlin.gradle.testbase.assertTasksExecuted
 import org.jetbrains.kotlin.gradle.testbase.assertTasksUpToDate
 import org.jetbrains.kotlin.gradle.testbase.build
+import org.jetbrains.kotlin.gradle.testbase.buildAndFail
 import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
 import org.jetbrains.kotlin.gradle.testbase.plugins
 import org.jetbrains.kotlin.gradle.testbase.project
@@ -56,6 +60,74 @@ import kotlin.test.assertNotEquals
 )
 @SwiftPMImportGradlePluginTests
 class FetchSyntheticImportProjectPackagesTests : KGPBaseTest() {
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
+    fun `fetch task - await worker can start before owner worker`(version: GradleVersion) {
+        val testBuildOptions = defaultBuildOptions.copy(
+            maxWorkers = 2,
+        )
+
+        project("empty", version, buildOptions = testBuildOptions) {
+            withLockFileFixture {
+                val sharedRepo = repoRef("SharedPackage").also { createRepo(it.name, listOf("1.0.0")) }
+                val ownerProjectName = "owner"
+                val joinerProjectName = "joiner"
+                val serviceName = "swift-resolve-worker-start-gate"
+
+                initSwiftPmProject(cacheDirFile) {}
+
+                val ownerProject = project("empty", version, buildOptions = testBuildOptions) {
+                    initSwiftPmProject(cacheDirFile) {
+                        configureSwiftImportTestExecution(
+                            serviceName,
+                            SwiftImportTestExecutionKind.SWIFT_RESOLVE,
+                            SwiftImportTestExecutionRole.OWNER,
+                        )
+                        swiftPMDependencies {
+                            packageResolvedSynchronization = PackageResolvedSynchronization.Identifier("sharedLock")
+                            swiftPackage(
+                                url = url(sharedRepo.url),
+                                version = exact("1.0.0"),
+                                products = listOf(product(sharedRepo.name)),
+                            )
+                        }
+                    }
+                }
+
+                val joinerProject = project("empty", version, buildOptions = testBuildOptions) {
+                    initSwiftPmProject(cacheDirFile) {
+                        configureSwiftImportTestExecution(
+                            serviceName,
+                            SwiftImportTestExecutionKind.SWIFT_RESOLVE,
+                            SwiftImportTestExecutionRole.JOINER,
+                        )
+                        swiftPMDependencies {
+                            packageResolvedSynchronization = PackageResolvedSynchronization.Identifier("sharedLock")
+                            swiftPackage(
+                                url = url(sharedRepo.url),
+                                version = exact("1.0.0"),
+                                products = listOf(product(sharedRepo.name)),
+                            )
+                        }
+                    }
+                }
+
+                include(ownerProject, ownerProjectName)
+                include(joinerProject, joinerProjectName)
+
+                buildAndFail(
+                    ":$ownerProjectName:${FetchSyntheticImportProjectPackages.TASK_NAME}",
+                    ":$joinerProjectName:${FetchSyntheticImportProjectPackages.TASK_NAME}",
+                    buildOptions = testBuildOptions,
+                ) {
+                    assertOutputContains(
+                        "Await worker started before the owner worker start hook timed out."
+                    )
+                }
+            }
+        }
+    }
 
     @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
     @GradleTest
@@ -432,4 +504,3 @@ class FetchSyntheticImportProjectPackagesTests : KGPBaseTest() {
         }
     }
 }
-

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.gradle.testbase.assertFileNotExists
 import org.jetbrains.kotlin.gradle.testbase.assertFilesContentEquals
 import org.jetbrains.kotlin.gradle.testbase.assertFilesExist
 import org.jetbrains.kotlin.gradle.testbase.assertOutputContains
+import org.jetbrains.kotlin.gradle.testbase.assertOutputDoesNotContain
 import org.jetbrains.kotlin.gradle.testbase.assertTasksExecuted
 import org.jetbrains.kotlin.gradle.testbase.assertTasksUpToDate
 import org.jetbrains.kotlin.gradle.testbase.build
@@ -116,12 +117,12 @@ class FetchSyntheticImportProjectPackagesTests : KGPBaseTest() {
                 include(ownerProject, ownerProjectName)
                 include(joinerProject, joinerProjectName)
 
-                buildAndFail(
+                build(
                     ":$ownerProjectName:${FetchSyntheticImportProjectPackages.TASK_NAME}",
                     ":$joinerProjectName:${FetchSyntheticImportProjectPackages.TASK_NAME}",
                     buildOptions = testBuildOptions,
                 ) {
-                    assertOutputContains(
+                    assertOutputDoesNotContain(
                         "Await worker started before the owner worker start hook timed out."
                     )
                 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPopularSwiftPMDependenciesTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPopularSwiftPMDependenciesTests.kt
@@ -11,7 +11,6 @@ import org.gradle.api.file.ProjectLayout
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.*
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.testing.prettyPrinted
@@ -1293,8 +1292,4 @@ private fun TestProject.testPackageManifest(
 
     val actualContent = packageSwift.readText()
     assertEquals(expectedContent, actualContent, "Package.swift content mismatch")
-}
-
-internal fun KotlinMultiplatformExtension.swiftPMDependencies(configure: SwiftPMImportExtension.() -> Unit) {
-    (this.extensions.getByName(SwiftPMImportExtension.EXTENSION_NAME) as SwiftPMImportExtension).configure()
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/spmImportTestUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/spmImportTestUtils.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.apple
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.testkit.runner.BuildResult
 import org.intellij.lang.annotations.Language
@@ -21,6 +22,10 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.PackageResolvedS
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FingerprintXcodeBuild
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_CHECKOUT_DIR
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_XCODE_DUMP_DIR
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportExecutionHooks
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportTestExecutionKind
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportTestExecutionService
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftPMImportExtension
 import org.jetbrains.kotlin.gradle.testbase.TestProject
 import org.jetbrains.kotlin.gradle.testbase.XCTestHelpers
 import org.jetbrains.kotlin.gradle.testbase.assertDirectoryExists
@@ -72,7 +77,7 @@ const val SYNTHETIC_IMPORT_DYLIB =
 fun createLocalSwiftPackage(
     localPackageDir: Path,
     packageName: String = "LocalSwiftPackage",
-    products : List<String> = listOf(packageName),
+    products: List<String> = listOf(packageName),
     sourceLanguage: SwiftPackageSourceLanguage = SwiftPackageSourceLanguage.SWIFT_WITH_OBJC,
 ) {
     localPackageDir.createDirectories()
@@ -117,7 +122,11 @@ fun createLocalSwiftPackageWithResources(
 
             @objc public class ResourceAccessor: NSObject {
                 @objc public static func resourceContent() -> String {
-                    guard let url = Bundle.module.url(forResource: "${resourceFileName.substringBeforeLast(".")}", withExtension: "${resourceFileName.substringAfterLast(".")}") else {
+                    guard let url = Bundle.module.url(forResource: "${resourceFileName.substringBeforeLast(".")}", withExtension: "${
+            resourceFileName.substringAfterLast(
+                "."
+            )
+        }") else {
                         return "RESOURCE_NOT_FOUND"
                     }
                     return (try? String(contentsOf: url)) ?? "RESOURCE_READ_ERROR"
@@ -327,14 +336,14 @@ internal fun createSwiftPmGitRepoWithTags(
 
     writePackageManifest(repoDir, packageName, products = products)
 
-    if(source != null){
+    if (source != null) {
         products.forEach { product ->
             repoDir.resolve("Sources/$product").createDirectories()
             repoDir.resolve("Sources/$product/$product.swift").writeText(
                 source
             )
         }
-    }else{
+    } else {
         products.forEach { product ->
             repoDir.resolve("Sources/$product").createDirectories()
             repoDir.resolve("Sources/$product/$product.swift").writeText(
@@ -453,7 +462,7 @@ internal fun swiftPMPackageFingerprint(
     projectDir.resolve("build").resolve(FingerprintSyntheticPackage.SYNTHETIC_PACKAGE_FINGERPRINT_PATH)
 
 internal fun swiftPMFingerprintCheckoutDir(
-    projectDir : Path,
+    projectDir: Path,
     rootProject: Path,
 ): Path {
     val packageFingerprint = parseSwiftPMFingerprint(swiftPMSyntheticPackageFingerprint(projectDir))
@@ -630,6 +639,92 @@ internal data class RepoRef(
     val url: String,
 ) : java.io.Serializable
 
+internal enum class SwiftImportTestExecutionRole {
+    OWNER,
+    JOINER,
+}
+
+internal fun KotlinMultiplatformExtension.swiftPMDependencies(configure: SwiftPMImportExtension.() -> Unit) {
+    (extensions.getByName(SwiftPMImportExtension.EXTENSION_NAME) as SwiftPMImportExtension).configure()
+}
+
+internal fun KotlinMultiplatformExtension.configureSwiftImportTestExecution(
+    serviceName: String,
+    kind: SwiftImportTestExecutionKind,
+    role: SwiftImportTestExecutionRole,
+) {
+    val service = swiftImportTestExecutionService(serviceName, kind)
+    swiftPMDependencies {
+        testExecutionService.set(service)
+        testExecutionHooks.set(swiftImportExecutionHooks(kind, role, service))
+    }
+}
+
+private fun swiftImportExecutionHooks(
+    kind: SwiftImportTestExecutionKind,
+    role: SwiftImportTestExecutionRole,
+    service: Provider<SwiftImportTestExecutionService>,
+): SwiftImportExecutionHooks {
+    if (kind == SwiftImportTestExecutionKind.SWIFT_RESOLVE && role == SwiftImportTestExecutionRole.OWNER) {
+        return SwiftResolveOwnerExecutionHooks(service)
+    }
+    if (kind == SwiftImportTestExecutionKind.SWIFT_RESOLVE) {
+        return SwiftResolveJoinerExecutionHooks(service)
+    }
+    if (role == SwiftImportTestExecutionRole.OWNER) {
+        return XcodebuildOwnerExecutionHooks(service)
+    }
+    return XcodebuildJoinerExecutionHooks(service)
+}
+
+private class SwiftResolveOwnerExecutionHooks(
+    private val service: Provider<SwiftImportTestExecutionService>,
+) : SwiftImportExecutionHooks {
+    override fun beforeSwiftResolveOwnerWorkerSubmission() {
+        service.get().markOwnerClaimed()
+    }
+}
+
+private class SwiftResolveJoinerExecutionHooks(
+    private val service: Provider<SwiftImportTestExecutionService>,
+) : SwiftImportExecutionHooks {
+    override fun beforeSwiftResolveClaim() {
+        service.get().awaitOwnerClaimed()
+    }
+
+    override fun beforeSwiftResolveOwnerWorkerSubmission() {
+        error("Expected this project to join Swift package resolve, but it owned the bucket")
+    }
+}
+
+private class XcodebuildOwnerExecutionHooks(
+    private val service: Provider<SwiftImportTestExecutionService>,
+) : SwiftImportExecutionHooks {
+    override fun beforeXcodebuildOwnerWorkerSubmission() {
+        service.get().markOwnerClaimed()
+    }
+}
+
+private class XcodebuildJoinerExecutionHooks(
+    private val service: Provider<SwiftImportTestExecutionService>,
+) : SwiftImportExecutionHooks {
+    override fun beforeXcodebuildClaim() {
+        service.get().awaitOwnerClaimed()
+    }
+
+    override fun beforeXcodebuildOwnerWorkerSubmission() {
+        error("Expected this project to join xcodebuild args dump, but it owned the bucket")
+    }
+}
+
+private fun KotlinMultiplatformExtension.swiftImportTestExecutionService(
+    serviceName: String,
+    kind: SwiftImportTestExecutionKind,
+): Provider<SwiftImportTestExecutionService> =
+    project.gradle.sharedServices.registerIfAbsent(serviceName, SwiftImportTestExecutionService::class.java) {
+        it.parameters.kind.set(kind)
+    }
+
 internal fun TestProject.withLockFileFixture(
     packageResolvedSynchronization: PackageResolvedSynchronization = PackageResolvedSynchronization.Identifier("default"),
     block: LockFileTestFixture.() -> Unit,
@@ -728,7 +823,7 @@ internal fun TestProject.dumpTaskGraph(
     return taskGraph
 }
 
-internal fun Set<String>.assertExactSwiftImportTasksInGraph(vararg tasks : String) {
+internal fun Set<String>.assertExactSwiftImportTasksInGraph(vararg tasks: String) {
     val taskToExclude = setOf(
         ":kmpPartiallyResolvedDependenciesChecker",
         ":downloadKotlinNativeDistribution",
@@ -743,7 +838,7 @@ internal fun Set<String>.assertExactSwiftImportTasksInGraph(vararg tasks : Strin
     filteredGraph.assertExactTaskGraph(*tasks)
 }
 
-internal fun Set<String>.assertExactTaskGraph(vararg tasks : String) {
+internal fun Set<String>.assertExactTaskGraph(vararg tasks: String) {
     val expected = tasks.toSet()
 
     val difference = (this - expected + (expected - this)).toSet()
@@ -838,7 +933,7 @@ private fun assertCheckoutVersion(checkoutRepoDir: Path, repoRef: RepoRef, versi
 
 internal fun assertGitIgnoreEquals(
     gitIgnorePath: Path,
-    expectedGitIgnoreContent: String
+    expectedGitIgnoreContent: String,
 ) {
     val actualGitIgnoreContent = gitIgnorePath.toFile().readText()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/DumpXcodeBuildArgs.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/DumpXcodeBuildArgs.kt
@@ -193,6 +193,7 @@ internal abstract class DumpXcodeBuildArgs : DefaultTask() {
             }
 
             is CoordinationClaim.Existing -> {
+                coordinationService.awaitXcodeDumpOwnerStarted(claim.bucket.key)
                 workerExecutor.noIsolation().submit(
                     XcodebuildArgsDumpAwaitWorkAction::class.java
                 ) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/DumpXcodeBuildArgs.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/DumpXcodeBuildArgs.kt
@@ -75,6 +75,12 @@ internal abstract class DumpXcodeBuildArgs : DefaultTask() {
     @get:Internal
     abstract val fingerprintCoordinationService: Property<SwiftImportFingerprintedCoordinationService>
 
+    @get:Internal
+    abstract val testExecutionHooks: Property<SwiftImportExecutionHooks>
+
+    @get:Internal
+    abstract val testExecutionService: Property<SwiftImportTestExecutionService>
+
     private val layout = project.layout
 
     @get:Internal
@@ -138,6 +144,7 @@ internal abstract class DumpXcodeBuildArgs : DefaultTask() {
 
     // ./gradlew clean
     init {
+        testExecutionHooks.convention(SwiftImportExecutionHooks.NONE)
         outputs.upToDateWhen {
             xcodebuildFinishedMarkerFile.exists()
         }
@@ -168,12 +175,14 @@ internal abstract class DumpXcodeBuildArgs : DefaultTask() {
 
         val syntheticPackageFingerprint = syntheticPackageFingerprintFile.readText().trim().split("\n")[1]
 
+        testExecutionHooks.get().beforeXcodebuildClaim()
         val claim = fingerprintCoordinationService.get().claimOrJoinXcodeDump(
             xcodebuildExecutionHash = readXcodebuildFingerprint(),
             xcodebuildSdk = xcodebuildSdk.get(),
         )
         when (claim) {
             is CoordinationClaim.Owner -> {
+                testExecutionHooks.get().beforeXcodebuildOwnerWorkerSubmission()
                 runOwnerXcodeDump(
                     dumpDir = claim.bucket.ownerDumpDir,
                     derivedDataDir = claim.bucket.ownerDerivedDataDir,
@@ -191,6 +200,7 @@ internal abstract class DumpXcodeBuildArgs : DefaultTask() {
                     it.key.set(claim.bucket.key)
                     it.ideaSyncEnabled.set(ideaSyncEnabled)
                     it.errorFile.set(errorFile)
+                    it.testExecutionService.set(testExecutionService)
                 }
             }
         }
@@ -233,6 +243,7 @@ internal abstract class DumpXcodeBuildArgs : DefaultTask() {
             params.ideaSyncEnabled.set(ideaSyncEnabled)
             params.errorFile.set(ideImportError)
             params.xcodebuildFinishedMarkerFile.set(xcodebuildFinishedMarkerFile)
+            params.testExecutionService.set(testExecutionService)
 
             if (isCoordinationEnabled) {
                 params.fingerprintCoordinationService.set(fingerprintCoordinationService)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/FetchSyntheticImportProjectPackages.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/FetchSyntheticImportProjectPackages.kt
@@ -145,6 +145,7 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
         )
         when (claim) {
             is CoordinationClaim.Existing -> {
+                coordinationService.get().awaitSwiftResolveOwnerStarted(claim.bucket.key)
                 workerExecutor.noIsolation().submit(SwiftResolveAwaitWorkAction::class.java) {
                     it.sourcePackageResolvedFile.set(claim.bucket.ownerPackageResolvedFile)
                     it.destinationPackageResolved.set(syntheticLockFile.get().asFile)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/FetchSyntheticImportProjectPackages.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/FetchSyntheticImportProjectPackages.kt
@@ -91,6 +91,7 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
     init {
         // KT-85468: a lenient failure during IDE sync writes an error file; while it exists the
         // task must not be up-to-date so the next build retries the resolve.
+        testExecutionHooks.convention(SwiftImportExecutionHooks.NONE)
         outputs.upToDateWhen { !ideImportError.get().asFile.exists() }
     }
 
@@ -110,6 +111,12 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
 
     @get:Internal
     abstract val coordinationService: Property<SwiftImportFingerprintedCoordinationService>
+
+    @get:Internal
+    abstract val testExecutionHooks: Property<SwiftImportExecutionHooks>
+
+    @get:Internal
+    abstract val testExecutionService: Property<SwiftImportTestExecutionService>
 
     @get:Inject
     abstract val fs: FileSystemOperations
@@ -132,6 +139,7 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
         }
 
         val ownerHash = syntheticPackageFingerprint.asFile.get().readText().trim().split("\n")[1]
+        testExecutionHooks.get().beforeSwiftResolveClaim()
         val claim = coordinationService.get().claimOrJoinSwiftResolve(
             packageHash = ownerHash,
         )
@@ -144,12 +152,14 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
                     it.destinationWorkspaceStateFile.set(workspaceStateJson.get().asFile)
                     it.syntheticPackageHash.set(claim.bucket.key)
                     it.coordinationService.set(coordinationService)
+                    it.testExecutionService.set(testExecutionService)
                     it.ideaSyncEnabled.set(ideaSyncEnabled)
                     it.errorFile.set(errorFile)
                 }
             }
 
             is CoordinationClaim.Owner -> {
+                testExecutionHooks.get().beforeSwiftResolveOwnerWorkerSubmission()
                 runOwnerSwiftResolve(
                     claim.bucket.ownerSyntheticImportProjectRoot,
                     claim.bucket.ownerSwiftPMDependenciesCheckout,
@@ -159,7 +169,6 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
         }
 
     }
-
 
     private fun runOwnerSwiftResolve(
         syntheticImportProjectRoot: File,
@@ -187,6 +196,7 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
             params.coordinationEnabled.set(isCoordinationEnabled)
             params.ideaSyncEnabled.set(ideaSyncEnabled)
             params.errorFile.set(ideImportError)
+            params.testExecutionService.set(testExecutionService)
 
             if (isCoordinationEnabled) {
                 params.coordinationService.set(coordinationService)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportFingerprintedCoordinationService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportFingerprintedCoordinationService.kt
@@ -163,6 +163,26 @@ internal abstract class SwiftImportFingerprintedCoordinationService : BuildServi
         }
     }
 
+    fun awaitXcodeDumpOwnerStarted(key: XcodeDumpBucketMapKey) {
+        val bucket = synchronized(stateLock) {
+            dumpBucketsByXcodebuildFingerprint[key]
+        } ?: error("No bucket found for key $key")
+
+        // Do not let a joiner submit its blocking worker until the owner worker has actually started.
+        // Otherwise, under a saturated Worker API pool, joiners can occupy the last slots while waiting
+        // and prevent the owner from ever starting.
+        bucket.ownerStarted.await()
+    }
+
+    fun markXcodeDumpStarted(key: XcodeDumpBucketMapKey) {
+        synchronized(stateLock) {
+            val bucket = dumpBucketsByXcodebuildFingerprint[key]
+                ?: error("Xcode dump bucket is missing for $key")
+
+            bucket.ownerStarted.countDown()
+        }
+    }
+
     fun markXcodeDumpCompleted(
         key: XcodeDumpBucketMapKey,
     ) {
@@ -221,6 +241,26 @@ internal abstract class SwiftImportFingerprintedCoordinationService : BuildServi
         }
     }
 
+    fun awaitSwiftResolveOwnerStarted(key: SwiftResolveBucketMapKey) {
+        val bucket = synchronized(stateLock) {
+            fetchBucketsBySyntheticPackageFingerprint[key]
+        } ?: error("Swift resolve bucket is missing for package hash $key")
+
+        // Do not let a joiner submit its blocking worker until the owner worker has actually started.
+        // Otherwise, under a saturated Worker API pool, joiners can occupy the last slots while waiting
+        // and prevent the owner from ever starting.
+        bucket.ownerStarted.await()
+    }
+
+    fun markSwiftResolveStarted(packageHash: SwiftResolveBucketMapKey) {
+        synchronized(stateLock) {
+            val bucket = fetchBucketsBySyntheticPackageFingerprint[packageHash]
+                ?: error("Swift resolve bucket is missing for package hash $packageHash")
+
+            bucket.ownerStarted.countDown()
+        }
+    }
+
     companion object {
         private const val SERVICE_NAME = "SwiftImportFingerprintedCoordinationService"
 
@@ -265,6 +305,7 @@ internal data class GeneratePackageBucketMapKey(
 
 internal open class CoordinationBucket(
     val completion: CountDownLatch = CountDownLatch(1),
+    val ownerStarted: CountDownLatch = CountDownLatch(1),
     var failure: Throwable? = null,
     var completed: Boolean = false,
 )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
@@ -166,6 +166,8 @@ internal val SwiftImportSetupAction = KotlinProjectSetupAction {
         it.onlyIf("SwiftPM import is only supported on macOS hosts") { isMacOSHost }
         it.onlyIf { hasDirectOrTransitiveSwiftPMDependencies.get() }
         it.ideaSyncEnabled.set(ideaSyncEnabled)
+        it.testExecutionHooks.set(swiftPMImportExtension.testExecutionHooks)
+        it.testExecutionService.set(swiftPMImportExtension.testExecutionService)
         it.dependsOn(hasDirectOrTransitiveSwiftPMDependencies)
         it.dependsOn(syncPersistedPackageResolvedToSyntheticSwiftPMPackage)
         it.dependsOn(syntheticImportProjectGenerationTaskForCinteropsAndLdDump)
@@ -919,6 +921,8 @@ private fun Project.registerDumpXcodebuildArgsTask(
         dumpTask.onlyIf("SwiftPM import doesn't support non macOS hosts") { isMacOSHost }
         dumpTask.onlyIf("Project does not have any SwiftPM dependencies") { hasDirectOrTransitiveSwiftPMDependencies.get() }
         dumpTask.dependsOn(hasDirectOrTransitiveSwiftPMDependencies)
+        dumpTask.testExecutionHooks.set(locateOrRegisterSwiftPMDependenciesExtension().testExecutionHooks)
+        dumpTask.testExecutionService.set(locateOrRegisterSwiftPMDependenciesExtension().testExecutionService)
         dumpTask.resolvedPackagesState.from(
             fetchSyntheticImportProjectPackages.map { it.inputManifests },
             fetchSyntheticImportProjectPackages.map { it.syntheticLockFile },

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportTestExecutionService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportTestExecutionService.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal enum class SwiftImportTestExecutionKind {
+    SWIFT_RESOLVE,
+    XCODEBUILD,
+}
+
+internal interface SwiftImportTestExecutionServiceParameters : BuildServiceParameters {
+    val kind: Property<SwiftImportTestExecutionKind>
+}
+
+internal abstract class SwiftImportTestExecutionService : BuildService<SwiftImportTestExecutionServiceParameters> {
+    private val ownerClaimed = CountDownLatch(1)
+    private val swiftResolveGate = OwnerStartedBeforeAwaitWorkerGate()
+    private val xcodebuildGate = OwnerStartedBeforeAwaitWorkerGate()
+    private val executionKind: SwiftImportTestExecutionKind
+        get() = parameters.kind.orNull ?: error("Swift import test execution kind is not configured")
+
+    fun markOwnerClaimed() {
+        ownerClaimed.countDown()
+    }
+
+    fun awaitOwnerClaimed() {
+        check(ownerClaimed.await(MARKER_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            "Timed out waiting for owner to claim the shared SwiftPM import bucket"
+        }
+    }
+
+    fun beforeSwiftResolveOwnerWorkerStarted() {
+        if (executionKind != SwiftImportTestExecutionKind.SWIFT_RESOLVE) return
+        swiftResolveGate.beforeOwnerWorkerStarted()
+    }
+
+    fun beforeSwiftResolveAwaitWorkerStarted() {
+        if (executionKind != SwiftImportTestExecutionKind.SWIFT_RESOLVE) return
+        swiftResolveGate.beforeAwaitWorkerStarted()
+    }
+
+    fun beforeXcodebuildOwnerWorkerStarted() {
+        if (executionKind != SwiftImportTestExecutionKind.XCODEBUILD) return
+        xcodebuildGate.beforeOwnerWorkerStarted()
+    }
+
+    fun beforeXcodebuildAwaitWorkerStarted() {
+        if (executionKind != SwiftImportTestExecutionKind.XCODEBUILD) return
+        xcodebuildGate.beforeAwaitWorkerStarted()
+    }
+
+    private class OwnerStartedBeforeAwaitWorkerGate {
+        private val awaitWorkerStarted = CountDownLatch(1)
+        private val ownerWorkerStartWaitTimedOut = AtomicBoolean(false)
+
+        fun beforeOwnerWorkerStarted() {
+            if (!awaitWorkerStarted.await(AWAIT_WORKER_START_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                ownerWorkerStartWaitTimedOut.set(true)
+            }
+        }
+
+        fun beforeAwaitWorkerStarted() {
+            awaitWorkerStarted.countDown()
+            check(ownerWorkerStartWaitTimedOut.get()) {
+                "Await worker started before the owner worker start hook timed out."
+            }
+        }
+    }
+
+    private companion object {
+        private const val MARKER_WAIT_TIMEOUT_MS = 30_000L
+        private const val AWAIT_WORKER_START_WAIT_TIMEOUT_MS = 2_000L
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftPMImportExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftPMImportExtension.kt
@@ -31,6 +31,17 @@ import java.io.OutputStream
 import java.io.Serializable
 import javax.inject.Inject
 
+internal interface SwiftImportExecutionHooks {
+    fun beforeSwiftResolveClaim() {}
+    fun beforeSwiftResolveOwnerWorkerSubmission() {}
+    fun beforeXcodebuildClaim() {}
+    fun beforeXcodebuildOwnerWorkerSubmission() {}
+
+    companion object {
+        val NONE: SwiftImportExecutionHooks = object : SwiftImportExecutionHooks {}
+    }
+}
+
 internal fun Project.locateOrRegisterSwiftPMDependenciesExtension(): SwiftPMImportExtension {
     val existingExtension = kotlinExtension.extensions.findByName(SwiftPMImportExtension.EXTENSION_NAME)
     if (existingExtension != null) {
@@ -89,6 +100,17 @@ abstract class SwiftPMImportExtension @Inject constructor(
 
     /** Minimum tvOS deployment target written to generated SwiftPM manifests. */
     val tvosMinimumDeploymentTarget: Property<String> = objects.property(String::class.java)
+
+    /**
+     * Test-only hooks that can block specific scheduling points in SwiftPM import tasks.
+     *
+     * The default value is a no-op implementation. Integration tests may replace this with a controlled hook object.
+     */
+    internal val testExecutionHooks: Property<SwiftImportExecutionHooks> =
+        objects.property(SwiftImportExecutionHooks::class.java).convention(SwiftImportExecutionHooks.NONE)
+
+    internal val testExecutionService: Property<SwiftImportTestExecutionService> =
+        objects.property(SwiftImportTestExecutionService::class.java)
 
     /**
      * Enables implicit discovery of Clang modules from imported SwiftPM packages.

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftResolveWorkAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftResolveWorkAction.kt
@@ -23,6 +23,7 @@ internal interface SwiftResolveAwaitWorkParameters : WorkParameters {
     val destinationPackageResolved: Property<File>
     val sourceWorkspaceStateFile: Property<File>
     val destinationWorkspaceStateFile: Property<File>
+    val testExecutionService: Property<SwiftImportTestExecutionService>
     val ideaSyncEnabled: Property<Boolean>
     val errorFile: RegularFileProperty
 }
@@ -35,6 +36,9 @@ internal abstract class SwiftResolveAwaitWorkAction @Inject constructor(val fs: 
         val errorFile = parameters.errorFile.get().asFile
         errorFile.delete()
         try {
+            if (parameters.testExecutionService.isPresent) {
+                parameters.testExecutionService.get().beforeSwiftResolveAwaitWorkerStarted()
+            }
             parameters.coordinationService.get().awaitSwiftResolved(parameters.syntheticPackageHash.get())
             finalizeFetchTask(
                 fs,
@@ -67,6 +71,7 @@ internal interface SwiftResolveWorkParameters : WorkParameters {
     val workspaceStateJson: RegularFileProperty
     val ideaSyncEnabled: Property<Boolean>
     val errorFile: RegularFileProperty
+    val testExecutionService: Property<SwiftImportTestExecutionService>
 }
 
 
@@ -80,6 +85,11 @@ internal abstract class SwiftResolveWorkAction @Inject constructor(
     override fun execute() {
         logger.info("Starting SwiftPM package resolution ${parameters.syntheticPackageHash.orNull?.let { "(bucket ${it})" }}")
         val errorFile = parameters.errorFile.get().asFile
+        if (parameters.coordinationEnabled.get()) {
+            if (parameters.testExecutionService.isPresent) {
+                parameters.testExecutionService.get().beforeSwiftResolveOwnerWorkerStarted()
+            }
+        }
         errorFile.delete()
         try {
             // Copy lock file from persisted

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftResolveWorkAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftResolveWorkAction.kt
@@ -89,6 +89,7 @@ internal abstract class SwiftResolveWorkAction @Inject constructor(
             if (parameters.testExecutionService.isPresent) {
                 parameters.testExecutionService.get().beforeSwiftResolveOwnerWorkerStarted()
             }
+            parameters.coordinationService.get().markSwiftResolveStarted(parameters.syntheticPackageHash.get())
         }
         errorFile.delete()
         try {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 internal interface XcodebuildAwaitArgsDumpWorkParameters : WorkParameters {
     val fingerprintCoordinationService: Property<SwiftImportFingerprintedCoordinationService>
     val key: Property<XcodeDumpBucketMapKey>
+    val testExecutionService: Property<SwiftImportTestExecutionService>
     val ideaSyncEnabled: Property<Boolean>
     val errorFile: RegularFileProperty
 }
@@ -38,6 +39,9 @@ internal abstract class XcodebuildArgsDumpAwaitWorkAction : WorkAction<Xcodebuil
         val errorFile = parameters.errorFile.get().asFile
         errorFile.delete()
         try {
+            if (parameters.testExecutionService.isPresent) {
+                parameters.testExecutionService.get().beforeXcodebuildAwaitWorkerStarted()
+            }
             parameters.fingerprintCoordinationService.get().awaitXcodeDump(parameters.key.get())
         } catch (failure: Throwable) {
             if (parameters.ideaSyncEnabled.get()) {
@@ -74,6 +78,7 @@ internal interface XcodebuildArgsDumpWorkParameters : WorkParameters {
     val ideaSyncEnabled: Property<Boolean>
     val errorFile: RegularFileProperty
     val xcodebuildFinishedMarkerFile: Property<File>
+    val testExecutionService: Property<SwiftImportTestExecutionService>
 }
 
 /**
@@ -90,6 +95,11 @@ internal abstract class XcodebuildArgsDumpWorkAction @Inject constructor(
     override fun execute() {
         logger.info("Starting xcodebuild dump ${parameters.xcodebuildExecutionFingerprint.orNull?.let { "(bucket ${it})" }}}")
         val errorFile = parameters.errorFile.get().asFile
+        if (parameters.coordinationEnabled.get()) {
+            if (parameters.testExecutionService.isPresent) {
+                parameters.testExecutionService.get().beforeXcodebuildOwnerWorkerStarted()
+            }
+        }
         errorFile.delete()
         try {
             doExecute()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/XcodebuildArgsDumpWorkAction.kt
@@ -99,6 +99,9 @@ internal abstract class XcodebuildArgsDumpWorkAction @Inject constructor(
             if (parameters.testExecutionService.isPresent) {
                 parameters.testExecutionService.get().beforeXcodebuildOwnerWorkerStarted()
             }
+            parameters.fingerprintCoordinationService.get().markXcodeDumpStarted(
+                key = parameters.xcodebuildExecutionFingerprint.get(),
+            )
         }
         errorFile.delete()
         try {


### PR DESCRIPTION
- The race condition in SwiftImportFingerprintedCoordinationService fixed.
- The race condition in SwiftImportFingerprintedCoordinationService reproduced.

#KT-87667 Ready for Review