### PR TITLE
[LL] Avoid duplicate `BuiltinTypes` instances in LL FIR sessions

### DIFF
--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/sessions/LLFirSession.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/sessions/LLFirSession.kt
@@ -57,9 +57,9 @@ import kotlin.uuid.Uuid
 @KaImplementationDetail
 abstract class LLFirSession(
     val ktModule: KaModule,
-    override val builtinTypes: BuiltinTypes,
+    builtinTypes: BuiltinTypes,
     kind: Kind,
-) : FirSession(kind) {
+) : FirSession(kind, builtinTypes) {
     abstract fun getScopeSession(): ScopeSession
 
     val project: Project

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirSession.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/FirSession.kt
@@ -14,7 +14,8 @@ import org.jetbrains.kotlin.util.TypeRegistry
 import kotlin.reflect.KClass
 
 abstract class FirSession @PrivateSessionConstructor constructor(
-    val kind: Kind
+    val kind: Kind,
+    val builtinTypes: BuiltinTypes = BuiltinTypes(),
 ) : ComponentArrayOwner<FirSessionComponent, FirSessionComponent>() {
     companion object : ConeTypeRegistry<FirSessionComponent, FirSessionComponent>() {
         inline fun <reified T : FirSessionComponent> sessionComponentAccessor(): ArrayMapAccessor<FirSessionComponent, FirSessionComponent, T> {
@@ -36,8 +37,6 @@ abstract class FirSession @PrivateSessionConstructor constructor(
             return generateNullableAccessor(T::class)
         }
     }
-
-    open val builtinTypes: BuiltinTypes = BuiltinTypes()
 
     final override val typeRegistry: TypeRegistry<FirSessionComponent, FirSessionComponent> = Companion
 


### PR DESCRIPTION
- `LLFirSession` held two duplicate `BuiltinTypes` instances: One from an eager initialization in the body of `FirSession`, the other as a shared instance from `LLFirBuiltinsSessionFactory`. This meant that each `LLFirSession` carried a useless `BuiltinTypes` instance, causing a waste of 1KB per session (becoming relevant at thousands of sessions).
- Move `builtinTypes` into `FirSession`'s primary constructor so LL sessions can hand the single shared instance straight to the base class.

^KT-87680 Fixed