### PR TITLE
[JVM] set visibility of lambda classes in private inline scope to Local

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.assignFrom
 import org.jetbrains.kotlin.utils.memoryOptimizedMap
 
 interface VisibilityPolicy {
-    fun forClass(declaration: IrClass, inInlineFunctionScope: Boolean): DescriptorVisibility = DescriptorVisibilities.PRIVATE
+    fun forClass(declaration: IrClass, inPublicInlineScope: Boolean): DescriptorVisibility = DescriptorVisibilities.PRIVATE
     fun forConstructor(declaration: IrConstructor, inInlineFunctionScope: Boolean): DescriptorVisibility = DescriptorVisibilities.PRIVATE
     fun forCapturedField(value: IrValueSymbol): DescriptorVisibility = DescriptorVisibilities.PRIVATE
     fun forSimpleFunction(declaration: IrSimpleFunction): DescriptorVisibility = DescriptorVisibilities.PRIVATE
@@ -230,7 +230,7 @@ open class LocalDeclarationsLowering(
 
     private inner class LocalClassContext(
         val declaration: IrClass,
-        val inInlineFunctionScope: Boolean,
+        val inPublicInlineScope: Boolean,
         val constructorContext: LocalContext?,
         override val sourceFileWhenInlined: IrFileEntry?,
     ) : LocalContext() {
@@ -746,7 +746,7 @@ open class LocalDeclarationsLowering(
 
             localClasses.values.forEach {
                 it.declaration.isOriginallyLocalDeclaration = true
-                it.declaration.visibility = visibilityPolicy.forClass(it.declaration, it.inInlineFunctionScope)
+                it.declaration.visibility = visibilityPolicy.forClass(it.declaration, it.inPublicInlineScope)
                 it.closure.capturedValues.associateTo(it.capturedValueToField) { capturedValue ->
                     capturedValue.owner to PotentiallyUnusedField()
                 }
@@ -1096,6 +1096,7 @@ open class LocalDeclarationsLowering(
         private fun collectLocalDeclarations() {
             class Data(
                 val isInInlineFunction: Boolean,
+                val isInPublicInlineScope: Boolean,
                 val sourceFileWhenInlined: IrFileEntry? = null,
             )
 
@@ -1110,6 +1111,7 @@ open class LocalDeclarationsLowering(
                         inlinedBlock,
                         Data(
                             isInInlineFunction = inlinedBlock.isFunctionInlining(),
+                            isInPublicInlineScope = inlinedBlock.inlinedFunctionSymbol?.owner?.isInPublicInlineScope ?: false,
                             sourceFileWhenInlined = inlinedBlock.inlinedFunctionFileEntry
                         )
                     )
@@ -1144,7 +1146,7 @@ open class LocalDeclarationsLowering(
                         localFunctions[declaration] = LocalFunctionContext(declaration, data.sourceFileWhenInlined)
                     }
 
-                    val newData = Data(declaration.isInline, data.sourceFileWhenInlined)
+                    val newData = Data(declaration.isInline, declaration.isInPublicInlineScope, data.sourceFileWhenInlined)
                     super.visitSimpleFunction(declaration, newData)
                 }
 
@@ -1176,13 +1178,16 @@ open class LocalDeclarationsLowering(
                         .singleOrNull()
 
                     localClasses[declaration] =
-                        LocalClassContext(declaration, data.inInlineFunctionScope, constructorContext, data.sourceFileWhenInlined)
+                        LocalClassContext(declaration, data.inPublicInlineScope, constructorContext, data.sourceFileWhenInlined)
                 }
 
                 private val Data.inInlineFunctionScope: Boolean
                     get() = isInInlineFunction ||
                             generateSequence(container) { it.parent as? IrDeclaration }.any { it is IrFunction && it.isInline }
-            }, Data( false, null))
+
+                private val Data.inPublicInlineScope: Boolean
+                    get() = isInPublicInlineScope || container.isInPublicInlineScope
+            }, Data(false, false, null))
         }
     }
 

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/LocalClasses.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/LocalClasses.kt
@@ -82,7 +82,7 @@ class LocalClassesInInlineLambdasLowering(val context: LoweringContext) : BodyLo
                          * stage, and only then will they be lifted to the nearest declaration container by [LocalDeclarationPopupLowering],
                          * so that's when we will change their visibility to private.
                          */
-                        override fun forClass(declaration: IrClass, inInlineFunctionScope: Boolean) = declaration.visibility
+                        override fun forClass(declaration: IrClass, inPublicInlineScope: Boolean) = declaration.visibility
                         override fun forSimpleFunction(declaration: IrSimpleFunction) = declaration.visibility
                     },
                     // Lambdas cannot introduce new type parameters to the scope, which means that all the captured type parameters

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmAnnotationImplementationTransformer.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmAnnotationImplementationTransformer.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.backend.jvm.lower
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.ir.createJvmIrBuilder
-import org.jetbrains.kotlin.backend.jvm.ir.isInPublicInlineScope
 import org.jetbrains.kotlin.backend.jvm.ir.javaClassReference
 import org.jetbrains.kotlin.backend.jvm.isPublicAbi
 import org.jetbrains.kotlin.backend.jvm.unboxInlineClass

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmLocalDeclarationsLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmLocalDeclarationsLowering.kt
@@ -75,9 +75,9 @@ internal val IrClass.isGeneratedLambdaClass: Boolean
 internal object JvmVisibilityPolicy : VisibilityPolicy {
     // Note: any condition that results in non-`LOCAL` visibility here should be duplicated in `JvmLocalDeclarationPopupLowering`,
     // else it won't detect the class as local.
-    override fun forClass(declaration: IrClass, inInlineFunctionScope: Boolean): DescriptorVisibility =
+    override fun forClass(declaration: IrClass, inPublicInlineScope: Boolean): DescriptorVisibility =
         if (declaration.isGeneratedLambdaClass) {
-            scopedVisibility(inInlineFunctionScope)
+            scopedVisibility(inPublicInlineScope)
         } else {
             declaration.visibility
         }
@@ -91,6 +91,6 @@ internal object JvmVisibilityPolicy : VisibilityPolicy {
     override fun forCapturedField(value: IrValueSymbol): DescriptorVisibility =
         JavaDescriptorVisibilities.PACKAGE_VISIBILITY // avoid requiring a synthetic accessor for it
 
-    private fun scopedVisibility(inInlineFunctionScope: Boolean): DescriptorVisibility =
-        if (inInlineFunctionScope) DescriptorVisibilities.PUBLIC else JavaDescriptorVisibilities.PACKAGE_VISIBILITY
+    private fun scopedVisibility(makePublic: Boolean): DescriptorVisibility =
+        if (makePublic) DescriptorVisibilities.PUBLIC else JavaDescriptorVisibilities.PACKAGE_VISIBILITY
 }

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmSingleAbstractMethodLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmSingleAbstractMethodLowering.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.backend.common.ScopeWithIr
 import org.jetbrains.kotlin.backend.common.lower.SingleAbstractMethodLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
-import org.jetbrains.kotlin.backend.jvm.ir.isInPublicInlineScope
 import org.jetbrains.kotlin.backend.jvm.ir.rawType
 import org.jetbrains.kotlin.backend.jvm.ir.suspendFunctionOriginal
 import org.jetbrains.kotlin.backend.jvm.isPublicAbi
@@ -23,6 +22,7 @@ import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.util.erasedUpperBound
+import org.jetbrains.kotlin.ir.util.isInPublicInlineScope
 import org.jetbrains.kotlin.ir.util.isOriginallyLocalDeclaration
 import org.jetbrains.kotlin.load.java.JavaDescriptorVisibilities
 import org.jetbrains.kotlin.utils.filterIsInstanceAnd

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/MappedEnumWhenLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/MappedEnumWhenLowering.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.backend.common.lower.irCatch
 import org.jetbrains.kotlin.backend.jvm.JvmBackendContext
 import org.jetbrains.kotlin.backend.jvm.JvmLoweredDeclarationOrigin
 import org.jetbrains.kotlin.backend.jvm.ir.findEnumValuesFunction
-import org.jetbrains.kotlin.backend.jvm.ir.isInPublicInlineScope
 import org.jetbrains.kotlin.backend.jvm.isPublicAbi
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrStatement

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrInlineUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrInlineUtils.kt
@@ -24,42 +24,6 @@ fun IrValueParameter.isInlineParameter(): Boolean =
             // making this return `false` requires using `@Suppress`.
             (!type.isNullable() || defaultValue?.expression?.type?.isNullable() == false)
 
-// Declarations in the scope of an externally visible inline function are implicitly part of the
-// public ABI of a Kotlin module. This function returns the visibility of a containing inline function
-// (determined *before* lowering), or null if the given declaration is not in the scope of an inline function.
-//
-// Currently, we mark all declarations in the scope of a public inline function as public, even if they are
-// contained in a nested private inline function. This is an over approximation, since private declarations
-// inside of a public inline function can still escape if they are used without being regenerated.
-// See `plugins/jvm-abi-gen/testData/compile/inlineNoRegeneration` for an example.
-val IrDeclaration.inlineScopeVisibility: DescriptorVisibility?
-    get() {
-        var owner: IrDeclaration? = original
-        var result: DescriptorVisibility? = null
-        while (owner != null) {
-            if (owner is IrFunction && owner.isInline) {
-                result = if (!DescriptorVisibilities.isPrivate(owner.visibility)) {
-                    if (owner.parentClassOrNull?.visibility?.let(DescriptorVisibilities::isPrivate) == true)
-                        DescriptorVisibilities.PRIVATE
-                    else
-                        return owner.visibility
-                } else {
-                    owner.visibility
-                }
-            }
-            owner = (owner.parent as? IrDeclaration)?.original
-        }
-        return result
-    }
-
-// True for declarations which are in the scope of an externally visible inline function.
-val IrDeclaration.isInPublicInlineScope: Boolean
-    get() = inlineScopeVisibility?.let(DescriptorVisibilities::isPrivate) == false
-
-// Map declarations to original declarations before lowering.
-private val IrDeclaration.original: IrDeclaration
-    get() = (this.attributeOwnerId as? IrDeclaration) ?: this
-
 fun IrStatement.unwrapRichInlineLambda(): IrRichFunctionReference? = when (this) {
     is IrBlock -> statements.lastOrNull()?.unwrapRichInlineLambda()
     is IrRichFunctionReference -> takeIf { it.origin == IrStatementOrigin.INLINE_LAMBDA }

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrInlineUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrInlineUtils.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlin.ir.util
 
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.DescriptorVisibility
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrFileEntry
 import org.jetbrains.kotlin.ir.declarations.*
@@ -71,3 +73,39 @@ private fun IrDeclarationParent.isInlineFunction(): Boolean {
 
 fun IrExpression.isLambdaBlock() =
     this is IrBlock && this.origin == IrStatementOrigin.LAMBDA
+
+// Declarations in the scope of an externally visible inline function are implicitly part of the
+// public ABI of a Kotlin module. This function returns the visibility of a containing inline function
+// (determined *before* lowering), or null if the given declaration is not in the scope of an inline function.
+//
+// Currently, for JVM we mark all declarations in the scope of a public inline function as public, even if they are
+// contained in a nested private inline function. This is an over approximation, since private declarations
+// inside of a public inline function can still escape if they are used without being regenerated.
+// See `plugins/jvm-abi-gen/testData/compile/inlineNoRegeneration` for an example.
+val IrDeclaration.inlineScopeVisibility: DescriptorVisibility?
+    get() {
+        var owner: IrDeclaration? = original
+        var result: DescriptorVisibility? = null
+        while (owner != null) {
+            if (owner is IrFunction && owner.isInline) {
+                result = if (!DescriptorVisibilities.isPrivate(owner.visibility)) {
+                    if (owner.parentClassOrNull?.visibility?.let(DescriptorVisibilities::isPrivate) == true)
+                        DescriptorVisibilities.PRIVATE
+                    else
+                        return owner.visibility
+                } else {
+                    owner.visibility
+                }
+            }
+            owner = (owner.parent as? IrDeclaration)?.original
+        }
+        return result
+    }
+
+// True for declarations which are in the scope of an externally visible inline function.
+val IrDeclaration.isInPublicInlineScope: Boolean
+    get() = inlineScopeVisibility?.let(DescriptorVisibilities::isPrivate) == false
+
+// Map declarations to original declarations before lowering.
+private val IrDeclaration.original: IrDeclaration
+    get() = (this.attributeOwnerId as? IrDeclaration) ?: this

--- a/compiler/testData/codegen/boxJvm/callableReference/callableReferenceMetadataVisibility.kt
+++ b/compiler/testData/codegen/boxJvm/callableReference/callableReferenceMetadataVisibility.kt
@@ -35,6 +35,11 @@ private fun syntheticClassVisibility(javaClass: Class<*>): Int {
 private fun isPublicAbi(javaClass: Class<*>): Boolean =
     metadataExtraInt(javaClass) and PUBLIC_ABI_FLAG != 0
 
+private inline fun privateFooInline(): Class<*> {
+    val callableReferenceInInline = ::foo
+    return callableReferenceInInline::class.java
+}
+
 fun box(): String {
     val callableReference = ::foo
 
@@ -43,7 +48,7 @@ fun box(): String {
         return "Fail: expected LOCAL visibility (5) for non-escaped callable reference, got $visibility"
     }
     if (isPublicAbi(callableReference::class.java)) {
-        return "Fail: expected non-escaped callable reference to not be public ABI"
+        return "Fail: expected non-escaped callable reference to NOT be public ABI"
     }
 
     visibility = syntheticClassVisibility(fooInline())
@@ -53,6 +58,15 @@ fun box(): String {
     if (!isPublicAbi(fooInline())) {
         return "Fail: expected escaped callable reference to be public ABI"
     }
+
+    visibility = syntheticClassVisibility(privateFooInline())
+    if (visibility != LOCAL_VISIBILITY) { // Callable Refs are still promoted to PUBLIC
+        return "Fail: expected LOCAL visibility (5) for non-escaped callable reference in private inline function, got $visibility"
+    }
+    if (isPublicAbi(privateFooInline())) {
+        return "Fail: expected non-escaped (private inline function) callable reference to NOT be public ABI"
+    }
+
 
     return callableReference()
 }

--- a/compiler/testData/codegen/boxJvm/reflection/lambdaClasses/lambdaMetadataVisibility.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/lambdaClasses/lambdaMetadataVisibility.kt
@@ -35,6 +35,11 @@ private fun syntheticClassVisibility(javaClass: Class<*>): Int {
 private fun isPublicAbi(javaClass: Class<*>): Boolean =
     metadataExtraInt(javaClass) and PUBLIC_ABI_FLAG != 0
 
+private inline fun privateLambdaInline(): Class<*> {
+    val lambda = @JvmSerializableLambda { "OK" }
+    return lambda::class.java
+}
+
 fun box(): String {
     val lambda = @JvmSerializableLambda { "OK" }
 
@@ -52,6 +57,14 @@ fun box(): String {
     }
     if (!isPublicAbi(fooInline())) {
         return "Fail: expected escaped lambda to be public ABI"
+    }
+
+    visibility = syntheticClassVisibility(privateLambdaInline())
+    if (visibility != LOCAL_VISIBILITY) { // Lambdas are still promoted to PUBLIC
+        return "Fail: expected LOCAL visibility (5) for non-escaped lambda in private inline function, got $visibility"
+    }
+    if (isPublicAbi(privateLambdaInline())) {
+        return "Fail: expected non-escaped (private inline function) lambda to NOT be public ABI"
     }
 
     return lambda()

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.backend.common.peek
 import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.backend.common.push
 import org.jetbrains.kotlin.backend.jvm.codegen.anyTypeArgument
-import org.jetbrains.kotlin.backend.jvm.ir.isInPublicInlineScope
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrElement


### PR DESCRIPTION
The final visibility of callable references and lambda classes depends on whether they are declared in inline functions or not:
- non-inlined ones have visibility `Local` (`package-private` access modifier in Java);
- visibility (and Java access) of ones in inline scopes were set to Public.

With this change, it is set to Public only when in non-private inline scopes.

^KT-87821 Fixed