### PR TITLE
Incremental compilation flag depended cache

### DIFF
--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/JsConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/JsConfigurationKeysContainer.kt
@@ -112,8 +112,6 @@ object JsConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.js.con
     val MINIMIZED_MEMBER_NAMES by key<Boolean>()
     val CALL_MAIN by key<Boolean>("Specify whether the 'main' function should be called upon execution.", defaultValue = "true")
     val IC_CACHE_DIRECTORY by key<String>(throwOnNull = false)
-    val IC_CACHE_READ_ONLY by key<Boolean>()
-    val PRESERVE_IC_ORDER by key<Boolean>()
     val IC_FILES_TO_LOAD by key<Set<String>>(throwOnNull = false)
     val ADDITIONAL_EXPORTED_DECLARATION_NAMES by key<Set<FqName>>()
 }

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/compilerWithIC.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/compilerWithIC.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.ir.backend.js
 
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.phaser.PhaserState
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -22,10 +23,38 @@ import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImplForJsIC
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import org.jetbrains.kotlin.js.config.JsGenerationGranularity
-import org.jetbrains.kotlin.psi2ir.descriptors.IrBuiltInsOverDescriptors
 import java.io.File
 
+private object JsICCacheInvalidatingKeys : ICCacheInvalidatingKeys {
+    override val stringKeys: List<CompilerConfigurationKey<String>>
+        get() = listOf(
+            JSConfigurationKeys.SOURCE_MAP_PREFIX,
+            JSConfigurationKeys.DEFINE_PLATFORM_MAIN_FUNCTION_ARGUMENTS
+        )
+
+    override val booleanKeys: List<CompilerConfigurationKey<Boolean>>
+        get() = listOf(
+            JSConfigurationKeys.SOURCE_MAP,
+            JSConfigurationKeys.USE_ES6_CLASSES,
+            JSConfigurationKeys.GENERATE_POLYFILLS,
+            JSConfigurationKeys.GENERATE_DTS,
+            JSConfigurationKeys.PROPERTY_LAZY_INITIALIZATION,
+            JSConfigurationKeys.GENERATE_INLINE_ANONYMOUS_FUNCTIONS,
+            JSConfigurationKeys.GENERATE_STRICT_IMPLICIT_EXPORT,
+            JSConfigurationKeys.COMPILE_SUSPEND_AS_JS_GENERATOR,
+            JSConfigurationKeys.OPTIMIZE_GENERATED_JS,
+        )
+
+    override val enumKeys: List<CompilerConfigurationKey<Enum<*>>>
+        get() = listOf(
+            JSConfigurationKeys.SOURCE_MAP_EMBED_SOURCES,
+            JSConfigurationKeys.SOURCEMAP_NAMES_POLICY,
+        )
+}
+
 class JsICContext(private val granularity: JsGenerationGranularity) : PlatformDependentICContext {
+    override fun getCacheInvalidatingKeys(): ICCacheInvalidatingKeys =
+        JsICCacheInvalidatingKeys
 
     override fun createIrFactory(): IrFactory =
         IrFactoryImplForJsIC(WholeWorldStageController())

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/CacheUpdater.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/CacheUpdater.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ir.backend.js.ic
 import org.jetbrains.kotlin.backend.common.serialization.IrInterningService
 import org.jetbrains.kotlin.backend.common.serialization.cityHash64String
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.perfManager
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
@@ -24,7 +25,6 @@ import org.jetbrains.kotlin.js.config.includes
 import org.jetbrains.kotlin.js.config.wasmCompilation
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.loader.KlibPlatformChecker
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.util.PhaseType
 import org.jetbrains.kotlin.util.tryMeasurePhaseTime
 import org.jetbrains.kotlin.utils.memoryOptimizedFilter
@@ -66,7 +66,15 @@ enum class DirtyFileState(val str: String) {
     REMOVED_FILE("removed file")
 }
 
+interface ICCacheInvalidatingKeys {
+    val stringKeys: List<CompilerConfigurationKey<String>>
+    val booleanKeys: List<CompilerConfigurationKey<Boolean>>
+    val enumKeys: List<CompilerConfigurationKey<Enum<*>>>
+}
+
 interface PlatformDependentICContext {
+    fun getCacheInvalidatingKeys(): ICCacheInvalidatingKeys
+
     fun createIrFactory(): IrFactory
 
     fun createBackendContext(
@@ -130,7 +138,11 @@ class CacheUpdater(
     private val irInterner = IrInterningService()
 
     private val cacheRootDir = run {
-        val configHash = icHasher.calculateConfigHash(compilerConfiguration, artifactConfiguration)
+        val configHash = icHasher.calculateConfigHash(
+            invalidatingKeys = icContext.getCacheInvalidatingKeys(),
+            config = compilerConfiguration,
+            artifactConfiguration = artifactConfiguration
+        )
         File(cacheDir, "version.${configHash.hash.lowBytes.toString(Character.MAX_RADIX)}")
     }
 

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/HashCalculatorForIC.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/HashCalculatorForIC.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.DumpIrTreeVisitor
 import org.jetbrains.kotlin.ir.util.isInterface
-import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import org.jetbrains.kotlin.js.config.ModuleKind
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.library.impl.buffer
@@ -156,42 +155,25 @@ private class HashCalculatorForIC(private val checkForClassStructuralChanges: Bo
 internal class ICHasher(checkForClassStructuralChanges: Boolean = false) {
     private val hashCalculator = HashCalculatorForIC(checkForClassStructuralChanges)
 
-    fun calculateConfigHash(config: CompilerConfiguration, artifactConfiguration: WebArtifactConfiguration): ICHash {
+    fun calculateConfigHash(
+        invalidatingKeys: ICCacheInvalidatingKeys,
+        config: CompilerConfiguration,
+        artifactConfiguration: WebArtifactConfiguration
+    ): ICHash {
         hashCalculator.update(KotlinCompilerVersion.VERSION)
 
-        val booleanKeys = listOf(
-            JSConfigurationKeys.SOURCE_MAP,
-            JSConfigurationKeys.USE_ES6_CLASSES,
-            JSConfigurationKeys.GENERATE_POLYFILLS,
-            JSConfigurationKeys.GENERATE_DTS,
-            JSConfigurationKeys.PROPERTY_LAZY_INITIALIZATION,
-            JSConfigurationKeys.GENERATE_INLINE_ANONYMOUS_FUNCTIONS,
-            JSConfigurationKeys.GENERATE_STRICT_IMPLICIT_EXPORT,
-            JSConfigurationKeys.COMPILE_SUSPEND_AS_JS_GENERATOR,
-            JSConfigurationKeys.OPTIMIZE_GENERATED_JS,
-        )
-        hashCalculator.updateConfigKeys(config, booleanKeys) { value: Boolean ->
+        hashCalculator.updateConfigKeys(config, invalidatingKeys.booleanKeys) { value: Boolean ->
             hashCalculator.update(if (value) 1 else 0)
         }
 
-        val enumKeys = listOf(
-            JSConfigurationKeys.SOURCE_MAP_EMBED_SOURCES,
-            JSConfigurationKeys.SOURCEMAP_NAMES_POLICY,
-        )
-        hashCalculator.updateConfigKeys(config, enumKeys) { value: Enum<*> ->
+        hashCalculator.updateConfigKeys(config, invalidatingKeys.enumKeys) { value: Enum<*> ->
             hashCalculator.update(value.ordinal)
         }
 
         hashCalculator.update(artifactConfiguration.moduleKind.ordinal)
         hashCalculator.update(artifactConfiguration.granularity.ordinal)
 
-        hashCalculator.updateConfigKeys(
-            config,
-            listOf(
-                JSConfigurationKeys.SOURCE_MAP_PREFIX,
-                JSConfigurationKeys.DEFINE_PLATFORM_MAIN_FUNCTION_ARGUMENTS
-            )
-        ) { value: String ->
+        hashCalculator.updateConfigKeys(config, invalidatingKeys.stringKeys) { value: String ->
             hashCalculator.update(value)
         }
 

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ic/IrFactoryImplForWasmIC.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ic/IrFactoryImplForWasmIC.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.backend.wasm.ic
 
+import org.jetbrains.kotlin.wasm.config.WasmConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.ir.backend.js.WholeWorldStageController
 import org.jetbrains.kotlin.ir.backend.js.ic.*
@@ -25,16 +26,51 @@ import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.Functions.tryGetAsso
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.Functions.unitGetInstanceBuiltIn
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.HeapTypes.anyBuiltInType
 import org.jetbrains.kotlin.backend.wasm.ir2wasm.Synthetics.HeapTypes.throwableBuiltInType
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.backend.js.JsCommonBackendContext
 import org.jetbrains.kotlin.ir.backend.js.utils.findUnitGetInstanceFunction
 import org.jetbrains.kotlin.ir.irAttribute
 import org.jetbrains.kotlin.ir.util.SymbolTable
-import org.jetbrains.kotlin.psi2ir.descriptors.IrBuiltInsOverDescriptors
+import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import java.io.File
 
+private object WasmICCacheInvalidatingKeys : ICCacheInvalidatingKeys {
+    override val stringKeys: List<CompilerConfigurationKey<String>>
+        get() = listOf(
+            JSConfigurationKeys.SOURCE_MAP_PREFIX,
+            WasmConfigurationKeys.WASM_INTERNAL_LOCAL_VARIABLE_PREFIX,
+        )
+
+    override val booleanKeys: List<CompilerConfigurationKey<Boolean>>
+        get() = listOf(
+            JSConfigurationKeys.SOURCE_MAP,
+            JSConfigurationKeys.GENERATE_DTS,
+            JSConfigurationKeys.PROPERTY_LAZY_INITIALIZATION,
+            WasmConfigurationKeys.WASM_ENABLE_ARRAY_RANGE_CHECKS,
+            WasmConfigurationKeys.WASM_DISABLE_ARRAY_RANGE_CHECKS_SAFE_ELIMINATION,
+            WasmConfigurationKeys.WASM_ENABLE_ASSERTS,
+            WasmConfigurationKeys.WASM_USE_TRAPS_INSTEAD_OF_EXCEPTIONS,
+            WasmConfigurationKeys.WASM_USE_NEW_EXCEPTION_PROPOSAL,
+            WasmConfigurationKeys.WASM_USE_STACK_SWITCHING_PROPOSAL,
+            WasmConfigurationKeys.WASM_DEBUG,
+            WasmConfigurationKeys.WASM_GENERATE_WAT,
+            WasmConfigurationKeys.WASM_GENERATE_DWARF,
+            WasmConfigurationKeys.WASM_FORCE_DEBUG_FRIENDLY_COMPILATION,
+            WasmConfigurationKeys.WASM_INCLUDED_MODULE_ONLY,
+            WasmConfigurationKeys.WASM_DISABLE_CROSS_FILE_OPTIMISATIONS,
+            WasmConfigurationKeys.WASM_GENERATE_CLOSED_WORLD_MULTIMODULE,
+        )
+
+    override val enumKeys: List<CompilerConfigurationKey<Enum<*>>>
+        get() = listOf()
+}
+
 abstract class WasmICContextBase : PlatformDependentICContext {
+    override fun getCacheInvalidatingKeys(): ICCacheInvalidatingKeys =
+        WasmICCacheInvalidatingKeys
+
     @OptIn(ObsoleteDescriptorBasedAPI::class)
     override fun createBackendContext(
         mainModule: IrModuleFragment,

--- a/js/js.config/gen/org/jetbrains/kotlin/js/config/JSConfigurationKeys.kt
+++ b/js/js.config/gen/org/jetbrains/kotlin/js/config/JSConfigurationKeys.kt
@@ -192,12 +192,6 @@ object JSConfigurationKeys {
     val IC_CACHE_DIRECTORY = CompilerConfigurationKey.create<String>("IC_CACHE_DIRECTORY")
 
     @JvmField
-    val IC_CACHE_READ_ONLY = CompilerConfigurationKey.create<Boolean>("IC_CACHE_READ_ONLY")
-
-    @JvmField
-    val PRESERVE_IC_ORDER = CompilerConfigurationKey.create<Boolean>("PRESERVE_IC_ORDER")
-
-    @JvmField
     val IC_FILES_TO_LOAD = CompilerConfigurationKey.create<Set<String>>("IC_FILES_TO_LOAD")
 
     @JvmField
@@ -392,14 +386,6 @@ var CompilerConfiguration.callMain: Boolean
 var CompilerConfiguration.icCacheDirectory: String?
     get() = get(JSConfigurationKeys.IC_CACHE_DIRECTORY)
     set(value) { putIfNotNull(JSConfigurationKeys.IC_CACHE_DIRECTORY, value) }
-
-var CompilerConfiguration.icCacheReadOnly: Boolean
-    get() = getBoolean(JSConfigurationKeys.IC_CACHE_READ_ONLY)
-    set(value) { put(JSConfigurationKeys.IC_CACHE_READ_ONLY, value) }
-
-var CompilerConfiguration.preserveIcOrder: Boolean
-    get() = getBoolean(JSConfigurationKeys.PRESERVE_IC_ORDER)
-    set(value) { put(JSConfigurationKeys.PRESERVE_IC_ORDER, value) }
 
 var CompilerConfiguration.icFilesToLoad: Set<String>
     get() = getSet(JSConfigurationKeys.IC_FILES_TO_LOAD)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinWasmGradlePluginIT.kt
@@ -261,6 +261,55 @@ class KotlinWasmGradlePluginIT : AbstractKotlinWasmGradlePluginIT() {
         }
     }
 
+    @OptIn(ExperimentalWasmDsl::class)
+    @DisplayName("Check wasm target compiles when switch compilation mode with IC enabled")
+    @GradleTest
+    fun jsTargetIncrementalMonolithToPerModuleClosedWorld(gradleVersion: GradleVersion) {
+        project("new-mpp-wasm-js", gradleVersion) {
+            buildGradleKts.modify {
+                it.replace("<JsEngine>", "d8")
+            }
+
+            buildScriptInjection {
+                kotlinMultiplatform.wasmJs {
+                    binaries.executable()
+                }
+            }
+
+            build(
+                ":compileDevelopmentExecutableKotlinWasmJs",
+                buildOptions = defaultBuildOptions.copy(
+                    wasmOptions = BuildOptions.WasmOptions(compilationMode = WasmCompilationMode.MONOLITH)
+                ),
+            ) {
+                assertHasDiagnostic(
+                    KotlinToolingDiagnostics.ExperimentalFeatureWarning,
+                    "Wasm compilation mode selecting"
+                )
+
+                assertTasksExecuted(":compileDevelopmentExecutableKotlinWasmJs")
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/redefined-wasm-module-name.wasm")
+            }
+
+            build(
+                ":compileDevelopmentExecutableKotlinWasmJs",
+                buildOptions = defaultBuildOptions.copy(
+                    wasmOptions = BuildOptions.WasmOptions(compilationMode = WasmCompilationMode.MULTIMODULE_CLOSED_WORLD)
+                ),
+            ) {
+                assertHasDiagnostic(
+                    KotlinToolingDiagnostics.ExperimentalFeatureWarning,
+                    "Wasm compilation mode selecting"
+                )
+
+                assertTasksExecuted(":compileDevelopmentExecutableKotlinWasmJs")
+
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/redefined-wasm-module-name.wasm")
+                assertFileInProjectExists("build/compileSync/wasmJs/main/developmentExecutable/kotlin/kotlin-kotlin-stdlib.wasm")
+            }
+        }
+    }
+
     @DisplayName("Check js target with binaryen with custom per-file argument")
     @GradleTest
     fun jsTargetWithBinaryenCustomPerFileArgument(gradleVersion: GradleVersion) {


### PR DESCRIPTION
In wasm changing the compiler flags did't affect incremental compilation caches which triggers cache reset so changing the compiler flags is no lead to unpredictable behaviour. JS compiler declares a set of compiler flags which effectively invalidates IC cache. So I introduce a similar set to Wasm.

Fixed KT-87583

@mglukhikh, i have removed in passing a few JS abandoned compiler configuration keys, so I need you for MR to be approved