### PR TITLE
Reflection: use `Class.kotlin` instead of `KClassImpl()`

### DIFF
--- a/compiler/testData/codegen/boxJvm/reflection/caching/boundReferenceParameterTypes.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/caching/boundReferenceParameterTypes.kt
@@ -1,0 +1,24 @@
+// TARGET_BACKEND: JVM
+// WITH_REFLECT
+import kotlin.reflect.KClassifier
+
+data class D(
+    val p01: Int,
+    val p02: Int? = 0,
+    val p03: Array<Int> = arrayOf(),
+    val p04: Array<Int>? = null,
+    val p05: String = "",
+    val p06: String? = null,
+)
+
+private fun getParameterTypeClassifiers(): List<KClassifier> =
+    D(1)::copy.parameters.map { it.type.classifier!! }
+
+fun box(): String {
+    val a = getParameterTypeClassifiers()
+    val b = getParameterTypeClassifiers()
+    for ((x, y) in a.zip(b)) {
+        if (x !== y) return "Fail: classifier seems to be not cached"
+    }
+    return "OK"
+}

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/types/DescriptorKType.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/types/DescriptorKType.kt
@@ -45,21 +45,21 @@ internal class DescriptorKType(
             is ClassDescriptor -> {
                 val jClass = descriptor.toJavaClass() ?: return null
                 if (KotlinBuiltIns.isArray(type)) {
-                    val argument = type.arguments.singleOrNull()?.type ?: return KClassImpl(jClass)
+                    val argument = type.arguments.singleOrNull()?.type ?: return jClass.kotlin
                     // Make the array element type nullable to make sure that `kotlin.Array<Int>` is mapped to `[Ljava/lang/Integer;`
                     // instead of `[I`. Also, `kotlin.Array<T>`, where `T` is a type parameter and `T : Int`, should be mapped to
                     // `[Ljava/lang/Integer;`.
                     val elementClassifier =
                         convert(argument.makeNullable())
                             ?: throw KotlinReflectionInternalError("Cannot determine classifier for array element type: $this")
-                    return KClassImpl(elementClassifier.jvmErasure.javaObjectType.createArrayType())
+                    return elementClassifier.jvmErasure.javaObjectType.createArrayType().kotlin
                 }
 
                 if (!TypeUtils.isNullableType(type)) {
-                    return KClassImpl(jClass.primitiveByWrapper ?: jClass)
+                    return (jClass.primitiveByWrapper ?: jClass).kotlin
                 }
 
-                return KClassImpl(jClass)
+                return jClass.kotlin
             }
             is TypeParameterDescriptor -> return KTypeParameterImpl(descriptor.toContainer(), descriptor)
             else -> return null


### PR DESCRIPTION
`Class.kotlin` invokes `getOrCreateKotlinClass`, which goes to `caches.kt` and obtains the `KClass` object from the cache. Not doing so resulted in the class metadata being loaded from scratch, which led to a performance regression.

 #KT-87408 Fixed