### PR TITLE
[Build] Move Jar entryCompression to common-configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,13 +177,6 @@ gradle.taskGraph.whenReady {
         "$profile build profile is active ($proguardMessage, $jarCompressionMessage). " +
                 "Use -Pteamcity=<true|false> to reproduce CI/local build"
     )
-
-    allTasks.filterIsInstance<org.gradle.jvm.tasks.Jar>().forEach { task ->
-        task.entryCompression = if (kotlinBuildProperties.jarCompression)
-            ZipEntryCompression.DEFLATED
-        else
-            ZipEntryCompression.STORED
-    }
 }
 
 val dist = tasks.register("dist") {

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
@@ -33,6 +33,7 @@ project.configureMigratedRootSettings()
 project.configureJsCacheRedirector()
 project.configurePublishingRetry()
 project.exposeCompileAllConfiguration()
+project.configureJarEntryCompression()
 
 // There are problems with common build dir:
 //  - some tests (in particular js and binary-compatibility-validator depend on the fixed (default) location
@@ -561,5 +562,14 @@ fun Project.exposeCompileAllConfiguration() {
             val task = tasks.named<JavaCompile>(it)
             artifacts.add(compileAllConfig.name, task.map { it.destinationDirectory }) { builtBy(task) }
         }
+    }
+}
+
+fun Project.configureJarEntryCompression() {
+    tasks.withType<org.gradle.jvm.tasks.Jar>().configureEach {
+        entryCompression = if (kotlinBuildProperties.jarCompression)
+            ZipEntryCompression.DEFLATED
+        else
+            ZipEntryCompression.STORED
     }
 }

--- a/repo/gradle-build-conventions/utilities/src/main/kotlin/BuildPropertiesExt.kt
+++ b/repo/gradle-build-conventions/utilities/src/main/kotlin/BuildPropertiesExt.kt
@@ -15,8 +15,6 @@ val KotlinBuildProperties.relocation: Boolean get() = postProcessing
 
 val KotlinBuildProperties.proguard: Boolean get() = postProcessing && booleanProperty("kotlin.build.proguard", isTeamcityBuild).get()
 
-val KotlinBuildProperties.jarCompression: Boolean get() = booleanProperty("kotlin.build.jar.compression", isTeamcityBuild).get()
-
 val KotlinBuildProperties.disableWerror: Boolean
     get() = booleanProperty("kotlin.build.disable.werror").get() || useFir.get() || booleanProperty("test.progressive.mode").get()
 

--- a/repo/kotlin-build-helpers/src/BuildProperties.kt
+++ b/repo/kotlin-build-helpers/src/BuildProperties.kt
@@ -146,6 +146,8 @@ class KotlinBuildProperties internal constructor(
 
     val verificationTasksDisabled: Provider<Boolean> = booleanProperty("kotlin.build.disable.verification.tasks")
 
+    val jarCompression: Boolean get() = booleanProperty("kotlin.build.jar.compression", isTeamcityBuild).get()
+
     private fun Provider<String>.toBoolean(defaultValue: Boolean = false): Provider<Boolean> = map {
         if (it.isEmpty()) return@map true // has property without value means 'true'
         return@map it.trim().toBoolean()


### PR DESCRIPTION
Context about this code:
jar compression is turned off by default in local builds to speed up them. It is turned on by default on teamcity.