### PR TITLE
KT-86151 [AFU] Support atomic properties in companion blocks and extensions on JVM

### DIFF
--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlinx.atomicfu.compiler.backend.AtomicHandlerType
 import org.jetbrains.kotlinx.atomicfu.compiler.backend.VolatilePropertyReference
 import org.jetbrains.kotlinx.atomicfu.compiler.backend.atomicfuRender
 import org.jetbrains.kotlinx.atomicfu.compiler.backend.common.AbstractAtomicfuTransformer.Companion.VOLATILE
+import org.jetbrains.kotlinx.atomicfu.compiler.backend.hasStaticBackingField
 import org.jetbrains.kotlinx.atomicfu.compiler.diagnostic.AtomicfuErrorMessages.CONSTRAINTS_MESSAGE
 
 abstract class AbstractAtomicfuIrBuilder(
@@ -191,7 +192,7 @@ abstract class AbstractAtomicfuIrBuilder(
             atomicArrayField,
             atomicfuProperty.visibility,
             isVar = false,
-            isStatic = parentContainer is IrFile,
+            isStatic = parentContainer is IrFile || atomicfuProperty.hasStaticBackingField,
             parentContainer
         )
         return AtomicArray(atomicArrayProperty)

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
@@ -121,18 +121,18 @@ abstract class AbstractAtomicfuIrBuilder(
     protected fun irVolatileField(
         name: String,
         valueType: IrType,
-        annotations: List<IrAnnotation>,
+        originalField: IrField,
         parentContainer: IrDeclarationContainer,
     ): IrField {
         return context.irFactory.buildField {
             this.name = Name.identifier(name + VOLATILE)
             this.type = valueType
             isFinal = false
-            isStatic = parentContainer is IrFile
+            isStatic = parentContainer is IrFile || originalField.isStatic
             visibility = DescriptorVisibilities.PRIVATE
             origin = AbstractAtomicSymbols.ATOMICFU_GENERATED_FIELD
         }.apply {
-            this.annotations = annotations + atomicfuSymbols.volatileAnnotation
+            this.annotations = originalField.annotations + atomicfuSymbols.volatileAnnotation
             this.parent = parentContainer
         }
     }
@@ -147,7 +147,7 @@ abstract class AbstractAtomicfuIrBuilder(
         return buildAndInitializeNewField(atomicfuField, parentContainer) { atomicFactoryCall: IrExpression? ->
             val valueType = atomicfuSymbols.atomicToPrimitiveType(atomicfuField.type as IrSimpleType)
             val initValue = atomicFactoryCall?.getAtomicFactoryValueArgument()
-            buildVolatileFieldOfType(atomicfuProperty.name.asString(), valueType, atomicfuField.annotations, initValue, parentContainer)
+            buildVolatileFieldOfType(atomicfuProperty.name.asString(), valueType, atomicfuField, initValue, parentContainer)
         }
     }
 
@@ -161,7 +161,7 @@ abstract class AbstractAtomicfuIrBuilder(
     abstract fun buildVolatileFieldOfType(
         name: String,
         valueType: IrType,
-        annotations: List<IrAnnotation>,
+        originalField: IrField,
         initExpr: IrExpression?,
         parentContainer: IrDeclarationContainer,
     ): IrField

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/AtomicfuJvmIrTransformer.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/AtomicfuJvmIrTransformer.kt
@@ -183,7 +183,10 @@ class AtomicfuJvmIrTransformer(
         with(atomicfuSymbols.createBuilder(atomicfuProperty.symbol)) {
             return when {
                 atomicfuProperty.isNotDelegatedAtomic() -> {
-                    if (isTopLevel) {
+                    // Top-level atomic properties are treated as effectively static properties,
+                    // and properties with static backing fields are already static.
+                    // Atomic field updaters don't support static fields, so we have to keep them boxed.
+                    if (isTopLevel || atomicfuProperty.hasStaticBackingField) {
                         buildBoxedAtomic(atomicfuProperty, parentContainer)
                     } else {
                         buildAtomicFieldUpdater(atomicfuProperty, parentContainer as IrClass)

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
@@ -77,14 +77,14 @@ class JvmAtomicfuIrBuilder(
     override fun buildVolatileFieldOfType(
         name: String,
         valueType: IrType,
-        annotations: List<IrAnnotation>,
+        originalField: IrField,
         initExpr: IrExpression?,
         parentContainer: IrDeclarationContainer
     ): IrField {
         // On JVM a volatile Int field is generated to replace an AtomicBoolean property
         val castBooleanToInt = valueType.isBoolean()
         val volatileFieldType = if (castBooleanToInt) irBuiltIns.intType else valueType
-        return irVolatileField(name, volatileFieldType, annotations, parentContainer).apply {
+        return irVolatileField(name, volatileFieldType, originalField, parentContainer).apply {
             if (initExpr != null) {
                 this.initializer = irExprBody(if (castBooleanToInt) toInt(initExpr) else initExpr)
             }

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlinx.atomicfu.compiler.backend.BoxedAtomic
 import org.jetbrains.kotlinx.atomicfu.compiler.backend.atomicfuRender
 import org.jetbrains.kotlinx.atomicfu.compiler.backend.common.AbstractAtomicfuIrBuilder
 import org.jetbrains.kotlinx.atomicfu.compiler.backend.common.AbstractAtomicSymbols
+import org.jetbrains.kotlinx.atomicfu.compiler.backend.hasStaticBackingField
 import org.jetbrains.kotlinx.atomicfu.compiler.diagnostic.AtomicfuErrorMessages.CONSTRAINTS_MESSAGE
 
 class JvmAtomicfuIrBuilder(
@@ -96,7 +97,7 @@ class JvmAtomicfuIrBuilder(
             atomicArrayField,
             atomicfuProperty.visibility,
             isVar = false,
-            isStatic = parentContainer is IrFile,
+            isStatic = parentContainer is IrFile || atomicfuProperty.hasStaticBackingField,
             parentContainer
         )
         return BoxedAtomic(atomicArrayProperty)

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/native/NativeAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/native/NativeAtomicfuIrBuilder.kt
@@ -90,12 +90,12 @@ class NativeAtomicfuIrBuilder(
     override fun buildVolatileFieldOfType(
         name: String,
         valueType: IrType,
-        annotations: List<IrAnnotation>,
+        originalField: IrField,
         initExpr: IrExpression?,
         parentContainer: IrDeclarationContainer
     ): IrField =
         // On K/N a volatile Boolean field is generated instead of an AtomicBoolean property
-        irVolatileField(name, valueType, annotations, parentContainer).apply {
+        irVolatileField(name, valueType, originalField, parentContainer).apply {
             if (initExpr != null) {
                 this.initializer = context.irFactory.createExpressionBody(initExpr)
             }

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/utils.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/utils.kt
@@ -11,3 +11,5 @@ import org.jetbrains.kotlin.ir.util.render
 
 internal fun IrProperty.atomicfuRender(): String =
     (if (isVar) "var" else "val") + " " + name.asString() + ": " + backingField?.type?.render()
+
+internal val IrProperty.hasStaticBackingField get() = backingField?.isStatic == true

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.kt
@@ -1,0 +1,42 @@
+// LANGUAGE: +CompanionBlocks +CompanionExtensions
+// TARGET_BACKEND: JVM_IR
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+class TraceTest {
+    companion {
+        private val defaultTrace = Trace()
+        private val a1 = atomic(5, defaultTrace)
+
+        fun testCompanionTrace() {
+            val oldValue = a1.value
+            defaultTrace { "before CAS value = $oldValue" }
+            val res = a1.compareAndSet(oldValue, oldValue * 10)
+            val newValue = a1.value
+            defaultTrace { "after CAS value = $newValue" }
+        }
+    }
+}
+
+private companion val TraceTest.extTrace = Trace()
+private companion val TraceTest.a = atomic(42, TraceTest.extTrace)
+
+fun testExtensionTrace() {
+    val oldValue = TraceTest.a.value
+    TraceTest.extTrace { "before CAS value = $oldValue" }
+    val res = TraceTest.a.compareAndSet(oldValue, oldValue * 10)
+    val newValue = TraceTest.a.value
+    TraceTest.extTrace { "after CAS value = $newValue" }
+}
+
+private fun test() {
+    TraceTest.testCompanionTrace()
+    testExtensionTrace()
+}
+
+fun box(): String {
+    test()
+    return "OK"
+}
+

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.txt
@@ -1,0 +1,20 @@
+@kotlin.Metadata
+public final class ComanionTracesKt {
+    // source: 'ComanionTraces.kt'
+    private synthetic final static field a: java.util.concurrent.atomic.AtomicInteger
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    private synthetic final static method getA(): java.util.concurrent.atomic.AtomicInteger
+    private final static method test(): void
+    public final static method testExtensionTrace(): void
+}
+
+@kotlin.Metadata
+public final class TraceTest {
+    // source: 'ComanionTraces.kt'
+    private synthetic final static field a1: java.util.concurrent.atomic.AtomicInteger
+    static method <clinit>(): void
+    public method <init>(): void
+    private synthetic final static method getA1(): java.util.concurrent.atomic.AtomicInteger
+    public final static method testCompanionTrace(): void
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
@@ -20,8 +20,8 @@ fun testCompanionBlock() {
     assertTrue(Outer.b.compareAndSet(null, "value"))
     assertEquals("value", Outer.b.value)
 
-    //assertEquals(0, Outer.arr[0].value)
-    //assertEquals(1, Outer.arr[0].incrementAndGet())
+    assertEquals(0, Outer.arr[0].value)
+    assertEquals(1, Outer.arr[0].incrementAndGet())
 }
 
 fun box(): String {

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
@@ -1,0 +1,30 @@
+// LANGUAGE: +CompanionBlocks
+// TARGET_BACKEND: JVM_IR
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+private class Outer {
+    companion {
+        internal val i = atomic(1)
+        internal val b = atomic<Any?>(null)
+        internal val arr = AtomicIntArray(2)
+    }
+}
+
+fun testCompanionBlock() {
+    assertEquals(1, Outer.i.value)
+    assertEquals(2, Outer.i.incrementAndGet())
+
+    assertNull(Outer.b.value)
+    assertTrue(Outer.b.compareAndSet(null, "value"))
+    assertEquals("value", Outer.b.value)
+
+    //assertEquals(0, Outer.arr[0].value)
+    //assertEquals(1, Outer.arr[0].incrementAndGet())
+}
+
+fun box(): String {
+    testCompanionBlock()
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.txt
@@ -13,7 +13,7 @@ final class Outer {
     private synthetic final static field i: java.util.concurrent.atomic.AtomicInteger
     static method <clinit>(): void
     public method <init>(): void
-    public synthetic final method getArr$main(): java.util.concurrent.atomic.AtomicIntegerArray
+    public synthetic final static method getArr$main(): java.util.concurrent.atomic.AtomicIntegerArray
     public synthetic final static method getB$main(): java.util.concurrent.atomic.AtomicReference
     public synthetic final static method getI$main(): java.util.concurrent.atomic.AtomicInteger
 }

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.txt
@@ -1,0 +1,19 @@
+@kotlin.Metadata
+public final class CompanionBlockPropertiesKt {
+    // source: 'CompanionBlockProperties.kt'
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    public final static method testCompanionBlock(): void
+}
+
+@kotlin.Metadata
+final class Outer {
+    // source: 'CompanionBlockProperties.kt'
+    private synthetic final static field arr: java.util.concurrent.atomic.AtomicIntegerArray
+    private synthetic final static field b: java.util.concurrent.atomic.AtomicReference
+    private synthetic final static field i: java.util.concurrent.atomic.AtomicInteger
+    static method <clinit>(): void
+    public method <init>(): void
+    public synthetic final method getArr$main(): java.util.concurrent.atomic.AtomicIntegerArray
+    public synthetic final static method getB$main(): java.util.concurrent.atomic.AtomicReference
+    public synthetic final static method getI$main(): java.util.concurrent.atomic.AtomicInteger
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
@@ -1,0 +1,20 @@
+// LANGUAGE: +CompanionExtensions +CompanionBlocks
+// TARGET_BACKEND: JVM_IR
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+public class Outer
+
+private companion val Outer.cA = atomic(1)
+private companion val Outer.cB = atomic<Any?>(null)
+
+fun testCompanionExt() {
+    assertEquals(1, Outer.cA.value)
+    assertEquals(2, Outer.cA.incrementAndGet())
+}
+
+fun box(): String {
+    testCompanionExt()
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
@@ -8,10 +8,18 @@ public class Outer
 
 private companion val Outer.cA = atomic(1)
 private companion val Outer.cB = atomic<Any?>(null)
+private companion val Outer.cArr = AtomicIntArray(2)
 
 fun testCompanionExt() {
     assertEquals(1, Outer.cA.value)
     assertEquals(2, Outer.cA.incrementAndGet())
+
+    assertNull(Outer.cB.value)
+    assertTrue(Outer.cB.compareAndSet(null, "value"))
+    assertEquals("value", Outer.cB.value)
+
+    assertEquals(0, Outer.cArr[0].value)
+    assertEquals(1, Outer.cArr[0].incrementAndGet())
 }
 
 fun box(): String {

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.txt
@@ -1,0 +1,17 @@
+@kotlin.Metadata
+public final class CompanionExtensionPropertiesKt {
+    // source: 'CompanionExtensionProperties.kt'
+    private synthetic final static field cA: java.util.concurrent.atomic.AtomicInteger
+    private synthetic final static field cB: java.util.concurrent.atomic.AtomicReference
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    private synthetic final static method getCA(): java.util.concurrent.atomic.AtomicInteger
+    private synthetic final static method getCB(): java.util.concurrent.atomic.AtomicReference
+    public final static method testCompanionExt(): void
+}
+
+@kotlin.Metadata
+public final class Outer {
+    // source: 'CompanionExtensionProperties.kt'
+    public method <init>(): void
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.txt
@@ -2,10 +2,12 @@
 public final class CompanionExtensionPropertiesKt {
     // source: 'CompanionExtensionProperties.kt'
     private synthetic final static field cA: java.util.concurrent.atomic.AtomicInteger
+    private synthetic final static field cArr: java.util.concurrent.atomic.AtomicIntegerArray
     private synthetic final static field cB: java.util.concurrent.atomic.AtomicReference
     static method <clinit>(): void
     public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
     private synthetic final static method getCA(): java.util.concurrent.atomic.AtomicInteger
+    private synthetic final static method getCArr(): java.util.concurrent.atomic.AtomicIntegerArray
     private synthetic final static method getCB(): java.util.concurrent.atomic.AtomicReference
     public final static method testCompanionExt(): void
 }

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.kt
@@ -1,0 +1,27 @@
+// LANGUAGE: +CompanionBlocks +CompanionExtensions
+// TARGET_BACKEND: JVM_IR
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+private inline fun AtomicLong.inc(): Long = this.incrementAndGet()
+
+public class C {
+    companion {
+        private val x = atomic(42L)
+
+        fun test(): Long = x.inc()
+    }
+}
+
+private companion val C.a = atomic(0L)
+private companion fun C.aInc(): Long = a.incrementAndGet()
+private companion val C.arr = AtomicLongArray(10)
+
+fun box(): String {
+    assertEquals(1L, C.a.inc())
+    assertEquals(43L, C.test())
+    assertEquals(2L, C.aInc())
+    assertEquals(1L, C.arr[0].inc())
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.txt
@@ -1,0 +1,24 @@
+@kotlin.Metadata
+public final class C {
+    // source: 'CompanionFunctions.kt'
+    private synthetic final static field x: java.util.concurrent.atomic.AtomicLong
+    static method <clinit>(): void
+    public method <init>(): void
+    private synthetic final static method getX(): java.util.concurrent.atomic.AtomicLong
+    public final static method test(): long
+}
+
+@kotlin.Metadata
+public final class CompanionFunctionsKt {
+    // source: 'CompanionFunctions.kt'
+    private synthetic final static field a: java.util.concurrent.atomic.AtomicLong
+    private synthetic final static field arr: java.util.concurrent.atomic.AtomicLongArray
+    static method <clinit>(): void
+    private final static method aInc(): long
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    private synthetic final static method getA(): java.util.concurrent.atomic.AtomicLong
+    private synthetic final static method getArr(): java.util.concurrent.atomic.AtomicLongArray
+    private synthetic final static method inc$atomicfu$ATOMIC_ARRAY$Long(p0: java.util.concurrent.atomic.AtomicLongArray, p1: int): long
+    private synthetic final static method inc$atomicfu$ATOMIC_FIELD_UPDATER$Long(p0: java.util.concurrent.atomic.AtomicLongFieldUpdater, p1: java.lang.Object): long
+    private synthetic final static method inc$atomicfu$BOXED_ATOMIC$Long(p0: java.util.concurrent.atomic.AtomicLong): long
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.kt
@@ -1,0 +1,47 @@
+// LANGUAGE: +CompanionBlocks +CompanionExtensions
+// TARGET_BACKEND: JVM_IR
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+private class DelegatedProperties {
+    companion {
+        val a = atomic(0)
+        var dA: Int by a
+        var d: Int by atomic(0)
+    }
+}
+
+private companion val DelegatedProperties.tA = atomic(0)
+private companion var DelegatedProperties.tdA: Int by DelegatedProperties.tA
+private companion var DelegatedProperties.tD: Int by atomic(0)
+
+private fun testDelegates() {
+    assertEquals(0, DelegatedProperties.dA)
+    DelegatedProperties.dA = 2
+    assertEquals(2, DelegatedProperties.dA)
+    assertEquals(2, DelegatedProperties.a.value)
+    assertEquals(3, DelegatedProperties.a.incrementAndGet())
+    assertEquals(3, DelegatedProperties.dA)
+
+    assertEquals(0, DelegatedProperties.d)
+    DelegatedProperties.d = 42
+    assertEquals(42, DelegatedProperties.d)
+
+    assertEquals(0, DelegatedProperties.tdA)
+    DelegatedProperties.tdA = 2
+    assertEquals(2, DelegatedProperties.tdA)
+    assertEquals(2, DelegatedProperties.tA.value)
+    assertEquals(3, DelegatedProperties.tA.incrementAndGet())
+    assertEquals(3, DelegatedProperties.tdA)
+
+    assertEquals(0, DelegatedProperties.tD)
+    DelegatedProperties.tD = 42
+    assertEquals(42, DelegatedProperties.tD)
+}
+
+fun box(): String {
+    testDelegates()
+    return "OK"
+}
+

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.txt
@@ -1,0 +1,28 @@
+@kotlin.Metadata
+public final class DelegatedCompanionPropertiesKt {
+    // source: 'DelegatedCompanionProperties.kt'
+    private synthetic final static field tA: java.util.concurrent.atomic.AtomicInteger
+    private synthetic volatile static field tD$volatile: int
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    private synthetic final static method getTA(): java.util.concurrent.atomic.AtomicInteger
+    private final static method getTD(): int
+    private final static method getTdA(): int
+    private final static method setTD(p0: int): void
+    private final static method setTdA(p0: int): void
+    private final static method testDelegates(): void
+}
+
+@kotlin.Metadata
+final class DelegatedProperties {
+    // source: 'DelegatedCompanionProperties.kt'
+    private synthetic final static field a: java.util.concurrent.atomic.AtomicInteger
+    private synthetic volatile static field d$volatile: int
+    static method <clinit>(): void
+    public method <init>(): void
+    public synthetic final static method getA(): java.util.concurrent.atomic.AtomicInteger
+    public final static method getD(): int
+    public final static method getDA(): int
+    public final static method setD(p0: int): void
+    public final static method setDA(p0: int): void
+}

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -253,6 +253,12 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("ComanionTraces.kt")
+    public void testComanionTraces() {
+      run("ComanionTraces.kt");
+    }
+
+    @Test
     @TestMetadata("CompanionBlockProperties.kt")
     public void testCompanionBlockProperties() {
       run("CompanionBlockProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -269,6 +269,12 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
     public void testCompanionExtensionProperties() {
       run("CompanionExtensionProperties.kt");
     }
+
+    @Test
+    @TestMetadata("DelegatedCompanionProperties.kt")
+    public void testDelegatedCompanionProperties() {
+      run("DelegatedCompanionProperties.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -237,6 +237,35 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
   }
 
   @Nested
+  @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks")
+  @TestDataPath("$PROJECT_ROOT")
+  @Tag("atomicfu-native")
+  @EnforcedHostTarget()
+  @UseExtTestCaseGroupProvider()
+  public class Companion_blocks {
+    private void run(String fileName) {
+      runTest("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInCompanion_blocks() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("CompanionBlockProperties.kt")
+    public void testCompanionBlockProperties() {
+      run("CompanionBlockProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("CompanionExtensionProperties.kt")
+    public void testCompanionExtensionProperties() {
+      run("CompanionExtensionProperties.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/context_parameters")
   @TestDataPath("$PROJECT_ROOT")
   @Tag("atomicfu-native")

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -271,6 +271,12 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("CompanionFunctions.kt")
+    public void testCompanionFunctions() {
+      run("CompanionFunctions.kt");
+    }
+
+    @Test
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
@@ -240,6 +240,36 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
   }
 
   @Nested
+  @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks")
+  @TestDataPath("$PROJECT_ROOT")
+  @Tag("klibIrInliner")
+  @Tag("atomicfu-native")
+  @EnforcedHostTarget()
+  @UseExtTestCaseGroupProvider()
+  public class Companion_blocks {
+    private void run(String fileName) {
+      runTest("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInCompanion_blocks() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("CompanionBlockProperties.kt")
+    public void testCompanionBlockProperties() {
+      run("CompanionBlockProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("CompanionExtensionProperties.kt")
+    public void testCompanionExtensionProperties() {
+      run("CompanionExtensionProperties.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/context_parameters")
   @TestDataPath("$PROJECT_ROOT")
   @Tag("klibIrInliner")

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
@@ -273,6 +273,12 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
     public void testCompanionExtensionProperties() {
       run("CompanionExtensionProperties.kt");
     }
+
+    @Test
+    @TestMetadata("DelegatedCompanionProperties.kt")
+    public void testDelegatedCompanionProperties() {
+      run("DelegatedCompanionProperties.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
@@ -257,6 +257,12 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
     }
 
     @Test
+    @TestMetadata("ComanionTraces.kt")
+    public void testComanionTraces() {
+      run("ComanionTraces.kt");
+    }
+
+    @Test
     @TestMetadata("CompanionBlockProperties.kt")
     public void testCompanionBlockProperties() {
       run("CompanionBlockProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
@@ -275,6 +275,12 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
     }
 
     @Test
+    @TestMetadata("CompanionFunctions.kt")
+    public void testCompanionFunctions() {
+      run("CompanionFunctions.kt");
+    }
+
+    @Test
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
@@ -238,6 +238,12 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
     }
 
     @Test
+    @TestMetadata("ComanionTraces.kt")
+    public void testComanionTraces() {
+      run("ComanionTraces.kt");
+    }
+
+    @Test
     @TestMetadata("CompanionBlockProperties.kt")
     public void testCompanionBlockProperties() {
       run("CompanionBlockProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
@@ -225,6 +225,32 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
   }
 
   @Nested
+  @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks")
+  @TestDataPath("$PROJECT_ROOT")
+  public class Companion_blocks {
+    private void run(String fileName) {
+      runTest("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInCompanion_blocks() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("CompanionBlockProperties.kt")
+    public void testCompanionBlockProperties() {
+      run("CompanionBlockProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("CompanionExtensionProperties.kt")
+    public void testCompanionExtensionProperties() {
+      run("CompanionExtensionProperties.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/context_parameters")
   @TestDataPath("$PROJECT_ROOT")
   public class Context_parameters {

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
@@ -254,6 +254,12 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
     public void testCompanionExtensionProperties() {
       run("CompanionExtensionProperties.kt");
     }
+
+    @Test
+    @TestMetadata("DelegatedCompanionProperties.kt")
+    public void testDelegatedCompanionProperties() {
+      run("DelegatedCompanionProperties.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
@@ -256,6 +256,12 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
     }
 
     @Test
+    @TestMetadata("CompanionFunctions.kt")
+    public void testCompanionFunctions() {
+      run("CompanionFunctions.kt");
+    }
+
+    @Test
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
@@ -254,6 +254,12 @@ public class AtomicfuJsWithInlinedFunInKlibTestGenerated extends AbstractAtomicf
     public void testCompanionExtensionProperties() {
       run("CompanionExtensionProperties.kt");
     }
+
+    @Test
+    @TestMetadata("DelegatedCompanionProperties.kt")
+    public void testDelegatedCompanionProperties() {
+      run("DelegatedCompanionProperties.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
@@ -225,6 +225,32 @@ public class AtomicfuJsWithInlinedFunInKlibTestGenerated extends AbstractAtomicf
   }
 
   @Nested
+  @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks")
+  @TestDataPath("$PROJECT_ROOT")
+  public class Companion_blocks {
+    private void run(String fileName) {
+      runTest("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInCompanion_blocks() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("CompanionBlockProperties.kt")
+    public void testCompanionBlockProperties() {
+      run("CompanionBlockProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("CompanionExtensionProperties.kt")
+    public void testCompanionExtensionProperties() {
+      run("CompanionExtensionProperties.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/context_parameters")
   @TestDataPath("$PROJECT_ROOT")
   public class Context_parameters {

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
@@ -256,6 +256,12 @@ public class AtomicfuJsWithInlinedFunInKlibTestGenerated extends AbstractAtomicf
     }
 
     @Test
+    @TestMetadata("CompanionFunctions.kt")
+    public void testCompanionFunctions() {
+      run("CompanionFunctions.kt");
+    }
+
+    @Test
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
@@ -238,6 +238,12 @@ public class AtomicfuJsWithInlinedFunInKlibTestGenerated extends AbstractAtomicf
     }
 
     @Test
+    @TestMetadata("ComanionTraces.kt")
+    public void testComanionTraces() {
+      run("ComanionTraces.kt");
+    }
+
+    @Test
     @TestMetadata("CompanionBlockProperties.kt")
     public void testCompanionBlockProperties() {
       run("CompanionBlockProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
@@ -238,6 +238,12 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
     }
 
     @Test
+    @TestMetadata("ComanionTraces.kt")
+    public void testComanionTraces() {
+      run("ComanionTraces.kt");
+    }
+
+    @Test
     @TestMetadata("CompanionBlockProperties.kt")
     public void testCompanionBlockProperties() {
       run("CompanionBlockProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
@@ -225,6 +225,32 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
   }
 
   @Nested
+  @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks")
+  @TestDataPath("$PROJECT_ROOT")
+  public class Companion_blocks {
+    private void run(String fileName) {
+      runTest("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInCompanion_blocks() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("CompanionBlockProperties.kt")
+    public void testCompanionBlockProperties() {
+      run("CompanionBlockProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("CompanionExtensionProperties.kt")
+    public void testCompanionExtensionProperties() {
+      run("CompanionExtensionProperties.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/context_parameters")
   @TestDataPath("$PROJECT_ROOT")
   public class Context_parameters {

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
@@ -256,6 +256,12 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
     }
 
     @Test
+    @TestMetadata("CompanionFunctions.kt")
+    public void testCompanionFunctions() {
+      run("CompanionFunctions.kt");
+    }
+
+    @Test
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
@@ -254,6 +254,12 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
     public void testCompanionExtensionProperties() {
       run("CompanionExtensionProperties.kt");
     }
+
+    @Test
+    @TestMetadata("DelegatedCompanionProperties.kt")
+    public void testDelegatedCompanionProperties() {
+      run("DelegatedCompanionProperties.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -248,6 +248,38 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
   }
 
   @Nested
+  @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks")
+  @TestDataPath("$PROJECT_ROOT")
+  @Tag("klibIrInliner")
+  @EnforcedProperty(property = ClassLevelProperty.TEST_KIND, propertyValue = "STANDALONE")
+  @EnforcedProperty(property = ClassLevelProperty.CACHE_MODE, propertyValue = "NO")
+  @UseExtTestCaseGroupProvider()
+  @Tag("atomicfu-native")
+  @EnforcedHostTarget()
+  public class Companion_blocks {
+    private void run(String fileName) {
+      runTest("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/" + fileName);
+    }
+
+    @Test
+    public void testAllFilesPresentInCompanion_blocks() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("CompanionBlockProperties.kt")
+    public void testCompanionBlockProperties() {
+      run("CompanionBlockProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("CompanionExtensionProperties.kt")
+    public void testCompanionExtensionProperties() {
+      run("CompanionExtensionProperties.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("plugins/atomicfu/atomicfu-compiler/testData/box/context_parameters")
   @TestDataPath("$PROJECT_ROOT")
   @Tag("klibIrInliner")

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -285,6 +285,12 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
     }
 
     @Test
+    @TestMetadata("CompanionFunctions.kt")
+    public void testCompanionFunctions() {
+      run("CompanionFunctions.kt");
+    }
+
+    @Test
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -267,6 +267,12 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
     }
 
     @Test
+    @TestMetadata("ComanionTraces.kt")
+    public void testComanionTraces() {
+      run("ComanionTraces.kt");
+    }
+
+    @Test
     @TestMetadata("CompanionBlockProperties.kt")
     public void testCompanionBlockProperties() {
       run("CompanionBlockProperties.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -283,6 +283,12 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
     public void testCompanionExtensionProperties() {
       run("CompanionExtensionProperties.kt");
     }
+
+    @Test
+    @TestMetadata("DelegatedCompanionProperties.kt")
+    public void testDelegatedCompanionProperties() {
+      run("DelegatedCompanionProperties.kt");
+    }
   }
 
   @Nested


### PR DESCRIPTION
Support atomic properties coming from companion blocks and extensions on JVM.

There's no difference in how atomic arrays are handled. Scalar properties, however, are always boxed, akin top-level atomic properties. That's because atomic field updaters don't support static fields.

Fixes KT-86151