### PR TITLE
Compute types a bit less agressively

### DIFF
--- a/compiler/testData/codegen/box/primitiveTypes/equalityWithObject/boxedNanEquals.kt
+++ b/compiler/testData/codegen/box/primitiveTypes/equalityWithObject/boxedNanEquals.kt
@@ -1,0 +1,22 @@
+// WITH_STDLIB
+// KT-86678: boxed Double NaN values must compare equal via ==/equals.
+
+fun box(): String {
+    val a = Double.NaN                          // 0x7FF8000000000000
+    val b = Double.fromBits(0xFFF80000L shl 32) // 0xFFF8000000000000 (also NaN)
+
+    if (!a.isNaN() || !b.isNaN()) return "Fail: operands not NaN"
+
+    // Primitive IEEE comparison: NaN != NaN.
+    if (a == b) return "Fail: primitive == should be false"
+    // equals/compareTo treat NaNs as equal.
+    if (a.compareTo(b) != 0) return "Fail: compareTo"
+    if (!a.equals(b)) return "Fail: equals"
+
+    val boxedA: Any = a
+    val boxedB: Any = b
+    if (!boxedA.equals(boxedB)) return "Fail: boxed equals"
+    if (boxedA != boxedB) return "Fail: boxed =="
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/primitiveTypes/equalityWithObject/boxedNanEquals.kt
+++ b/compiler/testData/codegen/box/primitiveTypes/equalityWithObject/boxedNanEquals.kt
@@ -1,5 +1,6 @@
 // WITH_STDLIB
 // KT-86678: boxed Double NaN values must compare equal via ==/equals.
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.4
 
 fun box(): String {
     val a = Double.NaN                          // 0x7FF8000000000000

--- a/compiler/testData/debug/stepping/annotatedLocalVariable.kt
+++ b/compiler/testData/debug/stepping/annotatedLocalVariable.kt
@@ -30,8 +30,9 @@ fun box() {
 // test.kt:8 box
 // test.kt:11 box
 // test.kt:13 box
+// test.kt:14 box
+// test.kt:14 box
 // test.kt:16 box
-// test.kt:17 box
 // test.kt:17 box
 // test.kt:18 box
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/ComputeTypesPass.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/ComputeTypesPass.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.ir.isUnconditional
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.getInlinedClassNative
 import org.jetbrains.kotlin.backend.konan.logMultiple
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
@@ -81,6 +82,8 @@ internal class ComputeTypesPass(val context: NativeBackendContext) : BodyLowerin
 
     private fun leastCommonAncestor(types: List<IrType>): IrType? {
         if (types.isEmpty()) return null
+        if (types.size == 1) return types[0]
+
         val isNullable = types.any { it.isNullable() }
         val classes = types.map { it.erasedUpperBound }
         // Since the analysis is local, nothing we can do about interfaces: if an interface is written to a variable,
@@ -171,6 +174,14 @@ internal class ComputeTypesPass(val context: NativeBackendContext) : BodyLowerin
         val variableWrites = mutableMapOf<IrVariable, BitSet>()
 
         fun BitSet.computeType() = this.mapEachBit { allVariablesWrites[it].value }.computeType()
+
+        fun IrType.trySwitchVariableType(variable: IrVariable) =
+                this.takeUnless {
+                    // Conservatively handle source code defined variables: if changing the type also alters the boxing,
+                    // this might be surprising for the programmer. See KT-86678 and KT-87165 for examples.
+                    (variable.origin == IrDeclarationOrigin.DEFINED
+                            && this.getInlinedClassNative() != variable.type.getInlinedClassNative())
+                }
 
         irBody.accept(object : IrVisitor<BitSet, BitSet>() {
             fun getVariableWriteId(variable: IrElement, value: IrExpression) = VariableWrite(variable, value).let { write ->
@@ -388,7 +399,7 @@ internal class ComputeTypesPass(val context: NativeBackendContext) : BodyLowerin
                         ?: error("A use of uninitialized variable ${variable.render()}")
                 val mergedVariableWrites = getValueVariablesWrites.getOrPut(expression) { BitSet() }
                 mergedVariableWrites.or(variableWrites)
-                expression.type = mergedVariableWrites.computeType() ?: variable.type
+                expression.type = mergedVariableWrites.computeType()?.trySwitchVariableType(variable) ?: variable.type
 
                 context.logMultiple {
                     +expression.render()
@@ -432,7 +443,7 @@ internal class ComputeTypesPass(val context: NativeBackendContext) : BodyLowerin
                 declaration.transformChildrenVoid(this)
 
                 val values = variableWrites[declaration]?.mapEachBit { allVariablesWrites[it].value }
-                val actualType = values?.computeType()
+                val actualType = values?.computeType()?.trySwitchVariableType(declaration)
                 if (actualType != null) {
                     declaration.type = if (declaration.origin == IrDeclarationOrigin.DEFINED && declaration.type.isNullable()) {
                         // For `DEFINED` variables, if the original type is nullable, preserve this:

--- a/native/native.tests/testData/codegen/boxing/boxedEquals.kt
+++ b/native/native.tests/testData/codegen/boxing/boxedEquals.kt
@@ -1,5 +1,6 @@
 // KIND: STANDALONE
 // KT-87165: boxes identity: `===` and `identityHashCode`.
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.4
 @file:OptIn(kotlin.experimental.ExperimentalNativeApi::class)
 
 import kotlin.native.identityHashCode

--- a/native/native.tests/testData/codegen/boxing/boxedEquals.kt
+++ b/native/native.tests/testData/codegen/boxing/boxedEquals.kt
@@ -1,0 +1,18 @@
+// KIND: STANDALONE
+// KT-87165: boxes identity: `===` and `identityHashCode`.
+@file:OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+
+import kotlin.native.identityHashCode
+
+fun box(): String {
+    val one: Any = 1_000_000
+    val sameOne: Any = one
+    val hash1 = one.identityHashCode()
+    val hash2 = sameOne.identityHashCode()
+    val referentiallyEqual = (one === sameOne)
+
+    if (!referentiallyEqual) return "fail: === is false"
+    if (hash1 != hash2) return "fail: identityHashCode are different"
+
+    return "OK"
+}


### PR DESCRIPTION
Handle source-defined variable in `ComputeTypesPass` more conservatively: don't change the type if it result in altering the boxing behaviour