### PR TITLE
[Test, Wasm] Ignore jsExportNameClash.kt only in monolith mode

### DIFF
--- a/compiler/testData/codegen/box/package/jsExportNameClash.kt
+++ b/compiler/testData/codegen/box/package/jsExportNameClash.kt
@@ -1,6 +1,7 @@
 // ISSUE: KT-60832, KT-65779
 // DONT_TARGET_EXACT_BACKEND: JVM, JVM_IR, NATIVE, WASM_WASI
-// IGNORE_BACKEND: WASM_JS
+// WASM_IGNORE_FOR: mode=regular
+// In both single-module and multi-module Wasm mode, the different modules individually don't have conflicting exports, so the test only fails for monolith
 // KT-65779: SyntaxError: Identifier 'bar' has already been declared
 
 // MODULE: m1


### PR DESCRIPTION
Narrow down `// IGNORE_BACKEND: WASM_JS` to `// WASM_IGNORE_FOR mode=regular`.

(follow-up to #6672)
