### PR TITLE
[Gradle] Make multiple plugins loaded check fail the build 

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
@@ -6,36 +6,34 @@
 package org.jetbrains.kotlin.gradle
 
 import org.gradle.util.GradleVersion
-import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING
-import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics.DeprecatedWarningGradleProperties
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics.PluginLoadedInMultipleProjectsError
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.util.checkedReplace
 import org.junit.jupiter.api.DisplayName
 import kotlin.io.path.appendText
-import kotlin.test.assertEquals
 
 @DisplayName("Different Gradle classloaders warning")
 @MppGradlePluginTests
 class DifferentClassloadersIT : KGPBaseTest() {
 
-    @DisplayName("Different classloaders message is not displayed")
+    @DisplayName("Different classloaders error is not thrown")
     @GradleTest
-    fun testDifferentClassloadersNotDisplayed(gradleVersion: GradleVersion) {
+    fun testDifferentClassloadersNotThrown(gradleVersion: GradleVersion) {
         project(
             "differentClassloaders",
             gradleVersion,
             buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
         ) {
             build("publish", "-PmppProjectDependency=true") {
-                assertOutputDoesNotContain(MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING)
-                assertOutputDoesNotContain(MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING)
+                assertNoDiagnostic(PluginLoadedInMultipleProjectsError)
             }
         }
     }
 
-    @DisplayName("Different classloader message is displayed on different plugin versions")
+    @DisplayName("Different classloader error is thrown on different plugin versions")
     @GradleTest
-    fun testDetectingDifferentClassLoaders(gradleVersion: GradleVersion) {
+    fun testDetectingDifferentClassLoadersError(gradleVersion: GradleVersion) {
         project(
             "differentClassloaders",
             gradleVersion,
@@ -45,15 +43,15 @@ class DifferentClassloadersIT : KGPBaseTest() {
             setupDifferentClassloadersProject()
 
             // after enabling isolated projects support by default we should not fail the build
-            build("publish", "-PmppProjectDependency=true") {
-                assertOutputContains(MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING)
+            buildAndFail("publish", "-PmppProjectDependency=true") {
+                assertHasDiagnostic(PluginLoadedInMultipleProjectsError)
             }
         }
     }
 
-    @DisplayName("KT-50598: Different classloaders message can be disabled")
+    @DisplayName("KT-50598: Different classloaders error can be disabled")
     @GradleTest
-    fun differentClassloadersWarningCanBeDisabled(gradleVersion: GradleVersion) {
+    fun differentClassloadersErrorCanBeDisabled(gradleVersion: GradleVersion) {
         project(
             "differentClassloaders",
             gradleVersion,
@@ -62,26 +60,27 @@ class DifferentClassloadersIT : KGPBaseTest() {
         ) {
             setupDifferentClassloadersProject()
 
-            fun checkThatWarningIsShown() {
+            fun checkThatErrorIsThrown() {
                 build("-PmppProjectDependency=true") {
-                    assertOutputContains(MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING)
-
-                    val specificProjectsReported = Regex("$MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING((?:'.*'(?:, )?)+)")
-                        .find(output)!!.groupValues[1].split(", ").map { it.removeSurrounding("'") }.toSet()
-
-                    assertEquals(setOf(":mpp-lib", ":jvm-app"), specificProjectsReported)
+                    assertHasDiagnostic(
+                        PluginLoadedInMultipleProjectsError,
+                        withSubstring = "':jvm-app', ':mpp-lib'"
+                    )
                 }
             }
 
-            checkThatWarningIsShown()
+            checkThatErrorIsThrown()
 
-            // check that the message is also printed on subsequent builds
-            checkThatWarningIsShown()
+            // check that the error is also thrown on subsequent builds
+            checkThatErrorIsThrown()
 
             // Test the flag that turns off the warnings
             build("-PmppProjectDependency=true", "-Pkotlin.pluginLoadedInMultipleProjects.ignore=true") {
-                assertOutputDoesNotContain(MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING)
-                assertOutputDoesNotContain(MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING)
+                assertNoDiagnostic(PluginLoadedInMultipleProjectsError)
+                assertHasDiagnostic(
+                    DeprecatedWarningGradleProperties,
+                    withSubstring = "kotlin.pluginLoadedInMultipleProjects.ignore",
+                )
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppRunJvm/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppRunJvm/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    kotlin("multiplatform") apply false
+}

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -625,7 +625,6 @@ public abstract class org/jetbrains/kotlin/gradle/plugin/KotlinOnlyTargetConfigu
 public final class org/jetbrains/kotlin/gradle/plugin/KotlinPluginInMultipleProjectsHolderKt {
 	public static final field MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING Ljava/lang/String;
 	public static final field MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_INFO Ljava/lang/String;
-	public static final field MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING Ljava/lang/String;
 }
 
 public class org/jetbrains/kotlin/gradle/plugin/KotlinPluginWrapper : org/jetbrains/kotlin/gradle/plugin/AbstractKotlinPluginWrapper {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleBuildServices.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinGradleBuildServices.kt
@@ -14,6 +14,8 @@ import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.Internal
 import org.jetbrains.kotlin.gradle.logging.kotlinDebug
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics.PluginLoadedInMultipleProjectsError
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.reportDiagnostic
 import org.jetbrains.kotlin.gradle.tasks.withType
 import org.jetbrains.kotlin.gradle.utils.SingleActionPerProject
 import org.jetbrains.kotlin.gradle.utils.kotlinSessionsDir
@@ -44,15 +46,12 @@ internal abstract class KotlinGradleBuildServices : BuildService<KotlinGradleBui
             project.gradle.taskGraph.whenReady {
                 if (multipleProjectsHolder.isInMultipleProjects(project, kotlinPluginVersion)) {
                     val loadedInProjects = multipleProjectsHolder.getAffectedProjects(project, kotlinPluginVersion)!!
-                    if (PropertiesProvider(project).ignorePluginLoadedInMultipleProjects != true) {
-                        project.logger.warn("\n$MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING")
-                        project.logger.warn(
-                            MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING + loadedInProjects.joinToString(limit = 4) { "'$it'" }
-                        )
+                    val propertiesProvider = PropertiesProvider(project)
+                    if (propertiesProvider.ignorePluginLoadedInMultipleProjects != true) {
+                        project.reportDiagnostic(PluginLoadedInMultipleProjectsError(loadedInProjects))
                     }
                     project.logger.info(
-                        "$MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_INFO: " +
-                                loadedInProjects.joinToString { "'$it'" }
+                        MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_INFO + loadedInProjects.joinToString { "'$it'" }
                     )
                 }
             }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginInMultipleProjectsHolder.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginInMultipleProjectsHolder.kt
@@ -94,7 +94,4 @@ const val MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING: String =
 
             "See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl"
 
-const val MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING: String =
-    "The Kotlin plugin was loaded in the following projects: "
-
 const val MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_INFO: String = "The full list of projects that loaded the Kotlin plugin is: "

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2418,6 +2418,31 @@ internal object KotlinToolingDiagnostics {
                 }
         }
     }
+
+    internal object PluginLoadedInMultipleProjectsError : ToolingDiagnosticFactory(
+        ERROR,
+        DiagnosticGroup.Kgp.Misconfiguration,
+    ) {
+        operator fun invoke(loadedInProjects: List<String>) = build {
+            title {
+                "The Kotlin Gradle plugin was loaded multiple times in different subprojects, " +
+                        "which is not supported and may break the build."
+            }
+                .description {
+                    "The Kotlin plugin was loaded in the following projects: " +
+                            loadedInProjects.joinToString(limit = 4, postfix = ".\n") { "'$it'" } +
+                            "This might happen in subprojects that apply the Kotlin plugins with the Gradle " +
+                            "'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal."
+                }
+                .solution {
+                    "Please add the Kotlin plugin to the common parent project or the root project, then remove " +
+                            "the versions in the subprojects. If the parent project does not need the plugin, add " +
+                            "'apply false' to the plugin line. As a last resort, set the " +
+                            "kotlin.pluginLoadedInMultipleProjects.ignore=true property to suppress the error. " +
+                            "See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl"
+                }
+        }
+    }
 }
 
 private fun String.indentLines(nSpaces: Int = 4, skipFirstLine: Boolean = true): String {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/GradleDeprecatedPropertyChecker.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/GradleDeprecatedPropertyChecker.kt
@@ -115,6 +115,11 @@ internal object GradleDeprecatedPropertyChecker : KotlinGradleProjectChecker {
                 Kotlin Gradle plugin has run JVM compilations using the Build Tools API by default since Kotlin 2.3.20. The legacy mode is deprecated and will be removed in Kotlin 2.5.0. Please create an issue if something is not working correctly when the Build Tools API is active: https://kotl.in/issue
             """.trimIndent()
         ), // since 2.4.0
+        DeprecatedProperty(
+            propertyName = "kotlin.pluginLoadedInMultipleProjects.ignore",
+            details = "This property should not be used in normal circumstances. If your build doesn't work without it, please consider " +
+                    "filing an issue and providing details: https://kotl.in/issue.",
+        ), // since 2.5.0
     )
 
     private val errorDeprecatedProperties: List<DeprecatedProperty> = listOf(


### PR DESCRIPTION
With this change, the check for multiple loaded Kotlin plugins
will now fail the build, unless the
kotlin.pluginLoadedInMultipleProjects.ignore flag is set
(previously the check will just emit a warning). The flag itself
has been deprecated with a suggestion to report an issue.

^KT-61225 Verification Pending