### PR TITLE
[ai] Add a code rule for marking compiler arguments removed

### DIFF
--- a/compiler/arguments/code-rules.md
+++ b/compiler/arguments/code-rules.md
@@ -1,0 +1,6 @@
+# Set `removedVersion` instead of removing arguments
+
+Pattern: src/org/jetbrains/kotlin/arguments/description
+
+Instead of removing a compiler argument definition, move it to the `removed` directory
+and specify the `removedVersion`.


### PR DESCRIPTION
When removing a compiler argument, it is a common mistake to remove the actual argument definition instead of marking it as "removed".

This commit adds a code rule to cover that.

See https://github.com/JetBrains/kotlin/blob/a36dfac4898893b0be7e747f4e410a1895706afe/repo/auto-code-review/README.md for context on code rules.