### PR TITLE
[BTA] Port missing metadata and classpath tests to bta-forward-tests

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/shared/src/compilation/assertions/filesAssertions.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/shared/src/compilation/assertions/filesAssertions.kt
@@ -148,3 +148,83 @@ fun assertOutputFileContains(fileName: String, expectedContent: String) {
     val fileContents = file.readText()
     assert(expectedContent in fileContents) { "File $file does not contain expected content.\n\nFile contents:\n$fileContents" }
 }
+
+/*
+ * The names below mirror the klib layout constants in `org.jetbrains.kotlin.library.components.KlibMetadataConstants`
+ * (metadata-specific names) and `org.jetbrains.kotlin.library.KLIB_MANIFEST_FILE_NAME` / the default klib component
+ * directory. Those live in `:compiler:util-klib`, which is intentionally not on the compile classpath of this test
+ * module (the tests compile against the BTA API and load the full compiler on a separate runtime classpath), so the
+ * relevant names are duplicated here rather than referenced directly.
+ */
+private const val KLIB_DEFAULT_COMPONENT_DIR = "default"
+private const val KLIB_MANIFEST_FILE_NAME = "manifest"
+private const val KLIB_METADATA_FOLDER_NAME = "linkdata"
+private const val KLIB_MODULE_METADATA_FILE_NAME = "module"
+private const val KLIB_ROOT_PACKAGE_FRAGMENT_FOLDER_NAME = "root_package"
+private const val KLIB_NONROOT_PACKAGE_FRAGMENT_FOLDER_PREFIX = "package_"
+private const val KLIB_METADATA_FILE_EXTENSION = "knm"
+
+/**
+ * Asserts that the compilation produced the skeleton of an unpacked metadata klib: the klib manifest
+ * (`default/manifest`) and the module metadata header (`default/linkdata/module`). These are the stable markers that
+ * the output is a valid klib directory rather than just some files, without pinning the package fragment names.
+ */
+context(module: ModuleContext)
+fun CompilationOutcome.assertIsUnpackedMetadataKlib() {
+    assertOutputsContains(
+        "$KLIB_DEFAULT_COMPONENT_DIR/$KLIB_MANIFEST_FILE_NAME",
+        "$KLIB_DEFAULT_COMPONENT_DIR/$KLIB_METADATA_FOLDER_NAME/$KLIB_MODULE_METADATA_FILE_NAME",
+    )
+}
+
+/**
+ * The directory (relative to the klib metadata `linkdata` folder) that stores the fragments of [packageFqName]: the
+ * root package (empty string) lives in `root_package`, a named package `foo.bar` in `package_foo.bar`.
+ */
+private fun linkDataPackageFolderName(packageFqName: String): String =
+    if (packageFqName.isEmpty()) {
+        KLIB_ROOT_PACKAGE_FRAGMENT_FOLDER_NAME
+    } else {
+        "$KLIB_NONROOT_PACKAGE_FRAGMENT_FOLDER_PREFIX$packageFqName"
+    }
+
+/**
+ * Asserts that the compilation produced exactly [expectedCount] `.knm` files (klib metadata package fragments) for the
+ * package [packageFqName] (empty string for the root package) in the module's unpacked metadata klib output.
+ */
+context(module: ModuleContext)
+fun assertKnmFileCount(packageFqName: String, expectedCount: Int) {
+    val packageDirectory = module.outputDirectory
+        .resolve(KLIB_DEFAULT_COMPONENT_DIR)
+        .resolve(KLIB_METADATA_FOLDER_NAME)
+        .resolve(linkDataPackageFolderName(packageFqName))
+    val knmFiles = if (packageDirectory.exists()) {
+        packageDirectory.walk()
+            .filter { it.isRegularFile() && it.fileName.toString().endsWith(".$KLIB_METADATA_FILE_EXTENSION") }
+            .map { it.relativeTo(module.outputDirectory).toString() }
+            .toList()
+    } else {
+        emptyList()
+    }
+    assertEquals(expectedCount, knmFiles.size) {
+        "Expected $expectedCount .$KLIB_METADATA_FILE_EXTENSION file(s) in $packageDirectory, but found ${knmFiles.size}: ${knmFiles.sorted()}"
+    }
+}
+
+/**
+ * Asserts that the compilation produced no `.knm` files (klib metadata package fragments) anywhere under the module's
+ * output directory.
+ *
+ * Useful for the empty-source case: with no sources the compiler creates no package fragment directories
+ * (`root_package`, `package_<fqName>`) at all, so there is no specific directory to point [assertKnmFileCount] at.
+ */
+context(module: ModuleContext)
+fun assertNoKnmFiles() {
+    val knmFiles = module.outputDirectory.walk()
+        .filter { it.isRegularFile() && it.fileName.toString().endsWith(".$KLIB_METADATA_FILE_EXTENSION") }
+        .map { it.relativeTo(module.outputDirectory).toString() }
+        .toList()
+    assertEquals(0, knmFiles.size) {
+        "Expected no .$KLIB_METADATA_FILE_EXTENSION files, but found ${knmFiles.size}: ${knmFiles.sorted()}"
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testCompatibility/kotlin/CrossPlatformNonIncrementalCompilationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testCompatibility/kotlin/CrossPlatformNonIncrementalCompilationTest.kt
@@ -48,4 +48,17 @@ class CrossPlatformNonIncrementalCompilationTest : BaseCompilationTest() {
             }
         }
     }
+
+    @DisplayName("A missing classpath dependency fails the compilation on all platforms")
+    @BtaV2StrategyAndPlatformAgnosticCompilationTest
+    fun missingClasspathDependencyFailsCompilationAllPlatforms(project: ProjectCreator) {
+        project {
+            // module-2 references `Bar` from module-1; without the dependency the reference is unresolved.
+            val consumer = module("basic-multimodule-project/module-2")
+            consumer.compile {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, ".*[Uu]nresolved reference.*Bar.*".toRegex())
+            }
+        }
+    }
 }

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/MetadataBuildersCompatibilitySmokeTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/MetadataBuildersCompatibilitySmokeTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+package org.jetbrains.kotlin.buildtools.forward.tests
+
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments
+import org.jetbrains.kotlin.buildtools.api.metadata.KotlinMetadataPlatformToolchain.Companion.metadata
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.DefaultStrategyAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.supportsMetadata
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+import kotlin.io.path.writeText
+
+class MetadataBuildersCompatibilitySmokeTest : BaseCompilationTest() {
+
+    @DisplayName("Metadata: toBuilder round-trip does not affect the original operation")
+    @DefaultStrategyAgnosticCompilationTest
+    fun testMetadataToBuilderOperationImmutability(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val toolchain = strategyConfig.first
+        assumeTrue(toolchain.supportsMetadata())
+        val sources = listOf(workingDirectory.resolve("common.kt").also { it.writeText("fun f() = 1") })
+        val destination = workingDirectory.resolve("klib")
+        val original = toolchain.metadata.metadataKlibCompilationOperationBuilder(sources, destination).apply {
+            compilerArguments[MetadataArguments.MODULE_NAME] = "original"
+        }.build()
+
+        val newBuilder = original.toBuilder()
+        newBuilder.compilerArguments[MetadataArguments.MODULE_NAME] = "modified"
+        val modified = newBuilder.build()
+
+        assertEquals("original", original.compilerArguments[MetadataArguments.MODULE_NAME])
+        assertEquals("modified", modified.compilerArguments[MetadataArguments.MODULE_NAME])
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/MetadataCompilationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/MetadataCompilationTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.forward.tests
+
+import org.jetbrains.kotlin.buildtools.api.arguments.MetadataArguments
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.assertions.*
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.MetadataProject
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.supportsMetadata
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+import kotlin.io.path.writeText
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.metadataProject as metadataProjectForStrategy
+
+@DisplayName("Functional tests for the metadata (common/KMP) compilation operation of the BTA")
+class MetadataCompilationTest : BaseCompilationTest() {
+
+    @DisplayName("Compiling common sources produces an unpacked metadata klib")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun compilesToUnpackedKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        metadataProject(strategyConfig) {
+            val module = moduleWithCommonSource()
+            module.compile {
+                assertIsUnpackedMetadataKlib()
+                assertKnmFileCount(packageFqName = "", expectedCount = 1)
+            }
+        }
+    }
+
+    @DisplayName("Common sources in a named package produce fragments in the matching package directory")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun namedPackageSourcesProduceFragmentsInPackageDirectory(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        metadataProject(strategyConfig) {
+            val module = moduleWithCommonSource(packageName = "common")
+            module.compile {
+                assertIsUnpackedMetadataKlib()
+                assertKnmFileCount(packageFqName = "common", expectedCount = 1)
+            }
+        }
+    }
+
+    @DisplayName("MODULE_NAME is reflected in the metadata klib manifest")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleNameIsWrittenToManifest(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val moduleName = "my-module"
+        metadataProject(strategyConfig) {
+            val module = moduleWithCommonSource()
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[MetadataArguments.MODULE_NAME] = moduleName
+            }) {
+                assertOutputFileContains("default/manifest", moduleName)
+            }
+        }
+    }
+
+    @DisplayName("CLASSPATH dependency is passed to the metadata compiler")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun classpathDependencyIsPassedToCompiler(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        metadataProject(strategyConfig) {
+            val library = module("basic-multimodule-project/module-1")
+            library.compile {}
+            // module-2 references `Bar` from module-1, so it only compiles when the library is on the classpath.
+            val consumer = module("basic-multimodule-project/module-2", dependencies = listOf(library))
+            consumer.compile {
+                assertIsUnpackedMetadataKlib()
+                assertKnmFileCount(packageFqName = "", expectedCount = 2)
+            }
+        }
+    }
+
+    @DisplayName("Metadata compilation with an empty source list does not crash")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun emptySourceListIsHandledGracefully(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        metadataProject(strategyConfig) {
+            val module = module("empty")
+            module.compile(assertions = {
+                assertIsUnpackedMetadataKlib()
+                assertNoKnmFiles()
+            })
+        }
+    }
+
+    private fun MetadataProject.moduleWithCommonSource(packageName: String? = null) =
+        module("empty").also { module ->
+            val packageDeclaration = packageName?.let { "package $it\n\n" } ?: ""
+            module.sourcesDirectory.resolve("common.kt").writeText(packageDeclaration + "fun greeting(): String = \"hello from common\"")
+        }
+
+    private fun metadataProject(
+        strategyConfig: CompilerExecutionStrategyConfiguration,
+        action: MetadataProject.() -> Unit,
+    ) {
+        assumeTrue(strategyConfig.first.supportsMetadata())
+        metadataProjectForStrategy(strategyConfig, action)
+    }
+}


### PR DESCRIPTION
Follow-up on https://github.com/JetBrains/kotlin/pull/6708