### PR TITLE
[kotlinx.serialization] Use contentEquals/contentDeepEquals to compar…

### DIFF
--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlinx.serialization.compiler.backend.ir
 
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irIfThen
+import org.jetbrains.kotlin.backend.common.lower.irNot
 import org.jetbrains.kotlin.backend.jvm.functionByName
 import org.jetbrains.kotlin.backend.jvm.ir.fileParent
 import org.jetbrains.kotlin.descriptors.ClassKind
@@ -233,7 +234,7 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
                 // emit call right away
                 +elementCall
             } else {
-                val partB = irNotEquals(property.irGet(substitutedPropertyType), initializerAdapter(initializer))
+                val partB = irNotEqualsConsideringArrayContent(property.type, property.irGet(substitutedPropertyType), initializerAdapter(initializer))
 
                 val condition = if (encodeDefaults == false) {
                     // drop default without call to .shouldEncodeElementDefault
@@ -250,6 +251,29 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
                 }
                 +irIfThen(condition, elementCall)
             }
+        }
+    }
+
+    private fun IrBuilderWithScope.irNotEqualsConsideringArrayContent(
+        type: IrType, value: IrExpression, default: IrExpression,
+    ): IrExpression {
+        val notNull = type.makeNotNull()
+        return when {
+            notNull.isArray() -> {
+                val symbol = compilerContext.contentDeepEqualsFunctionSymbol ?: return irNotEquals(value, default)
+                // `contentDeepEquals` is generic (`fun <T> Array<out T>?.contentDeepEquals(...)`), so bind `T` to the array
+                // element type — otherwise the produced IrCall would carry a null type-argument slot (malformed IR).
+                val elementType = (notNull as? IrSimpleType)?.arguments?.singleOrNull()?.typeOrNull
+                    ?: return irNotEquals(value, default)
+                irNot(irInvoke(symbol, listOf(value, default), typeArguments = listOf(elementType)))
+            }
+            // Primitive (`IntArray`…) and unsigned (`UIntArray`…) `contentEquals` overloads are non-generic — no type args.
+            notNull.isPrimitiveArray() || notNull.isUnsignedArray() -> {
+                val symbol = compilerContext.contentEqualsFunctionByArrayClassifier[notNull.classifierOrNull]
+                    ?: return irNotEquals(value, default)
+                irNot(irInvoke(symbol, listOf(value, default)))
+            }
+            else -> irNotEquals(value, default)
         }
     }
 

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/extensions/SerializationLoweringExtension.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/extensions/SerializationLoweringExtension.kt
@@ -19,8 +19,12 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
@@ -69,6 +73,28 @@ class SerializationPluginContext(baseContext: IrPluginContext) :
 
     internal val intArrayOfFunctionSymbol =
         finderForBuiltins.findFunctions(CallableId(StandardNames.BUILT_INS_PACKAGE_FQ_NAME, Name.identifier("intArrayOf"))).first()
+
+    /**
+     * `Array<out T>?.contentDeepEquals(other: Array<out T>?)`
+     */
+    internal val contentDeepEqualsFunctionSymbol: IrSimpleFunctionSymbol? by lazy {
+        finderForBuiltins
+            .findFunctions(CallableId(StandardNames.COLLECTIONS_PACKAGE_FQ_NAME, Name.identifier("contentDeepEquals")))
+            .singleOrNull { it.owner.parameters.firstOrNull { p -> p.kind == IrParameterKind.ExtensionReceiver }?.type?.isNullable() == true }
+    }
+
+    /**
+     * `contentEquals` overloads for primitive (`IntArray`, `ByteArray`,...) and unsigned (`UIntArray`, `UByteArray`,...) arrays, keyed by the receiver array classifier.
+     */
+    internal val contentEqualsFunctionByArrayClassifier: Map<IrClassifierSymbol, IrSimpleFunctionSymbol> by lazy {
+        finderForBuiltins
+            .findFunctions(CallableId(StandardNames.COLLECTIONS_PACKAGE_FQ_NAME, Name.identifier("contentEquals")))
+            .mapNotNull { fn ->
+                val ext = fn.owner.parameters.firstOrNull { it.kind == IrParameterKind.ExtensionReceiver } ?: return@mapNotNull null
+                if (!ext.type.isNullable()) return@mapNotNull null            // @SinceKotlin("1.4") nullable-receiver overloads
+                (ext.type.classifierOrNull ?: return@mapNotNull null) to fn
+            }.toMap()
+    }
 
     // Kotlin stdlib declarations
     internal val jvmFieldClassSymbol = finderForBuiltins.findClass(JvmStandardClassIds.Annotations.JvmField)!!
@@ -222,5 +248,3 @@ open class SerializationLoweringExtension @JvmOverloads constructor(
         }
     }
 }
-
-

--- a/plugins/kotlinx-serialization/testData/boxIr/encodeDefaultArrayContentEquals.kt
+++ b/plugins/kotlinx-serialization/testData/boxIr/encodeDefaultArrayContentEquals.kt
@@ -1,0 +1,81 @@
+// WITH_STDLIB
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlin.test.assertEquals
+
+@Serializable
+class ByteArrayHolder(val a: ByteArray = byteArrayOf(1, 2))
+
+@Serializable
+class PrimitiveArrayHolder(val a: IntArray = intArrayOf())
+
+@Serializable
+class ObjectArrayHolder(val a: Array<String> = arrayOf("x", "y"))
+
+@Serializable
+class NestedArrayHolder(val a: Array<IntArray> = arrayOf(intArrayOf(1), intArrayOf(2, 3)))
+
+@Serializable
+class NullableArrayHolder(val a: Array<String>? = null)
+
+@OptIn(ExperimentalUnsignedTypes::class)
+@Serializable
+class UnsignedArrayHolder(val a: UIntArray = uintArrayOf(1u, 2u))
+
+@OptIn(ExperimentalUnsignedTypes::class)
+@Serializable
+class UByteArrayHolder(val a: UByteArray = ubyteArrayOf(1u, 2u))
+
+@Serializable
+class AlwaysHolder(@EncodeDefault(EncodeDefault.Mode.ALWAYS) val a: IntArray = intArrayOf())
+
+private val encodeAll = Json { encodeDefaults = true }
+
+fun box(): String {
+    // Byte array: content-equal-to-default omitted, differing contents emitted.
+    assertEquals("{}", Json.encodeToString(ByteArrayHolder()))
+    assertEquals("{}", Json.encodeToString(ByteArrayHolder(byteArrayOf(1, 2))))
+    assertEquals("""{"a":[5]}""", Json.encodeToString(ByteArrayHolder(byteArrayOf(5))))
+
+    // Primitive array: content equal to the (empty) default is omitted, different content is emitted.
+    assertEquals("{}", Json.encodeToString(PrimitiveArrayHolder()))
+    assertEquals("{}", Json.encodeToString(PrimitiveArrayHolder(intArrayOf())))
+    assertEquals("""{"a":[7]}""", Json.encodeToString(PrimitiveArrayHolder(intArrayOf(7))))
+
+    // Object array: content-equal-to-default omitted (different array instance, equal contents), differing contents emitted.
+    assertEquals("{}", Json.encodeToString(ObjectArrayHolder(arrayOf("x", "y"))))
+    assertEquals("""{"a":["z"]}""", Json.encodeToString(ObjectArrayHolder(arrayOf("z"))))
+
+    // Nested object array: deep content equality. Inner arrays are fresh instances yet equal -> omitted.
+    assertEquals("{}", Json.encodeToString(NestedArrayHolder(arrayOf(intArrayOf(1), intArrayOf(2, 3)))))
+    // Same outer shape but a differing inner array must still be emitted (verifies deep, not shallow, comparison).
+    assertEquals("""{"a":[[1],[9,9]]}""", Json.encodeToString(NestedArrayHolder(arrayOf(intArrayOf(1), intArrayOf(9, 9)))))
+
+    // Nullable array: null vs null default omitted, a non-null value emitted.
+    assertEquals("{}", Json.encodeToString(NullableArrayHolder(null)))
+    assertEquals("""{"a":["a"]}""", Json.encodeToString(NullableArrayHolder(arrayOf("a"))))
+
+    // Unsigned array: content-equal-to-default omitted, differing contents emitted.
+    assertEquals("{}", Json.encodeToString(UnsignedArrayHolder(uintArrayOf(1u, 2u))))
+    assertEquals("""{"a":[5]}""", Json.encodeToString(UnsignedArrayHolder(uintArrayOf(5u))))
+
+    // Unsigned byte array: content-equal-to-default omitted, differing contents emitted.
+    assertEquals("{}", Json.encodeToString(UByteArrayHolder()))
+    assertEquals("{}", Json.encodeToString(UByteArrayHolder(ubyteArrayOf(1u, 2u))))
+    assertEquals("""{"a":[5]}""", Json.encodeToString(UByteArrayHolder(ubyteArrayOf(5u))))
+
+    // @EncodeDefault(ALWAYS) always emits, even with default Json and content equal to default.
+    assertEquals("""{"a":[]}""", Json.encodeToString(AlwaysHolder()))
+
+    // Json { encodeDefaults = true } always emits, regardless of content equality.
+    assertEquals("""{"a":[1,2]}""", encodeAll.encodeToString(ByteArrayHolder()))
+    assertEquals("""{"a":[]}""", encodeAll.encodeToString(PrimitiveArrayHolder()))
+    assertEquals("""{"a":["x","y"]}""", encodeAll.encodeToString(ObjectArrayHolder()))
+    assertEquals("""{"a":[[1],[2,3]]}""", encodeAll.encodeToString(NestedArrayHolder()))
+    assertEquals("""{"a":null}""", encodeAll.encodeToString(NullableArrayHolder()))
+    assertEquals("""{"a":[1,2]}""", encodeAll.encodeToString(UnsignedArrayHolder()))
+    assertEquals("""{"a":[1,2]}""", encodeAll.encodeToString(UByteArrayHolder()))
+
+    return "OK"
+}

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeTestGenerated.java
@@ -119,6 +119,12 @@ public class SerializationNativeTestGenerated extends AbstractNativeCodegenBoxTe
   }
 
   @Test
+  @TestMetadata("encodeDefaultArrayContentEquals.kt")
+  public void testEncodeDefaultArrayContentEquals() {
+    run("encodeDefaultArrayContentEquals.kt");
+  }
+
+  @Test
   @TestMetadata("enumsAreCached.kt")
   public void testEnumsAreCached() {
     run("enumsAreCached.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/SerializationNativeWithInlinedFunInKlibTestGenerated.java
@@ -120,6 +120,12 @@ public class SerializationNativeWithInlinedFunInKlibTestGenerated extends Abstra
   }
 
   @Test
+  @TestMetadata("encodeDefaultArrayContentEquals.kt")
+  public void testEncodeDefaultArrayContentEquals() {
+    run("encodeDefaultArrayContentEquals.kt");
+  }
+
+  @Test
   @TestMetadata("enumsAreCached.kt")
   public void testEnumsAreCached() {
     run("enumsAreCached.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLReversedSerializationBlackBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLReversedSerializationBlackBoxTestGenerated.java
@@ -115,6 +115,12 @@ public class LLReversedSerializationBlackBoxTestGenerated extends AbstractLLReve
     }
 
     @Test
+    @TestMetadata("encodeDefaultArrayContentEquals.kt")
+    public void testEncodeDefaultArrayContentEquals() {
+      run("encodeDefaultArrayContentEquals.kt");
+    }
+
+    @Test
     @TestMetadata("enumsAreCached.kt")
     public void testEnumsAreCached() {
       run("enumsAreCached.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLSerializationBlackBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLSerializationBlackBoxTestGenerated.java
@@ -115,6 +115,12 @@ public class LLSerializationBlackBoxTestGenerated extends AbstractLLSerializatio
     }
 
     @Test
+    @TestMetadata("encodeDefaultArrayContentEquals.kt")
+    public void testEncodeDefaultArrayContentEquals() {
+      run("encodeDefaultArrayContentEquals.kt");
+    }
+
+    @Test
     @TestMetadata("enumsAreCached.kt")
     public void testEnumsAreCached() {
       run("enumsAreCached.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationFirLightTreeBlackBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationFirLightTreeBlackBoxTestGenerated.java
@@ -115,6 +115,12 @@ public class SerializationFirLightTreeBlackBoxTestGenerated extends AbstractSeri
     }
 
     @Test
+    @TestMetadata("encodeDefaultArrayContentEquals.kt")
+    public void testEncodeDefaultArrayContentEquals() {
+      run("encodeDefaultArrayContentEquals.kt");
+    }
+
+    @Test
     @TestMetadata("enumsAreCached.kt")
     public void testEnumsAreCached() {
       run("enumsAreCached.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxTestGenerated.java
@@ -112,6 +112,12 @@ public class SerializationJsBoxTestGenerated extends AbstractSerializationJsBoxT
   }
 
   @Test
+  @TestMetadata("encodeDefaultArrayContentEquals.kt")
+  public void testEncodeDefaultArrayContentEquals() {
+    run("encodeDefaultArrayContentEquals.kt");
+  }
+
+  @Test
   @TestMetadata("enumsAreCached.kt")
   public void testEnumsAreCached() {
     run("enumsAreCached.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationJsBoxWithInlinedFunInKlibTestGenerated.java
@@ -112,6 +112,12 @@ public class SerializationJsBoxWithInlinedFunInKlibTestGenerated extends Abstrac
   }
 
   @Test
+  @TestMetadata("encodeDefaultArrayContentEquals.kt")
+  public void testEncodeDefaultArrayContentEquals() {
+    run("encodeDefaultArrayContentEquals.kt");
+  }
+
+  @Test
   @TestMetadata("enumsAreCached.kt")
   public void testEnumsAreCached() {
     run("enumsAreCached.kt");


### PR DESCRIPTION
…e Arrays when deciding whether to encode default value.

#KT-75702 Fixed