### PR TITLE
Open k2jklibcompiler class

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/K2JKlibCompiler.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/K2JKlibCompiler.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
  *
  */
 @OptIn(ObsoleteDescriptorBasedAPI::class)
-class K2JKlibCompiler : CLICompiler<K2JKlibCompilerArguments>() {
+open class K2JKlibCompiler : CLICompiler<K2JKlibCompilerArguments>() {
     override val platform: TargetPlatform
         get() = JvmPlatforms.defaultJvmPlatform
 


### PR DESCRIPTION
In order to be able to extend the k2jklibcompiler class we need to open it