### PR TITLE
JVM reflection: uncomment previously failing tests

### DIFF
--- a/compiler/testData/codegen/boxJvm/reflection/properties/getDelegate/companionBlockProperty.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/properties/getDelegate/companionBlockProperty.kt
@@ -25,9 +25,8 @@ fun box(): String {
     assertEquals("a", A::p.call())
     assertTrue(A::p is KMutableProperty0<*>)
 
-    // TODO: uncomment when KT-85767 is fixed.
-    // val pd = (A::p).apply { isAccessible = true }.getDelegate() as Delegate
-    // assertEquals("a", pd.storage)
+    val pd = (A::p).apply { isAccessible = true }.getDelegate() as Delegate
+    assertEquals("a", pd.storage)
 
     return "OK"
 }

--- a/compiler/testData/codegen/boxJvm/reflection/properties/getDelegate/method/delegateToConstFromCompanionBlock.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/properties/getDelegate/method/delegateToConstFromCompanionBlock.kt
@@ -16,8 +16,7 @@ class A {
 }
 
 fun box(): String {
-    // TODO: uncomment when KT-85767 is fixed.
-    // assertEquals(1, (A::s).apply { isAccessible = true }.getDelegate())
+    assertEquals(1, (A::s).apply { isAccessible = true }.getDelegate())
 
     return "OK"
 }


### PR DESCRIPTION
The bug was already fixed (probably in #6129).

^KT-85767 Fixed