### PR TITLE
[Wasm] remove redundant inline classes boxing/unboxing in State Machine function transformation code ^KT-87687

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/AbstractSuspendFunctionsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/AbstractSuspendFunctionsLowering.kt
@@ -56,9 +56,6 @@ abstract class AbstractSuspendFunctionsLowering<C : CommonBackendContext>(val co
 
     protected abstract fun IrBlockBodyBuilder.generateCoroutineStart(invokeSuspendFunction: IrFunction, receiver: IrExpression)
 
-    protected open fun IrBuilderWithScope.generateDelegatedCall(expectedType: IrType, delegatingCall: IrExpression): IrExpression =
-        delegatingCall
-
     private val symbols = context.symbols
     private val getContinuationSymbol = symbols.getContinuation
     private val continuationClassSymbol = getContinuationSymbol.owner.returnType.classifierOrFail as IrClassSymbol

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/JsSuspendFunctionsLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/JsSuspendFunctionsLowering.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.backend.common.lower.AbstractSuspendFunctionsLowerin
 import org.jetbrains.kotlin.backend.common.lower.FinallyBlocksLowering
 import org.jetbrains.kotlin.ir.backend.js.JsStatementOrigins
 import org.jetbrains.kotlin.backend.common.lower.ReturnableBlockTransformer
-import org.jetbrains.kotlin.backend.common.lower.coroutines.defaultLoweredSuspendFunctionReturnType
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.optimizations.LivenessAnalysis
 import org.jetbrains.kotlin.ir.IrElement
@@ -145,7 +144,7 @@ open class JsSuspendFunctionsLowering<C : JsCommonBackendContext>(
             // This is done solely to improve the debugging experience. Otherwise, a breakpoint set to the closing brace of the function
             // cannot be hit.
             val tempVar = scope.createTemporaryVariable(
-                generateDelegatedCall(irFunction.returnType, returnValue),
+                irExpression = returnValue,
                 irType = context.irBuiltIns.anyType,
             )
             statements[statements.lastIndex] = tempVar
@@ -333,36 +332,8 @@ open class JsSuspendFunctionsLowering<C : JsCommonBackendContext>(
         rootLoop.transformChildrenVoid(dispatchPointTransformer)
     }
 
-    private fun needUnboxingOrUnit(fromType: IrType, toType: IrType): Boolean {
-        val icUtils = context.inlineClassesUtils
-
-        return (icUtils.getInlinedClass(fromType) == null && icUtils.getInlinedClass(toType) != null) ||
-                (fromType.isUnit() && !toType.isUnit())
-    }
-
-    override fun IrBuilderWithScope.generateDelegatedCall(expectedType: IrType, delegatingCall: IrExpression): IrExpression {
-        val functionReturnType = (delegatingCall as? IrCall)?.symbol?.owner?.let { function ->
-            defaultLoweredSuspendFunctionReturnType(function.returnType, context.irBuiltIns)
-        } ?: delegatingCall.type
-
-        if (!needUnboxingOrUnit(functionReturnType, expectedType)) return delegatingCall
-
-        return irComposite(resultType = expectedType) {
-            val tmp = createTmpVariable(delegatingCall, irType = functionReturnType)
-            val coroutineSuspended = irCall(this@JsSuspendFunctionsLowering.context.symbols.coroutineSuspendedGetter)
-            val condition = irEqeqeq(irGet(tmp), coroutineSuspended)
-            +irIfThen(context.irBuiltIns.unitType, condition, irReturn(irGet(tmp)))
-            +irImplicitCast(irGet(tmp), expectedType)
-        }
-    }
-
-    override fun IrBlockBodyBuilder.generateCoroutineStart(invokeSuspendFunction: IrFunction, receiver: IrExpression) {
-        val call = irCall(invokeSuspendFunction.symbol).apply {
-            arguments[0] = receiver
-        }
-        val functionReturnType = scope.scopeOwnerSymbol.assertedCast<IrSimpleFunctionSymbol> { "Expected function symbol" }.owner.returnType
-        +irReturn(generateDelegatedCall(functionReturnType, call))
-    }
+    override fun IrBlockBodyBuilder.generateCoroutineStart(invokeSuspendFunction: IrFunction, receiver: IrExpression) =
+        +irReturn(irCall(invokeSuspendFunction.symbol).apply { arguments[0] = receiver })
 }
 
 internal sealed class SuspendFunctionKind {

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/StateMachineBuilder.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/StateMachineBuilder.kt
@@ -284,14 +284,8 @@ class StateMachineBuilder(
 
         if (expression.isSuspend) {
             val result = lastExpression()
-            val expectedType = expression.symbol.owner.returnType
-            val isInlineClassExpected = context.inlineClassesUtils.getInlinedClass(expectedType) != null
             val continueState = SuspendState(unit)
-            val unboxState = if (isInlineClassExpected) SuspendState(unit) else null
-
-            val dispatch = createDispatchPoint(unboxState ?: continueState)
-
-            if (unboxState != null) currentState.successors += unboxState
+            val dispatch = createDispatchPoint(continueState)
 
             currentState.successors += continueState
 
@@ -313,31 +307,11 @@ class StateMachineBuilder(
             val suspensionBlock = JsIrBuilder.buildBlock(unit, listOf(irReturn))
             addStatement(JsIrBuilder.buildIfElse(unit, check, suspensionBlock))
 
-            if (isInlineClassExpected) {
-                addStatement(JsIrBuilder.buildCall(stateSymbolSetter.symbol, unit).apply {
-                    arguments[0] = thisReceiver
-                    arguments[1] = createDispatchPoint(continueState)
-                })
-            }
-
             doContinue()
-
-            unboxState?.let { buildUnboxingState(it, continueState, expectedType) }
 
             updateState(continueState)
             addStatement(getSuspendResultAsType(expression.type))
         }
-    }
-
-    private fun buildUnboxingState(unboxState: SuspendState, continueState: SuspendState, expectedType: IrType) {
-        unboxState.successors += continueState
-        updateState(unboxState)
-        val result = getSuspendResultAsType(anyN)
-        val tmp = JsIrBuilder.buildVar(expectedType, function.owner, name = "unboxed", initializer = result)
-        addStatement(tmp)
-        addStatement(setSuspendResultValue(JsIrBuilder.buildGetValue(tmp.symbol)))
-
-        doDispatch(continueState)
     }
 
     override fun visitBreak(jump: IrBreak) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -85,9 +85,7 @@ internal class NativeSuspendFunctionsLowering(
 
                 return if (!expression.isSuspend || expression !in tailSuspendCalls)
                     shortCut
-                else irBuilder.at(expression).irReturn(
-                        irBuilder.generateDelegatedCall(irFunction.returnType, shortCut)
-                )
+                else irBuilder.at(expression).irReturn(shortCut)
             }
         })
     }


### PR DESCRIPTION
1. Currently, state machine generated for suspend functions contains excessive, legacy code for boxing/unboxing primitive values + inlined classes (even though, boxing/unboxing with more precise checks generated further by AutoboxingTransformer and TypeOperatorLowerings for K/Wasm, K/Js targets). This excessive code looks like the following:
```
VAR SYNTHESIZED_DECLARATION name:unboxed type:<root>.IC [val]
  CALL 'internal final fun unboxIntrinsic <T, R> (x: T of kotlin.wasm.internal.unboxIntrinsic): R of kotlin.wasm.internal.unboxIntrinsic declared in kotlin.wasm.internal' type=<root>.IC origin=SYNTHESIZED_STATEMENT
    TYPE_ARG T: kotlin.Any?
    TYPE_ARG R: <root>.IC
    ARG x: GET_VAR 'var suspendResult: kotlin.Any? [var] declared in <root>.$testCOROUTINE$.doResume' type=kotlin.Any? origin=SYNTHESIZED_STATEMENT
SET_VAR 'var suspendResult: kotlin.Any? [var] declared in <root>.$testCOROUTINE$.doResume' type=kotlin.Unit origin=SYNTHESIZED_STATEMENT
  CALL 'internal final fun boxIntrinsic <T, R> (x: T of kotlin.wasm.internal.boxIntrinsic): R of kotlin.wasm.internal.boxIntrinsic declared in kotlin.wasm.internal' type=kotlin.Any? origin=null
    TYPE_ARG T: <root>.IC
    TYPE_ARG R: kotlin.Any?
    ARG x: GET_VAR 'val unboxed: <root>.IC [val] declared in <root>.$testCOROUTINE$.doResume' type=<root>.IC origin=SYNTHESIZED_STATEMENT
```

Those checks were introduced first, because setters/getters inside `StateMachineBuilder` generated `REINTERPRET_CAST`. But then cast was replaced with `IMPLICIT_CAST`, which is now processes by AutoboxingTransformer and TypeOperatorLowetings. 

2. Also, in state machine for each suspension point generated the same code: 
```
local.tee $suspendResult
call $kotlin.coroutines.intrinsics.<get-COROUTINE_SUSPENDED>
ref.eq
if ;; label = @7
  local.get $suspendResult
  return
end
```
I experiment here with moving this code into a common place (block) by wrapping state machine code (inside `while` loop) into a returnable block that can either do `continue` or jump to a block with `COROUTINE_SUSPENDED` check from suspension point.

This PR aims to remove excessive boxing/unboxing code and to experiment with moving COROUTINE_SUSPENDED checks to a common place.

### preliminary size change (with the changes from https://github.com/JetBrains/kotlin/pull/6668) of compiled `KotlinConfApp-app-webApp.wasm (bytes)`

development
```
old: 27806774 
new: 27770295 (without boxing/unboxing + unified block for COROUTINE_SUSPENDED check + jump to the block from returnable block)
       -36000 (0.13%)
     27770470 (without boxing/unboxing)
       -36000 (0.13%)
```

production
```
old: 5895257
new: 5880605 (without boxing/unboxing + unified block for COROUTINE_SUSPENDED check + jump to the block from returnable block)
      -14000 (0.23%)
     5874632 (without boxing/unboxing)
      -20000 (0.33%)
```

fixes ^KT-87687