### PR TITLE
[Build] Use published marks in another place more

### DIFF
--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/repoArtifacts.kt
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/repoArtifacts.kt
@@ -13,6 +13,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.BasePluginExtension
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPlugin.JAVADOC_ELEMENTS_CONFIGURATION_NAME
@@ -297,19 +298,6 @@ fun Project.standardPublicJars() {
 @JvmOverloads
 fun Project.publish(moduleMetadata: Boolean = false, sbom: Boolean = true, configure: MavenPublication.() -> Unit = { }) {
     apply<KotlinBuildPublishingPlugin>()
-
-    tasks.register("writePublishedMark") {
-        dependsOn(tasks.named("publish"))
-        val publishedMarkFile = layout.buildDirectory.file("published.txt")
-        outputs.file(publishedMarkFile)
-        doLast {
-            publishedMarkFile.get().asFile.writeText("")
-        }
-    }
-    val publishedMark = configurations.consumable("publishedMark")
-    artifacts {
-        add(publishedMark.name, tasks.named("writePublishedMark"))
-    }
 
     if (!moduleMetadata) {
         tasks.withType<GenerateModuleMetadata> {

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/tasks.kt
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/tasks.kt
@@ -7,34 +7,13 @@
 // usages in build scripts are not tracked properly
 @file:Suppress("unused")
 
-import com.sun.management.OperatingSystemMXBean
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.attributes.Usage
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileSystemOperations
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
-import org.gradle.api.model.ObjectFactory
-import org.gradle.api.tasks.ClasspathNormalizer
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
-import org.gradle.kotlin.dsl.*
-import org.gradle.kotlin.dsl.support.serviceOf
-import org.gradle.process.CommandLineArgumentProvider
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.gradle.kotlin.dsl.project
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import java.io.File
-import java.lang.Character.isLowerCase
-import java.lang.Character.isUpperCase
-import java.lang.management.ManagementFactory
-import java.nio.file.Files
-import java.nio.file.Path
-import javax.inject.Inject
 
 val kotlinGradlePluginAndItsRequired = arrayOf(
     ":kotlin-assignment",
@@ -108,7 +87,7 @@ fun Task.dependsOnKotlinGradlePluginInstall() {
 }
 
 /**
- * Wires this task to `publishAllPublicationsToMavenRepository` for every module in
+ * Wires this task to `publish` for every module in
  * [kotlinGradlePluginAndItsRequired] that has such a task. Unlike [dependsOnKotlinGradlePluginInstall],
  * this writes to `<rootProject>/build/repo` (via `KotlinBuildPublishingPlugin`'s `"Maven"` repository)
  * rather than `~/.m2`, so nothing touches `maven.repo.local`.
@@ -117,24 +96,27 @@ fun Task.dependsOnKotlinGradlePluginInstall() {
  * have no `publishAllPublicationsToMavenRepository` task and are skipped silently.
  */
 fun Task.dependsOnKotlinGradlePluginPublishToBuildRepo() {
-    kotlinGradlePluginAndItsRequired.forEach { dependency ->
-        project.rootProject.tasks.findByPath("${dependency}:publishAllPublicationsToMavenRepository")?.let { task ->
-            dependsOn(task)
-        }
-    }
+    val publishedMark = project.configurations.detachedConfiguration(
+        *kotlinGradlePluginAndItsRequired.map { p ->
+            project.dependencies.project(p, configuration = "publishedMark")
+        }.toTypedArray())
+    inputs.files(publishedMark.incoming.artifactView { lenient(true) }.files)
+        .withPropertyName("publishedMarks")
+        .withPathSensitivity(PathSensitivity.NONE)
 }
 
 fun Task.dependsOnKotlinGradlePluginPublish() {
-    kotlinGradlePluginAndItsRequired
-        .filter {
+    val localPublishedMark = project.configurations.detachedConfiguration(
+        *kotlinGradlePluginAndItsRequired.filter {
             // Compose compiler plugin does not assemble with LV 1.9 and should not be a part of the dist bundle for now
             it != ":plugins:compose-compiler-plugin:compiler"
-        }
-        .forEach { dependency ->
-            project.rootProject.tasks.findByPath("${dependency}:publish")?.let { task ->
-                dependsOn(task)
-            }
-        }
+        }.map { p ->
+            project.dependencies.project(p, configuration = "localPublishedMark")
+        }.toTypedArray()
+    )
+    inputs.files(localPublishedMark.incoming.artifactView { lenient(true) }.files)
+        .withPropertyName("localPublishedMarks")
+        .withPathSensitivity(PathSensitivity.NONE)
 }
 
 fun Test.enableJunit5ExtensionsAutodetection() {

--- a/repo/gradle-build-conventions/gradle-plugins-common/src/main/kotlin/plugins/KotlinBuildPublishingPlugin.kt
+++ b/repo/gradle-build-conventions/gradle-plugins-common/src/main/kotlin/plugins/KotlinBuildPublishingPlugin.kt
@@ -193,6 +193,14 @@ fun Project.configureDefaultPublishing(
         dependsOn(tasks.named("publishToMavenLocal"))
     }
 
+    tasks.register("writePublishedMark") {
+        dependsOn(tasks.named("publish"))
+        val publishedMarkFile = layout.buildDirectory.file("published.txt")
+        outputs.file(publishedMarkFile)
+        doLast {
+            publishedMarkFile.get().asFile.writeText("")
+        }
+    }
     tasks.register("writeLocalPublishedMark") {
         dependsOn(tasks.named("publishToMavenLocal"))
         val publishedMarkFile = layout.buildDirectory.file("localPublished.txt")
@@ -201,8 +209,10 @@ fun Project.configureDefaultPublishing(
             publishedMarkFile.get().asFile.writeText("")
         }
     }
+    val publishedMark = configurations.consumable("publishedMark")
     val localPublishedMark = configurations.consumable("localPublishedMark")
     artifacts {
+        add(publishedMark.name, tasks.named("writePublishedMark"))
         add(localPublishedMark.name, tasks.named("writeLocalPublishedMark"))
     }
 }


### PR DESCRIPTION
The goal is to stop accessing tasks in other projects, so we use dummy files. Eventually we could use the local folders where the artifacts are published.