### PR TITLE
[JS] Unmute testContextualCallableReferenceEquality for JS_IR

### DIFF
--- a/compiler/testData/codegen/box/contextParameters/contextualCallableReferenceEquality.kt
+++ b/compiler/testData/codegen/box/contextParameters/contextualCallableReferenceEquality.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +ContextParameters +CallableReferencesToContextual
-// IGNORE_BACKEND: JVM_IR, JS_IR, WASM_JS, WASM_WASI
+// IGNORE_BACKEND: JVM_IR, WASM_JS, WASM_WASI
 // ^KT-86452, KT-87390
 
 import kotlin.reflect.KFunction


### PR DESCRIPTION
The following tests are failing on master (currently quarantined):
* `JsCodegenBoxWithInlinedFunInKlibTestGenerated$ContextParameters.testContextualCallableReferenceEquality`
* `JsCodegenBoxTestGenerated$ContextParameters.testContextualCallableReferenceEquality`

with error message:
```
Looks like this test can be unmuted. Remove JS_IR from the IGNORE_BACKEND directive for FIR for JS_IR
```

this PR unmutes them, as suggested in the message