### PR TITLE
[ai] Add a code rule saying that IR nodes shouldn't be accidentally lost

### DIFF
--- a/.space/CODEOWNERS
+++ b/.space/CODEOWNERS
@@ -135,6 +135,7 @@
 /compiler/frontend.java/ "Kotlin Frontend"
 /compiler/incremental-compilation-impl/ "Build Tools API"
 /compiler/ir/ReadMe.md "Kotlin Common Backend"
+/compiler/ir/code-rules.md "Kotlin Common Backend"
 /compiler/ir/backend.common/ "Kotlin JVM" "Kotlin Native" "Kotlin Wasm" "Kotlin Common Backend" "Kotlin JS"
 /compiler/ir/backend.js/ "Kotlin JS"
 /compiler/ir/backend.jvm/ "Kotlin JVM"

--- a/compiler/ir/code-rules.md
+++ b/compiler/ir/code-rules.md
@@ -1,0 +1,6 @@
+# Don't lose IR nodes
+
+Pattern: src
+
+When transforming Kotlin backend IR, make sure to preserve all expression nodes,
+unless it is known that the node can't have side effects.

--- a/kotlin-native/backend.native/compiler/ir/backend.native/code-rules.md
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/code-rules.md
@@ -1,0 +1,1 @@
+@/compiler/ir/code-rules.md


### PR DESCRIPTION
A common mistake when transforming IR is to accidentally "lose" IR nodes: like, if an `IrExpression` result is unused, remove that expression. Which is incorrect, as any IR expression can have side effects.

This commit adds a "code rule" covering that.

See https://github.com/JetBrains/kotlin/blob/a36dfac4898893b0be7e747f4e410a1895706afe/repo/auto-code-review/README.md for context on code rules.