### PR TITLE
KT-87670 - [AA] Clean up KaModules after usage

### DIFF
--- a/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeScriptExportRunner.kt
+++ b/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeScriptExportRunner.kt
@@ -45,10 +45,13 @@ public fun runTypeScriptExport(klibs: List<KlibInputModule<TypeScriptModuleConfi
     }
 
     val kaModules = createKaModulesForStandaloneAnalysis(klibs, config.targetPlatform)
-    val generator = ExportModelGenerator(config)
-    val exportModel = analyze(kaModules.useSiteModule) {
-        generator.generateExport(kaModules)
+    val exportModel = kaModules.use { kaModules ->
+        val generator = ExportModelGenerator(config)
+        analyze(kaModules.useSiteModule) {
+            generator.generateExport(kaModules)
+        }
     }
+
     val artifacts = TsArtifactProducer.generateArtifacts(exportModel, config.artifactConfiguration.granularity)
     config.artifactConfiguration.outputDirectory.normalizedAbsoluteFile.mkdirs()
     return when (config.artifactConfiguration.tsCompilationStrategy) {
@@ -107,4 +110,3 @@ internal data class FileArtifactKey(
     val packageFqName: FqName,
     val fileName: String,
 )
-

--- a/libraries/tools/analysis-api-based-klib-reader/src/org/jetbrains/kotlin/analysis/api/klib/reader/createKaModules.kt
+++ b/libraries/tools/analysis-api-based-klib-reader/src/org/jetbrains/kotlin/analysis/api/klib/reader/createKaModules.kt
@@ -5,6 +5,10 @@
 
 package org.jetbrains.kotlin.analysis.api.klib.reader
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager.getApplication
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.Disposer.dispose
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibraryModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
@@ -22,13 +26,16 @@ import org.jetbrains.kotlin.platform.TargetPlatform
  * @property cinteropReexportLibrary User cinterop klibs whose types originate from an externally-defined
  *   ObjC module; treated as platform-like (no generated Swift module), but distinguished from distribution
  *   platform libs since they are opted in by the caller.
+ *
+ * The underlying standalone Analysis API project should be disposed with [close] after the modules have been used.
  */
 public class KaModules<Config> internal constructor(
+    private val projectDisposable: Disposable,
     public val useSiteModule: KaModule,
     private val modulesToInputs: Map<KaLibraryModule, KlibInputModule<Config>>,
     public val platformLibraries: List<KaLibraryModule>,
     public val cinteropReexportLibrary: KaLibraryModule?,
-) {
+) : AutoCloseable {
     public val inputsToModules: Map<KlibInputModule<Config>, KaLibraryModule> = modulesToInputs.map { it.value to it.key }.toMap()
     public val mainModules: List<KaLibraryModule> = modulesToInputs.keys.toList()
 
@@ -37,6 +44,17 @@ public class KaModules<Config> internal constructor(
 
     public fun configFor(module: KaLibraryModule): Config =
         inputModuleFor(module)?.config ?: error("No config for module ${module.libraryName}")
+
+    public override fun close() {
+        val application = getApplication()
+        if (application.isWriteAccessAllowed) {
+            dispose(projectDisposable)
+        } else {
+            application.runWriteAction {
+                dispose(projectDisposable)
+            }
+        }
+    }
 }
 
 public fun <Config> createKaModulesForStandaloneAnalysis(
@@ -45,11 +63,13 @@ public fun <Config> createKaModulesForStandaloneAnalysis(
     platformLibraries: Collection<KlibInputModule<Config>> = emptyList(),
     cinteropReexportLibrary: KlibInputModule<Config>? = null,
 ): KaModules<Config> {
+    val projectDisposable = Disposer.newDisposable("KaModules.project")
     lateinit var binaryModules: Map<KaLibraryModule, KlibInputModule<Config>>
     lateinit var fakeSourceModule: KaSourceModule
     var platformLibraryModules: List<KaLibraryModule> = emptyList()
     var cinteropReexportLibraryModule: KaLibraryModule? = null
-    buildStandaloneAnalysisAPISession {
+
+    buildStandaloneAnalysisAPISession(projectDisposable) {
         buildKtModuleProvider {
             platform = targetPlatform
             binaryModules = inputs.associateBy { inputModuleIntoKaLibraryModule(it, targetPlatform) }
@@ -67,7 +87,7 @@ public fun <Config> createKaModulesForStandaloneAnalysis(
             )
         }
     }
-    return KaModules(fakeSourceModule, binaryModules, platformLibraryModules, cinteropReexportLibraryModule)
+    return KaModules(projectDisposable, fakeSourceModule, binaryModules, platformLibraryModules, cinteropReexportLibraryModule)
 }
 
 private fun <Config> KaModuleContainerBuilder.inputModuleIntoKaLibraryModule(

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
@@ -167,18 +167,20 @@ private fun translateModules(
         platformLibraries = config.platformLibsInputModule,
         cinteropReexportLibrary = cinteropReexportLibs.singleOrNull(),
     )
-    val explicitModulesTranslationResults = allModules
-        .filter { it.config.shouldBeFullyExported }
-        .map { translateModulePublicApi(it, kaModules, config) }
-    val transitiveExportRoots = allModules
-        .filterNot { it.config.shouldBeFullyExported }
-        .mapNotNull { kaModules.inputsToModules[it] }
-        .associateWith { inputModule ->
-            explicitModulesTranslationResults
-                .flatMap { it.externalTypeDeclarationReferences[inputModule] ?: emptyList() }
-        }
-    val transitiveModulesTranslationResults = translateCrossReferencingModulesTransitively(transitiveExportRoots, kaModules, config)
-    return explicitModulesTranslationResults + transitiveModulesTranslationResults
+    kaModules.use { kaModules ->
+        val explicitModulesTranslationResults = allModules
+            .filter { it.config.shouldBeFullyExported }
+            .map { translateModulePublicApi(it, kaModules, config) }
+        val transitiveExportRoots = allModules
+            .filterNot { it.config.shouldBeFullyExported }
+            .mapNotNull { kaModules.inputsToModules[it] }
+            .associateWith { inputModule ->
+                explicitModulesTranslationResults
+                    .flatMap { it.externalTypeDeclarationReferences[inputModule] ?: emptyList() }
+            }
+        val transitiveModulesTranslationResults = translateCrossReferencingModulesTransitively(transitiveExportRoots, kaModules, config)
+        return explicitModulesTranslationResults + transitiveModulesTranslationResults
+    }
 }
 
 /**


### PR DESCRIPTION
Note №1. Mostly AI-generated. Please review carefully.

Note №2. This is not a full fix. I believe that all usages of `StandaloneAnalysisAPISessionBuilder`must be fixed, but I don't have enough knowledge in AA or IntelliJ API. For now this is a quick fix to solve OOM on CI