### PR TITLE
Expose SwiftName from attribute and apinotes in imported decls

### DIFF
--- a/kotlin-native/Interop/Indexer/build.gradle.kts
+++ b/kotlin-native/Interop/Indexer/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     api(project(":kotlin-native:Interop:Runtime"))
     api(project(":kotlin-native:libclangInterop"))
     implementation(project(":native:kotlin-native-utils"))
+    implementation(libs.jackson.dataformat.yaml)
+    implementation(libs.jackson.module.kotlin)
 
     testImplementation(kotlin("test-junit"))
     testImplementation(project(":native:unsafe-mem"))

--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/ApiNotes.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/ApiNotes.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.native.interop.indexer
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import java.io.File
+
+/**
+ * `SwiftName` refinements extracted from Clang API notes (`*.apinotes`) files.
+ *
+ * The type hierarchy mirrors `clang/APINotes/Types.h` so that the semantics stay recognizable, but only the
+ * `SwiftName` field is kept, for classes, protocols, and their methods and properties. Every other refinement
+ * (nullability, availability, bridging, etc.) is intentionally dropped.
+ *
+ * The versioned `SwiftVersions:` section is also ignored on purpose. Those entries hold names for *older* Swift
+ * language modes; the top-level `SwiftName` is the current one, which is what Clang selects for any modern Swift
+ * version (see `APINotesReader::VersionedInfo`).
+ *
+ * @see load for the (modular-only) discovery rules.
+ */
+class ApiNotes private constructor(
+        private val classes: Map<String, Context>,
+        private val protocols: Map<String, Context>,
+) {
+    fun objCClass(name: String): Context? = classes[name]
+
+    fun protocol(name: String): Context? = protocols[name]
+
+    open class CommonEntityInfo(val swiftName: String?)
+
+    class Method(swiftName: String?) : CommonEntityInfo(swiftName)
+
+    class Property(swiftName: String?) : CommonEntityInfo(swiftName)
+
+    /** An Objective-C class or protocol context, holding the notes for its members. */
+    class Context internal constructor(
+            swiftName: String?,
+            private val instanceMethods: Map<String, Method>,
+            private val classMethods: Map<String, Method>,
+            private val instanceProperties: Map<String, Property>,
+            private val classProperties: Map<String, Property>,
+    ) : CommonEntityInfo(swiftName) {
+        fun method(selector: String, isInstance: Boolean): Method? =
+                (if (isInstance) instanceMethods else classMethods)[selector]
+
+        fun property(name: String, isInstance: Boolean): Property? =
+                (if (isInstance) instanceProperties else classProperties)[name]
+    }
+
+    companion object {
+        /**
+         * Discovers and parses the API notes applicable to [library], following Clang's discovery rules for
+         * modular interop: for each imported module, an `<ModuleName>.apinotes` file is looked up next to the
+         * module's headers (e.g. `Foo.framework/.../Headers/Foo.apinotes`).
+         *
+         * Header-based (non-modular) interop is not covered yet; such libraries produce null.
+         */
+        fun load(library: NativeLibrary): ApiNotes? {
+            val headerFilter = library.headerFilter
+            if (headerFilter !is NativeLibraryHeaderFilter.Predefined || headerFilter.modules.isEmpty()) {
+                return null
+            }
+
+            // Clang looks for `<ModuleName>.apinotes` in the module's headers directory. For every module header we
+            // already resolved, its parent directory is that headers directory (this also covers versioned frameworks,
+            // whose headers live in `Foo.framework/Versions/X/Headers`).
+            val headerDirs = headerFilter.headers.mapNotNullTo(linkedSetOf()) { File(it).parentFile }
+
+            val files = linkedSetOf<File>()
+            for (module in headerFilter.modules) {
+                for (dir in headerDirs) {
+                    val file = File(dir, "$module.apinotes")
+                    if (file.isFile) files += file
+                }
+            }
+            if (files.isEmpty()) return null
+
+            val classes = mutableMapOf<String, Context>()
+            val protocols = mutableMapOf<String, Context>()
+            for (file in files) {
+                val module = runCatching { mapper.readValue<ApiNotesModule>(file) }.getOrNull() ?: continue
+                module.classes.forEach { classes.putContext(it) }
+                module.protocols.forEach { protocols.putContext(it) }
+            }
+
+            return ApiNotes(classes, protocols)
+        }
+
+        private val mapper = JsonMapper.builder(YAMLFactory())
+                .propertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build()
+                .registerKotlinModule()
+
+        private fun MutableMap<String, Context>.putContext(raw: ApiNotesContext) {
+            val instanceMethods = mutableMapOf<String, Method>()
+            val classMethods = mutableMapOf<String, Method>()
+            for (method in raw.methods) {
+                val swiftName = method.swiftName.blankToNull() ?: continue
+                val target = if (method.methodKind == EntityKind.Instance) instanceMethods else classMethods
+                target[method.selector] = Method(swiftName)
+            }
+
+            val instanceProperties = mutableMapOf<String, Property>()
+            val classProperties = mutableMapOf<String, Property>()
+            for (property in raw.properties) {
+                val swiftName = property.swiftName.blankToNull() ?: continue
+                // A property without a PropertyKind applies to both the instance and the class property (matching Clang).
+                if (property.propertyKind != EntityKind.Class) instanceProperties[property.name] = Property(swiftName)
+                if (property.propertyKind != EntityKind.Instance) classProperties[property.name] = Property(swiftName)
+            }
+
+            val swiftName = raw.swiftName.blankToNull()
+            if (swiftName == null && instanceMethods.isEmpty() && classMethods.isEmpty() &&
+                    instanceProperties.isEmpty() && classProperties.isEmpty()
+            ) return
+            this[raw.name] = Context(swiftName, instanceMethods, classMethods, instanceProperties, classProperties)
+        }
+
+        private fun String?.blankToNull(): String? = this?.takeIf { it.isNotBlank() }
+    }
+}
+
+// The data classes below map only the subset of the API notes schema we consume. Unknown keys (SwiftBridge,
+// Nullability, Availability, SwiftVersions, Functions, Globals, Enumerators, Tags, Typedefs, ...) are ignored
+// via the mapper's disabled FAIL_ON_UNKNOWN_PROPERTIES.
+
+/** `MethodKind`/`PropertyKind` in API notes. `PropertyKind` may be absent, meaning "both". */
+private enum class EntityKind { Class, Instance }
+
+private data class ApiNotesModule(
+        val classes: List<ApiNotesContext> = emptyList(),
+        val protocols: List<ApiNotesContext> = emptyList(),
+)
+
+private data class ApiNotesContext(
+        val name: String,
+        val swiftName: String? = null,
+        val methods: List<ApiNotesMethod> = emptyList(),
+        val properties: List<ApiNotesProperty> = emptyList(),
+)
+
+private data class ApiNotesMethod(
+        val selector: String,
+        val methodKind: EntityKind,
+        val swiftName: String? = null,
+)
+
+private data class ApiNotesProperty(
+        val name: String,
+        val propertyKind: EntityKind? = null,
+        val swiftName: String? = null,
+)

--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
@@ -95,6 +95,30 @@ private class ObjCCategoryImpl(
 
 public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boolean = false) : NativeIndex() {
 
+    private val apiNotes: ApiNotes? by lazy {
+        if (library.apiNotesSwiftName) {
+            ApiNotes.load(library)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * The API notes [ApiNotes.Context] for the Objective-C class/protocol (or the class behind a category)
+     * that [memberCursor] — a method or property — belongs to, or `null` if there are no notes for it.
+     */
+    private fun apiNotesContainer(memberCursor: CValue<CXCursor>): ApiNotes.Context? {
+        return apiNotes?.let {
+            val parent = clang_getCursorSemanticParent(memberCursor)
+            return when (parent.kind) {
+                CXCursorKind.CXCursor_ObjCInterfaceDecl -> it.objCClass(getCursorSpelling(parent))
+                CXCursorKind.CXCursor_ObjCProtocolDecl -> it.protocol(getCursorSpelling(parent))
+                CXCursorKind.CXCursor_ObjCCategoryDecl -> it.objCClass(getCursorSpelling(getObjCCategoryClassCursor(parent)))
+                else -> null
+            }
+        }
+    }
+
     private sealed class DeclarationID {
         data class USR(val usr: String) : DeclarationID()
         data class Spelling(val spelling: String) : DeclarationID()
@@ -457,7 +481,8 @@ public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boole
                     isForwardDeclaration = false,
                     binaryName = getObjCBinaryName(cursor).takeIf { it != name },
                     typeParameters = parameters,
-                    swiftName = readSwiftName(cursor)
+                    // API notes supersede the in-header `swift_name` attribute, matching Clang.
+                    swiftName = apiNotes?.objCClass(name)?.swiftName ?: readSwiftName(cursor)
             )
         }) { objcClass ->
             addChildrenToObjCContainer(cursor, objcClass)
@@ -531,7 +556,8 @@ public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boole
                     binaryName = binaryName,
                     location = getLocation(cursor),
                     isForwardDeclaration = false,
-                    swiftName = readSwiftName(cursor)
+                    // API notes supersede the in-header `swift_name` attribute, matching Clang.
+                    swiftName = apiNotes?.protocol(name)?.swiftName ?: readSwiftName(cursor)
             )
         }) {
             addChildrenToObjCContainer(cursor, it)
@@ -1075,7 +1101,10 @@ public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boole
                     }
 
                     if (getter != null) {
-                        val property = ObjCProperty(entityName!!, getter, setter, readSwiftName(cursor))
+                        // API notes supersede the in-header `swift_name` attribute, matching Clang.
+                        val swiftName = apiNotesContainer(cursor)?.property(entityName!!, isInstance = !getter.isClass)?.swiftName
+                                ?: readSwiftName(cursor)
+                        val property = ObjCProperty(entityName!!, getter, setter, swiftName)
                         val objCContainer: ObjCContainerImpl? = when (container.kind) {
                             CXCursorKind.CXCursor_ObjCCategoryDecl -> getObjCCategoryAt(container)
                             CXCursorKind.CXCursor_ObjCInterfaceDecl -> getObjCClassAt(container)
@@ -1185,7 +1214,8 @@ public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boole
                 isInit = (clang_Cursor_isObjCInitMethod(cursor) != 0),
                 isExplicitlyDesignatedInitializer = hasAttribute(cursor, OBJC_DESIGNATED_INITIALIZER),
                 isDirect = hasAttribute(cursor, OBJC_DIRECT),
-                swiftName = readSwiftName(cursor),
+                // API notes supersede the in-header `swift_name` attribute, matching Clang.
+                swiftName = apiNotesContainer(cursor)?.method(selector, isInstance = !isClass)?.swiftName ?: readSwiftName(cursor),
         )
     }
 

--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -126,6 +126,7 @@ data class NativeLibrary(
         val headerExclusionPolicy: HeaderExclusionPolicy,
         val headerFilter: NativeLibraryHeaderFilter,
         val objCClassesIncludingCategories: Set<String>,
+        val apiNotesSwiftName: Boolean,
         val allowIncludingObjCCategoriesFromDefFile: Boolean,
 ) : Compilation
 

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -499,6 +499,13 @@ internal abstract class ObjCContainerStubBuilder(
 
     private val classifier = context.getKotlinClassFor(container, isMeta)
 
+    private val objcNameAnnotation: AnnotationStub.ObjC.ObjCName? =
+            if (!isMeta) {
+                container.swiftName?.let { AnnotationStub.ObjC.ObjCName(swiftName = it) }
+            } else {
+                null
+            }
+
     private val externalObjCAnnotation = when (container) {
         is ObjCProtocol -> {
             /*
@@ -608,7 +615,7 @@ internal abstract class ObjCContainerStubBuilder(
                 constructors = methods.filterIsInstance<ConstructorStub>(),
                 origin = origin,
                 modality = modality,
-                annotations = listOf(externalObjCAnnotation),
+                annotations = listOfNotNull(externalObjCAnnotation, objcNameAnnotation),
                 interfaces = interfaces,
                 companion = companion
         )

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIr.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIr.kt
@@ -197,6 +197,9 @@ sealed class AnnotationStub(val classifier: Classifier) {
                 ObjC(Classifier.topLevel(cinteropPackage, "ExternalObjCClass"))
 
         object Unavailable : ObjC(Classifier.topLevel(cinteropPackage, "ObjCUnavailable"))
+
+        class ObjCName(val name: String = "", val swiftName: String = "", val exact: Boolean = false) :
+                ObjC(Classifier.topLevel("kotlin.native", "ObjCName"))
     }
 
     sealed class CCall(classifier: Classifier) : AnnotationStub(classifier) {

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
@@ -396,6 +396,11 @@ private class MappingExtensions(
                     ("protocolGetter" to protocolGetter).asOptionalAnnotationArgument(),
                     ("binaryName" to binaryName).asOptionalAnnotationArgument()
             )
+            is AnnotationStub.ObjC.ObjCName -> mapOfNotNull(
+                    ("name" to name).asOptionalAnnotationArgument(),
+                    ("swiftName" to swiftName).asOptionalAnnotationArgument(),
+                    ("exact" to KmAnnotationArgument.BooleanValue(exact)).takeIf { exact }
+            )
             AnnotationStub.CCall.CString -> emptyMap()
             AnnotationStub.CCall.WCString -> emptyMap()
             is AnnotationStub.CCall.Symbol -> mapOfNotNull(

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrTextEmitter.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrTextEmitter.kt
@@ -493,6 +493,14 @@ class StubIrTextEmitter(
             }
         }
         AnnotationStub.ObjC.Unavailable -> "@ObjCUnavailable"
+        is AnnotationStub.ObjC.ObjCName -> {
+            val args = listOfNotNull(
+                    annotationStub.name.takeIf { it.isNotEmpty() }?.let { "name = ${it.quoteAsKotlinLiteral()}" },
+                    annotationStub.swiftName.takeIf { it.isNotEmpty() }?.let { "swiftName = ${it.quoteAsKotlinLiteral()}" },
+                    annotationStub.exact.takeIf { it }?.let { "exact = true" }
+            )
+            "@kotlin.native.ObjCName(${args.joinToString(", ")})"
+        }
         AnnotationStub.CCall.CString ->
             "@CCall.CString"
         AnnotationStub.CCall.WCString ->

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -709,6 +709,7 @@ internal fun buildNativeLibrary(
             headerExclusionPolicy = headerExclusionPolicy,
             headerFilter = headerFilter,
             objCClassesIncludingCategories = objCClassesIncludingCategories,
+            apiNotesSwiftName = def.config.apiNotesSwiftName,
             allowIncludingObjCCategoriesFromDefFile = def.config.allowIncludingObjCCategoriesFromDefFile,
     )
 }

--- a/kotlin-native/Interop/StubGenerator/test/org/jetbrains/kotlin/native/interop/gen/ApiNotesSwiftNameTest.kt
+++ b/kotlin-native/Interop/StubGenerator/test/org/jetbrains/kotlin/native/interop/gen/ApiNotesSwiftNameTest.kt
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.native.interop.gen
+
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.native.interop.indexer.NativeIndex
+import org.jetbrains.kotlin.native.interop.indexer.ObjCClass
+import org.jetbrains.kotlin.native.interop.indexer.ObjCContainer
+import org.jetbrains.kotlin.native.interop.indexer.ObjCMethod
+import org.jetbrains.kotlin.native.interop.indexer.ObjCProperty
+import org.jetbrains.kotlin.native.interop.indexer.ObjCProtocol
+import org.jetbrains.kotlin.native.interop.indexer.buildNativeIndex
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ApiNotesSwiftNameTest : InteropTestsBase() {
+
+    @BeforeEach
+    fun onlyOnMac() {
+        Assumptions.assumeTrue(HostManager.hostIsMac)
+    }
+
+    @Test
+    fun `class with SwiftName`() {
+        val index = index(
+                header = """
+                    @interface OriginalClass
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: OriginalClass
+                      SwiftName: RenamedClass
+                """
+        )
+        assertEquals("RenamedClass", index.objCClass("OriginalClass").swiftName)
+    }
+
+    @Test
+    fun `class without SwiftName has null swiftName`() {
+        val index = index(
+                header = """
+                    @interface PlainClass
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: PlainClass
+                """
+        )
+        assertNull(index.objCClass("PlainClass").swiftName)
+    }
+
+    @Test
+    fun `protocol with SwiftName`() {
+        val index = index(
+                header = """
+                    @protocol OriginalProtocol
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Protocols:
+                    - Name: OriginalProtocol
+                      SwiftName: RenamedProtocol
+                """
+        )
+        assertEquals("RenamedProtocol", index.objCProtocol("OriginalProtocol").swiftName)
+    }
+
+    @Test
+    fun `instance method with SwiftName`() {
+        val index = index(
+                header = """
+                    @interface C
+                    - (void)doWith:(int)value;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      Methods:
+                      - Selector: 'doWith:'
+                        MethodKind: Instance
+                        SwiftName: 'do(with:)'
+                """
+        )
+        assertEquals("do(with:)", index.objCClass("C").instanceMethod("doWith:").swiftName)
+    }
+
+    @Test
+    fun `class method with SwiftName`() {
+        val index = index(
+                header = """
+                    @interface C
+                    + (void)makeWith:(int)value;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      Methods:
+                      - Selector: 'makeWith:'
+                        MethodKind: Class
+                        SwiftName: 'make(with:)'
+                """
+        )
+        assertEquals("make(with:)", index.objCClass("C").classMethod("makeWith:").swiftName)
+    }
+
+    @Test
+    fun `instance and class methods with the same selector are renamed independently`() {
+        val index = index(
+                header = """
+                    @interface C
+                    - (void)shared;
+                    + (void)shared;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      Methods:
+                      - Selector: 'shared'
+                        MethodKind: Instance
+                        SwiftName: 'sharedInstance()'
+                      - Selector: 'shared'
+                        MethodKind: Class
+                        SwiftName: 'sharedClass()'
+                """
+        )
+        val c = index.objCClass("C")
+        assertEquals("sharedInstance()", c.instanceMethod("shared").swiftName)
+        assertEquals("sharedClass()", c.classMethod("shared").swiftName)
+    }
+
+    @Test
+    fun `method without SwiftName has null swiftName`() {
+        val index = index(
+                header = """
+                    @interface C
+                    - (void)untouched;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      Methods:
+                      - Selector: 'untouched'
+                        MethodKind: Instance
+                        Availability: none
+                """
+        )
+        assertNull(index.objCClass("C").instanceMethod("untouched").swiftName)
+    }
+
+    @Test
+    fun `instance property with SwiftName`() {
+        val index = index(
+                header = """
+                    @interface C
+                    @property int originalValue;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      Properties:
+                      - Name: originalValue
+                        PropertyKind: Instance
+                        SwiftName: renamedValue
+                """
+        )
+        assertEquals("renamedValue", index.objCClass("C").instanceProperty("originalValue").swiftName)
+    }
+
+    @Test
+    fun `class property with SwiftName`() {
+        val index = index(
+                header = """
+                    @interface C
+                    @property(class) int originalValue;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      Properties:
+                      - Name: originalValue
+                        PropertyKind: Class
+                        SwiftName: renamedValue
+                """
+        )
+        assertEquals("renamedValue", index.objCClass("C").classProperty("originalValue").swiftName)
+    }
+
+    @Test
+    fun `property without PropertyKind renames both instance and class properties`() {
+        val index = index(
+                header = """
+                    @interface C
+                    @property int shared;
+                    @property(class) int shared;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      Properties:
+                      - Name: shared
+                        SwiftName: renamedShared
+                """
+        )
+        val c = index.objCClass("C")
+        assertEquals("renamedShared", c.instanceProperty("shared").swiftName)
+        assertEquals("renamedShared", c.classProperty("shared").swiftName)
+    }
+
+    @Test
+    fun `protocol members with SwiftName`() {
+        val index = index(
+                header = """
+                    @protocol P
+                    - (void)doIt;
+                    @property int value;
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Protocols:
+                    - Name: P
+                      Methods:
+                      - Selector: 'doIt'
+                        MethodKind: Instance
+                        SwiftName: 'doIt()'
+                      Properties:
+                      - Name: value
+                        SwiftName: renamedValue
+                """
+        )
+        val p = index.objCProtocol("P")
+        assertEquals("doIt()", p.instanceMethod("doIt").swiftName)
+        assertEquals("renamedValue", p.instanceProperty("value").swiftName)
+    }
+
+    @Test
+    fun `API Notes SwiftName supersedes the in-header swift_name attribute`() {
+        val index = index(
+                header = """
+                    __attribute__((swift_name("HeaderClass")))
+                    @interface C
+                    - (void)doIt __attribute__((swift_name("headerDoIt()")));
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      SwiftName: NotesClass
+                      Methods:
+                      - Selector: 'doIt'
+                        MethodKind: Instance
+                        SwiftName: 'notesDoIt()'
+                """
+        )
+        val c = index.objCClass("C")
+        assertEquals("NotesClass", c.swiftName)
+        assertEquals("notesDoIt()", c.instanceMethod("doIt").swiftName)
+    }
+
+    @Test
+    fun `the in-header swift_name attribute is used when there is no API Notes entry`() {
+        val index = index(
+                header = """
+                    __attribute__((swift_name("HeaderClass")))
+                    @interface C
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                """
+        )
+        assertEquals("HeaderClass", index.objCClass("C").swiftName)
+    }
+
+    @Test
+    fun `API Notes are ignored when the feature is disabled`() {
+        val index = index(
+                header = """
+                    __attribute__((swift_name("HeaderClass")))
+                    @interface C
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      SwiftName: NotesClass
+                """,
+                apiNotesEnabled = false
+        )
+        // Falls back to the in-header attribute; the API notes rename is not applied.
+        assertEquals("HeaderClass", index.objCClass("C").swiftName)
+    }
+
+    @Test
+    fun `versioned SwiftVersions section is ignored in favor of the top-level SwiftName`() {
+        val index = index(
+                header = """
+                    @interface C
+                    @end
+                """,
+                apiNotes = """
+                    Name: TestModule
+                    Classes:
+                    - Name: C
+                      SwiftName: CurrentName
+                    SwiftVersions:
+                    - Version: 3.0
+                      Classes:
+                      - Name: C
+                        SwiftName: LegacyName
+                """
+        )
+        assertEquals("CurrentName", index.objCClass("C").swiftName)
+    }
+
+    private fun NativeIndex.objCClass(name: String): ObjCClass =
+            objCClasses.single { it.name == name }
+
+    private fun NativeIndex.objCProtocol(name: String): ObjCProtocol =
+            objCProtocols.single { it.name == name }
+
+    private fun ObjCContainer.instanceMethod(selector: String): ObjCMethod =
+            methods.single { it.selector == selector && !it.isClass }
+
+    private fun ObjCContainer.classMethod(selector: String): ObjCMethod =
+            methods.single { it.selector == selector && it.isClass }
+
+    private fun ObjCContainer.instanceProperty(name: String): ObjCProperty =
+            properties.single { it.name == name && !it.getter.isClass }
+
+    private fun ObjCContainer.classProperty(name: String): ObjCProperty =
+            properties.single { it.name == name && it.getter.isClass }
+
+    private fun index(
+            header: String,
+            apiNotes: String,
+            moduleName: String = "TestModule",
+            apiNotesEnabled: Boolean = true,
+    ): NativeIndex {
+        val files = testFiles()
+
+        files.file("$moduleName.h", header.trimIndent())
+        files.file("module.modulemap", """
+            module $moduleName {
+              header "$moduleName.h"
+              export *
+            }
+        """.trimIndent())
+        files.file("$moduleName.apinotes", apiNotes.trimIndent())
+
+        val defFile = files.file("test.def", """
+            language = Objective-C
+            modules = $moduleName
+            apiNotesSwiftName = $apiNotesEnabled
+
+        """.trimIndent())
+
+        val library = buildNativeLibraryFrom(defFile, files.directory)
+        return buildNativeIndex(library, verbose = false).index
+    }
+}

--- a/kotlin-native/platformLibs/src/platform/ios/Foundation.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Foundation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Security darwin 
 language = Objective-C
 package = platform.Foundation
 modules = Foundation
+apiNotesSwiftName = true
 
 compilerOpts = -framework Foundation
 linkerOpts = -framework Foundation

--- a/kotlin-native/platformLibs/src/platform/osx/Foundation.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Foundation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Foundation
 modules = Foundation
+apiNotesSwiftName = true
 
 compilerOpts = -framework Foundation
 linkerOpts = -framework Foundation

--- a/kotlin-native/platformLibs/src/platform/tvos/Foundation.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Foundation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Security darwin 
 language = Objective-C
 package = platform.Foundation
 modules = Foundation
+apiNotesSwiftName = true
 
 compilerOpts = -framework Foundation
 linkerOpts = -framework Foundation

--- a/kotlin-native/platformLibs/src/platform/watchos/Foundation.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/Foundation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Security darwin posix
 language = Objective-C
 package = platform.Foundation
 modules = Foundation
+apiNotesSwiftName = true
 
 compilerOpts = -framework Foundation
 linkerOpts = -framework Foundation

--- a/native/native.tests/testData/CInterop/swiftName/include/module.modulemap
+++ b/native/native.tests/testData/CInterop/swiftName/include/module.modulemap
@@ -1,0 +1,4 @@
+module swiftNameLib {
+    header "swiftNameLib.h"
+    export *
+}

--- a/native/native.tests/testData/CInterop/swiftName/include/swiftNameLib.apinotes
+++ b/native/native.tests/testData/CInterop/swiftName/include/swiftNameLib.apinotes
@@ -1,0 +1,9 @@
+Name: swiftNameLib
+Classes:
+- Name: NotesRenamed
+  SwiftName: NotesRenamedSwift
+- Name: Overridden
+  SwiftName: OverriddenNotesSwift
+Protocols:
+- Name: NotesProtocol
+  SwiftName: NotesProtocolSwift

--- a/native/native.tests/testData/CInterop/swiftName/include/swiftNameLib.h
+++ b/native/native.tests/testData/CInterop/swiftName/include/swiftNameLib.h
@@ -1,0 +1,17 @@
+// A class renamed only through the in-header `swift_name` attribute (no API notes entry).
+__attribute__((swift_name("SourceRenamedSwift")))
+@interface SourceRenamed
+@end
+
+// A class renamed only through API notes (no in-header attribute).
+@interface NotesRenamed
+@end
+
+// A class renamed by both: API notes must win (matching Clang).
+__attribute__((swift_name("OverriddenHeaderSwift")))
+@interface Overridden
+@end
+
+// A protocol renamed through API notes.
+@protocol NotesProtocol
+@end

--- a/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/disabled/contents.gold.txt
+++ b/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/disabled/contents.gold.txt
@@ -1,0 +1,92 @@
+library {
+  // module name: <pod1.def>
+
+  library fragment {
+    // package name: pod1
+
+    // class name: pod1/NotesProtocolProtocol
+    // class name: pod1/NotesProtocolProtocolMeta
+    // class name: pod1/NotesRenamed
+    // class name: pod1/NotesRenamed.Companion
+    // class name: pod1/NotesRenamedMeta
+    // class name: pod1/Overridden
+    // class name: pod1/Overridden.Companion
+    // class name: pod1/OverriddenMeta
+    // class name: pod1/SourceRenamed
+    // class name: pod1/SourceRenamed.Companion
+    // class name: pod1/SourceRenamedMeta
+
+    @kotlinx/cinterop/ExternalObjCClass(protocolGetter = "kniprot_pod1_NotesProtocol_0", binaryName = "NotesProtocol")
+    public abstract interface pod1/NotesProtocolProtocol : kotlinx/cinterop/ObjCObject {
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass(protocolGetter = "kniprot_pod1_NotesProtocol_0", binaryName = "NotesProtocol")
+    public abstract interface pod1/NotesProtocolProtocolMeta : kotlinx/cinterop/ObjCClass /* = kotlinx/cinterop/ObjCObjectMeta^ */ {
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/NotesRenamed : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/NotesRenamed.Companion : pod1/NotesRenamedMeta, kotlinx/cinterop/ObjCClassOf<pod1/NotesRenamed> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/NotesRenamedMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    @kotlin/native/ObjCName(swiftName = "OverriddenHeaderSwift")
+    public open class pod1/Overridden : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/Overridden.Companion : pod1/OverriddenMeta, kotlinx/cinterop/ObjCClassOf<pod1/Overridden> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/OverriddenMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    @kotlin/native/ObjCName(swiftName = "SourceRenamedSwift")
+    public open class pod1/SourceRenamed : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/SourceRenamed.Companion : pod1/SourceRenamedMeta, kotlinx/cinterop/ObjCClassOf<pod1/SourceRenamed> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/SourceRenamedMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+  }
+}

--- a/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/disabled/pod1.def
+++ b/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/disabled/pod1.def
@@ -1,0 +1,2 @@
+language = Objective-C
+modules = swiftNameLib

--- a/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/enabled/contents.gold.txt
+++ b/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/enabled/contents.gold.txt
@@ -1,0 +1,94 @@
+library {
+  // module name: <pod1.def>
+
+  library fragment {
+    // package name: pod1
+
+    // class name: pod1/NotesProtocolProtocol
+    // class name: pod1/NotesProtocolProtocolMeta
+    // class name: pod1/NotesRenamed
+    // class name: pod1/NotesRenamed.Companion
+    // class name: pod1/NotesRenamedMeta
+    // class name: pod1/Overridden
+    // class name: pod1/Overridden.Companion
+    // class name: pod1/OverriddenMeta
+    // class name: pod1/SourceRenamed
+    // class name: pod1/SourceRenamed.Companion
+    // class name: pod1/SourceRenamedMeta
+
+    @kotlinx/cinterop/ExternalObjCClass(protocolGetter = "kniprot_pod1_NotesProtocol_0", binaryName = "NotesProtocol")
+    @kotlin/native/ObjCName(swiftName = "NotesProtocolSwift")
+    public abstract interface pod1/NotesProtocolProtocol : kotlinx/cinterop/ObjCObject {
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass(protocolGetter = "kniprot_pod1_NotesProtocol_0", binaryName = "NotesProtocol")
+    public abstract interface pod1/NotesProtocolProtocolMeta : kotlinx/cinterop/ObjCClass /* = kotlinx/cinterop/ObjCObjectMeta^ */ {
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    @kotlin/native/ObjCName(swiftName = "NotesRenamedSwift")
+    public open class pod1/NotesRenamed : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/NotesRenamed.Companion : pod1/NotesRenamedMeta, kotlinx/cinterop/ObjCClassOf<pod1/NotesRenamed> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/NotesRenamedMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    @kotlin/native/ObjCName(swiftName = "OverriddenNotesSwift")
+    public open class pod1/Overridden : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/Overridden.Companion : pod1/OverriddenMeta, kotlinx/cinterop/ObjCClassOf<pod1/Overridden> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/OverriddenMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    @kotlin/native/ObjCName(swiftName = "SourceRenamedSwift")
+    public open class pod1/SourceRenamed : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/SourceRenamed.Companion : pod1/SourceRenamedMeta, kotlinx/cinterop/ObjCClassOf<pod1/SourceRenamed> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/SourceRenamedMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+  }
+}

--- a/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/enabled/pod1.def
+++ b/native/native.tests/testData/CInterop/swiftName/swiftNameDefs/enabled/pod1.def
@@ -1,0 +1,3 @@
+language = Objective-C
+modules = swiftNameLib
+apiNotesSwiftName = true

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateNativeTests.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateNativeTests.kt
@@ -93,6 +93,7 @@ fun main(args: Array<String>) {
                 model("framework.macros/macrosDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("builtins/builtinsDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("cCallMode/cCallMode", pattern = "^([^_](.+))$", recursive = false)
+                model("swiftName/swiftNameDefs", pattern = "^([^_](.+))$", recursive = false)
             }
             testClass<AbstractNativeCInteropNoFModulesTest>(
                 suiteTestClassName = "CInteropNoFModulesTestGenerated",
@@ -102,6 +103,7 @@ fun main(args: Array<String>) {
                 model("framework.macros/macrosDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("builtins/builtinsDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("cCallMode/cCallMode", pattern = "^([^_](.+))$", recursive = false)
+                model("swiftName/swiftNameDefs", pattern = "^([^_](.+))$", recursive = false)
             }
             testClass<AbstractNativeCInteropHeaderModeTest>(
                 suiteTestClassName = "CInteropHeaderModeTestGenerated",
@@ -111,6 +113,7 @@ fun main(args: Array<String>) {
                 model("framework.macros/macrosDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("builtins/builtinsDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("cCallMode/cCallMode", pattern = "^([^_](.+))$", recursive = false)
+                model("swiftName/swiftNameDefs", pattern = "^([^_](.+))$", recursive = false)
             }
             testClass<AbstractNativeCInteropKT39120Test>(
                 suiteTestClassName = "CInteropKT39120TestGenerated",

--- a/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/integration/utils/compileAndIndex.kt
+++ b/native/objcexport-header-generator/test/org/jetbrains/kotlin/backend/konan/tests/integration/utils/compileAndIndex.kt
@@ -39,6 +39,7 @@ internal fun compileAndIndex(
             modules = emptyList()
         ),
         objCClassesIncludingCategories = emptySet(),
+        apiNotesSwiftName = false,
         allowIncludingObjCCategoriesFromDefFile = false
     )
 

--- a/native/utils/src/org/jetbrains/kotlin/konan/util/DefFile.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/util/DefFile.kt
@@ -72,6 +72,7 @@ class DefFile(val file: File?, val config: DefFileConfig, val manifestAddendProp
         val allowIncludingObjCCategoriesFromDefFile: Boolean by AllowIncludingObjCCategoriesFromDefFile
         val userSetupHint: String? by UserSetupHint
         val skipNonImportableModules by SkipNonImportableModules
+        val apiNotesSwiftName by ApiNotesSwiftName
 
     }
 }

--- a/native/utils/src/org/jetbrains/kotlin/konan/util/DefFileProperty.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/util/DefFileProperty.kt
@@ -49,7 +49,8 @@ sealed interface DefFileProperty<T> {
         ExcludeDependentModules("excludeDependentModules"),
         DisableDesignatedInitializerChecks("disableDesignatedInitializerChecks"),
         AllowIncludingObjCCategoriesFromDefFile("allowIncludingObjCCategoriesFromDefFile"),
-        SkipNonImportableModules("skipNonImportableModules");
+        SkipNonImportableModules("skipNonImportableModules"),
+        ApiNotesSwiftName("apiNotesSwiftName");
 
         override fun parse(rawValue: String?): Boolean = rawValue.toBoolean()
     }


### PR DESCRIPTION
Apple SDK frameworks ship Clang API notes (`*.apinotes`) that rename Objective-C declarations for Swift via `SwiftName`. Previously cinterop only saw the in-header `swift_name` attribute, so these renames were invisible in the generated Kotlin interface.

Changes:

- Parse API notes. A new parser reads *.apinotes YAML (via Jackson), extracting only `SwiftName` for classes, protocols, methods and properties. Other refinements (nullability, availability, …) and the versioned `SwiftVersions` section are ignored. 

- Files are discovered following Clang's modular rule: `<ModuleName>.apinotes` next to the module's headers.

- Apply during indexing. The imported `swiftName` for classes, protocols, methods and properties is taken from the API notes, which take precedence over the in-header attribute, matching Clang.

- Emit into the interface. Class and protocol stubs carrying a Swift name emit `@kotlin.native.ObjCName(swiftName = ...)` †.

- Opt-in. A new `apiNotesSwiftName` def-file flag gates the feature, enabled only for `Foundation` for now.

† The semantic model carries Swift names for method and properties as well (both from in-header attributes and from apinotes), but `@ObjCName` emission currently covers classes and protocols only; members are a follow-up.

^ KT-81934 Fixed