### PR TITLE
KT-87784 [AFU] Support extension inline properties on scalar atomics

### DIFF
--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuTransformer.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuTransformer.kt
@@ -343,24 +343,47 @@ abstract class AbstractAtomicfuTransformer(
          * The following functions will be generated:
          * on JVM:
          * ```
-         * fun foo$atomicfu$AtomicFieldUpdater(atomicHandler: j.u.c.a.AtomicIntegerFieldUpdater, obj: Any?, arg: Int)
-         * fun foo$atomicfu$BoxedAtomic(atomicHandler: j.u.c.a.AtomicInteger, arg: Int)
-         * fun foo$atomicfu$AtomicArray(atomicHandler: j.u.c.a.AtomicIntegerArray, index: Int, arg: Int)
+         * fun foo$atomicfu$AtomicFieldUpdater$Int(atomicHandler: j.u.c.a.AtomicIntegerFieldUpdater, obj: Any?, arg: Int)
+         * fun foo$atomicfu$BoxedAtomic$Int(atomicHandler: j.u.c.a.AtomicInteger, arg: Int)
+         * fun foo$atomicfu$AtomicArray$Int(atomicHandler: j.u.c.a.AtomicIntegerArray, index: Int, arg: Int)
          * ```
          * On Native:
          * ```
-         * fun foo$atomicfu$PropRef(atomicHandler: () -> KMutableProperty<Int>, arg: Int)
-         * fun foo$atomicfu$AtomicArray(atomicHandler: kotlin.concurrent.AtomicIntArray, index: Int, arg: Int)
+         * fun foo$atomicfu$PropRef$Int(atomicHandler: () -> KMutableProperty<Int>, arg: Int)
+         * fun foo$atomicfu$AtomicArray$Int(atomicHandler: kotlin.concurrent.AtomicIntArray, index: Int, arg: Int)
          * ```
+         *
+         * This function also transforms getters and setters for inline extension properties.
+         * In this case, function names like `<get-bar>` and `<set-bar>` are mangled to
+         * `getBar$atomicfu$HANDLER_NAME$TYPE` and `setBar$atomicfu$HANDLER_NAME$TYPE`.
          */
         private fun IrDeclarationContainer.transformAllAtomicExtensions() {
-            declarations.filter { it is IrFunction && it.isAtomicExtension() }.forEach { atomicExtension ->
-                atomicExtension as IrFunction
-                declarations.addAll(transformedExtensionsForAllAtomicHandlers(atomicExtension))
+            val atomicExtensions = declarations.filter { declaration ->
+                declaration is IrFunction && declaration.isAtomicExtension() ||
+                        declaration is IrProperty && declaration.hasAtomicAccessors()
+            }
+            atomicExtensions.forEach { atomicExtension ->
+                when (atomicExtension) {
+                    is IrFunction -> {
+                        declarations.addAll(transformedExtensionsForAllAtomicHandlers(atomicExtension))
+                    }
+                    is IrProperty -> {
+                        declarations.addAll(atomicExtension.atomicAccessors().flatMap {
+                            transformedExtensionsForAllAtomicHandlers(it)
+                        })
+                    }
+                    else -> error("Unexpected atomic extension declaration: ${atomicExtension.render()}")
+                }
                 // the original atomic extension is removed
                 declarations.remove(atomicExtension)
             }
         }
+
+        private fun IrProperty.hasAtomicAccessors(): Boolean =
+            getter?.isAtomicExtension() == true || setter?.isAtomicExtension() == true
+
+        private fun IrProperty.atomicAccessors(): List<IrSimpleFunction> =
+            listOfNotNull(getter, setter).filter { it.isAtomicExtension() }
 
         abstract fun transformedExtensionsForAllAtomicHandlers(atomicExtension: IrFunction): List<IrSimpleFunction>
 
@@ -912,8 +935,16 @@ abstract class AbstractAtomicfuTransformer(
         symbol.owner.correspondingPropertySymbol?.owner
             ?: error("Atomic property accessor ${this.render()} expected to have non-null correspondingPropertySymbol" + CONSTRAINTS_MESSAGE)
 
-    private fun mangleAtomicExtension(name: String, atomicHandlerType: AtomicHandlerType, valueType: IrType) =
-        name + "$" + ATOMICFU + "$" + atomicHandlerType + "$" + if (valueType.isPrimitiveType()) valueType.classFqName?.shortName() else "Any"
+    private fun mangleAtomicExtension(name: String, atomicHandlerType: AtomicHandlerType, valueType: IrType): String {
+        val normalizedName = if ((name.startsWith("<get-") || name.startsWith("<set-")) && name.endsWith('>')) {
+            val prefix = name.substring(1, 4) // get | set
+            val suffix = name.substring(5, name.length - 1)
+            prefix + suffix.replaceFirstChar { it.uppercase() }
+        } else {
+            name
+        }
+        return normalizedName + "$" + ATOMICFU + "$" + atomicHandlerType + "$" + if (valueType.isPrimitiveType()) valueType.classFqName?.shortName() else "Any"
+    }
 
     internal fun IrValueParameter.capture(): IrGetValue = IrGetValueImpl(startOffset, endOffset, symbol.owner.type, symbol)
 }

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.ir.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.ir.txt
@@ -1,0 +1,316 @@
+FILE fqName:<root> fileName:/InlineExtensionProperties.kt
+  PROPERTY name:a visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+          ARG initial: CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicInt
+      correspondingProperty: PROPERTY name:a visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]' type=kotlinx.atomicfu.AtomicInt origin=null
+  PROPERTY name:s visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:s type:kotlinx.atomicfu.AtomicRef<kotlin.String> visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic <T> (initial: T of kotlinx.atomicfu.atomic): kotlinx.atomicfu.AtomicRef<T of kotlinx.atomicfu.atomic> declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicRef<kotlin.String> origin=null
+          TYPE_ARG T: kotlin.String
+          ARG initial: CONST String type=kotlin.String value="TEST"
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-s> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicRef<kotlin.String>
+      correspondingProperty: PROPERTY name:s visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-s> (): kotlinx.atomicfu.AtomicRef<kotlin.String> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:s type:kotlinx.atomicfu.AtomicRef<kotlin.String> visibility:private [final,static]' type=kotlinx.atomicfu.AtomicRef<kotlin.String> origin=null
+  PROPERTY name:arr visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:arr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (size: kotlin.Int) declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicIntArray origin=null
+          ARG size: CONST Int type=kotlin.Int value=10
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-arr> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicIntArray
+      correspondingProperty: PROPERTY name:arr visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-arr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:arr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final,static]' type=kotlinx.atomicfu.AtomicIntArray origin=null
+  PROPERTY name:l visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:l type:kotlinx.atomicfu.AtomicLong visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Long): kotlinx.atomicfu.AtomicLong declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicLong origin=null
+          ARG initial: CONST Long type=kotlin.Long value=9223372032559808513
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-l> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicLong
+      correspondingProperty: PROPERTY name:l visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-l> (): kotlinx.atomicfu.AtomicLong declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:l type:kotlinx.atomicfu.AtomicLong visibility:private [final,static]' type=kotlinx.atomicfu.AtomicLong origin=null
+  PROPERTY name:b visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:b type:kotlinx.atomicfu.AtomicBoolean visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Boolean): kotlinx.atomicfu.AtomicBoolean declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicBoolean origin=null
+          ARG initial: CONST Boolean type=kotlin.Boolean value=false
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicBoolean
+      correspondingProperty: PROPERTY name:b visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-b> (): kotlinx.atomicfu.AtomicBoolean declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlinx.atomicfu.AtomicBoolean visibility:private [final,static]' type=kotlinx.atomicfu.AtomicBoolean origin=null
+  CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.C
+    PROPERTY name:ma visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:ma type:kotlinx.atomicfu.AtomicInt visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG initial: CONST Int type=kotlin.Int value=0
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-ma> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicInt
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY name:ma visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ma> (): kotlinx.atomicfu.AtomicInt declared in <root>.C'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:ma type:kotlinx.atomicfu.AtomicInt visibility:private [final]' type=kotlinx.atomicfu.AtomicInt origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-ma>' type=<root>.C origin=null
+    PROPERTY name:ms visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:ms type:kotlinx.atomicfu.AtomicRef<kotlin.String> visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic <T> (initial: T of kotlinx.atomicfu.atomic): kotlinx.atomicfu.AtomicRef<T of kotlinx.atomicfu.atomic> declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicRef<kotlin.String> origin=null
+            TYPE_ARG T: kotlin.String
+            ARG initial: CONST String type=kotlin.String value="TEST"
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-ms> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicRef<kotlin.String>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY name:ms visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ms> (): kotlinx.atomicfu.AtomicRef<kotlin.String> declared in <root>.C'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:ms type:kotlinx.atomicfu.AtomicRef<kotlin.String> visibility:private [final]' type=kotlinx.atomicfu.AtomicRef<kotlin.String> origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-ms>' type=<root>.C origin=null
+    PROPERTY name:marr visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:marr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final]
+        EXPRESSION_BODY
+          CONSTRUCTOR_CALL 'public constructor <init> (size: kotlin.Int) declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicIntArray origin=null
+            ARG size: CONST Int type=kotlin.Int value=10
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-marr> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicIntArray
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY name:marr visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-marr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>.C'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:marr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final]' type=kotlinx.atomicfu.AtomicIntArray origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-marr>' type=<root>.C origin=null
+    PROPERTY name:ml visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:ml type:kotlinx.atomicfu.AtomicLong visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Long): kotlinx.atomicfu.AtomicLong declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicLong origin=null
+            ARG initial: CONST Long type=kotlin.Long value=9223372032559808513
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-ml> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicLong
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY name:ml visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ml> (): kotlinx.atomicfu.AtomicLong declared in <root>.C'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:ml type:kotlinx.atomicfu.AtomicLong visibility:private [final]' type=kotlinx.atomicfu.AtomicLong origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-ml>' type=<root>.C origin=null
+    PROPERTY name:mb visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:mb type:kotlinx.atomicfu.AtomicBoolean visibility:private [final]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Boolean): kotlinx.atomicfu.AtomicBoolean declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicBoolean origin=null
+            ARG initial: CONST Boolean type=kotlin.Boolean value=false
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-mb> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicBoolean
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY name:mb visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-mb> (): kotlinx.atomicfu.AtomicBoolean declared in <root>.C'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:mb type:kotlinx.atomicfu.AtomicBoolean visibility:private [final]' type=kotlinx.atomicfu.AtomicBoolean origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-mb>' type=<root>.C origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.C [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:memberTest visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+      BLOCK_BODY
+        CALL 'public final fun <set-value> (<set-?>: kotlin.Int): kotlin.Unit declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Unit origin=EQ
+          ARG <this>: CALL 'private final fun <get-ma> (): kotlinx.atomicfu.AtomicInt declared in <root>.C' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+            ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+          ARG <set-?>: CONST Int type=kotlin.Int value=-10
+        CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG a: CONST Int type=kotlin.Int value=10
+          ARG b: CALL 'private final fun <get-abs> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-ma> (): kotlinx.atomicfu.AtomicInt declared in <root>.C' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertFalse (x: kotlin.Boolean): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          ARG x: CALL 'private final fun <get-isEmpty> (<this>: kotlinx.atomicfu.AtomicRef<kotlin.String>): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-ms> (): kotlinx.atomicfu.AtomicRef<kotlin.String> declared in <root>.C' type=kotlinx.atomicfu.AtomicRef<kotlin.String> origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG a: CONST Int type=kotlin.Int value=-100
+          ARG b: CALL 'private final fun <get-scaledBy10> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-ma> (): kotlinx.atomicfu.AtomicInt declared in <root>.C' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'private final fun <set-scaledBy10> (<this>: kotlinx.atomicfu.AtomicInt, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          ARG <this>: CALL 'private final fun <get-ma> (): kotlinx.atomicfu.AtomicInt declared in <root>.C' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+            ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+          ARG value: CONST Int type=kotlin.Int value=200
+        CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG a: CONST Int type=kotlin.Int value=20
+          ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-ma> (): kotlinx.atomicfu.AtomicInt declared in <root>.C' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'private final fun <set-scaledBy10> (<this>: kotlinx.atomicfu.AtomicInt, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+          ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+            ARG <this>: CALL 'private final fun <get-marr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>.C' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+            ARG index: CONST Int type=kotlin.Int value=0
+          ARG value: CONST Int type=kotlin.Int value=300
+        CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG a: CONST Int type=kotlin.Int value=30
+          ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+              ARG <this>: CALL 'private final fun <get-marr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>.C' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+              ARG index: CONST Int type=kotlin.Int value=0
+        CALL 'public final fun assertFalse (x: kotlin.Boolean): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          ARG x: CALL 'private final fun <get-isTrue> (<this>: kotlinx.atomicfu.AtomicBoolean): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-mb> (): kotlinx.atomicfu.AtomicBoolean declared in <root>.C' type=kotlinx.atomicfu.AtomicBoolean origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG a: CONST Int type=kotlin.Int value=1
+          ARG b: CALL 'private final fun <get-low> (<this>: kotlinx.atomicfu.AtomicLong): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-ml> (): kotlinx.atomicfu.AtomicLong declared in <root>.C' type=kotlinx.atomicfu.AtomicLong origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG a: CONST Int type=kotlin.Int value=400
+          ARG b: CALL 'private final fun <get-squared> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>.C' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>(index:0): GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+            ARG <this>(index:1): CALL 'private final fun <get-ma> (): kotlinx.atomicfu.AtomicInt declared in <root>.C' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+    PROPERTY name:squared visibility:private modality:FINAL [val]
+      FUN name:<get-squared> visibility:private modality:FINAL returnType:kotlin.Int [inline]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:1 type:kotlinx.atomicfu.AtomicInt
+        correspondingProperty: PROPERTY name:squared visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-squared> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>.C'
+            CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+              ARG <this>: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>(index:1): kotlinx.atomicfu.AtomicInt declared in <root>.C.<get-squared>' type=kotlinx.atomicfu.AtomicInt origin=IMPLICIT_ARGUMENT
+              ARG other: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>(index:1): kotlinx.atomicfu.AtomicInt declared in <root>.C.<get-squared>' type=kotlinx.atomicfu.AtomicInt origin=IMPLICIT_ARGUMENT
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun topLevelTest (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      CALL 'public final fun memberTest (): kotlin.Unit declared in <root>.C' type=kotlin.Unit origin=null
+        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.C' type=<root>.C origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+  FUN name:topLevelTest visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+      CALL 'public final fun <set-value> (<set-?>: kotlin.Int): kotlin.Unit declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Unit origin=EQ
+        ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+        ARG <set-?>: CONST Int type=kotlin.Int value=-10
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=10
+        ARG b: CALL 'private final fun <get-abs> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertFalse (x: kotlin.Boolean): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG x: CALL 'private final fun <get-isEmpty> (<this>: kotlinx.atomicfu.AtomicRef<kotlin.String>): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-s> (): kotlinx.atomicfu.AtomicRef<kotlin.String> declared in <root>' type=kotlinx.atomicfu.AtomicRef<kotlin.String> origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=-100
+        ARG b: CALL 'private final fun <get-scaledBy10> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'private final fun <set-scaledBy10> (<this>: kotlinx.atomicfu.AtomicInt, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+        ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+        ARG value: CONST Int type=kotlin.Int value=200
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=20
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'private final fun <set-scaledBy10> (<this>: kotlinx.atomicfu.AtomicInt, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+        ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+          ARG <this>: CALL 'private final fun <get-arr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+          ARG index: CONST Int type=kotlin.Int value=0
+        ARG value: CONST Int type=kotlin.Int value=300
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=30
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+            ARG <this>: CALL 'private final fun <get-arr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+            ARG index: CONST Int type=kotlin.Int value=0
+      CALL 'public final fun assertFalse (x: kotlin.Boolean): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG x: CALL 'private final fun <get-isTrue> (<this>: kotlinx.atomicfu.AtomicBoolean): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-b> (): kotlinx.atomicfu.AtomicBoolean declared in <root>' type=kotlinx.atomicfu.AtomicBoolean origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=1
+        ARG b: CALL 'private final fun <get-low> (<this>: kotlinx.atomicfu.AtomicLong): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-l> (): kotlinx.atomicfu.AtomicLong declared in <root>' type=kotlinx.atomicfu.AtomicLong origin=GET_PROPERTY
+  PROPERTY name:abs visibility:private modality:FINAL [val]
+    FUN name:<get-abs> visibility:private modality:FINAL returnType:kotlin.Int [inline]
+      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:kotlinx.atomicfu.AtomicInt
+      correspondingProperty: PROPERTY name:abs visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-abs> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>'
+          CALL 'public final fun abs (n: kotlin.Int): kotlin.Int declared in kotlin.math' type=kotlin.Int origin=null
+            ARG n: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: kotlinx.atomicfu.AtomicInt declared in <root>.<get-abs>' type=kotlinx.atomicfu.AtomicInt origin=IMPLICIT_ARGUMENT
+  PROPERTY name:isEmpty visibility:private modality:FINAL [val]
+    FUN name:<get-isEmpty> visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:kotlinx.atomicfu.AtomicRef<kotlin.String>
+      correspondingProperty: PROPERTY name:isEmpty visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-isEmpty> (<this>: kotlinx.atomicfu.AtomicRef<kotlin.String>): kotlin.Boolean declared in <root>'
+          CALL 'public final fun isEmpty (<this>: kotlin.CharSequence): kotlin.Boolean declared in kotlin.text' type=kotlin.Boolean origin=null
+            ARG <this>: CALL 'public final fun <get-value> (): T of kotlinx.atomicfu.AtomicRef declared in kotlinx.atomicfu.AtomicRef' type=kotlin.String origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: kotlinx.atomicfu.AtomicRef<kotlin.String> declared in <root>.<get-isEmpty>' type=kotlinx.atomicfu.AtomicRef<kotlin.String> origin=IMPLICIT_ARGUMENT
+  PROPERTY name:isTrue visibility:private modality:FINAL [val]
+    FUN name:<get-isTrue> visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:kotlinx.atomicfu.AtomicBoolean
+      correspondingProperty: PROPERTY name:isTrue visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-isTrue> (<this>: kotlinx.atomicfu.AtomicBoolean): kotlin.Boolean declared in <root>'
+          CALL 'public final fun <get-value> (): kotlin.Boolean declared in kotlinx.atomicfu.AtomicBoolean' type=kotlin.Boolean origin=GET_PROPERTY
+            ARG <this>: GET_VAR '<this>: kotlinx.atomicfu.AtomicBoolean declared in <root>.<get-isTrue>' type=kotlinx.atomicfu.AtomicBoolean origin=IMPLICIT_ARGUMENT
+  PROPERTY name:low visibility:private modality:FINAL [val]
+    FUN name:<get-low> visibility:private modality:FINAL returnType:kotlin.Int [inline]
+      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:kotlinx.atomicfu.AtomicLong
+      correspondingProperty: PROPERTY name:low visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-low> (<this>: kotlinx.atomicfu.AtomicLong): kotlin.Int declared in <root>'
+          CALL 'public open fun toInt (): kotlin.Int declared in kotlin.Long' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun <get-value> (): kotlin.Long declared in kotlinx.atomicfu.AtomicLong' type=kotlin.Long origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: kotlinx.atomicfu.AtomicLong declared in <root>.<get-low>' type=kotlinx.atomicfu.AtomicLong origin=IMPLICIT_ARGUMENT
+  PROPERTY name:scaledBy10 visibility:private modality:FINAL [var]
+    FUN name:<get-scaledBy10> visibility:private modality:FINAL returnType:kotlin.Int [inline]
+      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:kotlinx.atomicfu.AtomicInt
+      correspondingProperty: PROPERTY name:scaledBy10 visibility:private modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-scaledBy10> (<this>: kotlinx.atomicfu.AtomicInt): kotlin.Int declared in <root>'
+          CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+            ARG <this>: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: kotlinx.atomicfu.AtomicInt declared in <root>.<get-scaledBy10>' type=kotlinx.atomicfu.AtomicInt origin=IMPLICIT_ARGUMENT
+            ARG other: CONST Int type=kotlin.Int value=10
+    FUN name:<set-scaledBy10> visibility:private modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:kotlinx.atomicfu.AtomicInt
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Int
+      correspondingProperty: PROPERTY name:scaledBy10 visibility:private modality:FINAL [var]
+      BLOCK_BODY
+        CALL 'public final fun <set-value> (<set-?>: kotlin.Int): kotlin.Unit declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Unit origin=EQ
+          ARG <this>: GET_VAR '<this>: kotlinx.atomicfu.AtomicInt declared in <root>.<set-scaledBy10>' type=kotlinx.atomicfu.AtomicInt origin=null
+          ARG <set-?>: CALL 'public final fun div (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=DIV
+            ARG <this>: GET_VAR 'value: kotlin.Int declared in <root>.<set-scaledBy10>' type=kotlin.Int origin=null
+            ARG other: CONST Int type=kotlin.Int value=10

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.ir2.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.ir2.txt
@@ -1,0 +1,563 @@
+FILE fqName:<root> fileName:/InlineExtensionProperties.kt
+  PROPERTY ATOMICFU_GENERATED_PROPERTY name:a visibility:private modality:FINAL [val]
+    FIELD ATOMICFU_GENERATED_FIELD name:a type:java.util.concurrent.atomic.AtomicInteger visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Int) declared in java.util.concurrent.atomic.AtomicInteger' type=java.util.concurrent.atomic.AtomicInteger origin=null
+          ARG value: CONST Int type=kotlin.Int value=0
+    FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-a> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicInteger
+      correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:a visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>'
+          GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:a type:java.util.concurrent.atomic.AtomicInteger visibility:private [final,static] declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+  PROPERTY ATOMICFU_GENERATED_PROPERTY name:s visibility:private modality:FINAL [val]
+    FIELD ATOMICFU_GENERATED_FIELD name:s type:java.util.concurrent.atomic.AtomicReference visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Any) declared in java.util.concurrent.atomic.AtomicReference' type=java.util.concurrent.atomic.AtomicReference origin=null
+          ARG value: CONST String type=kotlin.String value="TEST"
+    FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-s> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicReference
+      correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:s visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-s> (): java.util.concurrent.atomic.AtomicReference declared in <root>'
+          GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:s type:java.util.concurrent.atomic.AtomicReference visibility:private [final,static] declared in <root>' type=java.util.concurrent.atomic.AtomicReference origin=null
+  PROPERTY ATOMICFU_GENERATED_PROPERTY name:arr visibility:private modality:FINAL [val]
+    FIELD ATOMICFU_GENERATED_FIELD name:arr type:java.util.concurrent.atomic.AtomicIntegerArray visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (length: kotlin.Int) declared in java.util.concurrent.atomic.AtomicIntegerArray' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+          ARG length: CONST Int type=kotlin.Int value=10
+    FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-arr> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicIntegerArray
+      correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:arr visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-arr> (): java.util.concurrent.atomic.AtomicIntegerArray declared in <root>'
+          GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:arr type:java.util.concurrent.atomic.AtomicIntegerArray visibility:private [final,static] declared in <root>' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+  PROPERTY ATOMICFU_GENERATED_PROPERTY name:l visibility:private modality:FINAL [val]
+    FIELD ATOMICFU_GENERATED_FIELD name:l type:java.util.concurrent.atomic.AtomicLong visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Long) declared in java.util.concurrent.atomic.AtomicLong' type=java.util.concurrent.atomic.AtomicLong origin=null
+          ARG value: CONST Long type=kotlin.Long value=9223372032559808513
+    FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-l> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicLong
+      correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:l visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-l> (): java.util.concurrent.atomic.AtomicLong declared in <root>'
+          GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:l type:java.util.concurrent.atomic.AtomicLong visibility:private [final,static] declared in <root>' type=java.util.concurrent.atomic.AtomicLong origin=null
+  PROPERTY ATOMICFU_GENERATED_PROPERTY name:b visibility:private modality:FINAL [val]
+    FIELD ATOMICFU_GENERATED_FIELD name:b type:java.util.concurrent.atomic.AtomicBoolean visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Boolean) declared in java.util.concurrent.atomic.AtomicBoolean' type=java.util.concurrent.atomic.AtomicBoolean origin=null
+          ARG value: CONST Boolean type=kotlin.Boolean value=false
+    FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-b> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicBoolean
+      correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:b visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-b> (): java.util.concurrent.atomic.AtomicBoolean declared in <root>'
+          GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:b type:java.util.concurrent.atomic.AtomicBoolean visibility:private [final,static] declared in <root>' type=java.util.concurrent.atomic.AtomicBoolean origin=null
+  CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.C
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:ma$volatile visibility:private modality:FINAL [var]
+      FIELD ATOMICFU_GENERATED_FIELD name:ma$volatile type:kotlin.Int visibility:private
+        annotations:
+          Volatile
+        EXPRESSION_BODY
+          CONST Int type=kotlin.Int value=0
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-ma$volatile> visibility:private modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ma$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ma$volatile> (): kotlin.Int declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ma$volatile type:kotlin.Int visibility:private declared in <root>.C' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-ma$volatile>' type=<root>.C origin=null
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<set-ma$volatile> visibility:private modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ma$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <set-ma$volatile> (value: kotlin.Int): kotlin.Unit declared in <root>.C'
+            SET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ma$volatile type:kotlin.Int visibility:private declared in <root>.C' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<set-ma$volatile>' type=<root>.C origin=null
+              value: GET_VAR 'value: kotlin.Int declared in <root>.C.<set-ma$volatile>' type=kotlin.Int origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:ms$volatile visibility:private modality:FINAL [var]
+      FIELD ATOMICFU_GENERATED_FIELD name:ms$volatile type:kotlin.Any? visibility:private
+        annotations:
+          Volatile
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="TEST"
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-ms$volatile> visibility:private modality:FINAL returnType:kotlin.Any?
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ms$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ms$volatile> (): kotlin.Any? declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ms$volatile type:kotlin.Any? visibility:private declared in <root>.C' type=kotlin.Any? origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-ms$volatile>' type=<root>.C origin=null
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<set-ms$volatile> visibility:private modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Any?
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ms$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <set-ms$volatile> (value: kotlin.Any?): kotlin.Unit declared in <root>.C'
+            SET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ms$volatile type:kotlin.Any? visibility:private declared in <root>.C' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<set-ms$volatile>' type=<root>.C origin=null
+              value: GET_VAR 'value: kotlin.Any? declared in <root>.C.<set-ms$volatile>' type=kotlin.Any? origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:marr visibility:private modality:FINAL [val]
+      FIELD ATOMICFU_GENERATED_FIELD name:marr type:java.util.concurrent.atomic.AtomicIntegerArray visibility:private [final]
+        EXPRESSION_BODY
+          CONSTRUCTOR_CALL 'public constructor <init> (length: kotlin.Int) declared in java.util.concurrent.atomic.AtomicIntegerArray' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+            ARG length: CONST Int type=kotlin.Int value=10
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-marr> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicIntegerArray
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:marr visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-marr> (): java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:marr type:java.util.concurrent.atomic.AtomicIntegerArray visibility:private [final] declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-marr>' type=<root>.C origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:ml$volatile visibility:private modality:FINAL [var]
+      FIELD ATOMICFU_GENERATED_FIELD name:ml$volatile type:kotlin.Long visibility:private
+        annotations:
+          Volatile
+        EXPRESSION_BODY
+          CONST Long type=kotlin.Long value=9223372032559808513
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-ml$volatile> visibility:private modality:FINAL returnType:kotlin.Long
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ml$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ml$volatile> (): kotlin.Long declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ml$volatile type:kotlin.Long visibility:private declared in <root>.C' type=kotlin.Long origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-ml$volatile>' type=<root>.C origin=null
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<set-ml$volatile> visibility:private modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Long
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ml$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <set-ml$volatile> (value: kotlin.Long): kotlin.Unit declared in <root>.C'
+            SET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ml$volatile type:kotlin.Long visibility:private declared in <root>.C' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<set-ml$volatile>' type=<root>.C origin=null
+              value: GET_VAR 'value: kotlin.Long declared in <root>.C.<set-ml$volatile>' type=kotlin.Long origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:mb$volatile visibility:private modality:FINAL [var]
+      FIELD ATOMICFU_GENERATED_FIELD name:mb$volatile type:kotlin.Int visibility:private
+        annotations:
+          Volatile
+        EXPRESSION_BODY
+          WHEN type=kotlin.Int origin=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=false
+              then: CONST Int type=kotlin.Int value=1
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CONST Int type=kotlin.Int value=0
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-mb$volatile> visibility:private modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:mb$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-mb$volatile> (): kotlin.Int declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:mb$volatile type:kotlin.Int visibility:private declared in <root>.C' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<get-mb$volatile>' type=<root>.C origin=null
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<set-mb$volatile> visibility:private modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+        VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:mb$volatile visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <set-mb$volatile> (value: kotlin.Int): kotlin.Unit declared in <root>.C'
+            SET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:mb$volatile type:kotlin.Int visibility:private declared in <root>.C' type=kotlin.Unit origin=null
+              receiver: GET_VAR '<this>: <root>.C declared in <root>.C.<set-mb$volatile>' type=<root>.C origin=null
+              value: GET_VAR 'value: kotlin.Int declared in <root>.C.<set-mb$volatile>' type=kotlin.Int origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:ma$volatile$FU visibility:private modality:FINAL [val]
+      FIELD ATOMICFU_GENERATED_FIELD name:ma$volatile$FU type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun newUpdater (tclass: java.lang.Class, fieldName: kotlin.String): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+            ARG tclass: CALL 'public final fun <get-java> ($receiver: kotlin.reflect.KClass<*>): java.lang.Class declared in kotlin.jvm' type=java.lang.Class origin=GET_PROPERTY
+              ARG $receiver: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:KClass modality:ABSTRACT visibility:public superTypes:[kotlin.reflect.KDeclarationContainer; kotlin.reflect.KAnnotatedElement; kotlin.reflect.KClassifier]' type=kotlin.reflect.KClass<*>
+            ARG fieldName: CONST String type=kotlin.String value="ma$volatile"
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-ma$volatile$FU> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicIntegerFieldUpdater [companion]
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ma$volatile$FU visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ma$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ma$volatile$FU type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater visibility:private [final,static] declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:ms$volatile$FU visibility:private modality:FINAL [val]
+      FIELD ATOMICFU_GENERATED_FIELD name:ms$volatile$FU type:java.util.concurrent.atomic.AtomicReferenceFieldUpdater visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun newUpdater (tclass: java.lang.Class, vclass: java.lang.Class, fieldName: kotlin.String): java.util.concurrent.atomic.AtomicReferenceFieldUpdater declared in java.util.concurrent.atomic.AtomicReferenceFieldUpdater' type=java.util.concurrent.atomic.AtomicReferenceFieldUpdater origin=null
+            ARG tclass: CALL 'public final fun <get-java> ($receiver: kotlin.reflect.KClass<*>): java.lang.Class declared in kotlin.jvm' type=java.lang.Class origin=GET_PROPERTY
+              ARG $receiver: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:KClass modality:ABSTRACT visibility:public superTypes:[kotlin.reflect.KDeclarationContainer; kotlin.reflect.KAnnotatedElement; kotlin.reflect.KClassifier]' type=kotlin.reflect.KClass<*>
+            ARG vclass: CALL 'public final fun <get-java> ($receiver: kotlin.reflect.KClass<*>): java.lang.Class declared in kotlin.jvm' type=java.lang.Class origin=GET_PROPERTY
+              ARG $receiver: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:KClass modality:ABSTRACT visibility:public superTypes:[kotlin.reflect.KDeclarationContainer; kotlin.reflect.KAnnotatedElement; kotlin.reflect.KClassifier]' type=kotlin.reflect.KClass<*>
+            ARG fieldName: CONST String type=kotlin.String value="ms$volatile"
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-ms$volatile$FU> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicReferenceFieldUpdater [companion]
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ms$volatile$FU visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ms$volatile$FU> (): java.util.concurrent.atomic.AtomicReferenceFieldUpdater declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ms$volatile$FU type:java.util.concurrent.atomic.AtomicReferenceFieldUpdater visibility:private [final,static] declared in <root>.C' type=java.util.concurrent.atomic.AtomicReferenceFieldUpdater origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:ml$volatile$FU visibility:private modality:FINAL [val]
+      FIELD ATOMICFU_GENERATED_FIELD name:ml$volatile$FU type:java.util.concurrent.atomic.AtomicLongFieldUpdater visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun newUpdater (tclass: java.lang.Class, fieldName: kotlin.String): java.util.concurrent.atomic.AtomicLongFieldUpdater declared in java.util.concurrent.atomic.AtomicLongFieldUpdater' type=java.util.concurrent.atomic.AtomicLongFieldUpdater origin=null
+            ARG tclass: CALL 'public final fun <get-java> ($receiver: kotlin.reflect.KClass<*>): java.lang.Class declared in kotlin.jvm' type=java.lang.Class origin=GET_PROPERTY
+              ARG $receiver: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:KClass modality:ABSTRACT visibility:public superTypes:[kotlin.reflect.KDeclarationContainer; kotlin.reflect.KAnnotatedElement; kotlin.reflect.KClassifier]' type=kotlin.reflect.KClass<*>
+            ARG fieldName: CONST String type=kotlin.String value="ml$volatile"
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-ml$volatile$FU> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicLongFieldUpdater [companion]
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:ml$volatile$FU visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-ml$volatile$FU> (): java.util.concurrent.atomic.AtomicLongFieldUpdater declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:ml$volatile$FU type:java.util.concurrent.atomic.AtomicLongFieldUpdater visibility:private [final,static] declared in <root>.C' type=java.util.concurrent.atomic.AtomicLongFieldUpdater origin=null
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:mb$volatile$FU visibility:private modality:FINAL [val]
+      FIELD ATOMICFU_GENERATED_FIELD name:mb$volatile$FU type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun newUpdater (tclass: java.lang.Class, fieldName: kotlin.String): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+            ARG tclass: CALL 'public final fun <get-java> ($receiver: kotlin.reflect.KClass<*>): java.lang.Class declared in kotlin.jvm' type=java.lang.Class origin=GET_PROPERTY
+              ARG $receiver: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB INTERFACE name:KClass modality:ABSTRACT visibility:public superTypes:[kotlin.reflect.KDeclarationContainer; kotlin.reflect.KAnnotatedElement; kotlin.reflect.KClassifier]' type=kotlin.reflect.KClass<*>
+            ARG fieldName: CONST String type=kotlin.String value="mb$volatile"
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-mb$volatile$FU> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicIntegerFieldUpdater [companion]
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:mb$volatile$FU visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-mb$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:mb$volatile$FU type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater visibility:private [final,static] declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.C [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN ATOMICFU_GENERATED_FUNCTION name:getSquared$atomicfu$ATOMIC_ARRAY$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+      VALUE_PARAMETER kind:Regular name:handler$atomicfu index:1 type:java.util.concurrent.atomic.AtomicIntegerArray
+      VALUE_PARAMETER kind:Regular name:index$atomicfu index:2 type:kotlin.Int
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun getSquared$atomicfu$ATOMIC_ARRAY$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray, index$atomicfu: kotlin.Int): kotlin.Int declared in <root>.C'
+          CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+            ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+              CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.C.getSquared$atomicfu$ATOMIC_ARRAY$Int' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+                ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.C.getSquared$atomicfu$ATOMIC_ARRAY$Int' type=kotlin.Int origin=null
+            ARG other: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+              CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.C.getSquared$atomicfu$ATOMIC_ARRAY$Int' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+                ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.C.getSquared$atomicfu$ATOMIC_ARRAY$Int' type=kotlin.Int origin=null
+    FUN ATOMICFU_GENERATED_FUNCTION name:getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+      VALUE_PARAMETER kind:Regular name:handler$atomicfu index:1 type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+      VALUE_PARAMETER kind:Regular name:obj$atomicfu index:2 type:kotlin.Any?
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>.C'
+          CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+            ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+              CALL 'public final fun get (obj: kotlin.Any): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C.getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+                ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.C.getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=kotlin.Any? origin=null
+            ARG other: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+              CALL 'public final fun get (obj: kotlin.Any): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C.getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+                ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.C.getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=kotlin.Any? origin=null
+    FUN ATOMICFU_GENERATED_FUNCTION name:getSquared$atomicfu$BOXED_ATOMIC$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+      VALUE_PARAMETER kind:Regular name:handler$atomicfu index:1 type:java.util.concurrent.atomic.AtomicInteger
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun getSquared$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>.C'
+          CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+            ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+              CALL 'public final fun get (): kotlin.Int declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicInteger declared in <root>.C.getSquared$atomicfu$BOXED_ATOMIC$Int' type=java.util.concurrent.atomic.AtomicInteger origin=null
+            ARG other: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+              CALL 'public final fun get (): kotlin.Int declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicInteger declared in <root>.C.getSquared$atomicfu$BOXED_ATOMIC$Int' type=java.util.concurrent.atomic.AtomicInteger origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:memberTest visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+      BLOCK_BODY
+        CALL 'public final fun set (obj: kotlin.Any, newValue: kotlin.Int): kotlin.Unit declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Unit origin=null
+          ARG <this>: CALL 'private final fun <get-ma$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+          ARG obj: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+          ARG newValue: CONST Int type=kotlin.Int value=-10
+        CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG expected: CONST Int type=kotlin.Int value=10
+          ARG actual: CALL 'private final fun getAbs$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+            ARG handler$atomicfu: CALL 'private final fun <get-ma$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+            ARG obj$atomicfu: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertFalse (actual: kotlin.Boolean, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          ARG actual: CALL 'private final fun getIsEmpty$atomicfu$ATOMIC_FIELD_UPDATER$Any (handler$atomicfu: java.util.concurrent.atomic.AtomicReferenceFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=null
+            ARG handler$atomicfu: CALL 'private final fun <get-ms$volatile$FU> (): java.util.concurrent.atomic.AtomicReferenceFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicReferenceFieldUpdater origin=null
+            ARG obj$atomicfu: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG expected: CONST Int type=kotlin.Int value=-100
+          ARG actual: CALL 'private final fun getScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+            ARG handler$atomicfu: CALL 'private final fun <get-ma$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+            ARG obj$atomicfu: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'private final fun setScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-ma$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+          ARG obj$atomicfu: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+          ARG value: CONST Int type=kotlin.Int value=200
+        CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG expected: CONST Int type=kotlin.Int value=20
+          ARG actual: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (obj: kotlin.Any): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Int origin=null
+              ARG <this>: CALL 'private final fun <get-ma$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+              ARG obj: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'private final fun setScaledBy10$atomicfu$ATOMIC_ARRAY$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray, index$atomicfu: kotlin.Int, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-marr> (): java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+            ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+          ARG index$atomicfu: CONST Int type=kotlin.Int value=0
+          ARG value: CONST Int type=kotlin.Int value=300
+        CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG expected: CONST Int type=kotlin.Int value=30
+          ARG actual: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+              ARG <this>: CALL 'private final fun <get-marr> (): java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+                ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+              ARG i: CONST Int type=kotlin.Int value=0
+        CALL 'public final fun assertFalse (actual: kotlin.Boolean, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          ARG actual: CALL 'private final fun getIsTrue$atomicfu$ATOMIC_FIELD_UPDATER$Boolean (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=null
+            ARG handler$atomicfu: CALL 'private final fun <get-mb$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+            ARG obj$atomicfu: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG expected: CONST Int type=kotlin.Int value=1
+          ARG actual: CALL 'private final fun getLow$atomicfu$ATOMIC_FIELD_UPDATER$Long (handler$atomicfu: java.util.concurrent.atomic.AtomicLongFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+            ARG handler$atomicfu: CALL 'private final fun <get-ml$volatile$FU> (): java.util.concurrent.atomic.AtomicLongFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicLongFieldUpdater origin=null
+            ARG obj$atomicfu: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+        CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG expected: CONST Int type=kotlin.Int value=400
+          ARG actual: CALL 'private final fun getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>.C' type=kotlin.Int origin=null
+            ARG <this>: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+            ARG handler$atomicfu: CALL 'private final fun <get-ma$volatile$FU> (): java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.C' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+            ARG obj$atomicfu: GET_VAR '<this>: <root>.C declared in <root>.C.memberTest' type=<root>.C origin=IMPLICIT_ARGUMENT
+  FUN ATOMICFU_GENERATED_FUNCTION name:getAbs$atomicfu$ATOMIC_ARRAY$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerArray
+    VALUE_PARAMETER kind:Regular name:index$atomicfu index:1 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getAbs$atomicfu$ATOMIC_ARRAY$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray, index$atomicfu: kotlin.Int): kotlin.Int declared in <root>'
+        CALL 'public final fun abs (n: kotlin.Int): kotlin.Int declared in kotlin.math' type=kotlin.Int origin=null
+          ARG n: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.getAbs$atomicfu$ATOMIC_ARRAY$Int' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+              ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.getAbs$atomicfu$ATOMIC_ARRAY$Int' type=kotlin.Int origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getAbs$atomicfu$ATOMIC_FIELD_UPDATER$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    VALUE_PARAMETER kind:Regular name:obj$atomicfu index:1 type:kotlin.Any?
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getAbs$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>'
+        CALL 'public final fun abs (n: kotlin.Int): kotlin.Int declared in kotlin.math' type=kotlin.Int origin=null
+          ARG n: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (obj: kotlin.Any): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.getAbs$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+              ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.getAbs$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=kotlin.Any? origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getAbs$atomicfu$BOXED_ATOMIC$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicInteger
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getAbs$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>'
+        CALL 'public final fun abs (n: kotlin.Int): kotlin.Int declared in kotlin.math' type=kotlin.Int origin=null
+          ARG n: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (): kotlin.Int declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicInteger declared in <root>.getAbs$atomicfu$BOXED_ATOMIC$Int' type=java.util.concurrent.atomic.AtomicInteger origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getIsEmpty$atomicfu$ATOMIC_ARRAY$Any visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicReferenceArray
+    VALUE_PARAMETER kind:Regular name:index$atomicfu index:1 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getIsEmpty$atomicfu$ATOMIC_ARRAY$Any (handler$atomicfu: java.util.concurrent.atomic.AtomicReferenceArray, index$atomicfu: kotlin.Int): kotlin.Boolean declared in <root>'
+        CALL 'public final fun isEmpty (<this>: kotlin.CharSequence): kotlin.Boolean declared in kotlin.text' type=kotlin.Boolean origin=null
+          ARG <this>: TYPE_OP type=kotlin.Any? origin=CAST typeOperand=kotlin.Any?
+            CALL 'public final fun get <T> (i: kotlin.Int): T of java.util.concurrent.atomic.AtomicReferenceArray.get declared in java.util.concurrent.atomic.AtomicReferenceArray' type=kotlin.Any? origin=null
+              TYPE_ARG T: <none>
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicReferenceArray declared in <root>.getIsEmpty$atomicfu$ATOMIC_ARRAY$Any' type=java.util.concurrent.atomic.AtomicReferenceArray origin=null
+              ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.getIsEmpty$atomicfu$ATOMIC_ARRAY$Any' type=kotlin.Int origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getIsEmpty$atomicfu$ATOMIC_FIELD_UPDATER$Any visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+    VALUE_PARAMETER kind:Regular name:obj$atomicfu index:1 type:kotlin.Any?
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getIsEmpty$atomicfu$ATOMIC_FIELD_UPDATER$Any (handler$atomicfu: java.util.concurrent.atomic.AtomicReferenceFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Boolean declared in <root>'
+        CALL 'public final fun isEmpty (<this>: kotlin.CharSequence): kotlin.Boolean declared in kotlin.text' type=kotlin.Boolean origin=null
+          ARG <this>: TYPE_OP type=kotlin.Any? origin=CAST typeOperand=kotlin.Any?
+            CALL 'public final fun get <T> (obj: kotlin.Any): T of java.util.concurrent.atomic.AtomicReferenceFieldUpdater.get declared in java.util.concurrent.atomic.AtomicReferenceFieldUpdater' type=kotlin.Any? origin=null
+              TYPE_ARG T: <none>
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicReferenceFieldUpdater declared in <root>.getIsEmpty$atomicfu$ATOMIC_FIELD_UPDATER$Any' type=java.util.concurrent.atomic.AtomicReferenceFieldUpdater origin=null
+              ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.getIsEmpty$atomicfu$ATOMIC_FIELD_UPDATER$Any' type=kotlin.Any? origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getIsEmpty$atomicfu$BOXED_ATOMIC$Any visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicReference
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getIsEmpty$atomicfu$BOXED_ATOMIC$Any (handler$atomicfu: java.util.concurrent.atomic.AtomicReference): kotlin.Boolean declared in <root>'
+        CALL 'public final fun isEmpty (<this>: kotlin.CharSequence): kotlin.Boolean declared in kotlin.text' type=kotlin.Boolean origin=null
+          ARG <this>: TYPE_OP type=kotlin.Any? origin=CAST typeOperand=kotlin.Any?
+            CALL 'public final fun get <T> (): T of java.util.concurrent.atomic.AtomicReference.get declared in java.util.concurrent.atomic.AtomicReference' type=kotlin.Any? origin=null
+              TYPE_ARG T: <none>
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicReference declared in <root>.getIsEmpty$atomicfu$BOXED_ATOMIC$Any' type=java.util.concurrent.atomic.AtomicReference origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getIsTrue$atomicfu$ATOMIC_ARRAY$Boolean visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerArray
+    VALUE_PARAMETER kind:Regular name:index$atomicfu index:1 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getIsTrue$atomicfu$ATOMIC_ARRAY$Boolean (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray, index$atomicfu: kotlin.Int): kotlin.Boolean declared in <root>'
+        TYPE_OP type=kotlin.Boolean origin=CAST typeOperand=kotlin.Boolean
+          CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+            ARG arg0: CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.getIsTrue$atomicfu$ATOMIC_ARRAY$Boolean' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+              ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.getIsTrue$atomicfu$ATOMIC_ARRAY$Boolean' type=kotlin.Int origin=null
+            ARG arg1: CONST Int type=kotlin.Int value=1
+  FUN ATOMICFU_GENERATED_FUNCTION name:getIsTrue$atomicfu$ATOMIC_FIELD_UPDATER$Boolean visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    VALUE_PARAMETER kind:Regular name:obj$atomicfu index:1 type:kotlin.Any?
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getIsTrue$atomicfu$ATOMIC_FIELD_UPDATER$Boolean (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Boolean declared in <root>'
+        TYPE_OP type=kotlin.Boolean origin=CAST typeOperand=kotlin.Boolean
+          CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+            ARG arg0: CALL 'public final fun get (obj: kotlin.Any): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.getIsTrue$atomicfu$ATOMIC_FIELD_UPDATER$Boolean' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+              ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.getIsTrue$atomicfu$ATOMIC_FIELD_UPDATER$Boolean' type=kotlin.Any? origin=null
+            ARG arg1: CONST Int type=kotlin.Int value=1
+  FUN ATOMICFU_GENERATED_FUNCTION name:getIsTrue$atomicfu$BOXED_ATOMIC$Boolean visibility:private modality:FINAL returnType:kotlin.Boolean [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicBoolean
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getIsTrue$atomicfu$BOXED_ATOMIC$Boolean (handler$atomicfu: java.util.concurrent.atomic.AtomicBoolean): kotlin.Boolean declared in <root>'
+        TYPE_OP type=kotlin.Boolean origin=CAST typeOperand=kotlin.Boolean
+          CALL 'public final fun get (): kotlin.Boolean declared in java.util.concurrent.atomic.AtomicBoolean' type=kotlin.Boolean origin=null
+            ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicBoolean declared in <root>.getIsTrue$atomicfu$BOXED_ATOMIC$Boolean' type=java.util.concurrent.atomic.AtomicBoolean origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getLow$atomicfu$ATOMIC_ARRAY$Long visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicLongArray
+    VALUE_PARAMETER kind:Regular name:index$atomicfu index:1 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getLow$atomicfu$ATOMIC_ARRAY$Long (handler$atomicfu: java.util.concurrent.atomic.AtomicLongArray, index$atomicfu: kotlin.Int): kotlin.Int declared in <root>'
+        CALL 'public open fun toInt (): kotlin.Int declared in kotlin.Long' type=kotlin.Int origin=null
+          ARG <this>: TYPE_OP type=kotlin.Long origin=CAST typeOperand=kotlin.Long
+            CALL 'public final fun get (i: kotlin.Int): kotlin.Long declared in java.util.concurrent.atomic.AtomicLongArray' type=kotlin.Long origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicLongArray declared in <root>.getLow$atomicfu$ATOMIC_ARRAY$Long' type=java.util.concurrent.atomic.AtomicLongArray origin=null
+              ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.getLow$atomicfu$ATOMIC_ARRAY$Long' type=kotlin.Int origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getLow$atomicfu$ATOMIC_FIELD_UPDATER$Long visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicLongFieldUpdater
+    VALUE_PARAMETER kind:Regular name:obj$atomicfu index:1 type:kotlin.Any?
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getLow$atomicfu$ATOMIC_FIELD_UPDATER$Long (handler$atomicfu: java.util.concurrent.atomic.AtomicLongFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>'
+        CALL 'public open fun toInt (): kotlin.Int declared in kotlin.Long' type=kotlin.Int origin=null
+          ARG <this>: TYPE_OP type=kotlin.Long origin=CAST typeOperand=kotlin.Long
+            CALL 'public final fun get (obj: kotlin.Any): kotlin.Long declared in java.util.concurrent.atomic.AtomicLongFieldUpdater' type=kotlin.Long origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicLongFieldUpdater declared in <root>.getLow$atomicfu$ATOMIC_FIELD_UPDATER$Long' type=java.util.concurrent.atomic.AtomicLongFieldUpdater origin=null
+              ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.getLow$atomicfu$ATOMIC_FIELD_UPDATER$Long' type=kotlin.Any? origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getLow$atomicfu$BOXED_ATOMIC$Long visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicLong
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getLow$atomicfu$BOXED_ATOMIC$Long (handler$atomicfu: java.util.concurrent.atomic.AtomicLong): kotlin.Int declared in <root>'
+        CALL 'public open fun toInt (): kotlin.Int declared in kotlin.Long' type=kotlin.Int origin=null
+          ARG <this>: TYPE_OP type=kotlin.Long origin=CAST typeOperand=kotlin.Long
+            CALL 'public final fun get (): kotlin.Long declared in java.util.concurrent.atomic.AtomicLong' type=kotlin.Long origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicLong declared in <root>.getLow$atomicfu$BOXED_ATOMIC$Long' type=java.util.concurrent.atomic.AtomicLong origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getScaledBy10$atomicfu$ATOMIC_ARRAY$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerArray
+    VALUE_PARAMETER kind:Regular name:index$atomicfu index:1 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getScaledBy10$atomicfu$ATOMIC_ARRAY$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray, index$atomicfu: kotlin.Int): kotlin.Int declared in <root>'
+        CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+          ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.getScaledBy10$atomicfu$ATOMIC_ARRAY$Int' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+              ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.getScaledBy10$atomicfu$ATOMIC_ARRAY$Int' type=kotlin.Int origin=null
+          ARG other: CONST Int type=kotlin.Int value=10
+  FUN ATOMICFU_GENERATED_FUNCTION name:getScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    VALUE_PARAMETER kind:Regular name:obj$atomicfu index:1 type:kotlin.Any?
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>'
+        CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+          ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (obj: kotlin.Any): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.getScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+              ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.getScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=kotlin.Any? origin=null
+          ARG other: CONST Int type=kotlin.Int value=10
+  FUN ATOMICFU_GENERATED_FUNCTION name:getScaledBy10$atomicfu$BOXED_ATOMIC$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicInteger
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getScaledBy10$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>'
+        CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+          ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (): kotlin.Int declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicInteger declared in <root>.getScaledBy10$atomicfu$BOXED_ATOMIC$Int' type=java.util.concurrent.atomic.AtomicInteger origin=null
+          ARG other: CONST Int type=kotlin.Int value=10
+  FUN ATOMICFU_GENERATED_FUNCTION name:setScaledBy10$atomicfu$ATOMIC_ARRAY$Int visibility:private modality:FINAL returnType:kotlin.Unit [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerArray
+    VALUE_PARAMETER kind:Regular name:index$atomicfu index:1 type:kotlin.Int
+    VALUE_PARAMETER kind:Regular name:value index:2 type:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun set (i: kotlin.Int, newValue: kotlin.Int): kotlin.Unit declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.setScaledBy10$atomicfu$ATOMIC_ARRAY$Int' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+        ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.setScaledBy10$atomicfu$ATOMIC_ARRAY$Int' type=kotlin.Int origin=null
+        ARG newValue: CALL 'public final fun div (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=DIV
+          ARG <this>: GET_VAR 'value: kotlin.Int declared in <root>.setScaledBy10$atomicfu$ATOMIC_ARRAY$Int' type=kotlin.Int origin=null
+          ARG other: CONST Int type=kotlin.Int value=10
+  FUN ATOMICFU_GENERATED_FUNCTION name:setScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int visibility:private modality:FINAL returnType:kotlin.Unit [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    VALUE_PARAMETER kind:Regular name:obj$atomicfu index:1 type:kotlin.Any?
+    VALUE_PARAMETER kind:Regular name:value index:2 type:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun set (obj: kotlin.Any, newValue: kotlin.Int): kotlin.Unit declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.setScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+        ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.setScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=kotlin.Any? origin=null
+        ARG newValue: CALL 'public final fun div (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=DIV
+          ARG <this>: GET_VAR 'value: kotlin.Int declared in <root>.setScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=kotlin.Int origin=null
+          ARG other: CONST Int type=kotlin.Int value=10
+  FUN ATOMICFU_GENERATED_FUNCTION name:setScaledBy10$atomicfu$BOXED_ATOMIC$Int visibility:private modality:FINAL returnType:kotlin.Unit [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicInteger
+    VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun set (newValue: kotlin.Int): kotlin.Unit declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Unit origin=null
+        ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicInteger declared in <root>.setScaledBy10$atomicfu$BOXED_ATOMIC$Int' type=java.util.concurrent.atomic.AtomicInteger origin=null
+        ARG newValue: CALL 'public final fun div (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=DIV
+          ARG <this>: GET_VAR 'value: kotlin.Int declared in <root>.setScaledBy10$atomicfu$BOXED_ATOMIC$Int' type=kotlin.Int origin=null
+          ARG other: CONST Int type=kotlin.Int value=10
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun topLevelTest (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      CALL 'public final fun memberTest (): kotlin.Unit declared in <root>.C' type=kotlin.Unit origin=null
+        ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.C' type=<root>.C origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+  FUN name:topLevelTest visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+      CALL 'public final fun set (newValue: kotlin.Int): kotlin.Unit declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Unit origin=null
+        ARG <this>: CALL 'private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+        ARG newValue: CONST Int type=kotlin.Int value=-10
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG expected: CONST Int type=kotlin.Int value=10
+        ARG actual: CALL 'private final fun getAbs$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+      CALL 'public final fun assertFalse (actual: kotlin.Boolean, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG actual: CALL 'private final fun getIsEmpty$atomicfu$BOXED_ATOMIC$Any (handler$atomicfu: java.util.concurrent.atomic.AtomicReference): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-s> (): java.util.concurrent.atomic.AtomicReference declared in <root>' type=java.util.concurrent.atomic.AtomicReference origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG expected: CONST Int type=kotlin.Int value=-100
+        ARG actual: CALL 'private final fun getScaledBy10$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+      CALL 'private final fun setScaledBy10$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+        ARG handler$atomicfu: CALL 'private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+        ARG value: CONST Int type=kotlin.Int value=200
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG expected: CONST Int type=kotlin.Int value=20
+        ARG actual: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+          CALL 'public final fun get (): kotlin.Int declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Int origin=null
+            ARG <this>: CALL 'private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+      CALL 'private final fun setScaledBy10$atomicfu$ATOMIC_ARRAY$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray, index$atomicfu: kotlin.Int, value: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+        ARG handler$atomicfu: CALL 'private final fun <get-arr> (): java.util.concurrent.atomic.AtomicIntegerArray declared in <root>' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+        ARG index$atomicfu: CONST Int type=kotlin.Int value=0
+        ARG value: CONST Int type=kotlin.Int value=300
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG expected: CONST Int type=kotlin.Int value=30
+        ARG actual: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+          CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+            ARG <this>: CALL 'private final fun <get-arr> (): java.util.concurrent.atomic.AtomicIntegerArray declared in <root>' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+            ARG i: CONST Int type=kotlin.Int value=0
+      CALL 'public final fun assertFalse (actual: kotlin.Boolean, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG actual: CALL 'private final fun getIsTrue$atomicfu$BOXED_ATOMIC$Boolean (handler$atomicfu: java.util.concurrent.atomic.AtomicBoolean): kotlin.Boolean declared in <root>' type=kotlin.Boolean origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-b> (): java.util.concurrent.atomic.AtomicBoolean declared in <root>' type=java.util.concurrent.atomic.AtomicBoolean origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG expected: CONST Int type=kotlin.Int value=1
+        ARG actual: CALL 'private final fun getLow$atomicfu$BOXED_ATOMIC$Long (handler$atomicfu: java.util.concurrent.atomic.AtomicLong): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-l> (): java.util.concurrent.atomic.AtomicLong declared in <root>' type=java.util.concurrent.atomic.AtomicLong origin=null

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.kt
@@ -1,0 +1,71 @@
+import kotlinx.atomicfu.*
+import kotlin.test.*
+import kotlin.math.abs
+
+private inline val AtomicInt.abs: Int
+    get() = abs(value)
+
+private inline val AtomicRef<String>.isEmpty: Boolean
+    get() = value.isEmpty()
+
+private inline var AtomicInt.scaledBy10: Int
+    get() = value * 10
+    set(value) {
+        this.value = value / 10
+    }
+
+private inline val AtomicLong.low: Int
+    get() = value.toInt()
+
+private inline val AtomicBoolean.isTrue: Boolean
+    get() = value
+
+private val a = atomic(0)
+private val s = atomic("TEST")
+private val arr = AtomicIntArray(10)
+private val l = atomic(0x7fff_ffff_0000_0001L)
+private val b = atomic(false)
+
+class C {
+    private val ma = atomic(0)
+    private val ms = atomic("TEST")
+    private val marr = AtomicIntArray(10)
+    private val ml = atomic(0x7fff_ffff_0000_0001L)
+    private val mb = atomic(false)
+
+    private inline val AtomicInt.squared: Int get() = value * value
+
+    fun memberTest() {
+        ma.value = -10
+        assertEquals(10, ma.abs)
+        assertFalse(ms.isEmpty)
+        assertEquals(-100, ma.scaledBy10)
+        ma.scaledBy10 = 200
+        assertEquals(20, ma.value)
+        marr[0].scaledBy10 = 300
+        assertEquals(30, marr[0].value)
+        assertFalse(mb.isTrue)
+        assertEquals(1, ml.low)
+
+        assertEquals(400, ma.squared)
+    }
+}
+
+fun topLevelTest() {
+    a.value = -10
+    assertEquals(10, a.abs)
+    assertFalse(s.isEmpty)
+    assertEquals(-100, a.scaledBy10)
+    a.scaledBy10 = 200
+    assertEquals(20, a.value)
+    arr[0].scaledBy10 = 300
+    assertEquals(30, arr[0].value)
+    assertFalse(b.isTrue)
+    assertEquals(1, l.low)
+}
+
+fun box(): String {
+    topLevelTest()
+    C().memberTest()
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomic_extensions/InlineExtensionProperties.txt
@@ -1,0 +1,68 @@
+@kotlin.Metadata
+public final class C {
+    // source: 'InlineExtensionProperties.kt'
+    private synthetic final static field ma$volatile$FU: java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    private synthetic volatile field ma$volatile: int
+    private synthetic final field marr: java.util.concurrent.atomic.AtomicIntegerArray
+    private synthetic final static field mb$volatile$FU: java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    private synthetic volatile field mb$volatile: int
+    private synthetic final static field ml$volatile$FU: java.util.concurrent.atomic.AtomicLongFieldUpdater
+    private synthetic volatile field ml$volatile: long
+    private synthetic final static field ms$volatile$FU: java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+    private synthetic volatile field ms$volatile: java.lang.Object
+    static method <clinit>(): void
+    public method <init>(): void
+    private synthetic final static method getMa$volatile$FU(): java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    private synthetic final method getMa$volatile(): int
+    private synthetic final method getMarr(): java.util.concurrent.atomic.AtomicIntegerArray
+    private synthetic final static method getMb$volatile$FU(): java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    private synthetic final method getMb$volatile(): int
+    private synthetic final static method getMl$volatile$FU(): java.util.concurrent.atomic.AtomicLongFieldUpdater
+    private synthetic final method getMl$volatile(): long
+    private synthetic final static method getMs$volatile$FU(): java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+    private synthetic final method getMs$volatile(): java.lang.Object
+    private synthetic final method getSquared$atomicfu$ATOMIC_ARRAY$Int(p0: java.util.concurrent.atomic.AtomicIntegerArray, p1: int): int
+    private synthetic final method getSquared$atomicfu$ATOMIC_FIELD_UPDATER$Int(p0: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, p1: java.lang.Object): int
+    private synthetic final method getSquared$atomicfu$BOXED_ATOMIC$Int(p0: java.util.concurrent.atomic.AtomicInteger): int
+    public final method memberTest(): void
+    private synthetic final method setMa$volatile(p0: int): void
+    private synthetic final method setMb$volatile(p0: int): void
+    private synthetic final method setMl$volatile(p0: long): void
+    private synthetic final method setMs$volatile(p0: java.lang.Object): void
+}
+
+@kotlin.Metadata
+public final class InlineExtensionPropertiesKt {
+    // source: 'InlineExtensionProperties.kt'
+    private synthetic final static field a: java.util.concurrent.atomic.AtomicInteger
+    private synthetic final static field arr: java.util.concurrent.atomic.AtomicIntegerArray
+    private synthetic final static field b: java.util.concurrent.atomic.AtomicBoolean
+    private synthetic final static field l: java.util.concurrent.atomic.AtomicLong
+    private synthetic final static field s: java.util.concurrent.atomic.AtomicReference
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    private synthetic final static method getA(): java.util.concurrent.atomic.AtomicInteger
+    private synthetic final static method getAbs$atomicfu$ATOMIC_ARRAY$Int(p0: java.util.concurrent.atomic.AtomicIntegerArray, p1: int): int
+    private synthetic final static method getAbs$atomicfu$ATOMIC_FIELD_UPDATER$Int(p0: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, p1: java.lang.Object): int
+    private synthetic final static method getAbs$atomicfu$BOXED_ATOMIC$Int(p0: java.util.concurrent.atomic.AtomicInteger): int
+    private synthetic final static method getArr(): java.util.concurrent.atomic.AtomicIntegerArray
+    private synthetic final static method getB(): java.util.concurrent.atomic.AtomicBoolean
+    private synthetic final static method getIsEmpty$atomicfu$ATOMIC_ARRAY$Any(p0: java.util.concurrent.atomic.AtomicReferenceArray, p1: int): boolean
+    private synthetic final static method getIsEmpty$atomicfu$ATOMIC_FIELD_UPDATER$Any(p0: java.util.concurrent.atomic.AtomicReferenceFieldUpdater, p1: java.lang.Object): boolean
+    private synthetic final static method getIsEmpty$atomicfu$BOXED_ATOMIC$Any(p0: java.util.concurrent.atomic.AtomicReference): boolean
+    private synthetic final static method getIsTrue$atomicfu$ATOMIC_ARRAY$Boolean(p0: java.util.concurrent.atomic.AtomicIntegerArray, p1: int): boolean
+    private synthetic final static method getIsTrue$atomicfu$ATOMIC_FIELD_UPDATER$Boolean(p0: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, p1: java.lang.Object): boolean
+    private synthetic final static method getIsTrue$atomicfu$BOXED_ATOMIC$Boolean(p0: java.util.concurrent.atomic.AtomicBoolean): boolean
+    private synthetic final static method getL(): java.util.concurrent.atomic.AtomicLong
+    private synthetic final static method getLow$atomicfu$ATOMIC_ARRAY$Long(p0: java.util.concurrent.atomic.AtomicLongArray, p1: int): int
+    private synthetic final static method getLow$atomicfu$ATOMIC_FIELD_UPDATER$Long(p0: java.util.concurrent.atomic.AtomicLongFieldUpdater, p1: java.lang.Object): int
+    private synthetic final static method getLow$atomicfu$BOXED_ATOMIC$Long(p0: java.util.concurrent.atomic.AtomicLong): int
+    private synthetic final static method getS(): java.util.concurrent.atomic.AtomicReference
+    private synthetic final static method getScaledBy10$atomicfu$ATOMIC_ARRAY$Int(p0: java.util.concurrent.atomic.AtomicIntegerArray, p1: int): int
+    private synthetic final static method getScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int(p0: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, p1: java.lang.Object): int
+    private synthetic final static method getScaledBy10$atomicfu$BOXED_ATOMIC$Int(p0: java.util.concurrent.atomic.AtomicInteger): int
+    private synthetic final static method setScaledBy10$atomicfu$ATOMIC_ARRAY$Int(p0: java.util.concurrent.atomic.AtomicIntegerArray, p1: int, p2: int): void
+    private synthetic final static method setScaledBy10$atomicfu$ATOMIC_FIELD_UPDATER$Int(p0: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, p1: java.lang.Object, p2: int): void
+    private synthetic final static method setScaledBy10$atomicfu$BOXED_ATOMIC$Int(p0: java.util.concurrent.atomic.AtomicInteger, p1: int): void
+    public final static method topLevelTest(): void
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/InlineExtensionProperties.ir2.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/InlineExtensionProperties.ir2.txt
@@ -1,0 +1,88 @@
+FILE fqName:<root> fileName:/InlineExtensionProperties.kt
+  PROPERTY ATOMICFU_GENERATED_PROPERTY name:cA visibility:private modality:FINAL [val]
+    FIELD ATOMICFU_GENERATED_FIELD name:cA type:java.util.concurrent.atomic.AtomicInteger visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Int) declared in java.util.concurrent.atomic.AtomicInteger' type=java.util.concurrent.atomic.AtomicInteger origin=null
+          ARG value: CONST Int type=kotlin.Int value=1
+    FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-cA> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicInteger
+      correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:cA visibility:private modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-cA> (): java.util.concurrent.atomic.AtomicInteger declared in <root>'
+          GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:cA type:java.util.concurrent.atomic.AtomicInteger visibility:private [final,static] declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+  CLASS CLASS name:Outer modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Outer
+    PROPERTY ATOMICFU_GENERATED_PROPERTY name:a visibility:private modality:FINAL [val]
+      FIELD ATOMICFU_GENERATED_FIELD name:a type:java.util.concurrent.atomic.AtomicInteger visibility:private [final,static]
+        EXPRESSION_BODY
+          CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.Int) declared in java.util.concurrent.atomic.AtomicInteger' type=java.util.concurrent.atomic.AtomicInteger origin=null
+            ARG value: CONST Int type=kotlin.Int value=10
+      FUN ATOMICFU_GENERATED_PROPERTY_ACCESSOR name:<get-a> visibility:private modality:FINAL returnType:java.util.concurrent.atomic.AtomicInteger [companion]
+        correspondingProperty: PROPERTY ATOMICFU_GENERATED_PROPERTY name:a visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>.Outer'
+            GET_FIELD 'FIELD ATOMICFU_GENERATED_FIELD name:a type:java.util.concurrent.atomic.AtomicInteger visibility:private [final,static] declared in <root>.Outer' type=java.util.concurrent.atomic.AtomicInteger origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Outer [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Outer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:test visibility:public modality:FINAL returnType:kotlin.Unit [companion]
+      BLOCK_BODY
+        CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+          TYPE_ARG T: kotlin.Int
+          ARG expected: CONST Int type=kotlin.Int value=20
+          ARG actual: CALL 'private final fun getTwiceAsLarge$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+            ARG handler$atomicfu: CALL 'private final fun <get-a> (): java.util.concurrent.atomic.AtomicInteger declared in <root>.Outer' type=java.util.concurrent.atomic.AtomicInteger origin=null
+  FUN ATOMICFU_GENERATED_FUNCTION name:getTwiceAsLarge$atomicfu$ATOMIC_ARRAY$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerArray
+    VALUE_PARAMETER kind:Regular name:index$atomicfu index:1 type:kotlin.Int
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getTwiceAsLarge$atomicfu$ATOMIC_ARRAY$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray, index$atomicfu: kotlin.Int): kotlin.Int declared in <root>'
+        CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+          ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (i: kotlin.Int): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerArray' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerArray declared in <root>.getTwiceAsLarge$atomicfu$ATOMIC_ARRAY$Int' type=java.util.concurrent.atomic.AtomicIntegerArray origin=null
+              ARG i: GET_VAR 'index$atomicfu: kotlin.Int declared in <root>.getTwiceAsLarge$atomicfu$ATOMIC_ARRAY$Int' type=kotlin.Int origin=null
+          ARG other: CONST Int type=kotlin.Int value=2
+  FUN ATOMICFU_GENERATED_FUNCTION name:getTwiceAsLarge$atomicfu$ATOMIC_FIELD_UPDATER$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+    VALUE_PARAMETER kind:Regular name:obj$atomicfu index:1 type:kotlin.Any?
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getTwiceAsLarge$atomicfu$ATOMIC_FIELD_UPDATER$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, obj$atomicfu: kotlin.Any?): kotlin.Int declared in <root>'
+        CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+          ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (obj: kotlin.Any): kotlin.Int declared in java.util.concurrent.atomic.AtomicIntegerFieldUpdater' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicIntegerFieldUpdater declared in <root>.getTwiceAsLarge$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=java.util.concurrent.atomic.AtomicIntegerFieldUpdater origin=null
+              ARG obj: GET_VAR 'obj$atomicfu: kotlin.Any? declared in <root>.getTwiceAsLarge$atomicfu$ATOMIC_FIELD_UPDATER$Int' type=kotlin.Any? origin=null
+          ARG other: CONST Int type=kotlin.Int value=2
+  FUN ATOMICFU_GENERATED_FUNCTION name:getTwiceAsLarge$atomicfu$BOXED_ATOMIC$Int visibility:private modality:FINAL returnType:kotlin.Int [inline]
+    VALUE_PARAMETER kind:Regular name:handler$atomicfu index:0 type:java.util.concurrent.atomic.AtomicInteger
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun getTwiceAsLarge$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>'
+        CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+          ARG <this>: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+            CALL 'public final fun get (): kotlin.Int declared in java.util.concurrent.atomic.AtomicInteger' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'handler$atomicfu: java.util.concurrent.atomic.AtomicInteger declared in <root>.getTwiceAsLarge$atomicfu$BOXED_ATOMIC$Int' type=java.util.concurrent.atomic.AtomicInteger origin=null
+          ARG other: CONST Int type=kotlin.Int value=2
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun test (): kotlin.Unit declared in <root>.Outer' type=kotlin.Unit origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG expected: CONST Int type=kotlin.Int value=2
+        ARG actual: CALL 'private final fun getTwiceAsLarge$atomicfu$BOXED_ATOMIC$Int (handler$atomicfu: java.util.concurrent.atomic.AtomicInteger): kotlin.Int declared in <root>' type=kotlin.Int origin=null
+          ARG handler$atomicfu: CALL 'private final fun <get-cA> (): java.util.concurrent.atomic.AtomicInteger declared in <root>' type=java.util.concurrent.atomic.AtomicInteger origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/InlineExtensionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/InlineExtensionProperties.kt
@@ -1,0 +1,25 @@
+// LANGUAGE: +CompanionExtensions +CompanionBlocks
+// TARGET_BACKEND: JVM_IR
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+private inline val AtomicInt.twiceAsLarge: Int get() = value * 2
+
+public class Outer {
+    companion {
+        private val a = atomic(10)
+
+        fun test() {
+            assertEquals(20, a.twiceAsLarge)
+        }
+    }
+}
+
+private companion val Outer.cA = atomic(1)
+
+fun box(): String {
+    Outer.test()
+    assertEquals(2, Outer.cA.twiceAsLarge)
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/InlineExtensionProperties.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/InlineExtensionProperties.txt
@@ -1,0 +1,21 @@
+@kotlin.Metadata
+public final class InlineExtensionPropertiesKt {
+    // source: 'InlineExtensionProperties.kt'
+    private synthetic final static field cA: java.util.concurrent.atomic.AtomicInteger
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    private synthetic final static method getCA(): java.util.concurrent.atomic.AtomicInteger
+    private synthetic final static method getTwiceAsLarge$atomicfu$ATOMIC_ARRAY$Int(p0: java.util.concurrent.atomic.AtomicIntegerArray, p1: int): int
+    private synthetic final static method getTwiceAsLarge$atomicfu$ATOMIC_FIELD_UPDATER$Int(p0: java.util.concurrent.atomic.AtomicIntegerFieldUpdater, p1: java.lang.Object): int
+    private synthetic final static method getTwiceAsLarge$atomicfu$BOXED_ATOMIC$Int(p0: java.util.concurrent.atomic.AtomicInteger): int
+}
+
+@kotlin.Metadata
+public final class Outer {
+    // source: 'InlineExtensionProperties.kt'
+    private synthetic final static field a: java.util.concurrent.atomic.AtomicInteger
+    static method <clinit>(): void
+    public method <init>(): void
+    private synthetic final static method getA(): java.util.concurrent.atomic.AtomicInteger
+    public final static method test(): void
+}

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -81,6 +81,12 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
+    }
+
+    @Test
     @TestMetadata("InlineExtensionWithTypeParameterTest.kt")
     public void testInlineExtensionWithTypeParameterTest() {
       run("InlineExtensionWithTypeParameterTest.kt");
@@ -280,6 +286,12 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
     }
   }
 

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
@@ -83,6 +83,12 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
     }
 
     @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
+    }
+
+    @Test
     @TestMetadata("InlineExtensionWithTypeParameterTest.kt")
     public void testInlineExtensionWithTypeParameterTest() {
       run("InlineExtensionWithTypeParameterTest.kt");
@@ -284,6 +290,12 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
     }
   }
 

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
@@ -72,6 +72,12 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
     }
 
     @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
+    }
+
+    @Test
     @TestMetadata("InlineExtensionWithTypeParameterTest.kt")
     public void testInlineExtensionWithTypeParameterTest() {
       run("InlineExtensionWithTypeParameterTest.kt");
@@ -265,6 +271,12 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
     }
   }
 

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
@@ -72,6 +72,12 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
     }
 
     @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
+    }
+
+    @Test
     @TestMetadata("InlineExtensionWithTypeParameterTest.kt")
     public void testInlineExtensionWithTypeParameterTest() {
       run("InlineExtensionWithTypeParameterTest.kt");
@@ -265,6 +271,12 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
     }
   }
 

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -87,6 +87,12 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
     }
 
     @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
+    }
+
+    @Test
     @TestMetadata("InlineExtensionWithTypeParameterTest.kt")
     public void testInlineExtensionWithTypeParameterTest() {
       run("InlineExtensionWithTypeParameterTest.kt");
@@ -290,6 +296,12 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
     @TestMetadata("DelegatedCompanionProperties.kt")
     public void testDelegatedCompanionProperties() {
       run("DelegatedCompanionProperties.kt");
+    }
+
+    @Test
+    @TestMetadata("InlineExtensionProperties.kt")
+    public void testInlineExtensionProperties() {
+      run("InlineExtensionProperties.kt");
     }
   }
 


### PR DESCRIPTION
^KT-87784 fixes

Note that extension properties on atomic arrays are not supported and proper validation will be added as apart of KT-71791.