### PR TITLE
[IC][KMP] Add -Xuse-ic-classpath-metadata for JVM classpath metadata IC

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -9792,6 +9792,51 @@
                                 "deprecatedMessage": null
                             },
                             {
+                                "name": "Xuse-ic-classpath-metadata",
+                                "shortName": null,
+                                "deprecatedName": null,
+                                "description": {
+                                    "current": "Use classpath metadata for incremental compilation.\nThis is used solely for incremental compilation and should not be used directly.",
+                                    "valueInVersions": []
+                                },
+                                "delimiter": null,
+                                "affectsCompilationOutcome": true,
+                                "restrictedToCompilerPhase": null,
+                                "valueType": {
+                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                    "isNullable": {
+                                        "current": false,
+                                        "valueInVersions": []
+                                    },
+                                    "defaultValue": {
+                                        "current": false,
+                                        "valueInVersions": []
+                                    }
+                                },
+                                "valueDescription": {
+                                    "current": null,
+                                    "valueInVersions": []
+                                },
+                                "releaseVersionsMetadata": {
+                                    "introducedVersion": "2.5.0",
+                                    "stabilizedVersion": null,
+                                    "deprecatedVersion": null,
+                                    "removedVersion": null
+                                },
+                                "argumentType": {
+                                    "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",
+                                    "isNullable": {
+                                        "current": false,
+                                        "valueInVersions": []
+                                    },
+                                    "defaultValue": {
+                                        "current": false,
+                                        "valueInVersions": []
+                                    }
+                                },
+                                "deprecatedMessage": null
+                            },
+                            {
                                 "name": "Xuse-inline-scopes-numbers",
                                 "shortName": null,
                                 "deprecatedName": null,

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/JvmCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/JvmCompilerArguments.kt
@@ -1007,6 +1007,19 @@ The default value is 'inline'.""",
     }
 
     compilerArgument {
+        name = "Xuse-ic-classpath-metadata"
+        description = """
+            Use classpath metadata for incremental compilation.
+            This is used solely for incremental compilation and should not be used directly.
+        """.trimIndent().asReleaseDependent()
+        valueType = BooleanType.defaultFalse
+
+        lifecycle(
+            introducedVersion = KotlinReleaseVersion.v2_5_0,
+        )
+    }
+
+    compilerArgument {
         name = "Xjava-direct"
         description = "Experimental direct java support.".asReleaseDependent()
         valueType = BooleanType.defaultFalse

--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/argumentTransforms.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/argumentTransforms.kt
@@ -126,6 +126,7 @@ private val levelsToArgumentTransforms: Map<String, Map<String, ArgumentTransfor
 
             // KMP related
             drop("Xcommon-fragments-metadata-destination")
+            drop("Xuse-ic-classpath-metadata")
         }
         with(removedJvmCompilerArguments) {
             drop("Xuse-javac")

--- a/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/gen/org/jetbrains/kotlin/buildtools/internal/arguments/JvmCompilerArgumentsImpl.kt
@@ -104,6 +104,7 @@ import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArgumentsImpl.Companion.X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArgumentsImpl.Companion.X_USE_14_INLINE_CLASSES_MANGLING_SCHEME
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArgumentsImpl.Companion.X_USE_FAST_JAR_FILE_SYSTEM
+import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArgumentsImpl.Companion.X_USE_IC_CLASSPATH_METADATA
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArgumentsImpl.Companion.X_USE_INLINE_SCOPES_NUMBERS
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArgumentsImpl.Companion.X_USE_JAVAC
 import org.jetbrains.kotlin.buildtools.`internal`.arguments.JvmCompilerArgumentsImpl.Companion.X_USE_K2_KAPT
@@ -251,6 +252,7 @@ internal class JvmCompilerArgumentsImpl(
     if (X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE in this) { arguments.typeEnhancementImprovementsInStrictMode = get(X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE)}
     if (X_USE_14_INLINE_CLASSES_MANGLING_SCHEME in this) { arguments.useOldInlineClassesManglingScheme = get(X_USE_14_INLINE_CLASSES_MANGLING_SCHEME)}
     if (X_USE_FAST_JAR_FILE_SYSTEM in this) { arguments.useFastJarFileSystem = get(X_USE_FAST_JAR_FILE_SYSTEM)}
+    if (X_USE_IC_CLASSPATH_METADATA in this) { arguments.useIcClasspathMetadata = get(X_USE_IC_CLASSPATH_METADATA)}
     if (X_USE_INLINE_SCOPES_NUMBERS in this) { arguments.useInlineScopesNumbers = get(X_USE_INLINE_SCOPES_NUMBERS)}
     try { if (X_USE_JAVAC in this) { arguments.setUsingReflection("useJavac", get(X_USE_JAVAC))} } catch (e: NoSuchMethodError) { throw IllegalStateException("""Compiler parameter not recognized: X_USE_JAVAC. Current compiler version is: $KC_VERSION, but the argument was removed in 2.4.0""").initCause(e) }
     try { if (X_USE_K2_KAPT in this) { arguments.setUsingReflection("useK2Kapt", get(X_USE_K2_KAPT))} } catch (e: NoSuchMethodError) { throw IllegalStateException("""Compiler parameter not recognized: X_USE_K2_KAPT. Current compiler version is: $KC_VERSION, but the argument was removed in 2.3.0""").initCause(e) }
@@ -341,6 +343,7 @@ internal class JvmCompilerArgumentsImpl(
     try { this[X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE] = arguments.typeEnhancementImprovementsInStrictMode } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_14_INLINE_CLASSES_MANGLING_SCHEME] = arguments.useOldInlineClassesManglingScheme } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_FAST_JAR_FILE_SYSTEM] = arguments.useFastJarFileSystem } catch (_: NoSuchMethodError) {  }
+    try { this[X_USE_IC_CLASSPATH_METADATA] = arguments.useIcClasspathMetadata } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_INLINE_SCOPES_NUMBERS] = arguments.useInlineScopesNumbers } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_JAVAC] = arguments.getUsingReflection<Boolean>("useJavac") } catch (_: NoSuchMethodError) {  }
     try { this[X_USE_K2_KAPT] = arguments.getUsingReflection<Boolean?>("useK2Kapt") } catch (_: NoSuchMethodError) {  }
@@ -428,6 +431,7 @@ internal class JvmCompilerArgumentsImpl(
     if (X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE in this) { arguments.typeEnhancementImprovementsInStrictMode = get(X_TYPE_ENHANCEMENT_IMPROVEMENTS_STRICT_MODE)}
     if (X_USE_14_INLINE_CLASSES_MANGLING_SCHEME in this) { arguments.useOldInlineClassesManglingScheme = get(X_USE_14_INLINE_CLASSES_MANGLING_SCHEME)}
     if (X_USE_FAST_JAR_FILE_SYSTEM in this) { arguments.useFastJarFileSystem = get(X_USE_FAST_JAR_FILE_SYSTEM)}
+    if (X_USE_IC_CLASSPATH_METADATA in this) { arguments.useIcClasspathMetadata = get(X_USE_IC_CLASSPATH_METADATA)}
     if (X_USE_INLINE_SCOPES_NUMBERS in this) { arguments.useInlineScopesNumbers = get(X_USE_INLINE_SCOPES_NUMBERS)}
     try { if (X_USE_JAVAC in this) { arguments.setUsingReflection("useJavac", get(X_USE_JAVAC))} } catch (e: NoSuchMethodError) { throw IllegalStateException("""Compiler parameter not recognized: X_USE_JAVAC. Current compiler version is: $KC_VERSION, but the argument was removed in 2.4.0""").initCause(e) }
     try { if (X_USE_K2_KAPT in this) { arguments.setUsingReflection("useK2Kapt", get(X_USE_K2_KAPT))} } catch (e: NoSuchMethodError) { throw IllegalStateException("""Compiler parameter not recognized: X_USE_K2_KAPT. Current compiler version is: $KC_VERSION, but the argument was removed in 2.3.0""").initCause(e) }
@@ -658,6 +662,9 @@ internal class JvmCompilerArgumentsImpl(
 
     public val X_USE_FAST_JAR_FILE_SYSTEM: JvmCompilerArgument<Boolean?> =
         JvmCompilerArgument("X_USE_FAST_JAR_FILE_SYSTEM")
+
+    public val X_USE_IC_CLASSPATH_METADATA: JvmCompilerArgument<Boolean> =
+        JvmCompilerArgument("X_USE_IC_CLASSPATH_METADATA")
 
     public val X_USE_INLINE_SCOPES_NUMBERS: JvmCompilerArgument<Boolean> =
         JvmCompilerArgument("X_USE_INLINE_SCOPES_NUMBERS")

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
@@ -641,6 +641,17 @@ See KT-45671 for more details.""",
         }
 
     @Argument(
+        value = "-Xuse-ic-classpath-metadata",
+        description = """Use classpath metadata for incremental compilation.
+This is used solely for incremental compilation and should not be used directly.""",
+    )
+    var useIcClasspathMetadata: Boolean = false
+        set(value) {
+            checkFrozen()
+            field = value
+        }
+
+    @Argument(
         value = "-Xuse-inline-scopes-numbers",
         description = "Use inline scopes numbers for inline marker variables.",
     )

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArgumentsCopyGenerated.kt
@@ -78,6 +78,7 @@ fun copyK2JVMCompilerArguments(from: K2JVMCompilerArguments, to: K2JVMCompilerAr
     to.suppressMissingBuiltinsError = from.suppressMissingBuiltinsError
     to.typeEnhancementImprovementsInStrictMode = from.typeEnhancementImprovementsInStrictMode
     to.useFastJarFileSystem = from.useFastJarFileSystem
+    to.useIcClasspathMetadata = from.useIcClasspathMetadata
     to.useInlineScopesNumbers = from.useInlineScopesNumbers
     to.useOldClassFilesReading = from.useOldClassFilesReading
     to.useOldInlineClassesManglingScheme = from.useOldInlineClassesManglingScheme

--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/jvm/jvmArguments.kt
@@ -148,6 +148,7 @@ fun CompilerConfiguration.setupJvmSpecificArguments(arguments: K2JVMCompilerArgu
     put(JVMConfigurationKeys.IGNORED_ANNOTATIONS_FOR_BRIDGES, arguments.ignoredAnnotationsForBridges?.toList().orEmpty())
     arguments.commonFragmentsMetadataDestination?.let { commonFragmentsOutputDir = File(it) }
 
+    put(JVMConfigurationKeys.USE_IC_CLASSPATH_METADATA, arguments.useIcClasspathMetadata)
     put(JVMConfigurationKeys.USE_JAVA_DIRECT, arguments.javaDirect)
 }
 

--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmFrontendPipelinePhase.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmFrontendPipelinePhase.kt
@@ -351,7 +351,7 @@ object JvmFrontendPipelinePhase : PipelinePhase<ConfigurationPipelineArtifact, J
          *   but worked to some extent in some scenarios while the proper implementation is in development. It should be removed
          *   together with `if()` in the lambda below once we will get the full support of IC for KMP.
          */
-        val isKmpCompilationWithLegacyIC = configuration.hmppModuleStructure?.incrementalDependencies?.isEmpty() == true
+        val isKmpCompilationWithLegacyIC = !configuration.useIcClasspathMetadata
         var firJvmIncrementalCompilationSymbolProviders: FirJvmIncrementalCompilationSymbolProviders? = null
         var firJvmIncrementalCompilationSymbolProvidersIsInitialized = false
 

--- a/compiler/config.jvm/gen/org/jetbrains/kotlin/config/JVMConfigurationKeys.kt
+++ b/compiler/config.jvm/gen/org/jetbrains/kotlin/config/JVMConfigurationKeys.kt
@@ -180,6 +180,10 @@ object JVMConfigurationKeys {
     @JvmField
     val IC_METADATA_TRACKER = CompilerConfigurationKey.create<ICJvmMetadataTracker>("IC_METADATA_TRACKER")
 
+    // Enable classpath metadata for KMP incremental compilation
+    @JvmField
+    val USE_IC_CLASSPATH_METADATA = CompilerConfigurationKey.create<Boolean>("USE_IC_CLASSPATH_METADATA")
+
     // Use java-direct as frontend Java facade
     @JvmField
     val USE_JAVA_DIRECT = CompilerConfigurationKey.create<Boolean>("USE_JAVA_DIRECT")
@@ -377,6 +381,10 @@ var CompilerConfiguration.commonFragmentsOutputDir: File?
 var CompilerConfiguration.icMetadataTracker: ICJvmMetadataTracker?
     get() = get(JVMConfigurationKeys.IC_METADATA_TRACKER)
     set(value) { putIfNotNull(JVMConfigurationKeys.IC_METADATA_TRACKER, value) }
+
+var CompilerConfiguration.useIcClasspathMetadata: Boolean
+    get() = getBoolean(JVMConfigurationKeys.USE_IC_CLASSPATH_METADATA)
+    set(value) { put(JVMConfigurationKeys.USE_IC_CLASSPATH_METADATA, value) }
 
 var CompilerConfiguration.useJavaDirect: Boolean
     get() = getBoolean(JVMConfigurationKeys.USE_JAVA_DIRECT)

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/JvmConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/JvmConfigurationKeysContainer.kt
@@ -62,5 +62,6 @@ object JvmConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.confi
     val IGNORED_ANNOTATIONS_FOR_BRIDGES by key<List<String>>("Annotations fqNames that shall be skipped while copying the annotations from the target to the bridge functions.")
     val COMMON_FRAGMENTS_OUTPUT_DIR by key<File>("Path to outputs of common fragments metadata for KMP JVM IC", throwOnNull = false)
     val IC_METADATA_TRACKER by key<ICJvmMetadataTracker>("Tracks generated in-module JVM metadata for KMP JVM IC", throwOnNull = false)
+    val USE_IC_CLASSPATH_METADATA by key<Boolean>("Enable classpath metadata for KMP incremental compilation")
     val USE_JAVA_DIRECT by key<Boolean>("Use java-direct as frontend Java facade")
 }

--- a/compiler/testData/cli/jvm/extraHelp.out
+++ b/compiler/testData/cli/jvm/extraHelp.out
@@ -135,6 +135,8 @@ where advanced options include:
   -Xuse-14-inline-classes-mangling-scheme
                              Use the scheme for inline class mangling from version 1.4 instead of the one from 1.4.30.
   -Xuse-fast-jar-file-system Use the fast implementation of Jar FS. This may speed up compilation time, but it is experimental.
+  -Xuse-ic-classpath-metadata Use classpath metadata for incremental compilation.
+                             This is used solely for incremental compilation and should not be used directly.
   -Xuse-inline-scopes-numbers Use inline scopes numbers for inline marker variables.
   -Xuse-old-class-files-reading Use the old implementation for reading class files. This may slow down the compilation and cause problems with Groovy interop.
                              This can be used in the event of problems with the new implementation.

--- a/compiler/tests-integration/tests/org/jetbrains/kotlin/cli/LauncherScriptTest.kt
+++ b/compiler/tests-integration/tests/org/jetbrains/kotlin/cli/LauncherScriptTest.kt
@@ -781,6 +781,7 @@ Caused by: java.lang.AssertionError: assert
             K2JVMCompilerArguments::multiPlatform.cliArgument,
             K2JVMCompilerArguments::expectActualClasses.cliArgument,
             K2JVMCompilerArguments::incrementalCompilation.cliArgument,
+            K2JVMCompilerArguments::useIcClasspathMetadata.cliArgument,
             K2JVMCompilerArguments::fragments.cliArgument("common,platform"),
             K2JVMCompilerArguments::fragmentSources.cliArgument("common:${newCommonKt.absolutePath}"),
             K2JVMCompilerArguments::fragmentRefines.cliArgument("platform:common"),
@@ -792,6 +793,47 @@ Caused by: java.lang.AssertionError: assert
                     x.bar() // should not be visible
                       ^^^
             """.trimIndent()
+        )
+    }
+
+    /*
+     * Positive counterpart of [testDummyFragmentIncrementalClasspathTest]: with -Xuse-ic-classpath-metadata
+     * the new classpath-metadata IC symbol-provider path is used. Here the leaf `platform` fragment is recompiled
+     * incrementally against the previously produced common metadata (which supplies the `expect class Some`). Since
+     * the `common` fragment is provided as metadata on the incremental classpath rather than recompiled, the expect
+     * declaration resolves correctly and the `actual` platform code compiles successfully.
+     */
+    @Test
+    fun testFragmentIncrementalClasspathWithClasspathMetadata() {
+        val metadataDir = compileSimpleCommonPlatformProject()
+        val newPlatformKt = tmpdir.resolve("new-platform.kt").apply {
+            writeText(
+                """
+                    actual class Some {
+                        actual fun foo() {} // actualizes the expect `Some.foo` supplied by common metadata
+
+                        fun bar() {}
+                    }
+                """.trimIndent()
+            )
+        }
+        val newClassesDir = tmpdir.resolve("new-classes")
+        runProcess(
+            "kotlinc-jvm",
+            newPlatformKt.absolutePath,
+            K2JVMCompilerArguments::destination.cliArgument, newClassesDir.absolutePath,
+            K2JVMCompilerArguments::multiPlatform.cliArgument,
+            K2JVMCompilerArguments::expectActualClasses.cliArgument,
+            K2JVMCompilerArguments::incrementalCompilation.cliArgument,
+            K2JVMCompilerArguments::useIcClasspathMetadata.cliArgument,
+            K2JVMCompilerArguments::fragments.cliArgument("common,platform"),
+            K2JVMCompilerArguments::fragmentSources.cliArgument("platform:${newPlatformKt.absolutePath}"),
+            K2JVMCompilerArguments::fragmentRefines.cliArgument("platform:common"),
+            K2JVMCompilerArguments::fragmentIncrementalClasspath.cliArgument("common:${metadataDir.resolve("common").absolutePath}"),
+
+            expectedExitCode = 0,
+            expectedStdout = "",
+            expectedStderr = "",
         )
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
@@ -303,8 +303,9 @@ abstract class KotlinCompile @Inject constructor(
     }
 
     private fun K2JVMCompilerArguments.applyJvmClasspathMetadata() {
-        val metadataJvmDestinationFile = taskBuildCacheableOutputDirectory.file("metadata-jvm").get().asFile
+        useIcClasspathMetadata = true
 
+        val metadataJvmDestinationFile = taskBuildCacheableOutputDirectory.file("metadata-jvm").get().asFile
         commonFragmentsMetadataDestination = metadataJvmDestinationFile.absolutePath
         if (metadataJvmDestinationFile.exists()) {
             fragmentIncrementalClasspath = metadataJvmDestinationFile


### PR DESCRIPTION
The previous PR added support for storing and reading metadata in the incremental cache. With metadata now loaded directly from the cache rather than the file system, `-Xcommon-fragments-metadata-destination` and `-Xfragment-incremental-classpath` become obsolete and will be removed in a follow-up PR.

However, we still need a feature gate to preserve the previous (although incorrect) incremental compilation behavior, as some consumers currently rely on it. This PR introduces a new compiler argument that serves as that gate.