### PR TITLE
Incremental compilation: fixed compilation on dependency removal

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -254,13 +254,17 @@ class CacheBuilder(
                     val actualContentHash = SerializedIrFileFingerprint(library, fileIndex).fileFingerprint
                     // Missing metadata (a cache produced by a compiler older than 2.2.20) means the file has to be rebuilt.
                     val previousContentHash = cache.getMetadataOrNull(cachedFile)?.hash
-                    if (previousContentHash != actualContentHash)
+                    // A recorded dependency on a library that is not among the resolved libraries anymore
+                    // (e.g. the module was removed from the project after the cache had been built, KT-61644)
+                    // also means the file has to be rebuilt (the cache references a missing library which would lead
+                    // to a linkage error otherwise); there is nothing to propagate through such an edge.
+                    val [knownDependencies, removedDependencies] = cache.getFileDependencies(cachedFile)
+                            .partition { it.libName in uniqueNameToLibrary }
+                    if (previousContentHash != actualContentHash || removedDependencies.isNotEmpty())
                         changedFiles.add(libraryFile)
 
-                    val dependencies = cache.getFileDependencies(cachedFile)
-                    for (dependency in dependencies) {
-                        val dependentLibrary = uniqueNameToLibrary[dependency.libName]
-                                ?: error("Unknown dependent library ${dependency.libName}")
+                    for (dependency in knownDependencies) {
+                        val dependentLibrary = uniqueNameToLibrary[dependency.libName]!!
                         when (val kind = dependency.kind) {
                             is DependenciesTracker.DependencyKind.WholeModule ->
                                 reversedWholeLibraryDependencies.getOrPut(dependentLibrary) { mutableListOf() }.add(libraryFile)

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/main/main.1.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import user.*
+
+@Test
+fun doTest() {
+    assertEquals(43, bar())
+}

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/main/main.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/main/main.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import user.*
+
+@Test
+fun doTest() {
+    assertEquals(42, bar())
+}

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/main/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/main/module.info
@@ -1,0 +1,9 @@
+STEP 0:
+    dependencies: removedLib, userLib
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: userLib
+    modifications:
+        U : main.1.kt -> main.kt

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/project.info
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/project.info
@@ -1,0 +1,11 @@
+// KT-61644: a per-file cache records a dependency on a library that is later removed from the project;
+// the next build must rebuild the affected cache instead of failing with "Unknown dependent library"
+
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: removedLib, userLib, main
+
+STEP 0:
+    libs: removedLib, userLib, main
+
+STEP 1:
+    libs: userLib, main

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/removedLib/file1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/removedLib/file1.kt
@@ -1,0 +1,3 @@
+package removed
+
+fun removedFun() = 42

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/removedLib/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/removedLib/module.info
@@ -1,0 +1,4 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+    added cache: file1.kt

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/userLib/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/userLib/file1.1.kt
@@ -1,0 +1,3 @@
+package user
+
+fun bar() = 43

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/userLib/file1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/userLib/file1.kt
@@ -1,0 +1,5 @@
+package user
+
+import removed.*
+
+fun bar() = removedFun()

--- a/native/native.tests/testData/caches/ic/dependencies/removedDependency/userLib/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/removedDependency/userLib/module.info
@@ -1,0 +1,11 @@
+STEP 0:
+    dependencies: removedLib
+    modifications:
+        U : file1.kt -> file1.kt
+    added cache: file1.kt
+
+// The dependency on removedLib is dropped, but file1.kt's cache from step 0 still holds it.
+STEP 1:
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt


### PR DESCRIPTION
When a dependency (a library) has been removed, the build might fail with an exception (no library found among the dependencies). But in such case, all what it means is that this file is just needs to be treated as changed (otherwise there would be a linkage error), and rebuild its cache as for other changed files.