### PR TITLE
JVM: Ignore return value of tail-call suspend calls, returning Unit

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -586,10 +586,14 @@ class ExpressionCodegen(
         fun IrFunction.returnTypeMayBeInferred(): Boolean =
             this is IrSimpleFunction && (returnType.isTypeParameter() || allOverridden().any { it.returnType.isTypeParameter() })
 
+        fun IrFunction.isSuspendFunctionOrDefaultStubReturningUnit(): Boolean =
+            this is IrSimpleFunction && isSuspend &&
+                    ((attributeOwnerId as? IrFunction)?.returnType ?: returnType).isUnit()
+
         return when {
             expression.type.isUnit() &&
                     irFunction.shouldContainSuspendMarkers() &&
-                    callee.suspendFunctionOriginal().returnTypeMayBeInferred() -> {
+                    (callee.suspendFunctionOriginal().returnTypeMayBeInferred() || callee.isSuspendFunctionOrDefaultStubReturningUnit()) -> {
                 // In some cases of Unit functions with tail-call of another function, we shall overwrite the return value
                 //  with Unit because:
                 // 1. NewInference allows casting `() -> T` to `() -> Unit`, so we cannot trust return lambda types;
@@ -599,6 +603,8 @@ class ExpressionCodegen(
                 //  b) suspend fun foo(f: suspend () -> Unit) { return f() }
                 // Note that in (2a) it would be incorrect to return non-Unit from `foo` or fail
                 // with CHECKCAST even if `f()` actually returned non-Unit value.
+                // 3. Any suspend method can be resumed with an incorrectly typed value by using unsafe cast of a continuation
+                //    to another generic type, e.g. to Continuation<Any>
                 //
                 // This is especially important for calls of suspend functions, but is also used for other cases when Unit
                 // functions are generated to non-void bytecode methods. Note that `shouldContainSuspendMarkers()` and

--- a/compiler/testData/codegen/boxJvm/coroutines/kt87499.kt
+++ b/compiler/testData/codegen/boxJvm/coroutines/kt87499.kt
@@ -1,0 +1,58 @@
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+private val tasks = ArrayDeque<() -> Unit>()
+
+private suspend fun yieldOnce(): Unit = suspendCoroutine { continuation ->
+    tasks.addLast { continuation.resume(Unit) }
+}
+
+private fun runBlocking(block: suspend () -> Unit) {
+    var completed = false
+    var failure: Throwable? = null
+
+    block.startCoroutine(object : Continuation<Unit> {
+        override val context = EmptyCoroutineContext
+
+        override fun resumeWith(result: Result<Unit>) {
+            completed = true
+            failure = result.exceptionOrNull()
+        }
+    })
+
+    while (!completed) {
+        val task = tasks.removeFirstOrNull() ?: error("Coroutine suspended without a queued continuation")
+        task()
+    }
+
+    failure?.let { throw it }
+}
+
+private suspend fun launchedEffect(block: suspend () -> Unit) {
+    yieldOnce()
+    block()
+}
+
+@Suppress("UNCHECKED_CAST")
+private suspend fun animateScrollTo(v: Int, spec: String = ""): Unit =
+    suspendCoroutineUninterceptedOrReturn { continuation ->
+        tasks.addLast {
+            (continuation as Continuation<Any?>).resume(v.toFloat())
+        }
+        COROUTINE_SUSPENDED
+    }
+
+fun box(): String {
+    runBlocking {
+        for (branch in 0..2) {
+            launchedEffect {
+                when (branch) {
+                    1 -> animateScrollTo(100)   // omit default -> $default; Unit-typed, Float at runtime
+                    2 -> animateScrollTo(0)
+                    else -> Unit
+                }
+            }
+        }
+    }
+    return "OK"
+}

--- a/compiler/testData/debug/localVariables/suspend/completion/nonStaticSimple.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/nonStaticSimple.kt
@@ -14,6 +14,7 @@ suspend fun box() {
 // test.kt:4 <init>:
 // test.kt:9 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 // test.kt:5 foo: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
+// test.kt:9 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 // test.kt:10 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 
 // EXPECTATIONS JS_IR

--- a/compiler/testData/debug/localVariables/suspend/completion/nonStaticStateMachine.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/nonStaticStateMachine.kt
@@ -29,6 +29,7 @@ suspend fun box() {
 // test.kt:10 foo1: l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=A$foo1$1, $result:java.lang.Object=null
 // test.kt:11 foo1: l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=A$foo1$1, $result:java.lang.Object=null
 // test.kt:12 foo1: l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=A$foo1$1, $result:java.lang.Object=null, dead:long=42:long
+// test.kt:16 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 // test.kt:17 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 
 // EXPECTATIONS WASM

--- a/compiler/testData/debug/localVariables/suspend/completion/staticSimpleReceiver.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/staticSimpleReceiver.kt
@@ -15,6 +15,7 @@ suspend fun box() {
 // test.kt:4 <init>:
 // test.kt:9 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 // test.kt:6 foo: $this$foo:A=A, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
+// test.kt:9 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 // test.kt:10 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 
 // EXPECTATIONS JS_IR

--- a/compiler/testData/debug/localVariables/suspend/completion/staticStateMachine.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/staticStateMachine.kt
@@ -23,6 +23,7 @@ suspend fun box() {
 // test.kt:7 foo1: l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null
 // test.kt:8 foo1: l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null
 // test.kt:9 foo1: l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, dead:long=42:long
+// test.kt:12 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 // test.kt:13 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 
 // EXPECTATIONS JS_IR

--- a/compiler/testData/debug/localVariables/suspend/completion/staticStateMachineReceiver.kt
+++ b/compiler/testData/debug/localVariables/suspend/completion/staticStateMachineReceiver.kt
@@ -27,6 +27,7 @@ suspend fun box() {
 // test.kt:9 foo1: $this$foo1:A=A, l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null
 // test.kt:10 foo1: $this$foo1:A=A, l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null
 // test.kt:11 foo1: $this$foo1:A=A, l:long=42:long, $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1, $continuation:kotlin.coroutines.Continuation=TestKt$foo1$1, $result:java.lang.Object=null, dead:long=42:long
+// test.kt:14 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 // test.kt:15 box: $completion:kotlin.coroutines.Continuation=Generated_Box_MainKt$main$1
 
 // EXPECTATIONS JS_IR

--- a/compiler/testData/debug/stepping/suspendClosingBrace.kt
+++ b/compiler/testData/debug/stepping/suspendClosingBrace.kt
@@ -45,6 +45,7 @@ suspend fun box() {
 // test.kt:11 foo
 // test.kt:12 foo
 // GeneratedCodeMarkers.kt:... box
+// GeneratedCodeMarkers.kt:... box
 // test.kt:18 box
 
 // EXPECTATIONS NATIVE


### PR DESCRIPTION
RCA: 878636b1f82e849ea9e3efa3433cdf899751a9ce fixed long-standing issue with suspend Unit function calls appearing as not returning Unit if the Unit function is tail-call, but callee does not return Unit.

This happens when the callee is resumed with non-Unit value - usually, the value is discarded, but in several cases, including reflection, the value is not discarded and, as a result, Unit-returning function appears to return non-Unit value.

The fix disabled this optimization and made tail-call optimization sound.

However, it did not cover cases when the function returning Unit is deliberately resumed with non-Unit value. So, when user deliberately makes the code unsound. Before the fix, the unsoundness was intrinsic and was somewhat covered. The fix (justifiably) assumed that all cases of unsoundness have been eliminated. It did not take into account cases when a user deliberately (or mistakenly) writes unsound code.

The correct fix of the regression would be to forbid these cases of unsoundness, but it is unreasonable, since the language supports casting, leaving checks to the user.

What we can do instead is restore the defensive mechanism, which was in the place when we deliberately abused the unsoundness.

No future action is there, since the user code is essentially buggy.
 #KT-87499 Fixed