### PR TITLE
[IR] Fixed an annotation check problem with unbound symbols

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/AdditionalIrUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/AdditionalIrUtils.kt
@@ -187,7 +187,12 @@ fun IrClassSymbol.hasEqualClassId(classId: ClassId): Boolean {
     }
 }
 
-fun List<IrAnnotation>.hasAnnotation(classId: ClassId): Boolean = any { it.classId == classId }
+fun List<IrAnnotation>.hasAnnotation(classId: ClassId): Boolean =
+    // Note: check can be simplified to just classId comparison after IrAnnotation node migration is complete KT-74200.
+    hasAnnotation(
+        // Getting classId from an unbound annotation will throw an exception, go along the path where this is worked around.
+        classId.asSingleFqName()
+    )
 
 fun List<IrAnnotation>.hasAnnotation(fqName: FqName): Boolean =
     any { it.isAnnotationWithEqualFqName(fqName) }


### PR DESCRIPTION
Checking if an IR element has a certain annotation used to take `classId` off of it. But the annotation might be unbound, and it was worked around earlier for a function taking `fqName` as an argument.

This commit just calls the same function converting the passed `classId` to `FqName` first.

 #KQA-3132