### PR TITLE
[Build] Remove duplication of `generatedSourcesTask` utilities

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api/build.gradle.kts
+++ b/compiler/build-tools/kotlin-build-tools-api/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -7,6 +6,7 @@ plugins {
     kotlin("jvm")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
     id("project-tests-convention")
+    id("generated-sources")
 }
 
 configureKotlinCompileTasksGradleCompatibility()
@@ -51,7 +51,6 @@ projectTests {
 generatedSourcesTask(
     taskName = "generateBtaSources",
     generatorProject = ":compiler:build-tools:kotlin-build-tools-generator",
-    generatorRoot = "compiler/build-tools/kotlin-build-tools-generator/src",
     generatorMainClass = "org.jetbrains.kotlin.buildtools.generator.MainKt",
     argsProvider = { generationRoot ->
         listOf(
@@ -62,104 +61,3 @@ generatedSourcesTask(
         )
     }
 )
-
-// Everything below is copied from "generated-sources" plugin, as applying it in this particular module creates a dependency cycle and
-// breaks the build. This should be deleted when a solution for the cyclical dependency problem is solved.
-// See KT-79146
-
-/**
- * This utility function creates [taskName] task, which invokes specified code generator which produces some new
- *   sources for the current module in the directory ./gen
- *
- * @param [taskName] name for the created task
- * @param [generatorProject] module of the code generator
- * @param [generatorRoot] path to the `src` directory of the code generator
- * @param [generatorMainClass] FQN of the generator main class
- * @param [argsProvider] used for specifying the CLI arguments to the generator.
- *   By default, it passes the pass to the generated sources (`./gen`)
- * @param [dependOnTaskOutput] set to false disable the gradle dependency between the generation task and the compilation of the current
- *   module. This is needed for cases when the module with generator depends on the module for which it generates new sources.
- *   Use it with caution
- */
-fun Project.generatedSourcesTask(
-    taskName: String,
-    generatorProject: String,
-    generatorRoot: String,
-    generatorMainClass: String,
-    argsProvider: JavaExec.(generationRoot: Directory) -> List<String> = { listOf(it.toString()) },
-    dependOnTaskOutput: Boolean = true
-): TaskProvider<JavaExec> {
-    val generatorClasspath: Configuration by configurations.creating
-
-    dependencies {
-        generatorClasspath(project(generatorProject))
-    }
-
-    return generatedSourcesTask(
-        taskName,
-        generatorClasspath,
-        generatorRoot,
-        generatorMainClass,
-        argsProvider,
-        dependOnTaskOutput = dependOnTaskOutput,
-    )
-}
-
-/**
- * The utility can be used for sources generation by third-party tools.
- * For instance, it's used for Kotlin and KDoc lexer generations by JFlex.
- */
-fun Project.generatedSourcesTask(
-    taskName: String,
-    generatorClasspath: Configuration,
-    generatorRoot: String,
-    generatorMainClass: String,
-    argsProvider: JavaExec.(generationRoot: Directory) -> List<String> = { listOf(it.toString()) },
-    dependOnTaskOutput: Boolean = true,
-    commonSourceSet: Boolean = false,
-): TaskProvider<JavaExec> {
-    val genPath = if (commonSourceSet) {
-        "common/src/gen"
-    } else {
-        "gen"
-    }
-    val generationRoot = layout.projectDirectory.dir(genPath)
-    val task = tasks.register<JavaExec>(taskName) {
-        workingDir = rootDir
-        classpath = generatorClasspath
-        mainClass.set(generatorMainClass)
-        systemProperties["line.separator"] = "\n"
-        systemProperties["teamcity"] = kotlinBuildProperties.isTeamcityBuild.get()
-        args(argsProvider(generationRoot))
-
-        @Suppress("NAME_SHADOWING")
-        val generatorRoot = "$rootDir/$generatorRoot"
-        val generatorConfigurationFiles = fileTree(generatorRoot) {
-            include("**/*.kt")
-        }
-
-        inputs.files(generatorConfigurationFiles)
-        outputs.dir(generationRoot)
-    }
-
-    if (!commonSourceSet) {
-        sourceSets.named("main") {
-            val dependency: Any = when (dependOnTaskOutput) {
-                true -> task
-                false -> generationRoot
-            }
-            java.srcDirs(dependency)
-        }
-    }
-
-    apply(plugin = "idea")
-    (this as ExtensionAware).extensions.configure<IdeaModel>("idea") {
-        this.module.generatedSourceDirs.add(generationRoot.asFile)
-    }
-    return task
-}
-
-private val Project.sourceSets: SourceSetContainer
-    get() = extensions.getByType<JavaPluginExtension>().sourceSets
-
-

--- a/compiler/multiplatform-parsing/build.gradle.kts
+++ b/compiler/multiplatform-parsing/build.gradle.kts
@@ -132,7 +132,7 @@ for (lexerName in listOf("KDoc", "Kotlin")) {
                 "--nobak", // Prevent generating backup `.kt~` files
             )
         },
-        commonSourceSet = true,
+        generatedSourceSetKind = GeneratedSourceSetKind.KmpCommon,
         additionalInputsToTrack = { fileCollection ->
             fileCollection.from(lexerFile)
             fileCollection.from(skeletonDownloadTask)

--- a/libraries/tools/kotlin-gradle-plugin-api/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-api/build.gradle.kts
@@ -1,5 +1,4 @@
 import gradle.GradlePluginVariant
-import org.gradle.plugins.ide.idea.model.IdeaModel
 
 plugins {
     id("common-configuration")
@@ -8,6 +7,7 @@ plugins {
     id("gradle-plugin-dependency-configuration")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
     id("gradle-plugin-api-reference")
+    id("generated-sources")
 }
 
 pluginApiReference {
@@ -62,8 +62,8 @@ registerKotlinSourceForVersionRange(
 generatedSourcesTask(
     taskName = "generateKotlinVersionConstant",
     generatorProject = ":gradle:generators:native-cache-kotlin-version",
-    generatorRoot = "libraries/tools/gradle/generators/native-cache-kotlin-version/src",
     generatorMainClass = "org.jetbrains.kotlin.gradle.generators.native.cache.version.MainKt",
+    generatedSourceSetKind = GeneratedSourceSetKind.JvmCommon,
     argsProvider = { generationRoot ->
         listOf(
             generationRoot.toString(),
@@ -71,10 +71,8 @@ generatedSourcesTask(
             layout.projectDirectory.file("native-cache-kotlin-versions.txt").toString(),
         )
     }
-)
-
-// 1. Trigger apiDump after generation
-tasks.named("generateKotlinVersionConstant").configure {
+).configure {
+    // 1. Trigger apiDump after generation
     finalizedBy("apiDump")
 }
 
@@ -92,103 +90,6 @@ configurations.all {
         }
     }
 }
-
-// Everything below is copied from "generated-sources" plugin, as applying it in this particular module creates a dependency cycle and
-// breaks the build. This should be deleted when a solution for the cyclical dependency problem is solved.
-// See KT-79146
-
-/**
- * This utility function creates [taskName] task, which invokes specified code generator which produces some new
- *   sources for the current module in the directory ./gen
- *
- * @param [taskName] name for the created task
- * @param [generatorProject] module of the code generator
- * @param [generatorRoot] path to the `src` directory of the code generator
- * @param [generatorMainClass] FQN of the generator main class
- * @param [argsProvider] used for specifying the CLI arguments to the generator.
- *   By default, it passes the pass to the generated sources (`./gen`)
- * @param [dependOnTaskOutput] set to false disable the gradle dependency between the generation task and the compilation of the current
- *   module. This is needed for cases when the module with generator depends on the module for which it generates new sources.
- *   Use it with caution
- */
-fun Project.generatedSourcesTask(
-    taskName: String,
-    generatorProject: String,
-    generatorRoot: String,
-    generatorMainClass: String,
-    argsProvider: JavaExec.(generationRoot: Directory) -> List<String> = { listOf(it.toString()) },
-    dependOnTaskOutput: Boolean = true,
-): TaskProvider<JavaExec> {
-    val generatorClasspath: Configuration by configurations.creating
-
-    dependencies {
-        generatorClasspath(project(generatorProject))
-    }
-
-    return generatedSourcesTask(
-        taskName,
-        generatorClasspath,
-        generatorRoot,
-        generatorMainClass,
-        argsProvider,
-        dependOnTaskOutput = dependOnTaskOutput,
-    )
-}
-
-/**
- * The utility can be used for sources generation by third-party tools.
- * For instance, it's used for Kotlin and KDoc lexer generations by JFlex.
- */
-fun Project.generatedSourcesTask(
-    taskName: String,
-    generatorClasspath: Configuration,
-    generatorRoot: String,
-    generatorMainClass: String,
-    argsProvider: JavaExec.(generationRoot: Directory) -> List<String> = { listOf(it.toString()) },
-    dependOnTaskOutput: Boolean = true,
-    commonSourceSet: Boolean = false,
-): TaskProvider<JavaExec> {
-    val genPath = if (commonSourceSet) {
-        "common/src/gen"
-    } else {
-        "gen"
-    }
-    val generationRoot = layout.projectDirectory.dir(genPath)
-    val task = tasks.register<JavaExec>(taskName) {
-        workingDir = rootDir
-        classpath = generatorClasspath
-        mainClass.set(generatorMainClass)
-        systemProperties["line.separator"] = "\n"
-        systemProperties["teamcity"] = kotlinBuildProperties.isTeamcityBuild.get()
-        args(argsProvider(generationRoot))
-
-        @Suppress("NAME_SHADOWING")
-        val generatorRoot = "$rootDir/$generatorRoot"
-        val generatorConfigurationFiles = fileTree(generatorRoot) {
-            include("**/*.kt")
-        }
-
-        inputs.files(generatorConfigurationFiles)
-        outputs.dir(generationRoot)
-    }
-
-    sourceSets.named("common") {
-        val dependency: Any = when (dependOnTaskOutput) {
-            true -> task
-            false -> generationRoot
-        }
-        java.srcDirs(dependency)
-    }
-
-    apply(plugin = "idea")
-    (this as ExtensionAware).extensions.configure<IdeaModel>("idea") {
-        this.module.generatedSourceDirs.add(generationRoot.asFile)
-    }
-    return task
-}
-
-private val Project.sourceSets: SourceSetContainer
-    get() = extensions.getByType<JavaPluginExtension>().sourceSets
 
 tasks.withType<Jar>().configureEach {
     if (name.endsWith("Jar") || name == "jar") {

--- a/repo/gradle-build-conventions/generators/src/main/kotlin/generatorTasks.kt
+++ b/repo/gradle-build-conventions/generators/src/main/kotlin/generatorTasks.kt
@@ -62,6 +62,7 @@ fun Project.generatedSourcesTask(
     generatorMainClass: String,
     argsProvider: JavaExec.(generationRoot: Directory) -> List<String> = { listOf(it.toString()) },
     dependOnTaskOutput: Boolean = true,
+    generatedSourceSetKind: GeneratedSourceSetKind = GeneratedSourceSetKind.JvmMain,
     additionalInputsToTrack: (ConfigurableFileCollection) -> Unit = {},
 ): TaskProvider<JavaExec> {
     val generatorDependencies = configurations.dependencyScope("${taskName}GeneratorDependencies")
@@ -77,6 +78,7 @@ fun Project.generatedSourcesTask(
         generatorMainClass,
         argsProvider,
         dependOnTaskOutput = dependOnTaskOutput,
+        generatedSourceSetKind = generatedSourceSetKind,
         additionalInputsToTrack = additionalInputsToTrack,
     )
 }
@@ -91,15 +93,10 @@ fun Project.generatedSourcesTask(
     generatorMainClass: String,
     argsProvider: JavaExec.(generationRoot: Directory) -> List<String> = { listOf(it.toString()) },
     dependOnTaskOutput: Boolean = true,
-    commonSourceSet: Boolean = false,
+    generatedSourceSetKind: GeneratedSourceSetKind = GeneratedSourceSetKind.JvmMain,
     additionalInputsToTrack: (ConfigurableFileCollection) -> Unit = {},
 ): TaskProvider<JavaExec> {
-    val genPath = if (commonSourceSet) {
-        "common/src/gen"
-    } else {
-        "gen"
-    }
-    val generationRoot = layout.projectDirectory.dir(genPath)
+    val generationRoot = layout.projectDirectory.dir(generatedSourceSetKind.genPath)
     val task = tasks.register<JavaExec>(taskName) {
         workingDir = rootDir
         classpath(generatorClasspath)
@@ -125,15 +122,18 @@ fun Project.generatedSourcesTask(
         false -> generationRoot
     }
 
-    if (!commonSourceSet) {
-        val javaSourceSets = extensions.getByType<JavaPluginExtension>().sourceSets
-        javaSourceSets.named("main") {
-            java.srcDirs(dependency)
+    when (generatedSourceSetKind.isKmp) {
+        true -> {
+            val kmpSourceSets = extensions.getByType<KotlinMultiplatformExtension>().sourceSets
+            kmpSourceSets.named(generatedSourceSetKind.sourceSetName) {
+                kotlin.srcDirs(dependency)
+            }
         }
-    } else {
-        val kmpSourceSets = extensions.getByType<KotlinMultiplatformExtension>().sourceSets
-        kmpSourceSets.named("commonMain") {
-            kotlin.srcDirs(dependency)
+        false -> {
+            val javaSourceSets = extensions.getByType<JavaPluginExtension>().sourceSets
+            javaSourceSets.named(generatedSourceSetKind.sourceSetName) {
+                java.srcDirs(dependency)
+            }
         }
     }
 
@@ -144,3 +144,12 @@ fun Project.generatedSourcesTask(
     return task
 }
 
+enum class GeneratedSourceSetKind(
+    val genPath: String,
+    val sourceSetName: String,
+    val isKmp: Boolean,
+) {
+    JvmMain(genPath = "gen", sourceSetName = "main", isKmp = false),
+    JvmCommon(genPath = "gen", sourceSetName = "common", isKmp = false),
+    KmpCommon(genPath = "common/src/gen", sourceSetName = "commonMain", isKmp = true),
+}


### PR DESCRIPTION
It seems that the issue why the duplication was needed in the first place was fixed in f97381cef87f9fe1270952d318936ef665e0beef.

Also introduce a more flexible way to configure in which directory and sourceset the generated sources will appear, which covers both variaous pure-jvm and KMP setups.

^KT-79146 Obsolete