### PR TITLE
Update KLIB compatibility test tasks

### DIFF
--- a/js/js.tests/klib-compatibility/build.gradle.kts
+++ b/js/js.tests/klib-compatibility/build.gradle.kts
@@ -139,7 +139,6 @@ customFirstStageTest("2.4.0")
 
 /* Custom-second-stage test task for the two compiler major versions: previous one and the latest one . */
 // TODO: Keep updating the following compiler versions to be the previous one and latest one(as as soon it's released).
-customSecondStageTest("2.3.0")
 customSecondStageTest("2.4.0")
 
 // TODO: Keep updating the following compiler versions to be the previous major one.

--- a/js/js.tests/klib-compatibility/build.gradle.kts
+++ b/js/js.tests/klib-compatibility/build.gradle.kts
@@ -142,7 +142,7 @@ customFirstStageTest("2.4.0")
 customSecondStageTest("2.4.0")
 
 // TODO: Keep updating the following compiler versions to be the previous major one.
-customStagesAggregateTest("2.3.0")
+customStagesAggregateTest("2.4.0")
 
 tasks.test {
     // The default test task does not resolve the necessary dependencies and does not set up the environment.

--- a/native/native.tests/klib-compatibility/build.gradle.kts
+++ b/native/native.tests/klib-compatibility/build.gradle.kts
@@ -194,10 +194,10 @@ customSecondStageTest("2.4.0")
 // Should backward and forward tests be executed together in one Gradle task -> so/dylib versions would be inevitably mixed up
 
 // TODO: Drop these short tasks after KT-84712, when full tasks `testCustomFirstStage_$version` and `testCustomSecondStage_$version` will become very fast
-customStagesAggregateTest("2.3.0", "first")
-customStagesAggregateTest("2.3.0", "second")
+customStagesAggregateTest("2.4.0", "first")
+customStagesAggregateTest("2.4.0", "second")
 // TODO: Drop the next one after KTI migrates to execution of  `testMinimalInAggregate_firstStage` and `testMinimalInAggregate_secondStage`
-customCompilerTest(CustomCompilerVersion("2.3.0"), "testMinimalInAggregate", "aggregate-first-stage")
+customCompilerTest(CustomCompilerVersion("2.4.0"), "testMinimalInAggregate", "aggregate-first-stage")
 
 projectTests {
     testGenerator("org.jetbrains.kotlin.generators.tests.GenerateNativeKlibCompatibilityTestsKt", generateTestsInBuildDirectory = true) {

--- a/native/native.tests/klib-compatibility/build.gradle.kts
+++ b/native/native.tests/klib-compatibility/build.gradle.kts
@@ -182,7 +182,6 @@ customFirstStageTest("2.4.0")
 
 /* Custom-second-stage test task for the two compiler major versions: previous one and the latest one . */
 // TODO: Keep updating two following compiler versions to be the previous and latest ones.
-customSecondStageTest("2.3.0")
 customSecondStageTest("2.4.0")
 // add `customSecondStageTest("2.5.0-Beta1")`, as soon it is released, and remove 2.3.0
 

--- a/wasm/wasm.tests/klib-compatibility/build.gradle.kts
+++ b/wasm/wasm.tests/klib-compatibility/build.gradle.kts
@@ -117,7 +117,6 @@ customFirstStageTest("2.4.0")
 
 /* Custom-second-stage test task for the two compiler major versions: previous one and the latest one . */
 // TODO: Keep updating the following compiler versions to be the previous one and latest one(as as soon it's released).
-customSecondStageTest("2.3.0")
 customSecondStageTest("2.4.0")
 
 // TODO: Keep updating the following compiler version to be the previous major one.

--- a/wasm/wasm.tests/klib-compatibility/build.gradle.kts
+++ b/wasm/wasm.tests/klib-compatibility/build.gradle.kts
@@ -120,7 +120,7 @@ customFirstStageTest("2.4.0")
 customSecondStageTest("2.4.0")
 
 // TODO: Keep updating the following compiler version to be the previous major one.
-customStagesAggregateTest("2.3.0")
+customStagesAggregateTest("2.4.0")
 
 tasks.test {
     // The default test task does not resolve the necessary dependencies and does not set up the environment.


### PR DESCRIPTION
Nightly build: https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KlibBackwardAndForwardCompatibilityTestsNightly/1003984807

Update: It's green.