### PR TITLE
[FIR] Pass UsageState.UnusedFromCoercion only for last statement in lambda block.

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirUnusedCheckerBase.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirUnusedCheckerBase.kt
@@ -117,8 +117,7 @@ abstract class FirUnusedCheckerBase : FirBasicDeclarationChecker(MppCheckerKind.
             for (i in statements.indices) {
                 val statement = statements[i]
                 val isUsed = when {
-                    block.isUnitCoerced -> UsageState.UnusedFromCoercion
-                    i == lastIndex -> data // is implicit return
+                    i == lastIndex -> if (block.isUnitCoerced) UsageState.UnusedFromCoercion else data // is implicit return
                     else -> UsageState.Unused
                 }
                 statement.accept(this, isUsed)

--- a/compiler/testData/diagnostics/tests/crv/lambdas.kt
+++ b/compiler/testData/diagnostics/tests/crv/lambdas.kt
@@ -25,7 +25,7 @@ fun main() {
         stringF() // used
     }
     unitLambda {
-        <!RETURN_VALUE_NOT_USED_COERCION!>stringF<!>() // unused because not the last statement
+        <!RETURN_VALUE_NOT_USED!>stringF<!>() // unused because not the last statement
         <!RETURN_VALUE_NOT_USED_COERCION!>stringF<!>()
     }
     <!RETURN_VALUE_NOT_USED!>stringLambdaReturns<!> {


### PR DESCRIPTION
For all other statements, regular `.Unused` should be passed instead.

#KT-87775 Fixed