### PR TITLE
[K/N][Tests] Add IC cache tests for reworked virtual trampolines

### DIFF
--- a/native/native.tests/testData/caches/ic/dependencies/changedExternalDependency/project.info
+++ b/native/native.tests/testData/caches/ic/dependencies/changedExternalDependency/project.info
@@ -1,5 +1,6 @@
-// KT-87194: changing an external library to an already-cached version doesn't rebuild application's cache
-// DISABLE_NATIVE
+// DISABLE_NATIVE: targetFamily=MINGW
+
+// Reproducer for KT-87194
 
 MODULES: externalLib, userLib, main
 

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib1/file1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib1/file1.kt
@@ -1,0 +1,9 @@
+package test
+
+interface I {
+    fun foo(): String
+}
+
+open class Parent {
+    open fun foo(): String = "parent"
+}

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib1/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib1/module.info
@@ -1,0 +1,7 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+    added cache: file1.kt
+
+STEP 1:
+    unchanged cache: file1.kt

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/file1.1.kt
@@ -1,0 +1,5 @@
+package test
+
+open class Child : Parent(), I {
+    final override fun foo(): String = "child-final"
+}

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/file1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/file1.kt
@@ -1,0 +1,5 @@
+package test
+
+open class Child : Parent(), I {
+    override fun foo(): String = "child-open"
+}

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/file2.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/file2.kt
@@ -1,0 +1,5 @@
+package test
+
+fun viaInterface(i: I): String = i.foo()
+fun viaParent(parent: Parent): String = parent.foo()
+fun viaChild(child: Child): String = child.foo()

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/lib2/module.info
@@ -1,0 +1,14 @@
+STEP 0:
+    dependencies: lib1
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+    added cache: file1.kt, file2.kt
+
+// file1.1.kt: cross-module child override open -> final
+STEP 1:
+    dependencies: lib1
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt
+    unchanged cache: file2.kt

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/main/main.1.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    val child = Child()
+    assertEquals("child-final", viaInterface(child))
+    assertEquals("child-final", viaParent(child))
+    assertEquals("child-final", viaChild(child))
+}

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/main/main.kt
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/main/main.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    val child = Child()
+    assertEquals("child-open", viaInterface(child))
+    assertEquals("child-open", viaParent(child))
+    assertEquals("child-open", viaChild(child))
+}

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/main/module.info
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/main/module.info
@@ -1,0 +1,9 @@
+STEP 0:
+    dependencies: lib1, lib2
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: lib1, lib2
+    modifications:
+        U : main.1.kt -> main.kt

--- a/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/project.info
+++ b/native/native.tests/testData/caches/ic/dependencies/crossModuleInterfaceOverrideToFinal/project.info
@@ -1,0 +1,8 @@
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: lib1, lib2, main
+
+STEP 0:
+    libs: lib1, lib2, main
+
+STEP 1:
+    libs: lib2, main

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file1.1.kt
@@ -1,0 +1,11 @@
+package test
+
+interface I {
+    fun foo(): String
+}
+
+open class Parent {
+    open fun foo(): String = "parent-open"
+}
+
+open class Child : Parent(), I

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file1.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file1.kt
@@ -1,0 +1,11 @@
+package test
+
+interface I {
+    fun foo(): String
+}
+
+open class Parent {
+    fun foo(): String = "parent-final"
+}
+
+open class Child : Parent(), I

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file2.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file2.kt
@@ -1,0 +1,4 @@
+package test
+
+fun viaInterface(i: I): String = i.foo()
+

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file3.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/file3.kt
@@ -1,0 +1,4 @@
+package test
+
+fun viaParent(parent: Parent): String = parent.foo()
+fun viaChild(child: Child): String = child.foo()

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/module.info
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/lib/module.info
@@ -1,0 +1,13 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+        U : file3.kt -> file3.kt
+    added cache: file1.kt, file2.kt, file3.kt
+
+// file1.1.kt: Parent.foo final -> open while Child still implements I via Parent.foo
+STEP 1:
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt, file3.kt
+    unchanged cache: file2.kt

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/main/main.1.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    val child = Child()
+    assertEquals("parent-open", viaInterface(child))
+    assertEquals("parent-open", viaParent(child))
+    assertEquals("parent-open", viaChild(child))
+}

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/main/main.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/main/main.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    val child = Child()
+    assertEquals("parent-final", viaInterface(child))
+    assertEquals("parent-final", viaParent(child))
+    assertEquals("parent-final", viaChild(child))
+}

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/main/module.info
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/main/module.info
@@ -1,0 +1,9 @@
+STEP 0:
+    dependencies: lib
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: lib
+    modifications:
+        U : main.1.kt -> main.kt

--- a/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/project.info
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceFinalFunToOpen/project.info
@@ -1,0 +1,8 @@
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: lib, main
+
+STEP 0:
+    libs: lib, main
+
+STEP 1:
+    libs: lib, main

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/file1.1.kt
@@ -1,0 +1,11 @@
+package test
+
+interface I {
+    fun foo(): String
+}
+
+open class Parent {
+    fun foo(): String = "parent-final"
+}
+
+open class Child : Parent(), I

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/file1.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/file1.kt
@@ -1,0 +1,11 @@
+package test
+
+interface I {
+    fun foo(): String
+}
+
+open class Parent {
+    open fun foo(): String = "parent-open"
+}
+
+open class Child : Parent(), I

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/file2.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/file2.kt
@@ -1,0 +1,5 @@
+package test
+
+fun viaInterface(i: I): String = i.foo()
+fun viaParent(parent: Parent): String = parent.foo()
+fun viaChild(child: Child): String = child.foo()

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/module.info
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/lib/module.info
@@ -1,0 +1,12 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+    added cache: file1.kt, file2.kt
+
+// file1.1.kt: Parent.foo open -> final while Child still implements I via Parent.foo
+STEP 1:
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt
+    unchanged cache: file2.kt

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/main/main.1.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    val child = Child()
+    assertEquals("parent-final", viaInterface(child))
+    assertEquals("parent-final", viaParent(child))
+    assertEquals("parent-final", viaChild(child))
+}

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/main/main.kt
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/main/main.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    val child = Child()
+    assertEquals("parent-open", viaInterface(child))
+    assertEquals("parent-open", viaParent(child))
+    assertEquals("parent-open", viaChild(child))
+}

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/main/module.info
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/main/module.info
@@ -1,0 +1,9 @@
+STEP 0:
+    dependencies: lib
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: lib
+    modifications:
+        U : main.1.kt -> main.kt

--- a/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/project.info
+++ b/native/native.tests/testData/caches/ic/members/classInterfaceOpenFunToFinal/project.info
@@ -1,0 +1,10 @@
+// KT-87777: linking fails when an inherited open method becomes final
+// DISABLE_NATIVE
+
+MODULES: lib, main
+
+STEP 0:
+    libs: lib, main
+
+STEP 1:
+    libs: lib, main

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/file1.1.kt
@@ -1,0 +1,6 @@
+package test
+
+interface I { fun f(): Int }
+open class C : I {
+    final override fun f(): Int = 2
+}

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/file1.kt
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/file1.kt
@@ -1,0 +1,6 @@
+package test
+
+interface I { fun f(): Int }
+open class C : I {
+    override fun f(): Int = 1
+}

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/file2.kt
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/file2.kt
@@ -1,0 +1,4 @@
+package test
+
+fun viaInterface(i: I): Int = i.f()
+fun viaClass(c: C): Int = c.f()

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/module.info
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/lib/module.info
@@ -1,0 +1,12 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+    added cache: file1.kt, file2.kt
+
+STEP 1:
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt
+    unchanged cache: file2.kt
+

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/main/main.1.kt
@@ -1,0 +1,8 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals(2, viaInterface(C()))
+    assertEquals(2, viaClass(C()))
+}

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/main/main.kt
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/main/main.kt
@@ -1,0 +1,8 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals(1, viaInterface(C()))
+    assertEquals(1, viaClass(C()))
+}

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/main/module.info
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/main/module.info
@@ -1,0 +1,10 @@
+STEP 0:
+    dependencies: lib
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: lib
+    modifications:
+        U : main.1.kt -> main.kt
+

--- a/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/project.info
+++ b/native/native.tests/testData/caches/ic/members/interfaceOverrideToFinal/project.info
@@ -1,0 +1,9 @@
+// This is a reproducer for KT-85888
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: lib, main
+
+STEP 0:
+    libs: lib, main
+
+STEP 1:
+    libs: lib, main

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/file1.1.kt
@@ -1,0 +1,3 @@
+package test
+open class A { fun foo(): Int = 1 }
+open class B : A()

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/file1.kt
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/file1.kt
@@ -1,0 +1,3 @@
+package test
+open class A { open fun foo(): Int = 1 }
+open class B : A() { override fun foo(): Int = 2 }

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/file2.kt
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/file2.kt
@@ -1,0 +1,3 @@
+package test
+
+fun callFoo(a: A): Int = a.foo()

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/module.info
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/lib/module.info
@@ -1,0 +1,12 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+    added cache: file1.kt, file2.kt
+
+STEP 1:
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt
+    unchanged cache: file2.kt
+

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/main/main.1.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals(1, callFoo(B()))
+}

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/main/main.kt
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/main/main.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals(2, callFoo(B()))
+}

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/main/module.info
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/main/module.info
@@ -1,0 +1,10 @@
+STEP 0:
+    dependencies: lib
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: lib
+    modifications:
+        U : main.1.kt -> main.kt
+

--- a/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/project.info
+++ b/native/native.tests/testData/caches/ic/members/losingVirtualityWithPriorOverride/project.info
@@ -1,0 +1,9 @@
+// This is a reproducer for KT-85888
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: lib, main
+
+STEP 0:
+    libs: lib, main
+
+STEP 1:
+    libs: lib, main

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/file1.1.kt
@@ -1,0 +1,9 @@
+package test
+
+interface I {
+    fun foo(): String = "interface"
+}
+
+open class Parent
+
+open class Child : Parent(), I

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/file1.kt
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/file1.kt
@@ -1,0 +1,9 @@
+package test
+
+interface I
+
+open class Parent {
+    open fun foo(): String = "class-open"
+}
+
+open class Child : Parent(), I

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/file2.kt
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/file2.kt
@@ -1,0 +1,3 @@
+package test
+
+fun callFoo(child: Child): String = child.foo()

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/module.info
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/lib/module.info
@@ -1,0 +1,12 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+    added cache: file1.kt, file2.kt
+
+// file1.1.kt: move foo from open parent class member to interface default implementation
+STEP 1:
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt
+    unchanged cache: file2.kt

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/main/main.1.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals("interface", callFoo(Child()))
+}

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/main/main.kt
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/main/main.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals("class-open", callFoo(Child()))
+}

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/main/module.info
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/main/module.info
@@ -1,0 +1,9 @@
+STEP 0:
+    dependencies: lib
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: lib
+    modifications:
+        U : main.1.kt -> main.kt

--- a/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/project.info
+++ b/native/native.tests/testData/caches/ic/members/moveClassOpenFunToInterface/project.info
@@ -1,0 +1,8 @@
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: lib, main
+
+STEP 0:
+    libs: lib, main
+
+STEP 1:
+    libs: lib, main

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file1.1.kt
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file1.1.kt
@@ -1,0 +1,11 @@
+package test
+
+open class A {
+    fun foo(): Int = 2
+}
+
+open class B : A()
+
+open class C : B() {
+    open fun bar(): Int = super.foo() + 1
+}

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file1.2.kt
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file1.2.kt
@@ -1,0 +1,11 @@
+package test
+
+open class A {
+    open fun foo(): Int = 3
+}
+
+open class B : A()
+
+open class C : B() {
+    open fun bar(): Int = super.foo() + 1
+}

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file1.kt
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file1.kt
@@ -1,0 +1,11 @@
+package test
+
+open class A {
+    open fun foo(): Int = 1
+}
+
+open class B : A()
+
+open class C : B() {
+    open fun bar(): Int = super.foo() + 1
+}

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file2.kt
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/file2.kt
@@ -1,0 +1,3 @@
+package test
+
+fun performVirtualCall(c: C): Int = c.bar()

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/module.info
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/lib/module.info
@@ -1,0 +1,19 @@
+STEP 0:
+    modifications:
+        U : file1.kt -> file1.kt
+        U : file2.kt -> file2.kt
+    added cache: file1.kt, file2.kt
+
+// A.foo becomes final through B's fake override; C's super call is regenerated.
+STEP 1:
+    modifications:
+        U : file1.1.kt -> file1.kt
+    modified cache: file1.kt
+    unchanged cache: file2.kt
+
+// A.foo becomes open again through the same fake-override chain.
+STEP 2:
+    modifications:
+        U : file1.2.kt -> file1.kt
+    modified cache: file1.kt
+    unchanged cache: file2.kt

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/main.1.kt
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/main.1.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals(3, performVirtualCall(C()))
+}

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/main.2.kt
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/main.2.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals(4, performVirtualCall(C()))
+}

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/main.kt
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/main.kt
@@ -1,0 +1,7 @@
+import kotlin.test.*
+import test.*
+
+@Test
+fun runTest() {
+    assertEquals(2, performVirtualCall(C()))
+}

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/module.info
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/main/module.info
@@ -1,0 +1,14 @@
+STEP 0:
+    dependencies: lib
+    modifications:
+        U : main.kt -> main.kt
+
+STEP 1:
+    dependencies: lib
+    modifications:
+        U : main.1.kt -> main.kt
+
+STEP 2:
+    dependencies: lib
+    modifications:
+        U : main.2.kt -> main.kt

--- a/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/project.info
+++ b/native/native.tests/testData/caches/ic/members/openFunToFinalSuperCall/project.info
@@ -1,0 +1,11 @@
+// DISABLE_NATIVE: targetFamily=MINGW
+MODULES: lib, main
+
+STEP 0:
+    libs: lib, main
+
+STEP 1:
+    libs: lib, main
+
+STEP 2:
+    libs: lib, main


### PR DESCRIPTION
- Add Native incremental compilation tests for KT-85925 trampoline rework 
- Re-enable reproducer for external dependency bug [KT-87194](https://youtrack.jetbrains.com/issue/KT-87194)

^KT-85925, ^KT-87777