### PR TITLE
[IC][KMP] Route JVM metadata via incremental cache

### DIFF
--- a/build-common/src/org/jetbrains/kotlin/incremental/ICJvmMetadataTrackerImpl.kt
+++ b/build-common/src/org/jetbrains/kotlin/incremental/ICJvmMetadataTrackerImpl.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.incremental
+
+import org.jetbrains.kotlin.incremental.components.ICJvmMetadataTracker
+import java.io.File
+
+class ICJvmMetadataTrackerImpl : ICJvmMetadataTracker {
+    val metadataByModule: Map<String, Map<File, ByteArray>>
+        field = hashMapOf<String, MutableMap<File, ByteArray>>()
+
+    override fun report(fragmentName: String, sourceFile: File, metadata: ByteArray) {
+        metadataByModule.getOrPut(fragmentName) { hashMapOf() }[sourceFile] = metadata
+    }
+}

--- a/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt
+++ b/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.io.FileUtil.toSystemIndependentName
 import com.intellij.util.io.BooleanDataDescriptor
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.kotlin.build.GeneratedJvmClass
+import org.jetbrains.kotlin.build.report.debug
 import org.jetbrains.kotlin.incremental.DifferenceCalculatorForPackageFacade.Companion.getVisibleTypeAliasFqNames
 import org.jetbrains.kotlin.incremental.components.SubtypeTracker
 import org.jetbrains.kotlin.incremental.storage.*
@@ -90,7 +91,9 @@ open class IncrementalJvmCache(
 
     private val outputDir by lazy(LazyThreadSafetyMode.NONE) { requireNotNull(targetOutputDir) { "Target is expected to have output directory" } }
 
-    protected open fun debugLog(message: String) {}
+    protected open fun debugLog(message: String) {
+        icContext.reporter.debug { message }
+    }
 
     fun isTrackedFile(file: File) = sourceToClassesMap.contains(file)
 

--- a/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt
+++ b/build-common/src/org/jetbrains/kotlin/incremental/IncrementalJvmCache.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.build.GeneratedJvmClass
 import org.jetbrains.kotlin.incremental.DifferenceCalculatorForPackageFacade.Companion.getVisibleTypeAliasFqNames
 import org.jetbrains.kotlin.incremental.components.SubtypeTracker
 import org.jetbrains.kotlin.incremental.storage.*
+import org.jetbrains.kotlin.incremental.storage.ByteArrayExternalizer
 import org.jetbrains.kotlin.inline.InlineFunction
 import org.jetbrains.kotlin.inline.InlineFunctionOrAccessor
 import org.jetbrains.kotlin.inline.InlinePropertyAccessor
@@ -63,6 +64,7 @@ open class IncrementalJvmCache(
         private const val INLINE_FUNCTIONS = "inline-functions"
         private const val INTERNAL_NAME_TO_SOURCE = "internal-name-to-source"
         private const val JAVA_SOURCES_PROTO_MAP = "java-sources-proto-map"
+        private const val METADATA_MAP = "metadata"
 
         private const val MODULE_MAPPING_FILE_NAME = "." + ModuleMapping.MAPPING_FILE_EXT
     }
@@ -84,6 +86,8 @@ open class IncrementalJvmCache(
     // gradle only
     private val javaSourcesProtoMap = registerMap(JavaSourcesProtoMap(JAVA_SOURCES_PROTO_MAP.storageFile, icContext))
 
+    private val metadataMap = registerMap(MetadataMap(METADATA_MAP.storageFile, icContext))
+
     private val outputDir by lazy(LazyThreadSafetyMode.NONE) { requireNotNull(targetOutputDir) { "Target is expected to have output directory" } }
 
     protected open fun debugLog(message: String) {}
@@ -104,6 +108,14 @@ open class IncrementalJvmCache(
 
     fun isMultifileFacade(className: JvmClassName): Boolean =
         className in multifileFacadeToParts
+
+    override fun markDirty(removedAndCompiledSources: Collection<File>) {
+        super.markDirty(removedAndCompiledSources)
+
+        for (fragmentName in metadataMap.keys) {
+            metadataMap.remove(fragmentName, removedAndCompiledSources)
+        }
+    }
 
     override fun getClassFilePath(internalClassName: String): String {
         return toSystemIndependentName(File(outputDir, "$internalClassName.class").normalize().absolutePath)
@@ -127,6 +139,10 @@ open class IncrementalJvmCache(
 
     open fun saveFileToCache(generatedClass: GeneratedJvmClass, changesCollector: ChangesCollector) {
         saveClassToCache(KotlinClassInfo.createFrom(generatedClass.outputClass), generatedClass.sourceFiles, changesCollector)
+    }
+
+    fun saveMetadataToCache(fragmentName: String, metadata: Map<File, ByteArray>) {
+        metadataMap.append(fragmentName, metadata)
     }
 
     /**
@@ -370,6 +386,9 @@ open class IncrementalJvmCache(
     override fun getModuleMappingData(): ByteArray? {
         return protoMap[JvmClassName.byInternalName(MODULE_MAPPING_FILE_NAME)]?.bytes
     }
+
+    override fun getMetadata(fragmentName: String): Map<File, ByteArray> =
+        metadataMap[fragmentName] ?: emptyMap()
 
     private inner class ProtoMap(
         storageFile: File,
@@ -636,6 +655,55 @@ open class IncrementalJvmCache(
 
         override fun dumpValue(value: Map<InlineFunctionOrAccessor, Long>): String =
             value.mapKeys { it.key.jvmMethodSignature.asString() }.dumpMap { java.lang.Long.toHexString(it) }
+    }
+
+    private inner class MetadataMap(
+        storageFile: File,
+        icContext: IncrementalCompilationContext,
+    ) : BasicStringMap<Map<File, ByteArray>>(
+        storageFile,
+        MapExternalizer(icContext.fileDescriptorForSourceFiles, ByteArrayExternalizer),
+        icContext,
+    ) {
+        operator fun get(key: String, file: File): ByteArray? = storage[key]?.get(file)
+
+        @Synchronized
+        fun append(key: String, entries: Map<File, ByteArray>) {
+            if (entries.isEmpty()) return
+
+            val merged = storage[key]?.let { HashMap(it) } ?: HashMap(entries.size)
+            merged.putAll(entries)
+
+            storage[key] = merged
+
+            for ([file, _] in entries) {
+                debugLog("[$key] Saved metadata for file: ${file.path}")
+            }
+        }
+
+        @Synchronized
+        fun remove(key: String, files: Collection<File>) {
+            val inner = storage[key] ?: return
+
+            val filesToRemove = files.filterTo(hashSetOf()) { it in inner }
+            if (filesToRemove.isEmpty()) return
+
+            val merged = HashMap(inner).apply { keys.removeAll(filesToRemove) }
+
+            if (merged.isEmpty()) {
+                storage.remove(key)
+            } else {
+                storage[key] = merged
+            }
+
+            for (file in filesToRemove) {
+                debugLog("[$key] Removed metadata for file: ${file.path}")
+            }
+        }
+
+        override fun dumpValue(value: Map<File, ByteArray>): String =
+            value.entries.sortedBy { it.key.path }
+                .joinToString(", ", "{", "}") { "${it.key} -> ${java.lang.Long.toHexString(it.value.md5())}" }
     }
 
     private fun KotlinClassInfo.scopeFqName() = when (classKind) {

--- a/build-common/src/org/jetbrains/kotlin/incremental/buildUtil.kt
+++ b/build-common/src/org/jetbrains/kotlin/incremental/buildUtil.kt
@@ -108,7 +108,8 @@ fun updateIncrementalCache(
     generatedFiles: Iterable<GeneratedFile>,
     cache: IncrementalJvmCache,
     changesCollector: ChangesCollector,
-    javaChangesTracker: JavaClassesTrackerImpl?
+    javaChangesTracker: JavaClassesTrackerImpl?,
+    jvmMetadataTracker: ICJvmMetadataTrackerImpl?,
 ) {
     for (generatedFile in generatedFiles) {
         when {
@@ -122,6 +123,10 @@ fun updateIncrementalCache(
 
     javaChangesTracker?.javaClassesUpdates?.forEach { (val source, val serializedJavaClass = proto) ->
         cache.saveJavaClassProto(source, serializedJavaClass, changesCollector)
+    }
+
+    jvmMetadataTracker?.metadataByModule?.forEach { [moduleName, metadata] ->
+        cache.saveMetadataToCache(moduleName, metadata)
     }
 
     cache.clearCacheForRemovedClasses(changesCollector)

--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmConfigurationPipelinePhase.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmConfigurationPipelinePhase.kt
@@ -27,8 +27,6 @@ import org.jetbrains.kotlin.cli.reportException
 import org.jetbrains.kotlin.cli.reportLog
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.incremental.components.*
-import org.jetbrains.kotlin.K1Deprecation
-import org.jetbrains.kotlin.load.java.JavaClassesTracker
 import org.jetbrains.kotlin.load.kotlin.incremental.components.IncrementalCompilationComponents
 import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
@@ -125,6 +123,7 @@ object JvmConfigurationUpdater : ConfigurationUpdater<K2JVMCompilerArguments>() 
         inlineConstTracker = services[InlineConstTracker::class.java]
         enumWhenTracker = services[EnumWhenTracker::class.java]
         fileMappingTracker = services[ICFileMappingTracker::class.java]
+        icMetadataTracker = services[ICJvmMetadataTracker::class.java]
         incrementalCompilationComponents = services[IncrementalCompilationComponents::class.java]
     }
 

--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmSerializeCommonMetadataPipelinePhase.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/metadata/JvmSerializeCommonMetadataPipelinePhase.kt
@@ -13,12 +13,14 @@ import org.jetbrains.kotlin.cli.pipeline.metadata.MetadataFrontendPipelineArtifa
 import org.jetbrains.kotlin.cli.pipeline.metadata.MetadataInMemorySerializationArtifact
 import org.jetbrains.kotlin.cli.pipeline.metadata.MetadataKlibInMemorySerializerPhase
 import org.jetbrains.kotlin.config.commonFragmentsOutputDir
+import org.jetbrains.kotlin.config.icMetadataTracker
 import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.pipeline.AllModulesFrontendOutput
 import org.jetbrains.kotlin.library.SerializedFirMetadata
 import org.jetbrains.kotlin.library.components.KlibMetadataComponentLayout
 import org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf
 import org.jetbrains.kotlin.library.metadata.parseModuleHeader
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.notExists
 import kotlin.io.path.readBytes
@@ -46,11 +48,22 @@ internal object JvmSerializeCommonMetadataPipelinePhase : PipelinePhase<JvmFront
                 sourceFiles = input.sourceFiles,
             )
 
-            val destinationDir = outputDir.resolve(output.session.moduleData.name.asStringStripSpecialMarkers())
+            val moduleName = output.session.moduleData.name.asStringStripSpecialMarkers()
+            val destinationDir = outputDir.resolve(moduleName)
+
+            val serializedMetadata = MetadataKlibInMemorySerializerPhase.executePhase(inputForPhase)
+
+            configuration.icMetadataTracker?.let { metadataTracker ->
+                serializedMetadata.firMetadata.fragments.flatten().forEach { firFile ->
+                    // Fragments without a source path come from content generated for compiler plugins. We intentionally
+                    // don't track them: IC always marks such generated files as dirty before compilation, so their
+                    // metadata is regenerated on every round and never needs to be restored from the cache.
+                    firFile.path?.let { metadataTracker.report(moduleName, File(it), firFile.content) }
+                }
+            }
 
             val metadataInMemory =
-                MetadataKlibInMemorySerializerPhase.executePhase(inputForPhase)
-                    .mergeMetadataHeader(loadPreviousMetadataHeader(destinationDir.toPath()))
+                serializedMetadata.mergeMetadataHeader(loadPreviousMetadataHeader(destinationDir.toPath()))
 
             JvmMetadataKlibFileWriterPhase.writeToDisc(
                 metadataInMemory,

--- a/compiler/config.jvm/gen/org/jetbrains/kotlin/config/JVMConfigurationKeys.kt
+++ b/compiler/config.jvm/gen/org/jetbrains/kotlin/config/JVMConfigurationKeys.kt
@@ -13,6 +13,7 @@ package org.jetbrains.kotlin.config
  */
 
 import java.io.File
+import org.jetbrains.kotlin.incremental.components.ICJvmMetadataTracker
 import org.jetbrains.kotlin.load.kotlin.incremental.components.IncrementalCompilationComponents
 import org.jetbrains.kotlin.modules.Module
 
@@ -178,6 +179,10 @@ object JVMConfigurationKeys {
     // Path to outputs of common fragments metadata for KMP JVM IC
     @JvmField
     val COMMON_FRAGMENTS_OUTPUT_DIR = CompilerConfigurationKey.create<File>("COMMON_FRAGMENTS_OUTPUT_DIR")
+
+    // Tracks generated in-module JVM metadata for KMP JVM IC
+    @JvmField
+    val IC_METADATA_TRACKER = CompilerConfigurationKey.create<ICJvmMetadataTracker>("IC_METADATA_TRACKER")
 
 }
 
@@ -372,4 +377,8 @@ var CompilerConfiguration.ignoredAnnotationsForBridges: List<String>
 var CompilerConfiguration.commonFragmentsOutputDir: File?
     get() = get(JVMConfigurationKeys.COMMON_FRAGMENTS_OUTPUT_DIR)
     set(value) { putIfNotNull(JVMConfigurationKeys.COMMON_FRAGMENTS_OUTPUT_DIR, value) }
+
+var CompilerConfiguration.icMetadataTracker: ICJvmMetadataTracker?
+    get() = get(JVMConfigurationKeys.IC_METADATA_TRACKER)
+    set(value) { putIfNotNull(JVMConfigurationKeys.IC_METADATA_TRACKER, value) }
 

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/JvmConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/JvmConfigurationKeysContainer.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.config.keys.generator
 
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.config.keys.generator.model.KeysContainer
+import org.jetbrains.kotlin.incremental.components.ICJvmMetadataTracker
 import org.jetbrains.kotlin.load.kotlin.incremental.components.IncrementalCompilationComponents
 import org.jetbrains.kotlin.modules.Module
 import java.io.File
@@ -61,4 +62,5 @@ object JvmConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.confi
     val WHEN_GENERATION_SCHEME by key<JvmWhenGenerationScheme>("Specifies generation scheme for type-checking 'when' expressions.")
     val IGNORED_ANNOTATIONS_FOR_BRIDGES by key<List<String>>("Annotations fqNames that shall be skipped while copying the annotations from the target to the bridge functions.")
     val COMMON_FRAGMENTS_OUTPUT_DIR by key<File>("Path to outputs of common fragments metadata for KMP JVM IC", throwOnNull = false)
+    val IC_METADATA_TRACKER by key<ICJvmMetadataTracker>("Tracks generated in-module JVM metadata for KMP JVM IC", throwOnNull = false)
 }

--- a/compiler/daemon/daemon-client/src/main/kotlin/CompilerCallbackServicesFacadeServer.kt
+++ b/compiler/daemon/daemon-client/src/main/kotlin/CompilerCallbackServicesFacadeServer.kt
@@ -69,6 +69,9 @@ open class CompilerCallbackServicesFacadeServer(
     override fun incrementalCache_getModuleMappingData(target: TargetId): ByteArray? =
         incrementalCompilationComponents!!.getIncrementalCache(target).getModuleMappingData()
 
+    override fun incrementalCache_getMetadata(target: TargetId, fragmentName: String): Map<File, ByteArray> =
+        incrementalCompilationComponents!!.getIncrementalCache(target).getMetadata(fragmentName)
+
     // todo: remove (the method it called was relevant only for old IC)
     override fun incrementalCache_registerInline(target: TargetId, fromPath: String, jvmSignature: String, toPath: String) {
     }

--- a/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompilerCallbackServicesFacade.kt
+++ b/compiler/daemon/daemon-common/src/org/jetbrains/kotlin/daemon/common/CompilerCallbackServicesFacade.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.daemon.common
 import org.jetbrains.kotlin.incremental.components.LookupInfo
 import org.jetbrains.kotlin.load.kotlin.incremental.components.JvmPackagePartProto
 import org.jetbrains.kotlin.modules.TargetId
+import java.io.File
 import java.io.Serializable
 import java.rmi.Remote
 import java.rmi.RemoteException
@@ -64,6 +65,9 @@ interface CompilerCallbackServicesFacade : Remote {
 
     @Throws(RemoteException::class)
     fun incrementalCache_getModuleMappingData(target: TargetId): ByteArray?
+
+    @Throws(RemoteException::class)
+    fun incrementalCache_getMetadata(target: TargetId, fragmentName: String): Map<File, ByteArray>
 
     @Throws(RemoteException::class)
     fun incrementalCache_registerInline(target: TargetId, fromPath: String, jvmSignature: String, toPath: String)

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCacheClient.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/RemoteIncrementalCacheClient.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.daemon.common.withMeasure
 import org.jetbrains.kotlin.load.kotlin.incremental.components.IncrementalCache
 import org.jetbrains.kotlin.load.kotlin.incremental.components.JvmPackagePartProto
 import org.jetbrains.kotlin.modules.TargetId
+import java.io.File
 
 class RemoteIncrementalCacheClient(
     @Suppress("DEPRECATION") val facade: org.jetbrains.kotlin.daemon.common.CompilerCallbackServicesFacade,
@@ -37,6 +38,8 @@ class RemoteIncrementalCacheClient(
     override fun getPackagePartData(partInternalName: String): JvmPackagePartProto? = profiler.withMeasure(this) { facade.incrementalCache_getPackagePartData(target, partInternalName) }
 
     override fun getModuleMappingData(): ByteArray? = profiler.withMeasure(this) { facade.incrementalCache_getModuleMappingData(target) }
+
+    override fun getMetadata(fragmentName: String): Map<File, ByteArray> = profiler.withMeasure(this) { facade.incrementalCache_getMetadata(target, fragmentName) }
 
     override fun getClassFilePath(internalClassName: String): String = profiler.withMeasure(this) { facade.incrementalCache_getClassFilePath(target,internalClassName) }
 

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunnerBase.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunnerBase.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.config.Services
 import org.jetbrains.kotlin.incremental.DifferenceCalculatorForPackageFacade.Companion.getVisibleTypeAliasFqNames
 import org.jetbrains.kotlin.incremental.components.ExpectActualTracker
 import org.jetbrains.kotlin.incremental.components.ICFileMappingTracker
+import org.jetbrains.kotlin.incremental.components.ICJvmMetadataTracker
 import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.incremental.components.SubtypeTracker
 import org.jetbrains.kotlin.incremental.javaInterop.JavaInteropCoordinator
@@ -97,7 +98,8 @@ abstract class IncrementalJvmCompilerRunnerBase(
         updateIncrementalCache(
             generatedFiles, caches.platformCache, changesCollector,
             @OptIn(K1Deprecation::class)
-            services[JavaClassesTracker::class.java] as? JavaClassesTrackerImpl
+            services[JavaClassesTracker::class.java] as? JavaClassesTrackerImpl,
+            services[ICJvmMetadataTracker::class.java] as? ICJvmMetadataTrackerImpl
         )
     }
 
@@ -183,6 +185,7 @@ abstract class IncrementalJvmCompilerRunnerBase(
             val targetToCache = mapOf(targetId to caches.platformCache)
             val incrementalComponents = IncrementalCompilationComponentsImpl(targetToCache)
             register(IncrementalCompilationComponents::class.java, incrementalComponents)
+            register(ICJvmMetadataTracker::class.java, ICJvmMetadataTrackerImpl())
             @OptIn(K1Deprecation::class)
             javaInteropCoordinator.makeJavaClassesTracker(caches.platformCache)?.let {
                 register(JavaClassesTracker::class.java, it)

--- a/compiler/util/src/org/jetbrains/kotlin/load/kotlin/incremental/components/IncrementalCache.kt
+++ b/compiler/util/src/org/jetbrains/kotlin/load/kotlin/incremental/components/IncrementalCache.kt
@@ -16,6 +16,7 @@
 
 package org.jetbrains.kotlin.load.kotlin.incremental.components
 
+import java.io.File
 import java.io.Serializable
 
 data class JvmPackagePartProto(val data: ByteArray, val strings: Array<String>) : Serializable
@@ -30,6 +31,8 @@ interface IncrementalCache {
     fun getPackagePartData(partInternalName: String): JvmPackagePartProto?
 
     fun getModuleMappingData(): ByteArray?
+
+    fun getMetadata(fragmentName: String): Map<File, ByteArray>
 
     fun getClassFilePath(internalClassName: String): String
 

--- a/core/compiler.common/src/org/jetbrains/kotlin/incremental/components/ICJvmMetadataTracker.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/incremental/components/ICJvmMetadataTracker.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.incremental.components
+
+import java.io.File
+
+interface ICJvmMetadataTracker {
+    fun report(fragmentName: String, sourceFile: File, metadata: ByteArray)
+
+    object DoNothing : ICJvmMetadataTracker {
+        override fun report(fragmentName: String, sourceFile: File, metadata: ByteArray) {
+        }
+    }
+}

--- a/jps/jps-plugin/src/org/jetbrains/kotlin/jps/targets/KotlinJvmModuleBuildTarget.kt
+++ b/jps/jps-plugin/src/org/jetbrains/kotlin/jps/targets/KotlinJvmModuleBuildTarget.kt
@@ -351,7 +351,7 @@ class KotlinJvmModuleBuildTarget(kotlinContext: KotlinCompileContext, jpsModuleB
     ) {
         super.updateCaches(dirtyFilesHolder, jpsIncrementalCache, files, changesCollector, environment)
 
-        updateIncrementalCache(files, jpsIncrementalCache as IncrementalJvmCache, changesCollector, null)
+        updateIncrementalCache(files, jpsIncrementalCache as IncrementalJvmCache, changesCollector, null, null)
     }
 
     override val globalLookupCacheId: String


### PR DESCRIPTION
This PR adds support for storing and reading metadata in the incremental cache. At the moment, the implementation simply persists and retrieves the data without using it. The metadata will be consumed by the IC provider, which will be implemented in a follow-up PR.