### PR TITLE
[Maven] Restore manifest check in maven tests

### DIFF
--- a/libraries/tools/kotlin-maven-plugin-test/src/it/test-kotlin-version-in-manifest/src/main/kotlin/test.kt
+++ b/libraries/tools/kotlin-maven-plugin-test/src/it/test-kotlin-version-in-manifest/src/main/kotlin/test.kt
@@ -65,15 +65,14 @@ fun main(args: Array<String>) {
         if (value != null) append(" (actual value: $value)")
         else append(" (attribute is not found)")
     }
-    // KTI-3420/Broken-MavenTest-after-bumping-to-Language-Version-2.5 (waiting for next bootstrap)
-    // val incorrectVersionValues = versionValues.filterValues { it != KOTLIN_VERSION_VALUE }
-    // if (incorrectVersionValues.isNotEmpty()) {
-    //     errors.appendLine("Manifests at these locations do not have the correct value of the $KOTLIN_VERSION attribute ($KOTLIN_VERSION_VALUE). " +
-    //                     "Please ensure that kotlin_language_version in libraries/build.gradle corresponds to the value in kotlin.KotlinVersion:")
-    //     incorrectVersionValues.entries.joinTo(errors, "\n", transform = ::renderEntry)
-    //     errors.appendLine()
-    //     errors.appendLine()
-    // }
+    val incorrectVersionValues = versionValues.filterValues { it != KOTLIN_VERSION_VALUE }
+    if (incorrectVersionValues.isNotEmpty()) {
+        errors.appendLine("Manifests at these locations do not have the correct value of the $KOTLIN_VERSION attribute ($KOTLIN_VERSION_VALUE). " +
+                        "Please ensure that kotlin_language_version in libraries/build.gradle corresponds to the value in kotlin.KotlinVersion:")
+        incorrectVersionValues.entries.joinTo(errors, "\n", transform = ::renderEntry)
+        errors.appendLine()
+        errors.appendLine()
+    }
 
     val incorrectRuntimeComponentValues = runtimeComponentValues.filterValues { it != KOTLIN_RUNTIME_COMPONENT_VALUE }
     if (incorrectRuntimeComponentValues.isNotEmpty()) {


### PR DESCRIPTION
KTI-3420

The root cause for the issue was having the following in `gradle.properties`:
```
bootstrap.kotlin.default.version=2.5.0-dev-498
kotlinLanguageVersion=2.4
```
Because of that, the MavenTests expected to have `Kotlin-Version: 2.5` in the jar manifest but was getting `2.4` (as we were compiling with LV = 2.4)

Now, since the LV is bumped to 2.5 (see [~~KT-87532~~](https://youtrack.jetbrains.com/issue/KT-87532/Bump-kotlinLanguageVersion-in-gradle.properties)), we can restore the manifest check.

NOTE: this PR won't close KTI-3420 since the issue will likely come back during branching from 2.5.20 to 2.6.0. We need to come up with a long-term fix, but let's start by re-enabling the check :)