### PR TITLE
KT-67440 [AFU] Enforce initialization order between delegate and backing field

### DIFF
--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuTransformer.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuTransformer.kt
@@ -128,41 +128,67 @@ abstract class AbstractAtomicfuTransformer(
         }
     }
 
+    internal class DeclarationsWorklist {
+        private val toRemove: MutableList<IrDeclaration> = mutableListOf()
+        private val toInsertOrdered: MutableList<OrderedInsertion> = mutableListOf()
+
+        private data class OrderedInsertion(val toInsert: IrDeclaration, val before: IrDeclaration)
+
+        fun removeDeclaration(declaration: IrDeclaration) {
+            toRemove.add(declaration)
+        }
+
+        fun insertBefore(toInsert: IrDeclaration, before: IrDeclaration) {
+            toInsertOrdered.add(OrderedInsertion(toInsert, before))
+        }
+
+        fun applyUpdates(declarations: MutableList<IrDeclaration>) {
+            toInsertOrdered.forEach { (toInsert, before) ->
+                val idx = declarations.indexOf(before)
+                check(idx >= 0) {
+                    "Declaration was not found: ${before.render()}\nIt is required to insert ${toInsert.render()}"
+                }
+                declarations.add(idx, toInsert)
+            }
+            declarations.removeAll(toRemove)
+        }
+    }
+
     abstract inner class AtomicPropertiesTransformer : IrTransformer<IrFunction?>() {
 
         override fun visitClass(declaration: IrClass, data: IrFunction?): IrStatement {
-            val declarationsToBeRemoved = mutableListOf<IrDeclaration>()
+            val worklist = DeclarationsWorklist()
             declaration.declarations.withIndex().filter { it.value.isAtomicfuTypeProperty() }.forEach {
-                transformAtomicProperty(it.value as IrProperty, it.index, declarationsToBeRemoved)
+                transformAtomicProperty(it.value as IrProperty, it.index, worklist)
             }
-            declaration.declarations.removeAll(declarationsToBeRemoved)
+            worklist.applyUpdates(declaration.declarations)
             return super.visitClass(declaration, data)
         }
 
         override fun visitFile(declaration: IrFile, data: IrFunction?): IrFile {
-            val declarationsToBeRemoved = mutableListOf<IrDeclaration>()
+            val worklist = DeclarationsWorklist()
             declaration.declarations.withIndex().filter { it.value.isAtomicfuTypeProperty() }.forEach {
-                transformAtomicProperty(it.value as IrProperty, it.index, declarationsToBeRemoved)
+                transformAtomicProperty(it.value as IrProperty, it.index, worklist)
             }
-            declaration.declarations.removeAll(declarationsToBeRemoved)
+            worklist.applyUpdates(declaration.declarations)
             return super.visitFile(declaration, data)
         }
 
-        private fun transformAtomicProperty(atomicfuProperty: IrProperty, index: Int, declarationsToBeRemoved: MutableList<IrDeclaration>) {
+        private fun transformAtomicProperty(atomicfuProperty: IrProperty, index: Int, worklist: DeclarationsWorklist) {
             if (atomicfuProperty.backingField == null) {
                 error("Atomic property should have a backing field: ${atomicfuProperty.render()}" + CONSTRAINTS_MESSAGE)
             }
             val parentContainer = atomicfuProperty.parents.firstIsInstance<IrDeclarationContainer>()
             val atomicHandler = createAtomicHandler(atomicfuProperty, parentContainer)?.also {
                 registerAtomicHandler(atomicfuProperty, it, index, parentContainer)
-                declarationsToBeRemoved.add(atomicfuProperty)
+                worklist.removeDeclaration(atomicfuProperty)
             }
             if (atomicHandler == null) {
                 if (atomicfuProperty.isDelegatedToAtomic()) {
-                    parentContainer.transformDelegatedAtomic(atomicfuProperty)
+                    parentContainer.transformDelegatedAtomic(atomicfuProperty, worklist)
                 }
                 if (atomicfuProperty.isTrace()) {
-                    declarationsToBeRemoved.add(atomicfuProperty)
+                    worklist.removeDeclaration(atomicfuProperty)
                 }
             }
         }
@@ -199,7 +225,7 @@ abstract class AbstractAtomicfuTransformer(
          *
          * NOTE: Delegation to atomic factory and mutable delegation properties will soon be deprecated: https://github.com/Kotlin/kotlinx-atomicfu/issues/463
          */
-        private fun IrDeclarationContainer.transformDelegatedAtomic(atomicProperty: IrProperty) {
+        private fun IrDeclarationContainer.transformDelegatedAtomic(atomicProperty: IrProperty, worklist: DeclarationsWorklist) {
             val parentContainer = this
             val getDelegate = atomicProperty.backingField?.initializer?.expression
             require(getDelegate is IrCall) {
@@ -215,7 +241,9 @@ abstract class AbstractAtomicfuTransformer(
                 getDelegate.isAtomicFactoryCall() -> {
                     val delegateVolatileField = with(atomicfuSymbols.createBuilder(atomicProperty.symbol)) {
                         buildVolatileField(atomicProperty, parentContainer).also {
-                            declarations.add(it)
+                            // The field has to be inserted before the property declaration to ensure that
+                            // the field initialization will happen before the property accesses.
+                            worklist.insertBefore(toInsert = it, before = atomicProperty)
                         }
                     }
                     atomicProperty.getter?.delegateToVolatileAccessors(delegateVolatileField)

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/delegated/InitializationOrderTest.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/delegated/InitializationOrderTest.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/delegated/InitializationOrderTest.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/delegated/InitializationOrderTest.kt
@@ -1,0 +1,29 @@
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+class Delegator {
+    private val a = atomic("")
+    private var d: String by atomic("")
+
+    private val b = atomic(0)
+    private var bDelegate: Int by b
+
+    init {
+        d = "initialized"
+        a.value = "initialized"
+        bDelegate = -1
+        b.value = 42
+    }
+
+    fun test() {
+        assertEquals("initialized", d)
+        assertEquals("initialized", a.value)
+        assertEquals(42, b.value)
+        assertEquals(42, bDelegate)
+    }
+}
+
+fun box(): String {
+    Delegator().test()
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/delegated/InitializationOrderTest.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/delegated/InitializationOrderTest.txt
@@ -1,0 +1,28 @@
+@kotlin.Metadata
+public final class Delegator {
+    // source: 'InitializationOrderTest.kt'
+    private synthetic final static field a$volatile$FU: java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+    private synthetic volatile field a$volatile: java.lang.Object
+    private synthetic final static field b$volatile$FU: java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    private synthetic volatile field b$volatile: int
+    private synthetic volatile field d$volatile: java.lang.Object
+    static method <clinit>(): void
+    public method <init>(): void
+    private synthetic final static method getA$volatile$FU(): java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+    private synthetic final method getA$volatile(): java.lang.Object
+    private synthetic final static method getB$volatile$FU(): java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    private synthetic final method getB$volatile(): int
+    private final method getBDelegate(): int
+    private final method getD(): java.lang.String
+    private synthetic final method setA$volatile(p0: java.lang.Object): void
+    private synthetic final method setB$volatile(p0: int): void
+    private final method setBDelegate(p0: int): void
+    private final method setD(p0: java.lang.String): void
+    public final method test(): void
+}
+
+@kotlin.Metadata
+public final class InitializationOrderTestKt {
+    // source: 'InitializationOrderTest.kt'
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+}

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -274,6 +274,12 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
     public void testDelegatedPropertiesTest() {
       run("DelegatedPropertiesTest.kt");
     }
+
+    @Test
+    @TestMetadata("InitializationOrderTest.kt")
+    public void testInitializationOrderTest() {
+      run("InitializationOrderTest.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
@@ -279,6 +279,12 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
     public void testDelegatedPropertiesTest() {
       run("DelegatedPropertiesTest.kt");
     }
+
+    @Test
+    @TestMetadata("InitializationOrderTest.kt")
+    public void testInitializationOrderTest() {
+      run("InitializationOrderTest.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
@@ -256,6 +256,12 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
     public void testDelegatedPropertiesTest() {
       run("DelegatedPropertiesTest.kt");
     }
+
+    @Test
+    @TestMetadata("InitializationOrderTest.kt")
+    public void testInitializationOrderTest() {
+      run("InitializationOrderTest.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
@@ -256,6 +256,12 @@ public class AtomicfuJsWithInlinedFunInKlibTestGenerated extends AbstractAtomicf
     public void testDelegatedPropertiesTest() {
       run("DelegatedPropertiesTest.kt");
     }
+
+    @Test
+    @TestMetadata("InitializationOrderTest.kt")
+    public void testInitializationOrderTest() {
+      run("InitializationOrderTest.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
@@ -256,6 +256,12 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
     public void testDelegatedPropertiesTest() {
       run("DelegatedPropertiesTest.kt");
     }
+
+    @Test
+    @TestMetadata("InitializationOrderTest.kt")
+    public void testInitializationOrderTest() {
+      run("InitializationOrderTest.kt");
+    }
   }
 
   @Nested

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -291,6 +291,12 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
     public void testDelegatedPropertiesTest() {
       run("DelegatedPropertiesTest.kt");
     }
+
+    @Test
+    @TestMetadata("InitializationOrderTest.kt")
+    public void testInitializationOrderTest() {
+      run("InitializationOrderTest.kt");
+    }
   }
 
   @Nested


### PR DESCRIPTION
For properties delegated by an atomic factory functions, the plugin generates a volatile backing and initializes it. If there's a consturctor writing a value to the property, the generated field's initialization can be inserted after it, effectively overriding the value initialized in constructor. This change orders a delegated property and a generated backing field declarations to ensure proper initialization order.

^KT-67440 fixed