### PR TITLE
[KT-86731] Integrate new Kotlin JS Browser Test pipeline with IDEA in debug mode

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -73,27 +73,28 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
     }
 
     @GradleTest
-    fun `debugging without a chromium runner reports a diagnostic`(gradleVersion: GradleVersion) {
+    fun `debugging a firefox runner fails`(gradleVersion: GradleVersion) {
         project(
             "empty",
             gradleVersion = gradleVersion,
             buildOptions = defaultBuildOptions,
         ) {
             jsProject {
+                chromium()
                 firefox("myFirefox")
             }
 
-            build(":jsBrowserTest", "--browser-debug") {
+            buildAndFail(":jsBrowserTest", "--browser-debug", "--browser-debug-runner=myFirefox") {
                 assertHasDiagnostic(
                     KotlinToolingDiagnostics.NoChromiumRunnerForBrowserDebug,
-                    withSubstring = "Kotlin launches Chromium with the test settings of the 'myFirefox' runner.",
+                    withSubstring = "'myFirefox' is not a Chromium runner.",
                 )
             }
         }
     }
 
     @GradleTest
-    fun `debugging with several chromium runners reports a diagnostic`(gradleVersion: GradleVersion) {
+    fun `debugging an undeclared runner fails`(gradleVersion: GradleVersion) {
         project(
             "empty",
             gradleVersion = gradleVersion,
@@ -104,10 +105,10 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
                 chromium("second")
             }
 
-            build(":jsBrowserTest", "--browser-debug") {
+            buildAndFail(":jsBrowserTest", "--browser-debug") {
                 assertHasDiagnostic(
-                    KotlinToolingDiagnostics.SeveralChromiumRunnersForBrowserDebug,
-                    withSubstring = "Kotlin debugs 'first', the other Chromium runners are not run in this build.",
+                    KotlinToolingDiagnostics.UnknownRunnerForBrowserDebug,
+                    withSubstring = "Declared runners: 'first', 'second'.",
                 )
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -73,6 +73,47 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
     }
 
     @GradleTest
+    fun `debugging without a chromium runner reports a diagnostic`(gradleVersion: GradleVersion) {
+        project(
+            "empty",
+            gradleVersion = gradleVersion,
+            buildOptions = defaultBuildOptions,
+        ) {
+            jsProject {
+                firefox("myFirefox")
+            }
+
+            build(":jsBrowserTest", "--browser-debug") {
+                assertHasDiagnostic(
+                    KotlinToolingDiagnostics.NoChromiumRunnerForBrowserDebug,
+                    withSubstring = "Kotlin launches Chromium with the test settings of the 'myFirefox' runner.",
+                )
+            }
+        }
+    }
+
+    @GradleTest
+    fun `debugging with several chromium runners reports a diagnostic`(gradleVersion: GradleVersion) {
+        project(
+            "empty",
+            gradleVersion = gradleVersion,
+            buildOptions = defaultBuildOptions,
+        ) {
+            jsProject {
+                chromium("first")
+                chromium("second")
+            }
+
+            build(":jsBrowserTest", "--browser-debug") {
+                assertHasDiagnostic(
+                    KotlinToolingDiagnostics.SeveralChromiumRunnersForBrowserDebug,
+                    withSubstring = "Kotlin debugs 'first', the other Chromium runners are not run in this build.",
+                )
+            }
+        }
+    }
+
+    @GradleTest
     fun `verify launchArgs configuration with browser api access`(gradleVersion: GradleVersion) {
         project(
             "empty",

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -4341,7 +4341,7 @@ public final class org/jetbrains/kotlin/gradle/targets/js/subtargets/DefaultDist
 	public fun getOutputDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 }
 
-public abstract class org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest : org/jetbrains/kotlin/gradle/tasks/KotlinTest, org/jetbrains/kotlin/gradle/targets/js/npm/RequiresNpmDependenciesTask {
+public abstract class org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest : org/jetbrains/kotlin/gradle/tasks/KotlinTest, org/jetbrains/kotlin/gradle/plugin/diagnostics/UsesKotlinToolingDiagnostics, org/jetbrains/kotlin/gradle/targets/js/npm/RequiresNpmDependenciesTask {
 	protected fun createTestExecuter ()Lorg/gradle/api/internal/tasks/testing/TestExecuter;
 	protected fun createTestExecutionSpec ()Lorg/gradle/api/internal/tasks/testing/TestExecutionSpec;
 	public final fun environment (Ljava/lang/String;Ljava/lang/String;)V
@@ -4356,6 +4356,7 @@ public abstract class org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTes
 	public final fun getTestFramework ()Lorg/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework;
 	public final fun getTestFrameworkSettings ()Ljava/lang/String;
 	public final fun onTestFrameworkSet (Lorg/gradle/api/Action;)V
+	public fun reportDiagnostic (Lorg/jetbrains/kotlin/gradle/plugin/diagnostics/ToolingDiagnostic;Z)V
 	public fun setCompilation (Lorg/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrCompilation;)V
 	public final fun setDebug (Z)V
 	public final fun setEnvironment (Ljava/util/Map;)V

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2435,6 +2435,7 @@ internal object KotlinToolingDiagnostics {
                 .solution {
                     "Use the Playwright browser test DSL to enable it"
                 }
+                .documentationLink(URI("https://kotlinlang.org/docs/whatsnew-eap.html#a-new-dsl-for-browser-testing"))
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2422,6 +2422,22 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
+    internal object BrowserDebugOptionsNotSupportedByTestFramework : ToolingDiagnosticFactory(
+        predefinedSeverity = WARNING,
+        predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
+    ) {
+        operator fun invoke(taskPath: String) = build {
+            title { "Browser debug options are not supported by this test framework" }
+                .description {
+                    "Browser debug options were passed to '$taskPath', but its test framework is only debuggable when the " +
+                            "IDE sets the debug session up. The tests run without a debugger."
+                }
+                .solution {
+                    "Use the Playwright browser test DSL to enable it"
+                }
+        }
+    }
+
     internal object NoChromiumRunnerForBrowserDebug : ToolingDiagnosticFactory(
         predefinedSeverity = WARNING,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2439,35 +2439,39 @@ internal object KotlinToolingDiagnostics {
     }
 
     internal object NoChromiumRunnerForBrowserDebug : ToolingDiagnosticFactory(
-        predefinedSeverity = WARNING,
+        predefinedSeverity = FATAL,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
     ) {
         operator fun invoke(runnerName: String) = build {
             title { "Browser test debugging requires a Chromium runner" }
                 .description {
                     "The debugger attaches over the Chrome DevTools Protocol, which is only supported by Chromium-based " +
-                            "browsers, so Firefox and WebKit runners cannot be debugged. No Chromium runner is configured, " +
-                            "so Kotlin launches Chromium with the test settings of the '$runnerName' runner."
+                            "browsers, so the Firefox and WebKit runners cannot be debugged. " +
+                            "'$runnerName' is not a Chromium runner."
                 }
                 .solution {
-                    "Declare a chromium() runner in the browser test DSL to configure the debug browser"
+                    "Pass --browser-debug-runner with the name of a chromium() runner"
                 }
         }
     }
 
-    internal object SeveralChromiumRunnersForBrowserDebug : ToolingDiagnosticFactory(
-        predefinedSeverity = WARNING,
+    internal object UnknownRunnerForBrowserDebug : ToolingDiagnosticFactory(
+        predefinedSeverity = FATAL,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
     ) {
-        operator fun invoke(runnerNames: List<String>, debuggedRunnerName: String) = build {
-            title { "Several Chromium runners are configured for browser test debugging" }
+        operator fun invoke(runnerName: String, declaredRunnerNames: List<String>) = build {
+            title { "No browser test runner is declared under the requested name" }
                 .description {
-                    "A debug session attaches a debugger to a single browser, but several Chromium runners are configured: " +
-                            runnerNames.joinToString { "'$it'" } + ". " +
-                            "Kotlin debugs '$debuggedRunnerName', the other Chromium runners are not run in this build."
+                    "Browser test debugging attaches a debugger to the runner named by --browser-debug-runner, but " +
+                            "'$runnerName' is not declared. " +
+                            if (declaredRunnerNames.isEmpty()) {
+                                "No browser test runners are declared."
+                            } else {
+                                "Declared runners: " + declaredRunnerNames.joinToString { "'$it'" } + "."
+                            }
                 }
                 .solution {
-                    "Declare the Chromium runner that should be debugged first, or leave a single Chromium runner declared"
+                    "Declare a chromium(\"$runnerName\") or  a chromium() runner, or pass --browser-debug-runner with a declared runner name"
                 }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2422,6 +2422,39 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
+    internal object NoChromiumRunnerForBrowserDebug : ToolingDiagnosticFactory(
+        predefinedSeverity = WARNING,
+        predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
+    ) {
+        operator fun invoke(runnerName: String) = build {
+            title { "No Chromium runner is configured for browser test debugging" }
+                .description {
+                    "Browser test debugging attaches a debugger to Chromium, but no Chromium runner is configured. " +
+                            "Kotlin launches Chromium with the test settings of the '$runnerName' runner."
+                }
+                .solution {
+                    "Declare a chromium() runner in the browser test DSL to configure the debug browser"
+                }
+        }
+    }
+
+    internal object SeveralChromiumRunnersForBrowserDebug : ToolingDiagnosticFactory(
+        predefinedSeverity = WARNING,
+        predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
+    ) {
+        operator fun invoke(runnerNames: List<String>, debuggedRunnerName: String) = build {
+            title { "Several Chromium runners are configured for browser test debugging" }
+                .description {
+                    "A debug session attaches a debugger to a single browser, but several Chromium runners are configured: " +
+                            runnerNames.joinToString { "'$it'" } + ". " +
+                            "Kotlin debugs '$debuggedRunnerName', the other Chromium runners are not run in this build."
+                }
+                .solution {
+                    "Declare the Chromium runner that should be debugged first, or leave a single Chromium runner declared"
+                }
+        }
+    }
+
     internal object NewJsTestDslNotSupportedForWasmError : ToolingDiagnosticFactory(
         predefinedSeverity = ERROR,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2443,10 +2443,11 @@ internal object KotlinToolingDiagnostics {
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
     ) {
         operator fun invoke(runnerName: String) = build {
-            title { "No Chromium runner is configured for browser test debugging" }
+            title { "Browser test debugging requires a Chromium runner" }
                 .description {
-                    "Browser test debugging attaches a debugger to Chromium, but no Chromium runner is configured. " +
-                            "Kotlin launches Chromium with the test settings of the '$runnerName' runner."
+                    "The debugger attaches over the Chrome DevTools Protocol, which is only supported by Chromium-based " +
+                            "browsers, so Firefox and WebKit runners cannot be debugged. No Chromium runner is configured, " +
+                            "so Kotlin launches Chromium with the test settings of the '$runnerName' runner."
                 }
                 .solution {
                     "Declare a chromium() runner in the browser test DSL to configure the debug browser"

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2440,7 +2440,7 @@ internal object KotlinToolingDiagnostics {
     }
 
     internal object NoChromiumRunnerForBrowserDebug : ToolingDiagnosticFactory(
-        predefinedSeverity = FATAL,
+        predefinedSeverity = ERROR,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
     ) {
         operator fun invoke(runnerName: String) = build {
@@ -2457,7 +2457,7 @@ internal object KotlinToolingDiagnostics {
     }
 
     internal object UnknownRunnerForBrowserDebug : ToolingDiagnosticFactory(
-        predefinedSeverity = FATAL,
+        predefinedSeverity = ERROR,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
     ) {
         operator fun invoke(runnerName: String, declaredRunnerNames: List<String>) = build {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2474,6 +2474,7 @@ internal object KotlinToolingDiagnostics {
                 .solution {
                     "Declare a chromium(\"$runnerName\") or  a chromium() runner, or pass --browser-debug-runner with a declared runner name"
                 }
+                .documentationLink(URI("https://kotl.in/new-js-browser-test-dsl"))
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2435,7 +2435,7 @@ internal object KotlinToolingDiagnostics {
                 .solution {
                     "Use the Playwright browser test DSL to enable it"
                 }
-                .documentationLink(URI("https://kotlinlang.org/docs/whatsnew-eap.html#a-new-dsl-for-browser-testing"))
+                .documentationLink(URI("https://kotl.in/new-js-browser-test-dsl"))
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.js.ir
 
 import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginLifecycle
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
@@ -59,15 +60,11 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
         // locateOrRegisterTask returns the existing task when already registered by another target.
         val browserInstallTasks = jdBrowserRunners
             .map { runner -> runner.getBrowserKind() }
-            .distinct()
-            .map { browserType ->
-                project.locateOrRegisterTask<PlaywrightBrowserInstall>(browserType.getPwInstallBrowserTaskName(), args = listOf(testCompilation)) {
-                    browsers.add(browserType.browserName)
-                }
-                if (testTaskProvider.get().browserDebugRequested.get()){
-                    browsers.add("chromium")
-                }
-            }
+            .toSet()
+            .map { browserKind -> project.registerBrowserInstall(browserKind, testCompilation) }
+
+
+        val chromiumInstallTask = project.registerBrowserInstall(PwBrowserKind.CHROMIUM, testCompilation)
 
         testTaskProvider.configure { testTask ->
             val objects = project.objects
@@ -77,6 +74,9 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
             // Per-browser tasks are independent and can run in parallel.
             // KT-87599: Design host-wide toolchain management
             browserInstallTasks.forEach { installTask -> testTask.dependsOn(installTask) }
+            testTask.dependsOn(
+                testTask.browserDebugRequested.map { if (it) listOf(chromiumInstallTask) else emptyList() }
+            )
 
             // All install tasks write to the same global browsers directory; any one is sufficient to derive the path.
             inputs.playwrightBrowsersDirectory.set(browserInstallTasks.first().flatMap { it.outputDir })
@@ -112,12 +112,24 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
     }
 }
 
-internal fun KotlinBrowserTestRunnerDsl.getBrowserKind(): PwBrowserKind = when (this) {
-    is KotlinFirefoxTestRunner -> PwBrowserKind.FIREFOX
-    is KotlinWebkitTestRunner -> PwBrowserKind.WEBKIT
-    is KotlinChromiumTestRunner -> PwBrowserKind.CHROMIUM
-    else -> throw IllegalArgumentException("Unsupported browser runner: ${this::class.simpleName}")
-}
+private fun Project.registerBrowserInstall(
+    browserKind: PwBrowserKind,
+    testCompilation: KotlinJsIrCompilation,
+): TaskProvider<PlaywrightBrowserInstall> =
+    locateOrRegisterTask<PlaywrightBrowserInstall>(
+        browserKind.getPwInstallBrowserTaskName(),
+        args = listOf(testCompilation),
+    ) {
+        browsers.add(browserKind.browserName)
+    }
+
+private fun KotlinBrowserTestRunnerDsl.getBrowserKind(): PwBrowserKind =
+    when (this) {
+        is KotlinFirefoxTestRunner -> PwBrowserKind.FIREFOX
+        is KotlinWebkitTestRunner -> PwBrowserKind.WEBKIT
+        is KotlinChromiumTestRunner -> PwBrowserKind.CHROMIUM
+        else -> throw IllegalArgumentException("Unsupported browser runner: ${this::class.simpleName}")
+    }
 
 private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
     project: Project,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -63,9 +63,6 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
             .toSet()
             .map { browserKind -> project.registerBrowserInstall(browserKind, testCompilation) }
 
-
-        val chromiumInstallTask = project.registerBrowserInstall(PwBrowserKind.CHROMIUM, testCompilation)
-
         testTaskProvider.configure { testTask ->
             val objects = project.objects
             val inputs = KotlinPlaywrightJsTestFramework.createInputs(objects)
@@ -74,9 +71,6 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
             // Per-browser tasks are independent and can run in parallel.
             // KT-87599: Design host-wide toolchain management
             browserInstallTasks.forEach { installTask -> testTask.dependsOn(installTask) }
-            testTask.dependsOn(
-                testTask.browserDebug.map { if (it) listOf(chromiumInstallTask) else emptyList() }
-            )
 
             // All install tasks write to the same global browsers directory; any one is sufficient to derive the path.
             inputs.playwrightBrowsersDirectory.set(browserInstallTasks.first().flatMap { it.outputDir })

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -64,6 +64,9 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
                 project.locateOrRegisterTask<PlaywrightBrowserInstall>(browserType.getPwInstallBrowserTaskName(), args = listOf(testCompilation)) {
                     browsers.add(browserType.browserName)
                 }
+                if (testTaskProvider.get().browserDebugRequested.get()){
+                    browsers.add("chromium")
+                }
             }
 
         testTaskProvider.configure { testTask ->

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -123,7 +123,7 @@ private fun Project.registerBrowserInstall(
         browsers.add(browserKind.browserName)
     }
 
-private fun KotlinBrowserTestRunnerDsl.getBrowserKind(): PwBrowserKind =
+internal fun KotlinBrowserTestRunnerDsl.getBrowserKind(): PwBrowserKind =
     when (this) {
         is KotlinFirefoxTestRunner -> PwBrowserKind.FIREFOX
         is KotlinWebkitTestRunner -> PwBrowserKind.WEBKIT

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -75,7 +75,7 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
             // KT-87599: Design host-wide toolchain management
             browserInstallTasks.forEach { installTask -> testTask.dependsOn(installTask) }
             testTask.dependsOn(
-                testTask.browserDebugRequested.map { if (it) listOf(chromiumInstallTask) else emptyList() }
+                testTask.browserDebug.map { if (it) listOf(chromiumInstallTask) else emptyList() }
             )
 
             // All install tasks write to the same global browsers directory; any one is sufficient to derive the path.

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -95,6 +95,15 @@ internal constructor(
     // task it debugs and sends the ports it picked through the environment, which reaches every task of the build.
     @get:Input
     @get:Option(
+        option = "browser-debug-runner",
+        description = "The name of the browser test runner to debug. Defaults to 'chromium'. " +
+                "Only Chromium runners can be debugged. Only used with --browser-debug.",
+    )
+    internal val browserDebugRunner: Property<String> = objects.property(String::class.java)
+        .convention(providers.environmentVariable(BROWSER_DEBUG_RUNNER_ENV).orElse("chromium"))
+
+    @get:Input
+    @get:Option(
         option = "browser-debug-port",
         description = "The port a CDP-compatible debugger can attach to. Defaults to $DEFAULT_DEBUG_PORT. " +
                 "Only used with --browser-debug.",
@@ -247,6 +256,7 @@ internal constructor(
         debug = true
         debuggableFramework.kotlinJsBrowserDebugOptions.set(
             objects.newInstance(KotlinJsBrowserDebugOptions::class.java).apply {
+                runnerName.set(browserDebugRunner)
                 debugPort.set(browserDebugPort.map { parsePort(it, "--browser-debug-port") })
                 debuggerReadyPort.set(browserDebugReadyPort.map { parsePort(it, "--browser-debug-ready-port") })
                 debuggerReadyTimeoutMillis.set(browserDebugReadyTimeout.map { parseTimeoutMillis(it) })
@@ -266,6 +276,7 @@ internal constructor(
 }
 
 // Set by the IDE with the ports it picked. The same names are in the IntelliJ plugin.
+internal const val BROWSER_DEBUG_RUNNER_ENV = "KOTLIN_BROWSER_DEBUG_RUNNER"
 internal const val BROWSER_DEBUG_PORT_ENV = "KOTLIN_BROWSER_DEBUG_PORT"
 internal const val BROWSER_DEBUG_READY_PORT_ENV = "KOTLIN_BROWSER_DEBUG_READY_PORT"
 internal const val BROWSER_DEBUG_READY_TIMEOUT_ENV = "KOTLIN_BROWSER_DEBUG_READY_TIMEOUT"

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -249,12 +249,12 @@ internal constructor(
         }
 
         debug = true
-        debuggableFramework.configureDebug(
-            KotlinJsBrowserDebugOptions(
-                debugPort = browserDebugPort.orNull?.let { parsePort(it, "--browser-debug-port") },
-                debuggerReadyPort = browserDebugReadyPort.orNull?.let { parsePort(it, "--browser-debug-ready-port") },
-                debuggerReadyTimeoutMillis = browserDebugReadyTimeout.orNull?.let { parseTimeoutMillis(it) },
-            )
+        debuggableFramework.debugOptions.set(
+            objects.newInstance(KotlinJsBrowserDebugOptions::class.java).apply {
+                debugPort.set(browserDebugPort.orNull?.let { parsePort(it, "--browser-debug-port") })
+                debuggerReadyPort.set(browserDebugReadyPort.orNull?.let { parsePort(it, "--browser-debug-ready-port") })
+                debuggerReadyTimeoutMillis.set(browserDebugReadyTimeout.orNull?.let { parseTimeoutMillis(it) })
+            }
         )
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -6,12 +6,16 @@
 package org.jetbrains.kotlin.gradle.targets.js.testing
 
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.tasks.testing.TestExecuter
 import org.gradle.api.internal.tasks.testing.TestExecutionSpec
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.work.NormalizeLineEndings
@@ -73,6 +77,49 @@ internal constructor(
 
     @Input
     var debug: Boolean = false
+
+    // Frameworks that can't debug just warn that these were ignored. Karma is set up by the IDE init script.
+    @get:Input
+    @get:Optional
+    @get:Option(
+        option = "browser-debug",
+        description = "Runs the browser tests of this task in debug mode.",
+    )
+    internal val browserDebug: Property<Boolean> = objects.property(Boolean::class.java)
+
+    @get:Input
+    @get:Optional
+    @get:Option(
+        option = "browser-debug-port",
+        description = "The port a CDP-compatible debugger can attach to. Implies --browser-debug.",
+    )
+    internal val browserDebugPort: Property<String> = objects.property(String::class.java)
+
+    @get:Input
+    @get:Optional
+    @get:Option(
+        option = "browser-debug-ready-port",
+        description = "The loopback port to connect to before running the tests, to wait for a debugger to attach. " +
+                "Implies --browser-debug.",
+    )
+    internal val browserDebugReadyPort: Property<String> = objects.property(String::class.java)
+
+    @get:Input
+    @get:Optional
+    @get:Option(
+        option = "browser-debug-ready-timeout",
+        description = "How long to wait for a debugger to attach, in milliseconds. Implies --browser-debug.",
+    )
+    internal val browserDebugReadyTimeout: Property<String> = objects.property(String::class.java)
+
+    // True if any browser debug option was passed.
+    @get:Internal
+    internal val browserDebugRequested: Provider<Boolean>
+        get() = browserDebugPort.map { true }
+            .orElse(browserDebugReadyPort.map { true })
+            .orElse(browserDebugReadyTimeout.map { true })
+            .orElse(browserDebug)
+            .orElse(false)
 
     @Suppress("unused")
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
@@ -162,6 +209,8 @@ internal constructor(
     }
 
     override fun createTestExecutionSpec(): TestExecutionSpec {
+        configureBrowserDebug()
+
         val launchOpts = objects.processLaunchOptions {
             workingDir.set(this@KotlinJsTest.testFramework!!.workingDir)
             executable.set(this@KotlinJsTest.testFramework!!.executable)
@@ -180,4 +229,48 @@ internal constructor(
         val testExecuter = testFramework!!.createTestExecuter() ?: super.createTestExecuter()
         return testExecuter
     }
+
+    internal fun configureBrowserDebug() {
+        if (!browserDebugRequested.get()) return
+
+        val debuggableFramework = testFramework as? KotlinJsBrowserDebuggableFramework
+        if (debuggableFramework == null) {
+            logger.warn(
+                "Browser debug options were passed to '$path', but its test framework does not support browser " +
+                        "debugging. The options are ignored."
+            )
+            return
+        }
+
+        debug = true
+        debuggableFramework.configureDebug(
+            KotlinJsBrowserDebugOptions(
+                debugPort = (browserDebugPort.orNull ?: browserDebugEnv(BROWSER_DEBUG_PORT_ENV))
+                    ?.let { parsePort(it, "--browser-debug-port") },
+                debuggerReadyPort = (browserDebugReadyPort.orNull ?: browserDebugEnv(BROWSER_DEBUG_READY_PORT_ENV))
+                    ?.let { parsePort(it, "--browser-debug-ready-port") },
+                debuggerReadyTimeoutMillis = (browserDebugReadyTimeout.orNull ?: browserDebugEnv(BROWSER_DEBUG_READY_TIMEOUT_ENV))
+                    ?.let { parseTimeoutMillis(it) },
+            )
+        )
+    }
+
+    // Don't use providers.environmentVariable here. It would become a config cache input and the port
+    // is different on every run.
+    private fun browserDebugEnv(name: String): String? = System.getenv(name)
+
+    private fun parsePort(value: String, option: String): Int =
+        value.toIntOrNull()?.takeIf { it in 1..65535 }
+            ?: throw GradleException("$option must be an integer between 1 and 65535, but was '$value'")
+
+    private fun parseTimeoutMillis(value: String): Int =
+        value.toIntOrNull()?.takeIf { it > 0 }
+            ?: throw GradleException(
+                "--browser-debug-ready-timeout must be a positive number of milliseconds, but was '$value'"
+            )
 }
+
+// Set by the IDE with the ports it picked. The same names are in the IntelliJ plugin.
+internal const val BROWSER_DEBUG_PORT_ENV = "KOTLIN_BROWSER_DEBUG_PORT"
+internal const val BROWSER_DEBUG_READY_PORT_ENV = "KOTLIN_BROWSER_DEBUG_READY_PORT"
+internal const val BROWSER_DEBUG_READY_TIMEOUT_ENV = "KOTLIN_BROWSER_DEBUG_READY_TIMEOUT"

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -243,9 +243,9 @@ internal constructor(
         debug = true
         debuggableFramework.debugOptions.set(
             objects.newInstance(KotlinJsBrowserDebugOptions::class.java).apply {
-                debugPort.set(browserDebugPort.orNull?.let { parsePort(it, "--browser-debug-port") })
-                debuggerReadyPort.set(browserDebugReadyPort.orNull?.let { parsePort(it, "--browser-debug-ready-port") })
-                debuggerReadyTimeoutMillis.set(browserDebugReadyTimeout.orNull?.let { parseTimeoutMillis(it) })
+                debugPort.set(browserDebugPort.map { parsePort(it, "--browser-debug-port") })
+                debuggerReadyPort.set(browserDebugReadyPort.map { parsePort(it, "--browser-debug-ready-port") })
+                debuggerReadyTimeoutMillis.set(browserDebugReadyTimeout.map { parseTimeoutMillis(it) })
             }
         )
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.work.NormalizeLineEndings
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.UsesKotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.targets.js.RequiredKotlinJsDependency
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.npm.RequiresNpmDependenciesTask
@@ -42,7 +43,8 @@ internal constructor(
     providers: ProviderFactory,
     execOps: ExecOperations,
 ) : KotlinTest(execOps),
-    RequiresNpmDependenciesTask {
+    RequiresNpmDependenciesTask,
+    UsesKotlinToolingDiagnostics {
 
     @Input
     var environment = mutableMapOf<String, String>()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -94,14 +94,15 @@ internal constructor(
     // The options below only refine a debug run: --browser-debug is what turns one on. The IDE passes it on the
     // task it debugs and sends the ports it picked through the environment, which reaches every task of the build.
     @get:Input
-    @get:Optional
     @get:Option(
         option = "browser-debug-port",
-        description = "The port a CDP-compatible debugger can attach to. Only used with --browser-debug.",
+        description = "The port a CDP-compatible debugger can attach to. Defaults to $DEFAULT_DEBUG_PORT. " +
+                "Only used with --browser-debug.",
     )
     internal val browserDebugPort: Property<String> = objects.property(String::class.java)
-        .convention(providers.environmentVariable(BROWSER_DEBUG_PORT_ENV))
+        .convention(providers.environmentVariable(BROWSER_DEBUG_PORT_ENV).orElse(DEFAULT_DEBUG_PORT.toString()))
 
+    // Unset means the run doesn't wait: the port is one the debugger listens on, so there is nothing to default to.
     @get:Input
     @get:Optional
     @get:Option(
@@ -113,13 +114,16 @@ internal constructor(
         .convention(providers.environmentVariable(BROWSER_DEBUG_READY_PORT_ENV))
 
     @get:Input
-    @get:Optional
     @get:Option(
         option = "browser-debug-ready-timeout",
-        description = "How long to wait for a debugger to attach, in milliseconds. Only used with --browser-debug.",
+        description = "How long to wait for a debugger to attach, in milliseconds. " +
+                "Defaults to $DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS. Only used with --browser-debug.",
     )
     internal val browserDebugReadyTimeout: Property<String> = objects.property(String::class.java)
-        .convention(providers.environmentVariable(BROWSER_DEBUG_READY_TIMEOUT_ENV))
+        .convention(
+            providers.environmentVariable(BROWSER_DEBUG_READY_TIMEOUT_ENV)
+                .orElse(DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS.toString())
+        )
 
     @Suppress("unused")
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
@@ -241,7 +245,7 @@ internal constructor(
         }
 
         debug = true
-        debuggableFramework.debugOptions.set(
+        debuggableFramework.kotlinJsBrowserDebugOptions.set(
             objects.newInstance(KotlinJsBrowserDebugOptions::class.java).apply {
                 debugPort.set(browserDebugPort.map { parsePort(it, "--browser-debug-port") })
                 debuggerReadyPort.set(browserDebugReadyPort.map { parsePort(it, "--browser-debug-ready-port") })

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -13,13 +13,13 @@ import org.gradle.api.internal.tasks.testing.TestExecuter
 import org.gradle.api.internal.tasks.testing.TestExecutionSpec
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.work.NormalizeLineEndings
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.UsesKotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.targets.js.RequiredKotlinJsDependency
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
@@ -82,7 +82,7 @@ internal constructor(
     @Input
     var debug: Boolean = false
 
-    // Frameworks that can't debug just warn that these were ignored. Karma is set up by the IDE init script.
+    // Frameworks these options can't drive report a diagnostic instead. Karma is set up by the IDE init script.
     @get:Input
     @get:Option(
         option = "browser-debug",
@@ -91,11 +91,13 @@ internal constructor(
     internal val browserDebug: Property<Boolean> = objects.property(Boolean::class.java)
         .convention(false)
 
+    // The options below only refine a debug run: --browser-debug is what turns one on. The IDE passes it on the
+    // task it debugs and sends the ports it picked through the environment, which reaches every task of the build.
     @get:Input
     @get:Optional
     @get:Option(
         option = "browser-debug-port",
-        description = "The port a CDP-compatible debugger can attach to. Implies --browser-debug.",
+        description = "The port a CDP-compatible debugger can attach to. Only used with --browser-debug.",
     )
     internal val browserDebugPort: Property<String> = objects.property(String::class.java)
         .convention(providers.environmentVariable(BROWSER_DEBUG_PORT_ENV))
@@ -105,7 +107,7 @@ internal constructor(
     @get:Option(
         option = "browser-debug-ready-port",
         description = "The loopback port to connect to before running the tests, to wait for a debugger to attach. " +
-                "Implies --browser-debug.",
+                "Only used with --browser-debug.",
     )
     internal val browserDebugReadyPort: Property<String> = objects.property(String::class.java)
         .convention(providers.environmentVariable(BROWSER_DEBUG_READY_PORT_ENV))
@@ -114,18 +116,10 @@ internal constructor(
     @get:Optional
     @get:Option(
         option = "browser-debug-ready-timeout",
-        description = "How long to wait for a debugger to attach, in milliseconds. Implies --browser-debug.",
+        description = "How long to wait for a debugger to attach, in milliseconds. Only used with --browser-debug.",
     )
     internal val browserDebugReadyTimeout: Property<String> = objects.property(String::class.java)
         .convention(providers.environmentVariable(BROWSER_DEBUG_READY_TIMEOUT_ENV))
-
-    // True if any browser debug option was passed.
-    @get:Internal
-    internal val browserDebugRequested: Provider<Boolean>
-        get() = browserDebugPort.map { true }
-            .orElse(browserDebugReadyPort.map { true })
-            .orElse(browserDebugReadyTimeout.map { true })
-            .orElse(browserDebug)
 
     @Suppress("unused")
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
@@ -237,14 +231,12 @@ internal constructor(
     }
 
     internal fun configureBrowserDebug() {
-        if (!browserDebugRequested.get()) return
+        if (!browserDebug.get()) return
 
         val debuggableFramework = testFramework as? KotlinJsBrowserDebuggableFramework
         if (debuggableFramework == null) {
-            logger.warn(
-                "Browser debug options were passed to '$path', but its test framework does not support browser " +
-                        "debugging. The options are ignored."
-            )
+            // Karma is debugged through the IDE init script, which turns `debug` on before this runs.
+            if (!debug) reportDiagnostic(KotlinToolingDiagnostics.BrowserDebugOptionsNotSupportedByTestFramework(path))
             return
         }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -14,6 +14,7 @@ import org.gradle.api.internal.tasks.testing.TestExecutionSpec
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
@@ -38,6 +39,7 @@ internal constructor(
     @Internal
     override var compilation: KotlinJsIrCompilation,
     private val objects: ObjectFactory,
+    providers: ProviderFactory,
     execOps: ExecOperations,
 ) : KotlinTest(execOps),
     RequiresNpmDependenciesTask {
@@ -80,12 +82,12 @@ internal constructor(
 
     // Frameworks that can't debug just warn that these were ignored. Karma is set up by the IDE init script.
     @get:Input
-    @get:Optional
     @get:Option(
         option = "browser-debug",
         description = "Runs the browser tests of this task in debug mode.",
     )
     internal val browserDebug: Property<Boolean> = objects.property(Boolean::class.java)
+        .convention(false)
 
     @get:Input
     @get:Optional
@@ -94,6 +96,7 @@ internal constructor(
         description = "The port a CDP-compatible debugger can attach to. Implies --browser-debug.",
     )
     internal val browserDebugPort: Property<String> = objects.property(String::class.java)
+        .convention(providers.environmentVariable(BROWSER_DEBUG_PORT_ENV))
 
     @get:Input
     @get:Optional
@@ -103,6 +106,7 @@ internal constructor(
                 "Implies --browser-debug.",
     )
     internal val browserDebugReadyPort: Property<String> = objects.property(String::class.java)
+        .convention(providers.environmentVariable(BROWSER_DEBUG_READY_PORT_ENV))
 
     @get:Input
     @get:Optional
@@ -111,6 +115,7 @@ internal constructor(
         description = "How long to wait for a debugger to attach, in milliseconds. Implies --browser-debug.",
     )
     internal val browserDebugReadyTimeout: Property<String> = objects.property(String::class.java)
+        .convention(providers.environmentVariable(BROWSER_DEBUG_READY_TIMEOUT_ENV))
 
     // True if any browser debug option was passed.
     @get:Internal
@@ -119,7 +124,6 @@ internal constructor(
             .orElse(browserDebugReadyPort.map { true })
             .orElse(browserDebugReadyTimeout.map { true })
             .orElse(browserDebug)
-            .orElse(false)
 
     @Suppress("unused")
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
@@ -245,19 +249,12 @@ internal constructor(
         debug = true
         debuggableFramework.configureDebug(
             KotlinJsBrowserDebugOptions(
-                debugPort = (browserDebugPort.orNull ?: browserDebugEnv(BROWSER_DEBUG_PORT_ENV))
-                    ?.let { parsePort(it, "--browser-debug-port") },
-                debuggerReadyPort = (browserDebugReadyPort.orNull ?: browserDebugEnv(BROWSER_DEBUG_READY_PORT_ENV))
-                    ?.let { parsePort(it, "--browser-debug-ready-port") },
-                debuggerReadyTimeoutMillis = (browserDebugReadyTimeout.orNull ?: browserDebugEnv(BROWSER_DEBUG_READY_TIMEOUT_ENV))
-                    ?.let { parseTimeoutMillis(it) },
+                debugPort = browserDebugPort.orNull?.let { parsePort(it, "--browser-debug-port") },
+                debuggerReadyPort = browserDebugReadyPort.orNull?.let { parsePort(it, "--browser-debug-ready-port") },
+                debuggerReadyTimeoutMillis = browserDebugReadyTimeout.orNull?.let { parseTimeoutMillis(it) },
             )
         )
     }
-
-    // Don't use providers.environmentVariable here. It would become a config cache input and the port
-    // is different on every run.
-    private fun browserDebugEnv(name: String): String? = System.getenv(name)
 
     private fun parsePort(value: String, option: String): Int =
         value.toIntOrNull()?.takeIf { it in 1..65535 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.npm.RequiresNpmDependenciesTask
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import org.jetbrains.kotlin.gradle.targets.js.testing.mocha.KotlinMocha
+import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
 import org.jetbrains.kotlin.gradle.tasks.KotlinTest
 import org.jetbrains.kotlin.gradle.utils.domainObjectSet
 import org.jetbrains.kotlin.gradle.utils.newFileProperty
@@ -100,7 +101,7 @@ internal constructor(
                 "Only Chromium runners can be debugged. Only used with --browser-debug.",
     )
     internal val browserDebugRunner: Property<String> = objects.property(String::class.java)
-        .convention(providers.environmentVariable(BROWSER_DEBUG_RUNNER_ENV).orElse("chromium"))
+        .convention(providers.environmentVariable(BROWSER_DEBUG_RUNNER_ENV).orElse(PwBrowserKind.CHROMIUM.browserName))
 
     @get:Input
     @get:Option(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
@@ -40,18 +40,18 @@ interface KotlinJsTestFramework : RequiresNpmDependencies {
     companion object
 }
 
-internal abstract class KotlinJsBrowserDebugOptions {
+internal interface KotlinJsBrowserDebugOptions {
     @get:Input
     @get:Optional
-    abstract val debugPort: Property<Int>
+    val debugPort: Property<Int>
 
     @get:Input
     @get:Optional
-    abstract val debuggerReadyPort: Property<Int>
+    val debuggerReadyPort: Property<Int>
 
     @get:Input
     @get:Optional
-    abstract val debuggerReadyTimeoutMillis: Property<Int>
+    val debuggerReadyTimeoutMillis: Property<Int>
 }
 
 internal interface KotlinJsBrowserDebuggableFramework {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
@@ -40,17 +40,19 @@ interface KotlinJsTestFramework : RequiresNpmDependencies {
     companion object
 }
 
+internal const val DEFAULT_DEBUG_PORT = 9222
+internal const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 60_000
+
 internal interface KotlinJsBrowserDebugOptions {
     @get:Input
-    @get:Optional
     val debugPort: Property<Int>
 
+    /** Set only when the run should wait until a debugger is attached. */
     @get:Input
     @get:Optional
     val debuggerReadyPort: Property<Int>
 
     @get:Input
-    @get:Optional
     val debuggerReadyTimeoutMillis: Property<Int>
 }
 
@@ -58,5 +60,5 @@ internal interface KotlinJsBrowserDebuggableFramework {
     /** Set only for a run that is being debugged, so an unset value means no browser debugging. */
     @get:Nested
     @get:Optional
-    val debugOptions: Property<KotlinJsBrowserDebugOptions>
+    val kotlinJsBrowserDebugOptions: Property<KotlinJsBrowserDebugOptions>
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
@@ -35,3 +35,14 @@ interface KotlinJsTestFramework : RequiresNpmDependencies {
 
     companion object
 }
+
+// null means not set, so the framework uses its own default.
+internal data class KotlinJsBrowserDebugOptions(
+    val debugPort: Int? = null,
+    val debuggerReadyPort: Int? = null,
+    val debuggerReadyTimeoutMillis: Int? = null,
+)
+
+internal interface KotlinJsBrowserDebuggableFramework {
+    fun configureDebug(options: KotlinJsBrowserDebugOptions)
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
@@ -8,7 +8,11 @@ package org.jetbrains.kotlin.gradle.targets.js.testing
 import org.gradle.api.file.Directory
 import org.gradle.api.internal.tasks.testing.TestExecuter
 import org.gradle.api.internal.tasks.testing.TestExecutionSpec
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import org.jetbrains.kotlin.gradle.targets.js.npm.RequiresNpmDependencies
 import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions
 
@@ -36,13 +40,23 @@ interface KotlinJsTestFramework : RequiresNpmDependencies {
     companion object
 }
 
-// null means not set, so the framework uses its own default.
-internal data class KotlinJsBrowserDebugOptions(
-    val debugPort: Int? = null,
-    val debuggerReadyPort: Int? = null,
-    val debuggerReadyTimeoutMillis: Int? = null,
-)
+internal abstract class KotlinJsBrowserDebugOptions {
+    @get:Input
+    @get:Optional
+    abstract val debugPort: Property<Int>
+
+    @get:Input
+    @get:Optional
+    abstract val debuggerReadyPort: Property<Int>
+
+    @get:Input
+    @get:Optional
+    abstract val debuggerReadyTimeoutMillis: Property<Int>
+}
 
 internal interface KotlinJsBrowserDebuggableFramework {
-    fun configureDebug(options: KotlinJsBrowserDebugOptions)
+    /** Set only for a run that is being debugged, so an unset value means no browser debugging. */
+    @get:Nested
+    @get:Optional
+    val debugOptions: Property<KotlinJsBrowserDebugOptions>
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTestFramework.kt
@@ -44,6 +44,10 @@ internal const val DEFAULT_DEBUG_PORT = 9222
 internal const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 60_000
 
 internal interface KotlinJsBrowserDebugOptions {
+    /** Name of the browser runner to debug. It must be a Chromium one, the framework rejects the rest. */
+    @get:Input
+    val runnerName: Property<String>
+
     @get:Input
     val debugPort: Property<Int>
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -106,19 +106,15 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override val executable: Property<String> = objects.property(nodeJs.executable)
 
-    private val debugOptions: Property<PwDebugOptions> = objects.property<PwDebugOptions>()
-        .convention(PwDebugOptions())
+    @get:Nested
+    @get:Optional
+    override val debugOptions: Property<KotlinJsBrowserDebugOptions> = objects.property<KotlinJsBrowserDebugOptions>()
 
-    override fun configureDebug(options: KotlinJsBrowserDebugOptions) {
-        val defaultPwOptions = debugOptions.get()
-        debugOptions.set(
-            PwDebugOptions(
-                remoteDebuggingPort = options.debugPort ?: defaultPwOptions.remoteDebuggingPort,
-                debuggerReadyPort = options.debuggerReadyPort ?: defaultPwOptions.debuggerReadyPort,
-                debuggerReadyTimeoutMillis = options.debuggerReadyTimeoutMillis ?: defaultPwOptions.debuggerReadyTimeoutMillis,
-            )
-        )
-    }
+    private fun KotlinJsBrowserDebugOptions.toPwDebugOptions() = PwDebugOptions(
+        remoteDebuggingPort = debugPort.getOrElse(DEFAULT_DEBUG_PORT),
+        debuggerReadyPort = debuggerReadyPort.orNull,
+        debuggerReadyTimeoutMillis = debuggerReadyTimeoutMillis.getOrElse(DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS),
+    )
 
     @get:Internal
     override val requiredNpmDependencies: Set<RequiredKotlinJsDependency> = setOf(
@@ -181,17 +177,17 @@ internal class KotlinPlaywrightJsTestFramework(
         ).toList()
 
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
-        val debugOptions = if (debug) debugOptions.get() else null
+        val pwDebugOptions = debugOptions.orNull?.toPwDebugOptions()
 
         val pwRunners = buildList {
-            if (debugOptions != null) {
+            if (pwDebugOptions != null) {
                 val runner = pickDebugRunner(task)
                 add(
                     runner.createPwRunnerSpec(
                         PwBrowserKind.CHROMIUM,
                         browsersDirectory,
                         cliArgs,
-                        debugOptions,
+                        pwDebugOptions,
                     )
                 )
             } else {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -219,7 +219,7 @@ internal class KotlinPlaywrightJsTestFramework(
         browserKind = kind,
         browsersDirectory = browsersDirectory,
         testsLocation = testsLocation.get(),
-        buildTestsExecutionerUrl = { baseUrl -> buildRunnerUrl(baseUrl, cliArgs) },
+        buildTestsExecutionerUrl = { baseUrl -> buildRunnerUrl(baseUrl, cliArgs, isDebugEnabled = debugOptions != null) },
         timeout = timeout.get().toKotlinDuration(),
         finishMarker = finishMarker.get(),
         headless = headless.get(),
@@ -229,9 +229,9 @@ internal class KotlinPlaywrightJsTestFramework(
         debugOptions = debugOptions,
     )
 
-    private fun BrowserRunnerInput.buildRunnerUrl(baseUrl: URI, cliArgs: List<String>): URI {
+    private fun BrowserRunnerInput.buildRunnerUrl(baseUrl: URI, cliArgs: List<String>, isDebugEnabled: Boolean): URI {
         val runnerConfig = KotlinBrowserRunnerConfig(
-            timeout = timeout.get(),
+            timeout = if (isDebugEnabled) Duration.ZERO else timeout.get(),
             testsFinishedMarker = finishMarker.get(),
             kotlinTestCliArguments = cliArgs
         )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -108,13 +108,8 @@ internal class KotlinPlaywrightJsTestFramework(
 
     @get:Nested
     @get:Optional
-    override val debugOptions: Property<KotlinJsBrowserDebugOptions> = objects.property<KotlinJsBrowserDebugOptions>()
+    override val kotlinJsBrowserDebugOptions: Property<KotlinJsBrowserDebugOptions> = objects.property<KotlinJsBrowserDebugOptions>()
 
-    private fun KotlinJsBrowserDebugOptions.toPwDebugOptions() = PwDebugOptions(
-        remoteDebuggingPort = debugPort.getOrElse(DEFAULT_DEBUG_PORT),
-        debuggerReadyPort = debuggerReadyPort.orNull,
-        debuggerReadyTimeoutMillis = debuggerReadyTimeoutMillis.getOrElse(DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS),
-    )
 
     @get:Internal
     override val requiredNpmDependencies: Set<RequiredKotlinJsDependency> = setOf(
@@ -177,17 +172,17 @@ internal class KotlinPlaywrightJsTestFramework(
         ).toList()
 
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
-        val pwDebugOptions = debugOptions.orNull?.toPwDebugOptions()
+        val debugOptions = kotlinJsBrowserDebugOptions.orNull
 
         val pwRunners = buildList {
-            if (pwDebugOptions != null) {
+            if (debugOptions != null) {
                 val runner = pickDebugRunner(task)
                 add(
                     runner.createPwRunnerSpec(
                         PwBrowserKind.CHROMIUM,
                         browsersDirectory,
                         cliArgs,
-                        pwDebugOptions,
+                        debugOptions,
                     )
                 )
             } else {
@@ -218,7 +213,7 @@ internal class KotlinPlaywrightJsTestFramework(
         kind: PwBrowserKind,
         browsersDirectory: Path,
         cliArgs: List<String>,
-        debugOptions: PwDebugOptions? = null,
+        debugOptions: KotlinJsBrowserDebugOptions? = null,
     ): PwRunnerSpec = PwRunnerSpec(
         name = name.get(),
         browserKind = kind,
@@ -231,7 +226,13 @@ internal class KotlinPlaywrightJsTestFramework(
         launchArgs = launchArgs.get(),
         launchEnvironmentVariables = launchEnvironmentVariables.get(),
         customBrowserExecutable = customBrowserExecutable.asPathOrNull,
-        debugOptions = debugOptions,
+        debugOptions = debugOptions?.let {
+            PwDebugOptions(
+                it.debugPort.get(),
+                it.debuggerReadyPort.orNull,
+                it.debuggerReadyTimeoutMillis.get()
+            )
+        }
     )
 
     private fun BrowserRunnerInput.buildRunnerUrl(baseUrl: URI, cliArgs: List<String>, isDebugEnabled: Boolean): URI {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -222,6 +222,7 @@ internal class KotlinPlaywrightJsTestFramework(
 
     private fun BrowserRunnerInput.buildRunnerUrl(baseUrl: URI, cliArgs: List<String>): URI {
         val runnerConfig = KotlinBrowserRunnerConfig(
+            timeout = timeout.get(),
             testsFinishedMarker = finishMarker.get(),
             kotlinTestCliArguments = cliArgs
         )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -156,9 +156,17 @@ internal class KotlinPlaywrightJsTestFramework(
         ).toList()
 
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
-        val debugOptions = if (debug) PwDebugOptions(
-            remoteDebuggingPort = debugPort.orNull,
-        ) else null
+        val debugOptions = if (debug) {
+            if (!debugPort.isPresent) {
+                task.logger.warn(
+                    "IDEA did not configure a remote debugging port for this Playwright debug run. " +
+                            "Continuing without IDEA debugger attachment."
+                )
+            }
+            PwDebugOptions(debugPort.orNull)
+        } else {
+            null
+        }
 
         val pwRunners = buildList {
             val chromiumRunners = frameworkTaskInputs.chromiumRunners.get()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.gradle.targets.js.testing.playwright
 
-import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.tasks.testing.TestExecuter
@@ -25,6 +24,8 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.ir.npmToolingDir
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin.Companion.kotlinNodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.npm.NpmProjectModules
+import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsBrowserDebugOptions
+import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsBrowserDebuggableFramework
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTestFramework
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinTestRunnerCliArgs
@@ -33,15 +34,11 @@ import org.jetbrains.kotlin.gradle.utils.getFile
 import org.jetbrains.kotlin.gradle.utils.listProperty
 import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions
 import org.jetbrains.kotlin.gradle.utils.property
-import java.io.File
-import java.net.InetAddress
-import java.net.ServerSocket
 import java.net.URI
 import java.nio.file.Path
 import java.time.Duration
 import javax.inject.Inject
 import kotlin.time.toKotlinDuration
-
 
 /**
  * Kotlin/JS browser test framework backed by [Playwright][com.microsoft.playwright.Playwright]
@@ -50,7 +47,7 @@ internal class KotlinPlaywrightJsTestFramework(
     @Transient override val compilation: KotlinJsIrCompilation,
     override val frameworkTaskInputs: Inputs,
     private val objects: ObjectFactory,
-) : KotlinJsTestFramework {
+) : KotlinJsTestFramework, KotlinJsBrowserDebuggableFramework {
 
     abstract class Inputs @Inject constructor(objects: ObjectFactory) {
         @get:Nested
@@ -110,47 +107,16 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override val executable: Property<String> = objects.property(nodeJs.executable)
 
-    private val debugPort: Property<Int> = objects.property<Int>()
+    private val debugPort: Property<Int> = objects.property<Int>().convention(DEFAULT_DEBUG_PORT)
 
-    @Transient
-    private var debuggerReadySocket: ServerSocket? = null
+    // null means we don't wait for a debugger before running the tests.
+    private var debuggerReadyPort: Int? = null
+    private var debuggerReadyTimeoutMillis: Int = DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS
 
-    class DebugSessionInfo(
-        val url: URI,
-        val bundleDirectory: File,
-        val debuggerReadyPort: Int,
-    )
-
-    /** Prepares everything IDEA needs before it creates the remote debug configuration. */
-    @Suppress("unused")
-    fun prepareDebugSession(task: KotlinJsTest): DebugSessionInfo {
-        if (frameworkTaskInputs.chromiumRunners.get().isEmpty()) {
-            task.logger.warn(
-                "No Chromium runner is configured for Playwright debugging. " +
-                        "Kotlin will launch Chromium using the first configured browser runner's test settings. " +
-                        "Define a Chromium runner in the browser test DSL to customize the debug browser configuration."
-            )
-        }
-        val runner = getDebugRunner()
-        return DebugSessionInfo(
-            url = buildDebugUrl(task, runner),
-            bundleDirectory = runner.testsLocation.get().bundleLocation.get().asFile,
-            debuggerReadyPort = prepareDebuggerReadyPort(),
-        )
-    }
-
-    /** Completes the two-phase setup with the CDP port allocated by IDEA. */
-    @Suppress("unused")
-    fun configureRemoteDebuggingPort(remoteDebuggingPort: Int) {
-        debugPort.set(remoteDebuggingPort)
-    }
-
-    private fun prepareDebuggerReadyPort(): Int {
-        check(debuggerReadySocket == null) { "Playwright debugger readiness socket is already prepared" }
-        return ServerSocket(0, 1, InetAddress.getLoopbackAddress()).also {
-            it.soTimeout = DEBUGGER_READY_TIMEOUT_MILLIS
-            debuggerReadySocket = it
-        }.localPort
+    override fun configureDebug(options: KotlinJsBrowserDebugOptions) {
+        options.debugPort?.let { debugPort.set(it) }
+        options.debuggerReadyPort?.let { debuggerReadyPort = it }
+        options.debuggerReadyTimeoutMillis?.let { debuggerReadyTimeoutMillis = it }
     }
 
     @get:Internal
@@ -162,21 +128,6 @@ internal class KotlinPlaywrightJsTestFramework(
     internal val npmToolingEnvDir: DirectoryProperty = objects.directoryProperty().convention(compilation.npmToolingDir())
 
     override fun createTestExecuter(): TestExecuter<*> = PlaywrightTestExecutor()
-
-    /**
-     * Used by IntelliJ IDEA to determine the Playwright test page URL for browser test debug sessions.
-     * Called from the Ultimate Gradle init script before the browser is launched, so source mappings can be prepared.
-     */
-    @Suppress("unused")
-    fun buildDebugUrl(task: KotlinJsTest): URI = buildDebugUrl(task, getDebugRunner())
-
-    private fun buildDebugUrl(task: KotlinJsTest, runner: BrowserRunnerInput): URI {
-        val cliArgs = KotlinTestRunnerCliArgs(
-            include = task.includePatterns,
-            exclude = task.excludePatterns,
-        ).toList()
-        return runner.buildRunnerUrl(runner.testsLocation.get().url.get(), cliArgs)
-    }
 
     private fun getDebugRunner(): ChromiumRunnerInput {
         frameworkTaskInputs.chromiumRunners.get().firstOrNull()?.let { return it }
@@ -215,6 +166,14 @@ internal class KotlinPlaywrightJsTestFramework(
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
         val debugOptions = if (debug) takeDebugOptions() else null
 
+        if (debug && frameworkTaskInputs.chromiumRunners.get().isEmpty()) {
+            task.logger.warn(
+                "No Chromium runner is configured for Playwright debugging. " +
+                        "Kotlin will launch Chromium using the first configured browser runner's test settings. " +
+                        "Define a Chromium runner in the browser test DSL to customize the debug browser configuration."
+            )
+        }
+
         val pwRunners = buildList {
             if (debugOptions != null) {
                 val runner = getDebugRunner()
@@ -251,18 +210,12 @@ internal class KotlinPlaywrightJsTestFramework(
     }
 
     private fun takeDebugOptions(): PwDebugOptions {
-        if (!debugPort.isPresent) {
-            throw GradleException("IDEA did not configure a remote debugging port for this Playwright debug run")
-        }
         val remoteDebuggingPort = debugPort.get()
 
-        // The execution spec owns and closes the socket after this point.
-        val readySocket = debuggerReadySocket
-            ?: throw GradleException("IDEA did not configure debugger attachment synchronization for this Playwright debug run")
-        debuggerReadySocket = null
         return PwDebugOptions(
             remoteDebuggingPort = remoteDebuggingPort,
-            debuggerReadySocket = readySocket,
+            debuggerReadyPort = debuggerReadyPort,
+            debuggerReadyTimeoutMillis = debuggerReadyTimeoutMillis,
         )
     }
 
@@ -302,8 +255,8 @@ internal class KotlinPlaywrightJsTestFramework(
             ?: error("No Playwright browser runners configured")
 
     companion object {
-        private const val DEBUGGER_READY_TIMEOUT_MILLIS = 30_000
-
+        private const val DEFAULT_DEBUG_PORT = 9222
+        private const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 30_000
         fun createInputs(objects: ObjectFactory): Inputs =
             objects.newInstance(Inputs::class.java)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.targets.js.testing.playwright
 
+import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.tasks.testing.TestExecuter
@@ -32,6 +33,9 @@ import org.jetbrains.kotlin.gradle.utils.getFile
 import org.jetbrains.kotlin.gradle.utils.listProperty
 import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions
 import org.jetbrains.kotlin.gradle.utils.property
+import java.io.File
+import java.net.InetAddress
+import java.net.ServerSocket
 import java.net.URI
 import java.nio.file.Path
 import java.time.Duration
@@ -106,12 +110,48 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override val executable: Property<String> = objects.property(nodeJs.executable)
 
-    /**
-     * Chromium remote debugging port supplied by IntelliJ IDEA when a Playwright browser test debug session is started.
-     * The Ultimate Gradle init script sets it before Gradle asks this framework to create the execution spec.
-     */
+    private val debugPort: Property<Int> = objects.property<Int>()
+
+    @Transient
+    private var debuggerReadySocket: ServerSocket? = null
+
+    class DebugSessionInfo(
+        val url: URI,
+        val bundleDirectory: File,
+        val debuggerReadyPort: Int,
+    )
+
+    /** Prepares everything IDEA needs before it creates the remote debug configuration. */
     @Suppress("unused")
-    val debugPort: Property<Int> = objects.property<Int>()
+    fun prepareDebugSession(task: KotlinJsTest): DebugSessionInfo {
+        if (frameworkTaskInputs.chromiumRunners.get().isEmpty()) {
+            task.logger.warn(
+                "No Chromium runner is configured for Playwright debugging. " +
+                        "Kotlin will launch Chromium using the first configured browser runner's test settings. " +
+                        "Define a Chromium runner in the browser test DSL to customize the debug browser configuration."
+            )
+        }
+        val runner = getDebugRunner()
+        return DebugSessionInfo(
+            url = buildDebugUrl(task, runner),
+            bundleDirectory = runner.testsLocation.get().bundleLocation.get().asFile,
+            debuggerReadyPort = prepareDebuggerReadyPort(),
+        )
+    }
+
+    /** Completes the two-phase setup with the CDP port allocated by IDEA. */
+    @Suppress("unused")
+    fun configureRemoteDebuggingPort(remoteDebuggingPort: Int) {
+        debugPort.set(remoteDebuggingPort)
+    }
+
+    private fun prepareDebuggerReadyPort(): Int {
+        check(debuggerReadySocket == null) { "Playwright debugger readiness socket is already prepared" }
+        return ServerSocket(0, 1, InetAddress.getLoopbackAddress()).also {
+            it.soTimeout = DEBUGGER_READY_TIMEOUT_MILLIS
+            debuggerReadySocket = it
+        }.localPort
+    }
 
     @get:Internal
     override val requiredNpmDependencies: Set<RequiredKotlinJsDependency> = setOf(
@@ -128,18 +168,30 @@ internal class KotlinPlaywrightJsTestFramework(
      * Called from the Ultimate Gradle init script before the browser is launched, so source mappings can be prepared.
      */
     @Suppress("unused")
-    fun buildDebugUrl(task: KotlinJsTest): URI {
+    fun buildDebugUrl(task: KotlinJsTest): URI = buildDebugUrl(task, getDebugRunner())
+
+    private fun buildDebugUrl(task: KotlinJsTest, runner: BrowserRunnerInput): URI {
         val cliArgs = KotlinTestRunnerCliArgs(
             include = task.includePatterns,
             exclude = task.excludePatterns,
         ).toList()
-        val runner = getDebugRunner()
         return runner.buildRunnerUrl(runner.testsLocation.get().url.get(), cliArgs)
     }
 
-    @Suppress("unused")
-    fun getDebugRunner(): ChromiumRunnerInput =
-        frameworkTaskInputs.chromiumRunners.get().firstOrNull() ?: createDefaultDebugRunner()
+    private fun getDebugRunner(): ChromiumRunnerInput {
+        frameworkTaskInputs.chromiumRunners.get().firstOrNull()?.let { return it }
+
+        val configuredRunner = firstRunnerInput()
+        return createChromiumInputs(objects).apply {
+            name.convention("chromium")
+            testsLocation.convention(configuredRunner.testsLocation)
+            timeout.convention(configuredRunner.timeout)
+            headless.convention(true)
+            launchArgs.convention(emptyList())
+            launchEnvironmentVariables.convention(emptyMap())
+            finishMarker.convention(configuredRunner.finishMarker)
+        }
+    }
 
     override fun createTestExecutionSpec(
         task: KotlinJsTest,
@@ -161,20 +213,10 @@ internal class KotlinPlaywrightJsTestFramework(
         ).toList()
 
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
-        val debugOptions = if (debug) {
-            if (!debugPort.isPresent) {
-                task.logger.warn(
-                    "IDEA did not configure a remote debugging port for this Playwright debug run. " +
-                            "Continuing without IDEA debugger attachment."
-                )
-            }
-            PwDebugOptions(debugPort.orNull)
-        } else {
-            null
-        }
+        val debugOptions = if (debug) takeDebugOptions() else null
 
         val pwRunners = buildList {
-            if (debugOptions?.remoteDebuggingPort != null) {
+            if (debugOptions != null) {
                 val runner = getDebugRunner()
                 add(
                     runner.createPwRunnerSpec(
@@ -208,6 +250,22 @@ internal class KotlinPlaywrightJsTestFramework(
         )
     }
 
+    private fun takeDebugOptions(): PwDebugOptions {
+        if (!debugPort.isPresent) {
+            throw GradleException("IDEA did not configure a remote debugging port for this Playwright debug run")
+        }
+        val remoteDebuggingPort = debugPort.get()
+
+        // The execution spec owns and closes the socket after this point.
+        val readySocket = debuggerReadySocket
+            ?: throw GradleException("IDEA did not configure debugger attachment synchronization for this Playwright debug run")
+        debuggerReadySocket = null
+        return PwDebugOptions(
+            remoteDebuggingPort = remoteDebuggingPort,
+            debuggerReadySocket = readySocket,
+        )
+    }
+
     private fun BrowserRunnerInput.createPwRunnerSpec(
         kind: PwBrowserKind,
         browsersDirectory: Path,
@@ -237,19 +295,6 @@ internal class KotlinPlaywrightJsTestFramework(
         return runnerConfig.buildUrlWithConfigState(baseUrl)
     }
 
-    private fun createDefaultDebugRunner(): ChromiumRunnerInput {
-        val configuredRunner = firstRunnerInput()
-        return createChromiumInputs(objects).apply {
-            name.convention("chromium")
-            testsLocation.convention(configuredRunner.testsLocation)
-            timeout.convention(configuredRunner.timeout)
-            headless.convention(true)
-            launchArgs.convention(emptyList())
-            launchEnvironmentVariables.convention(emptyMap())
-            finishMarker.convention(configuredRunner.finishMarker)
-        }
-    }
-
     private fun firstRunnerInput(): BrowserRunnerInput =
         frameworkTaskInputs.chromiumRunners.get().firstOrNull()
             ?: frameworkTaskInputs.firefoxRunners.get().firstOrNull()
@@ -257,6 +302,8 @@ internal class KotlinPlaywrightJsTestFramework(
             ?: error("No Playwright browser runners configured")
 
     companion object {
+        private const val DEBUGGER_READY_TIMEOUT_MILLIS = 30_000
+
         fun createInputs(objects: ObjectFactory): Inputs =
             objects.newInstance(Inputs::class.java)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -14,6 +14,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClientSettings
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersion
 import org.jetbrains.kotlin.gradle.targets.js.RequiredKotlinJsDependency
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTestsLocation
@@ -133,25 +134,21 @@ internal class KotlinPlaywrightJsTestFramework(
         val chromiumRunners = frameworkTaskInputs.chromiumRunners.get()
         chromiumRunners.firstOrNull()?.let { debugRunner ->
             if (chromiumRunners.size > 1) {
-                task.logger.warn(
-                    "Several Chromium runners are configured for '${task.path}': " +
-                            chromiumRunners.joinToString { "'${it.name.get()}'" } + ". " +
-                            "A debug session attaches to a single browser, so only '${debugRunner.name.get()}' is launched. " +
-                            "The other Chromium runners are not run in this build."
+                task.reportDiagnostic(
+                    KotlinToolingDiagnostics.SeveralChromiumRunnersForBrowserDebug(
+                        runnerNames = chromiumRunners.map { it.name.get() },
+                        debuggedRunnerName = debugRunner.name.get(),
+                    )
                 )
             }
             return debugRunner
         }
 
-        task.logger.warn(
-            "No Chromium runner is configured for Playwright debugging. " +
-                    "Kotlin will launch Chromium using the first configured browser runner's test settings. " +
-                    "Define a Chromium runner in the browser test DSL to customize the debug browser configuration."
-        )
-
         val configuredRunner = frameworkTaskInputs.firefoxRunners.get().firstOrNull()
             ?: frameworkTaskInputs.webkitRunners.get().firstOrNull()
             ?: error("No Playwright browser runners configured")
+
+        task.reportDiagnostic(KotlinToolingDiagnostics.NoChromiumRunnerForBrowserDebug(configuredRunner.name.get()))
 
         return createChromiumInputs(objects).apply {
             name.convention("chromium")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -129,10 +129,30 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override fun createTestExecuter(): TestExecuter<*> = PlaywrightTestExecutor()
 
-    private fun getDebugRunner(): ChromiumRunnerInput {
-        frameworkTaskInputs.chromiumRunners.get().firstOrNull()?.let { return it }
+    private fun pickDebugRunner(task: KotlinJsTest): ChromiumRunnerInput {
+        val chromiumRunners = frameworkTaskInputs.chromiumRunners.get()
+        chromiumRunners.firstOrNull()?.let { debugRunner ->
+            if (chromiumRunners.size > 1) {
+                task.logger.warn(
+                    "Several Chromium runners are configured for '${task.path}': " +
+                            chromiumRunners.joinToString { "'${it.name.get()}'" } + ". " +
+                            "A debug session attaches to a single browser, so only '${debugRunner.name.get()}' is launched. " +
+                            "The other Chromium runners are not run in this build."
+                )
+            }
+            return debugRunner
+        }
 
-        val configuredRunner = firstRunnerInput()
+        task.logger.warn(
+            "No Chromium runner is configured for Playwright debugging. " +
+                    "Kotlin will launch Chromium using the first configured browser runner's test settings. " +
+                    "Define a Chromium runner in the browser test DSL to customize the debug browser configuration."
+        )
+
+        val configuredRunner = frameworkTaskInputs.firefoxRunners.get().firstOrNull()
+            ?: frameworkTaskInputs.webkitRunners.get().firstOrNull()
+            ?: error("No Playwright browser runners configured")
+
         return createChromiumInputs(objects).apply {
             name.convention("chromium")
             testsLocation.convention(configuredRunner.testsLocation)
@@ -166,17 +186,9 @@ internal class KotlinPlaywrightJsTestFramework(
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
         val debugOptions = if (debug) debugOptions.get() else null
 
-        if (debug && frameworkTaskInputs.chromiumRunners.get().isEmpty()) {
-            task.logger.warn(
-                "No Chromium runner is configured for Playwright debugging. " +
-                        "Kotlin will launch Chromium using the first configured browser runner's test settings. " +
-                        "Define a Chromium runner in the browser test DSL to customize the debug browser configuration."
-            )
-        }
-
         val pwRunners = buildList {
             if (debugOptions != null) {
-                val runner = getDebugRunner()
+                val runner = pickDebugRunner(task)
                 add(
                     runner.createPwRunnerSpec(
                         PwBrowserKind.CHROMIUM,
@@ -237,12 +249,6 @@ internal class KotlinPlaywrightJsTestFramework(
         )
         return runnerConfig.buildUrlWithConfigState(baseUrl)
     }
-
-    private fun firstRunnerInput(): BrowserRunnerInput =
-        frameworkTaskInputs.chromiumRunners.get().firstOrNull()
-            ?: frameworkTaskInputs.firefoxRunners.get().firstOrNull()
-            ?: frameworkTaskInputs.webkitRunners.get().firstOrNull()
-            ?: error("No Playwright browser runners configured")
 
     companion object {
         fun createInputs(objects: ObjectFactory): Inputs =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -105,16 +105,18 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override val executable: Property<String> = objects.property(nodeJs.executable)
 
-    private val debugPort: Property<Int> = objects.property<Int>().convention(DEFAULT_DEBUG_PORT)
-
-    // null means we don't wait for a debugger before running the tests.
-    private var debuggerReadyPort: Int? = null
-    private var debuggerReadyTimeoutMillis: Int = DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS
+    private val debugOptions: Property<PwDebugOptions> = objects.property<PwDebugOptions>()
+        .convention(PwDebugOptions())
 
     override fun configureDebug(options: KotlinJsBrowserDebugOptions) {
-        options.debugPort?.let { debugPort.set(it) }
-        options.debuggerReadyPort?.let { debuggerReadyPort = it }
-        options.debuggerReadyTimeoutMillis?.let { debuggerReadyTimeoutMillis = it }
+        val defaultPwOptions = debugOptions.get()
+        debugOptions.set(
+            PwDebugOptions(
+                remoteDebuggingPort = options.debugPort ?: defaultPwOptions.remoteDebuggingPort,
+                debuggerReadyPort = options.debuggerReadyPort ?: defaultPwOptions.debuggerReadyPort,
+                debuggerReadyTimeoutMillis = options.debuggerReadyTimeoutMillis ?: defaultPwOptions.debuggerReadyTimeoutMillis,
+            )
+        )
     }
 
     @get:Internal
@@ -162,7 +164,7 @@ internal class KotlinPlaywrightJsTestFramework(
         ).toList()
 
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
-        val debugOptions = if (debug) takeDebugOptions() else null
+        val debugOptions = if (debug) debugOptions.get() else null
 
         if (debug && frameworkTaskInputs.chromiumRunners.get().isEmpty()) {
             task.logger.warn(
@@ -185,13 +187,13 @@ internal class KotlinPlaywrightJsTestFramework(
                 )
             } else {
                 frameworkTaskInputs.chromiumRunners.get().forEach {
-                    add(it.createPwRunnerSpec(PwBrowserKind.CHROMIUM, browsersDirectory, cliArgs, debugOptions))
+                    add(it.createPwRunnerSpec(PwBrowserKind.CHROMIUM, browsersDirectory, cliArgs))
                 }
                 frameworkTaskInputs.firefoxRunners.get().forEach {
-                    add(it.createPwRunnerSpec(PwBrowserKind.FIREFOX, browsersDirectory, cliArgs, debugOptions))
+                    add(it.createPwRunnerSpec(PwBrowserKind.FIREFOX, browsersDirectory, cliArgs))
                 }
                 frameworkTaskInputs.webkitRunners.get().forEach {
-                    add(it.createPwRunnerSpec(PwBrowserKind.WEBKIT, browsersDirectory, cliArgs, debugOptions))
+                    add(it.createPwRunnerSpec(PwBrowserKind.WEBKIT, browsersDirectory, cliArgs))
                 }
             }
         }
@@ -207,21 +209,11 @@ internal class KotlinPlaywrightJsTestFramework(
         )
     }
 
-    private fun takeDebugOptions(): PwDebugOptions {
-        val remoteDebuggingPort = debugPort.get()
-
-        return PwDebugOptions(
-            remoteDebuggingPort = remoteDebuggingPort,
-            debuggerReadyPort = debuggerReadyPort,
-            debuggerReadyTimeoutMillis = debuggerReadyTimeoutMillis,
-        )
-    }
-
     private fun BrowserRunnerInput.createPwRunnerSpec(
         kind: PwBrowserKind,
         browsersDirectory: Path,
         cliArgs: List<String>,
-        debugOptions: PwDebugOptions?,
+        debugOptions: PwDebugOptions? = null,
     ): PwRunnerSpec = PwRunnerSpec(
         name = name.get(),
         browserKind = kind,
@@ -253,8 +245,6 @@ internal class KotlinPlaywrightJsTestFramework(
             ?: error("No Playwright browser runners configured")
 
     companion object {
-        private const val DEFAULT_DEBUG_PORT = 9222
-        private const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 30_000
         fun createInputs(objects: ObjectFactory): Inputs =
             objects.newInstance(Inputs::class.java)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -121,35 +121,23 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override fun createTestExecuter(): TestExecuter<*> = PlaywrightTestExecutor()
 
-    private fun pickDebugRunner(task: KotlinJsTest): ChromiumRunnerInput {
+    private fun resolveDebugRunner(task: KotlinJsTest, requestedName: String): ChromiumRunnerInput {
         val chromiumRunners = frameworkTaskInputs.chromiumRunners.get()
-        chromiumRunners.firstOrNull()?.let { debugRunner ->
-            if (chromiumRunners.size > 1) {
-                task.reportDiagnostic(
-                    KotlinToolingDiagnostics.SeveralChromiumRunnersForBrowserDebug(
-                        runnerNames = chromiumRunners.map { it.name.get() },
-                        debuggedRunnerName = debugRunner.name.get(),
-                    )
+        chromiumRunners.firstOrNull { it.name.get() == requestedName }?.let { return it }
+
+        val otherRunners = frameworkTaskInputs.firefoxRunners.get() + frameworkTaskInputs.webkitRunners.get()
+        if (otherRunners.any { it.name.get() == requestedName }) {
+            task.reportDiagnostic(KotlinToolingDiagnostics.NoChromiumRunnerForBrowserDebug(requestedName))
+        } else {
+            task.reportDiagnostic(
+                KotlinToolingDiagnostics.UnknownRunnerForBrowserDebug(
+                    runnerName = requestedName,
+                    declaredRunnerNames = (chromiumRunners + otherRunners).map { it.name.get() },
                 )
-            }
-            return debugRunner
+            )
         }
 
-        val configuredRunner = frameworkTaskInputs.firefoxRunners.get().firstOrNull()
-            ?: frameworkTaskInputs.webkitRunners.get().firstOrNull()
-            ?: error("No Playwright browser runners configured")
-
-        task.reportDiagnostic(KotlinToolingDiagnostics.NoChromiumRunnerForBrowserDebug(configuredRunner.name.get()))
-
-        return createChromiumInputs(objects).apply {
-            name.convention("chromium")
-            testsLocation.convention(configuredRunner.testsLocation)
-            timeout.convention(configuredRunner.timeout)
-            headless.convention(true)
-            launchArgs.convention(emptyList())
-            launchEnvironmentVariables.convention(emptyMap())
-            finishMarker.convention(configuredRunner.finishMarker)
-        }
+        error("Could not resolve the '$requestedName' browser test runner")
     }
 
     override fun createTestExecutionSpec(
@@ -176,7 +164,7 @@ internal class KotlinPlaywrightJsTestFramework(
 
         val pwRunners = buildList {
             if (debugOptions != null) {
-                val runner = pickDebugRunner(task)
+                val runner = resolveDebugRunner(task, debugOptions.runnerName.get())
                 add(
                     runner.createPwRunnerSpec(
                         PwBrowserKind.CHROMIUM,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -13,6 +13,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.kotlin.dsl.mapProperty
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClient
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClientSettings
 import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersion
@@ -132,9 +133,13 @@ internal class KotlinPlaywrightJsTestFramework(
             include = task.includePatterns,
             exclude = task.excludePatterns,
         ).toList()
-        val runner = firstRunnerInput()
+        val runner = getDebugRunner()
         return runner.buildRunnerUrl(runner.testsLocation.get().url.get(), cliArgs)
     }
+
+    @Suppress("unused")
+    fun getDebugRunner(): ChromiumRunnerInput =
+        frameworkTaskInputs.chromiumRunners.get().firstOrNull() ?: createDefaultDebugRunner()
 
     override fun createTestExecutionSpec(
         task: KotlinJsTest,
@@ -169,21 +174,18 @@ internal class KotlinPlaywrightJsTestFramework(
         }
 
         val pwRunners = buildList {
-            val chromiumRunners = frameworkTaskInputs.chromiumRunners.get()
             if (debugOptions?.remoteDebuggingPort != null) {
-                // IntelliJ attaches to Playwright through Chromium CDP, so debug runs use one Chromium runner.
-                val runner = chromiumRunners.firstOrNull() ?: firstRunnerInput()
+                val runner = getDebugRunner()
                 add(
                     runner.createPwRunnerSpec(
                         PwBrowserKind.CHROMIUM,
                         browsersDirectory,
                         cliArgs,
                         debugOptions,
-                        useRunnerBrowserLaunchSettings = runner in chromiumRunners,
                     )
                 )
             } else {
-                chromiumRunners.forEach {
+                frameworkTaskInputs.chromiumRunners.get().forEach {
                     add(it.createPwRunnerSpec(PwBrowserKind.CHROMIUM, browsersDirectory, cliArgs, debugOptions))
                 }
                 frameworkTaskInputs.firefoxRunners.get().forEach {
@@ -211,7 +213,6 @@ internal class KotlinPlaywrightJsTestFramework(
         browsersDirectory: Path,
         cliArgs: List<String>,
         debugOptions: PwDebugOptions?,
-        useRunnerBrowserLaunchSettings: Boolean = true,
     ): PwRunnerSpec = PwRunnerSpec(
         name = name.get(),
         browserKind = kind,
@@ -221,10 +222,9 @@ internal class KotlinPlaywrightJsTestFramework(
         timeout = timeout.get().toKotlinDuration(),
         finishMarker = finishMarker.get(),
         headless = headless.get(),
-        // Firefox/WebKit fallback reuses the test URL/config, but must not reuse browser-specific launch settings for Chromium.
-        launchArgs = if (useRunnerBrowserLaunchSettings) launchArgs.get() else emptyList(),
-        launchEnvironmentVariables = if (useRunnerBrowserLaunchSettings) launchEnvironmentVariables.get() else emptyMap(),
-        customBrowserExecutable = if (useRunnerBrowserLaunchSettings) customBrowserExecutable.asPathOrNull else null,
+        launchArgs = launchArgs.get(),
+        launchEnvironmentVariables = launchEnvironmentVariables.get(),
+        customBrowserExecutable = customBrowserExecutable.asPathOrNull,
         debugOptions = debugOptions,
     )
 
@@ -235,6 +235,19 @@ internal class KotlinPlaywrightJsTestFramework(
             kotlinTestCliArguments = cliArgs
         )
         return runnerConfig.buildUrlWithConfigState(baseUrl)
+    }
+
+    private fun createDefaultDebugRunner(): ChromiumRunnerInput {
+        val configuredRunner = firstRunnerInput()
+        return createChromiumInputs(objects).apply {
+            name.convention("chromium")
+            testsLocation.convention(configuredRunner.testsLocation)
+            timeout.convention(configuredRunner.timeout)
+            headless.convention(true)
+            launchArgs.convention(emptyList())
+            launchEnvironmentVariables.convention(emptyMap())
+            finishMarker.convention(configuredRunner.finishMarker)
+        }
     }
 
     private fun firstRunnerInput(): BrowserRunnerInput =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -37,6 +37,7 @@ import java.time.Duration
 import javax.inject.Inject
 import kotlin.time.toKotlinDuration
 
+
 /**
  * Kotlin/JS browser test framework backed by [Playwright][com.microsoft.playwright.Playwright]
  */
@@ -104,6 +105,13 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override val executable: Property<String> = objects.property(nodeJs.executable)
 
+    /**
+     * Chromium remote debugging port supplied by IntelliJ IDEA when a Playwright browser test debug session is started.
+     * The Ultimate Gradle init script sets it before Gradle asks this framework to create the execution spec.
+     */
+    @Suppress("unused")
+    val debugPort: Property<Int> = objects.property<Int>()
+
     @get:Internal
     override val requiredNpmDependencies: Set<RequiredKotlinJsDependency> = setOf(
         NpmPackageVersion("playwright-core", PLAYWRIGHT_VERSION)
@@ -113,6 +121,20 @@ internal class KotlinPlaywrightJsTestFramework(
     internal val npmToolingEnvDir: DirectoryProperty = objects.directoryProperty().convention(compilation.npmToolingDir())
 
     override fun createTestExecuter(): TestExecuter<*> = PlaywrightTestExecutor()
+
+    /**
+     * Used by IntelliJ IDEA to determine the Playwright test page URL for browser test debug sessions.
+     * Called from the Ultimate Gradle init script before the browser is launched, so source mappings can be prepared.
+     */
+    @Suppress("unused")
+    fun buildDebugUrl(task: KotlinJsTest): URI {
+        val cliArgs = KotlinTestRunnerCliArgs(
+            include = task.includePatterns,
+            exclude = task.excludePatterns,
+        ).toList()
+        val runner = firstRunnerInput()
+        return runner.buildRunnerUrl(runner.testsLocation.get().url.get(), cliArgs)
+    }
 
     override fun createTestExecutionSpec(
         task: KotlinJsTest,
@@ -134,16 +156,34 @@ internal class KotlinPlaywrightJsTestFramework(
         ).toList()
 
         val browsersDirectory = frameworkTaskInputs.playwrightBrowsersDirectory.getFile().toPath()
+        val debugOptions = if (debug) PwDebugOptions(
+            remoteDebuggingPort = debugPort.orNull,
+        ) else null
 
         val pwRunners = buildList {
-            frameworkTaskInputs.chromiumRunners.get().forEach {
-                add(it.createPwRunnerSpec(PwBrowserKind.CHROMIUM, browsersDirectory, cliArgs))
-            }
-            frameworkTaskInputs.firefoxRunners.get().forEach {
-                add(it.createPwRunnerSpec(PwBrowserKind.FIREFOX, browsersDirectory, cliArgs))
-            }
-            frameworkTaskInputs.webkitRunners.get().forEach {
-                add(it.createPwRunnerSpec(PwBrowserKind.WEBKIT, browsersDirectory, cliArgs))
+            val chromiumRunners = frameworkTaskInputs.chromiumRunners.get()
+            if (debugOptions?.remoteDebuggingPort != null) {
+                // IntelliJ attaches to Playwright through Chromium CDP, so debug runs use one Chromium runner.
+                val runner = chromiumRunners.firstOrNull() ?: firstRunnerInput()
+                add(
+                    runner.createPwRunnerSpec(
+                        PwBrowserKind.CHROMIUM,
+                        browsersDirectory,
+                        cliArgs,
+                        debugOptions,
+                        useRunnerBrowserLaunchSettings = runner in chromiumRunners,
+                    )
+                )
+            } else {
+                chromiumRunners.forEach {
+                    add(it.createPwRunnerSpec(PwBrowserKind.CHROMIUM, browsersDirectory, cliArgs, debugOptions))
+                }
+                frameworkTaskInputs.firefoxRunners.get().forEach {
+                    add(it.createPwRunnerSpec(PwBrowserKind.FIREFOX, browsersDirectory, cliArgs, debugOptions))
+                }
+                frameworkTaskInputs.webkitRunners.get().forEach {
+                    add(it.createPwRunnerSpec(PwBrowserKind.WEBKIT, browsersDirectory, cliArgs, debugOptions))
+                }
             }
         }
 
@@ -162,6 +202,8 @@ internal class KotlinPlaywrightJsTestFramework(
         kind: PwBrowserKind,
         browsersDirectory: Path,
         cliArgs: List<String>,
+        debugOptions: PwDebugOptions?,
+        useRunnerBrowserLaunchSettings: Boolean = true,
     ): PwRunnerSpec = PwRunnerSpec(
         name = name.get(),
         browserKind = kind,
@@ -171,19 +213,26 @@ internal class KotlinPlaywrightJsTestFramework(
         timeout = timeout.get().toKotlinDuration(),
         finishMarker = finishMarker.get(),
         headless = headless.get(),
-        launchArgs = launchArgs.get(),
-        launchEnvironmentVariables = launchEnvironmentVariables.get(),
-        customBrowserExecutable = customBrowserExecutable.asPathOrNull
+        // Firefox/WebKit fallback reuses the test URL/config, but must not reuse browser-specific launch settings for Chromium.
+        launchArgs = if (useRunnerBrowserLaunchSettings) launchArgs.get() else emptyList(),
+        launchEnvironmentVariables = if (useRunnerBrowserLaunchSettings) launchEnvironmentVariables.get() else emptyMap(),
+        customBrowserExecutable = if (useRunnerBrowserLaunchSettings) customBrowserExecutable.asPathOrNull else null,
+        debugOptions = debugOptions,
     )
 
     private fun BrowserRunnerInput.buildRunnerUrl(baseUrl: URI, cliArgs: List<String>): URI {
         val runnerConfig = KotlinBrowserRunnerConfig(
-            timeout = timeout.get(),
             testsFinishedMarker = finishMarker.get(),
             kotlinTestCliArguments = cliArgs
         )
         return runnerConfig.buildUrlWithConfigState(baseUrl)
     }
+
+    private fun firstRunnerInput(): BrowserRunnerInput =
+        frameworkTaskInputs.chromiumRunners.get().firstOrNull()
+            ?: frameworkTaskInputs.firefoxRunners.get().firstOrNull()
+            ?: frameworkTaskInputs.webkitRunners.get().firstOrNull()
+            ?: error("No Playwright browser runners configured")
 
     companion object {
         fun createInputs(objects: ObjectFactory): Inputs =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -13,8 +13,6 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
-import org.gradle.kotlin.dsl.mapProperty
-import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClient
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClientSettings
 import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersion
 import org.jetbrains.kotlin.gradle.targets.js.RequiredKotlinJsDependency

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/KotlinPlaywrightJsTestFramework.kt
@@ -121,7 +121,7 @@ internal class KotlinPlaywrightJsTestFramework(
 
     override fun createTestExecuter(): TestExecuter<*> = PlaywrightTestExecutor()
 
-    private fun resolveDebugRunner(task: KotlinJsTest, requestedName: String): ChromiumRunnerInput {
+    private fun resolveDebugRunner(task: KotlinJsTest, requestedName: String): ChromiumRunnerInput? {
         val chromiumRunners = frameworkTaskInputs.chromiumRunners.get()
         chromiumRunners.firstOrNull { it.name.get() == requestedName }?.let { return it }
 
@@ -136,8 +136,7 @@ internal class KotlinPlaywrightJsTestFramework(
                 )
             )
         }
-
-        error("Could not resolve the '$requestedName' browser test runner")
+        return null
     }
 
     override fun createTestExecutionSpec(
@@ -165,14 +164,16 @@ internal class KotlinPlaywrightJsTestFramework(
         val pwRunners = buildList {
             if (debugOptions != null) {
                 val runner = resolveDebugRunner(task, debugOptions.runnerName.get())
-                add(
-                    runner.createPwRunnerSpec(
-                        PwBrowserKind.CHROMIUM,
-                        browsersDirectory,
-                        cliArgs,
-                        debugOptions,
+                runner?.let {
+                    add(
+                        runner.createPwRunnerSpec(
+                            PwBrowserKind.CHROMIUM,
+                            browsersDirectory,
+                            cliArgs,
+                            debugOptions,
+                        )
                     )
-                )
+                }
             } else {
                 frameworkTaskInputs.chromiumRunners.get().forEach {
                     add(it.createPwRunnerSpec(PwBrowserKind.CHROMIUM, browsersDirectory, cliArgs))

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -68,9 +68,6 @@ internal class PwRunnerSpec(
     val isDebugEnabled: Boolean = debugOptions != null,
 )
 
-internal const val DEFAULT_DEBUG_PORT = 9222
-internal const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 60_000
-
 private const val NO_TIMEOUT = 0.0
 
 internal class PwDebugOptions(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -321,18 +321,21 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         log.warn("Playwright executor doesn't support immediate stop")
     }
 
-    private fun List<String>.withRemoteDebuggingPort(port: Int): List<String> {
-        // Drop any CDP port the user passed, it would clash with the one we were given.
-        val args = mutableListOf<String>()
-        var skipNext = false
-        for (arg in this) {
-            when {
-                skipNext -> skipNext = false
-                arg == "--remote-debugging-port" -> skipNext = true
-                arg.startsWith("--remote-debugging-port=") -> Unit
-                else -> args.add(arg)
-            }
+}
+
+private const val REMOTE_DEBUGGING_PORT_ARG = "--remote-debugging-port"
+
+// Drops any CDP port the user passed, it would clash with the one we were given.
+internal fun List<String>.withRemoteDebuggingPort(port: Int): List<String> {
+    val args = mutableListOf<String>()
+    var skipPort = false
+    for ((index, arg) in withIndex()) {
+        when {
+            skipPort -> skipPort = false
+            arg.startsWith("$REMOTE_DEBUGGING_PORT_ARG=") -> Unit
+            arg == REMOTE_DEBUGGING_PORT_ARG -> skipPort = getOrNull(index + 1)?.toIntOrNull() != null
+            else -> args.add(arg)
         }
-        return args + "--remote-debugging-port=$port"
     }
+    return args + "$REMOTE_DEBUGGING_PORT_ARG=$port"
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -37,9 +37,11 @@ import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
-import java.net.URI
-import java.net.ServerSocket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.net.SocketTimeoutException
+import java.net.URI
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.time.Duration
@@ -65,9 +67,11 @@ internal class PwRunnerSpec(
 )
 
 internal class PwDebugOptions(
-    // IntelliJ starts a Chromium remote-debug configuration on this port before Gradle launches Playwright.
+    // A CDP debugger can attach to Chromium on this port.
     val remoteDebuggingPort: Int,
-    val debuggerReadySocket: ServerSocket,
+    // Set when the run should wait until a debugger is attached.
+    val debuggerReadyPort: Int?,
+    val debuggerReadyTimeoutMillis: Int,
 )
 
 /**
@@ -231,13 +235,16 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         }
 
         val runnerDebugPort = runner.debugOptions?.remoteDebuggingPort
+        if (runnerDebugPort != null && runner.headless) {
+            log.info("Running '${runner.name}' headed instead of headless, because it is being debugged")
+        }
         val launchOptions = BrowserType.LaunchOptions()
             .setHeadless(runnerDebugPort == null && runner.headless)
             .apply {
                 val launchArgs = if (runnerDebugPort != null) {
-                    // The IDE debugger speaks CDP here; non-Chromium runners are converted before reaching the executor.
+                    // The debugger needs CDP, so non-Chromium runners are swapped out before we get here.
                     check(runner.browserKind == PwBrowserKind.CHROMIUM) {
-                        "IntelliJ browser test debugging for Playwright is supported only with Chromium runners"
+                        "Browser test debugging for Playwright is supported only with Chromium runners"
                     }
                     runner.launchArgs.withRemoteDebuggingPort(runnerDebugPort)
                 } else {
@@ -274,14 +281,28 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         }
     }
 
+    // With no ready port we don't wait at all. The timeout covers the connect and the reply separately.
     private fun PwRunnerSpec.awaitDebuggerAttached() {
-        val readySocket = debugOptions?.debuggerReadySocket ?: return
+        val readyPort = debugOptions?.debuggerReadyPort ?: return
+        val timeoutMillis = debugOptions.debuggerReadyTimeoutMillis
+        log.info("Waiting up to $timeoutMillis ms for a debugger to attach to '$name'")
         try {
-            readySocket.use { serverSocket ->
-                serverSocket.accept().close()
+            Socket().use { socket ->
+                socket.connect(InetSocketAddress(InetAddress.getLoopbackAddress(), readyPort), timeoutMillis)
+                socket.soTimeout = timeoutMillis
+                check(socket.getInputStream().read() >= 0) {
+                    "The debugger readiness connection for '$name' on port $readyPort was closed without acknowledgement"
+                }
             }
         } catch (e: SocketTimeoutException) {
-            throw IllegalStateException("Timed out waiting for IntelliJ debugger to attach to '$name'", e)
+            throw IllegalStateException(
+                "Timed out after $timeoutMillis ms waiting for a debugger to attach to '$name' on port $readyPort", e
+            )
+        } catch (e: IOException) {
+            throw IllegalStateException(
+                "Could not reach the debugger readiness port $readyPort for '$name'. " +
+                        "The debugger is no longer waiting to attach.", e
+            )
         }
     }
 
@@ -291,7 +312,7 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
     }
 
     private fun List<String>.withRemoteDebuggingPort(port: Int): List<String> {
-        // User-provided CDP flags would conflict with the IDE-allocated port, so normalize them here.
+        // Drop any CDP port the user passed, it would clash with the one we were given.
         val args = mutableListOf<String>()
         var skipNext = false
         for (arg in this) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -266,7 +266,12 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         browser.use {
             val page = browser.newPage()
             page.use {
-                runner.awaitDebuggerAttached()
+                runner.debugOptions?.let { debugOptions ->
+                    debugOptions.debuggerReadyPort?.let { readyPort ->
+                        runner.awaitDebuggerAttached(readyPort, debugOptions.debuggerReadyTimeoutMillis)
+                    }
+                }
+
                 val timeoutMillis = if (runner.isDebugEnabled) NO_TIMEOUT else runner.timeout.inWholeMilliseconds.toDouble()
                 page.setDefaultTimeout(runner.timeout.inWholeMilliseconds.toDouble())
                 var finished = false
@@ -288,10 +293,8 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         }
     }
 
-    // With no ready port we don't wait at all. The timeout covers the connect and the reply separately.
-    private fun PwRunnerSpec.awaitDebuggerAttached() {
-        val readyPort = debugOptions?.debuggerReadyPort ?: return
-        val timeoutMillis = debugOptions.debuggerReadyTimeoutMillis
+    // The timeout covers the connect and the reply separately.
+    private fun PwRunnerSpec.awaitDebuggerAttached(readyPort: Int, timeoutMillis: Int) {
         log.info("Waiting up to $timeoutMillis ms for a debugger to attach to '$name'")
         try {
             Socket().use { socket ->

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -64,14 +64,18 @@ internal class PwRunnerSpec(
     val launchEnvironmentVariables: Map<String, String>,
     val customBrowserExecutable: Path?,
     val debugOptions: PwDebugOptions?,
+    val isDebugEnabled: Boolean = debugOptions != null,
 )
+
+private const val DEFAULT_DEBUG_PORT = 9222
+private const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 60_000
 
 internal class PwDebugOptions(
     // A CDP debugger can attach to Chromium on this port.
-    val remoteDebuggingPort: Int,
+    val remoteDebuggingPort: Int = DEFAULT_DEBUG_PORT,
     // Set when the run should wait until a debugger is attached.
-    val debuggerReadyPort: Int?,
-    val debuggerReadyTimeoutMillis: Int,
+    val debuggerReadyPort: Int? = null,
+    val debuggerReadyTimeoutMillis: Int = DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS,
 )
 
 /**
@@ -234,19 +238,19 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
             PwBrowserKind.WEBKIT -> playwright.webkit()
         }
 
-        val runnerDebugPort = runner.debugOptions?.remoteDebuggingPort
-        if (runnerDebugPort != null && runner.headless) {
+        if (runner.isDebugEnabled && runner.headless) {
             log.info("Running '${runner.name}' headed instead of headless, because it is being debugged")
         }
         val launchOptions = BrowserType.LaunchOptions()
-            .setHeadless(runnerDebugPort == null && runner.headless)
+            .setHeadless(!runner.isDebugEnabled && runner.headless)
             .apply {
-                val launchArgs = if (runnerDebugPort != null) {
+                val debugOptions = runner.debugOptions
+                val launchArgs = if (debugOptions != null) {
                     // The debugger needs CDP, so non-Chromium runners are swapped out before we get here.
                     check(runner.browserKind == PwBrowserKind.CHROMIUM) {
                         "Browser test debugging for Playwright is supported only with Chromium runners"
                     }
-                    runner.launchArgs.withRemoteDebuggingPort(runnerDebugPort)
+                    runner.launchArgs.withRemoteDebuggingPort(debugOptions.remoteDebuggingPort)
                 } else {
                     runner.launchArgs
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -278,7 +278,7 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         val readySocket = debugOptions?.debuggerReadySocket ?: return
         try {
             readySocket.use { serverSocket ->
-                serverSocket.accept().use { }
+                serverSocket.accept().close()
             }
         } catch (e: SocketTimeoutException) {
             throw IllegalStateException("Timed out waiting for IntelliJ debugger to attach to '$name'", e)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -24,6 +24,7 @@ package org.jetbrains.kotlin.gradle.targets.js.testing.playwright
 
 import com.microsoft.playwright.Browser
 import com.microsoft.playwright.BrowserType
+import com.microsoft.playwright.Page
 import com.microsoft.playwright.Playwright
 import com.microsoft.playwright.impl.Connection
 import com.microsoft.playwright.impl.driver.Driver
@@ -69,6 +70,8 @@ internal class PwRunnerSpec(
 
 private const val DEFAULT_DEBUG_PORT = 9222
 private const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 60_000
+
+private const val NO_TIMEOUT = 0.0
 
 internal class PwDebugOptions(
     // A CDP debugger can attach to Chromium on this port.
@@ -267,6 +270,7 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
             val page = browser.newPage()
             page.use {
                 runner.awaitDebuggerAttached()
+                val timeoutMillis = if (runner.isDebugEnabled) NO_TIMEOUT else runner.timeout.inWholeMilliseconds.toDouble()
                 page.setDefaultTimeout(runner.timeout.inWholeMilliseconds.toDouble())
                 var finished = false
                 page.onConsoleMessage {
@@ -279,8 +283,10 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
                 }
                 val url = runner.buildTestsExecutionerUrl(testLocationUrl)
                 log.info("Execute JS tests with ${runner.name} runner at URL: $url")
-                page.navigate(url.toString())
-                page.waitForCondition({ finished })
+                // Zero has to be passed per call: setDefaultTimeout(0) leaves waitForCondition with an
+                // already expired deadline instead of disabling it.
+                page.navigate(url.toString(), Page.NavigateOptions().setTimeout(timeoutMillis))
+                page.waitForCondition({ finished }, Page.WaitForConditionOptions().setTimeout(timeoutMillis))
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -68,17 +68,17 @@ internal class PwRunnerSpec(
     val isDebugEnabled: Boolean = debugOptions != null,
 )
 
-private const val DEFAULT_DEBUG_PORT = 9222
-private const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 60_000
+internal const val DEFAULT_DEBUG_PORT = 9222
+internal const val DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS = 60_000
 
 private const val NO_TIMEOUT = 0.0
 
 internal class PwDebugOptions(
     // A CDP debugger can attach to Chromium on this port.
-    val remoteDebuggingPort: Int = DEFAULT_DEBUG_PORT,
+    val remoteDebuggingPort: Int,
     // Set when the run should wait until a debugger is attached.
-    val debuggerReadyPort: Int? = null,
-    val debuggerReadyTimeoutMillis: Int = DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS,
+    val debuggerReadyPort: Int?,
+    val debuggerReadyTimeoutMillis: Int,
 )
 
 /**

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -59,6 +59,12 @@ internal class PwRunnerSpec(
     val launchArgs: List<String>,
     val launchEnvironmentVariables: Map<String, String>,
     val customBrowserExecutable: Path?,
+    val debugOptions: PwDebugOptions?,
+)
+
+internal class PwDebugOptions(
+    // IntelliJ starts a Chromium remote-debug configuration on this port before Gradle launches Playwright.
+    val remoteDebuggingPort: Int?,
 )
 
 /**
@@ -221,9 +227,20 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
             PwBrowserKind.WEBKIT -> playwright.webkit()
         }
         val launchOptions = BrowserType.LaunchOptions()
-            .setHeadless(runner.headless)
+            .setHeadless(runner.debugOptions == null && runner.headless)
             .apply {
-                if (runner.launchArgs.isNotEmpty()) setArgs(runner.launchArgs)
+                val debugPort = runner.debugOptions?.remoteDebuggingPort
+                val launchArgs = if (debugPort != null) {
+                    // The IDE debugger speaks CDP here; non-Chromium runners are converted before reaching the executor.
+                    check(runner.browserKind == PwBrowserKind.CHROMIUM) {
+                        "IntelliJ browser test debugging for Playwright is supported only with Chromium runners"
+                    }
+                    runner.launchArgs.withRemoteDebuggingPort(debugPort)
+                } else {
+                    runner.launchArgs
+                }
+
+                if (launchArgs.isNotEmpty()) setArgs(launchArgs)
                 if (runner.launchEnvironmentVariables.isNotEmpty()) setEnv(runner.launchEnvironmentVariables)
                 if (runner.customBrowserExecutable != null) setExecutablePath(runner.customBrowserExecutable)
             }
@@ -234,7 +251,6 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         browser.use {
             val page = browser.newPage()
             page.use {
-                page.setDefaultTimeout(runner.timeout.inWholeMilliseconds.toDouble())
                 var finished = false
                 page.onConsoleMessage {
                     if (it.text().startsWith(runner.finishMarker)) {
@@ -255,5 +271,20 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
     override fun stopNow() {
         // TODO: implement stop now now support
         log.warn("Playwright executor doesn't support immediate stop")
+    }
+
+    private fun List<String>.withRemoteDebuggingPort(port: Int): List<String> {
+        // User-provided CDP flags would conflict with the IDE-allocated port, so normalize them here.
+        val args = mutableListOf<String>()
+        var skipNext = false
+        for (arg in this) {
+            when {
+                skipNext -> skipNext = false
+                arg == "--remote-debugging-port" -> skipNext = true
+                arg.startsWith("--remote-debugging-port=") -> Unit
+                else -> args.add(arg)
+            }
+        }
+        return args + "--remote-debugging-port=$port"
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -314,7 +314,7 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
     }
 
     override fun stopNow() {
-        // TODO: implement stop now now support
+        // TODO: KT-88516 implement immediate stop support
         log.warn("Playwright executor doesn't support immediate stop")
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -251,6 +251,7 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         browser.use {
             val page = browser.newPage()
             page.use {
+                page.setDefaultTimeout(runner.timeout.inWholeMilliseconds.toDouble())
                 var finished = false
                 page.onConsoleMessage {
                     if (it.text().startsWith(runner.finishMarker)) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -38,6 +38,8 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.URI
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.time.Duration
@@ -64,7 +66,8 @@ internal class PwRunnerSpec(
 
 internal class PwDebugOptions(
     // IntelliJ starts a Chromium remote-debug configuration on this port before Gradle launches Playwright.
-    val remoteDebuggingPort: Int?,
+    val remoteDebuggingPort: Int,
+    val debuggerReadySocket: ServerSocket,
 )
 
 /**
@@ -252,6 +255,7 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
         browser.use {
             val page = browser.newPage()
             page.use {
+                runner.awaitDebuggerAttached()
                 page.setDefaultTimeout(runner.timeout.inWholeMilliseconds.toDouble())
                 var finished = false
                 page.onConsoleMessage {
@@ -267,6 +271,17 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
                 page.navigate(url.toString())
                 page.waitForCondition({ finished })
             }
+        }
+    }
+
+    private fun PwRunnerSpec.awaitDebuggerAttached() {
+        val readySocket = debugOptions?.debuggerReadySocket ?: return
+        try {
+            readySocket.use { serverSocket ->
+                serverSocket.accept().use { }
+            }
+        } catch (e: SocketTimeoutException) {
+            throw IllegalStateException("Timed out waiting for IntelliJ debugger to attach to '$name'", e)
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/playwright/PlaywrightTestExecutor.kt
@@ -226,16 +226,17 @@ internal class PlaywrightTestExecutor() : TestExecuter<PwExecutionSpec> {
             PwBrowserKind.FIREFOX -> playwright.firefox()
             PwBrowserKind.WEBKIT -> playwright.webkit()
         }
+
+        val runnerDebugPort = runner.debugOptions?.remoteDebuggingPort
         val launchOptions = BrowserType.LaunchOptions()
-            .setHeadless(runner.debugOptions == null && runner.headless)
+            .setHeadless(runnerDebugPort == null && runner.headless)
             .apply {
-                val debugPort = runner.debugOptions?.remoteDebuggingPort
-                val launchArgs = if (debugPort != null) {
+                val launchArgs = if (runnerDebugPort != null) {
                     // The IDE debugger speaks CDP here; non-Chromium runners are converted before reaching the executor.
                     check(runner.browserKind == PwBrowserKind.CHROMIUM) {
                         "IntelliJ browser test debugging for Playwright is supported only with Chromium runners"
                     }
-                    runner.launchArgs.withRemoteDebuggingPort(debugPort)
+                    runner.launchArgs.withRemoteDebuggingPort(runnerDebugPort)
                 } else {
                     runner.launchArgs
                 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -24,6 +24,10 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.getPwInstallBrowserTaskName
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.js.testing.WebpackBundleKotlinJsTests
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnostic
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.ToolingDiagnosticRenderingOptions
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.createAnExceptionForFatalDiagnostic
 import org.jetbrains.kotlin.gradle.targets.js.testing.DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS
 import org.jetbrains.kotlin.gradle.targets.js.testing.DEFAULT_DEBUG_PORT
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
@@ -204,7 +208,10 @@ class KotlinPlaywrightTestFrameworkWiringTest {
                 setup.project.tasks.getByName(it.getPwInstallBrowserTaskName())
             )
 
-            assertNotNull(installTask, "Expected ${it.getPwInstallBrowserTaskName()} task to be registered to install ${it.browserName} browsers")
+            assertNotNull(
+                installTask,
+                "Expected ${it.getPwInstallBrowserTaskName()} task to be registered to install ${it.browserName} browsers"
+            )
         }
     }
 
@@ -321,16 +328,19 @@ class KotlinPlaywrightTestFrameworkWiringTest {
 
     // Checks the browser debug wiring without starting a real browser.
     @Test
-    fun `playwright debug uses default chromium for firefox runner`() {
+    fun `playwright debug attaches to the chromium runner alongside a firefox one`() {
         val setup = buildBrowserTestProject {
-            firefox("selected") {
-                it.launchArgs.set(listOf("-devtools"))
-                it.launchEnvironmentVariables.set(mapOf("FIREFOX_DEBUG" to "1"))
+            chromium {
+                it.launchArgs.set(listOf("--no-sandbox"))
+                it.launchEnvironmentVariables.set(mapOf("CHROMIUM_DEBUG" to "1"))
             }
+            firefox("selected")
         }
         val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
         val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
-        framework.frameworkTaskInputs.firefoxRunners.get().single().testsLocation.set(location)
+        with(framework.frameworkTaskInputs) {
+            (chromiumRunners.get() + firefoxRunners.get()).forEach { it.testsLocation.set(location) }
+        }
 
         val firefoxInstallTask = assertIs<PlaywrightBrowserInstall>(
             setup.project.tasks.getByName(PwBrowserKind.FIREFOX.getPwInstallBrowserTaskName())
@@ -343,11 +353,6 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         assertEquals(setOf("chromium"), chromiumInstallTask.browsers.get().toSet())
 
         val testTask = setup.jsBrowserTestTask
-        assertFalse(
-            testTask.taskDependencies.getDependencies(testTask).contains(chromiumInstallTask),
-            "Expected no Chromium install dependency without browser debugging"
-        )
-
         val debuggerReadyPort = ServerSocket(0).use { it.localPort }
         testTask.browserDebug.set(true)
         testTask.browserDebugPort.set("32123")
@@ -372,11 +377,25 @@ class KotlinPlaywrightTestFrameworkWiringTest {
 
         assertEquals("chromium", runner.name)
         assertEquals(PwBrowserKind.CHROMIUM, runner.browserKind)
-        assertEquals(emptyList(), runner.launchArgs)
-        assertEquals(emptyMap(), runner.launchEnvironmentVariables)
+        assertEquals(listOf("--no-sandbox"), runner.launchArgs)
+        assertEquals(mapOf("CHROMIUM_DEBUG" to "1"), runner.launchEnvironmentVariables)
         assertEquals(32123, runner.debugOptions?.remoteDebuggingPort)
         assertEquals(debuggerReadyPort, runner.debugOptions?.debuggerReadyPort)
         assertEquals(45000, runner.debugOptions?.debuggerReadyTimeoutMillis)
+    }
+
+    @Test
+    fun `a debug run does not depend on the chromium install task without browser debug`() {
+        val setup = buildBrowserTestProject { firefox("selected") }
+        val chromiumInstallTask = assertIs<PlaywrightBrowserInstall>(
+            setup.project.tasks.getByName(PwBrowserKind.CHROMIUM.getPwInstallBrowserTaskName())
+        )
+        val testTask = setup.jsBrowserTestTask
+
+        assertFalse(
+            testTask.taskDependencies.getDependencies(testTask).contains(chromiumInstallTask),
+            "Expected no Chromium install dependency without browser debugging"
+        )
     }
 
     @Test
@@ -458,18 +477,19 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     }
 
     @Test
-    fun `a debug run launches the first of several chromium runners`() {
+    fun `a debug run launches the named chromium runner`() {
         val setup = buildBrowserTestProject {
             chromium("first")
             chromium("second")
         }
         setup.prepareExecutableFramework()
         setup.jsBrowserTestTask.browserDebug.set(true)
+        setup.jsBrowserTestTask.browserDebugRunner.set("second")
 
         val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
 
         // A debug session attaches to a single browser, so the other runners are left out.
-        assertEquals(listOf("first"), spec.runners.map { it.name })
+        assertEquals(listOf("second"), spec.runners.map { it.name })
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.WebpackBundleKotlinJsTests
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
+import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwDebugOptions
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwExecutionSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERSION
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
@@ -372,9 +373,10 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
         val debugOptions = spec.runners.single().debugOptions
 
-        assertEquals(9222, debugOptions?.remoteDebuggingPort)
+        val defaults = PwDebugOptions()
+        assertEquals(defaults.remoteDebuggingPort, debugOptions?.remoteDebuggingPort)
         assertNull(debugOptions?.debuggerReadyPort, "Without a readiness port the run must not wait for a debugger")
-        assertEquals(30_000, debugOptions?.debuggerReadyTimeoutMillis)
+        assertEquals(defaults.debuggerReadyTimeoutMillis, debugOptions?.debuggerReadyTimeoutMillis)
     }
 
     @Test
@@ -396,9 +398,10 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
         val debugOptions = spec.runners.single().debugOptions
 
-        assertEquals(9222, debugOptions?.remoteDebuggingPort, "An unset debug port must fall back to the default")
+        val defaults = PwDebugOptions()
+        assertEquals(defaults.remoteDebuggingPort, debugOptions?.remoteDebuggingPort, "An unset debug port must fall back to the default")
         assertEquals(54321, debugOptions?.debuggerReadyPort)
-        assertEquals(30_000, debugOptions?.debuggerReadyTimeoutMillis)
+        assertEquals(defaults.debuggerReadyTimeoutMillis, debugOptions?.debuggerReadyTimeoutMillis)
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -26,8 +26,9 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.js.testing.WebpackBundleKotlinJsTests
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
+import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS
+import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.DEFAULT_DEBUG_PORT
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
-import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwDebugOptions
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwExecutionSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwRunnerSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERSION
@@ -379,10 +380,9 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
         val debugOptions = spec.runners.single().debugOptions
 
-        val defaults = PwDebugOptions()
-        assertEquals(defaults.remoteDebuggingPort, debugOptions?.remoteDebuggingPort)
+        assertEquals(DEFAULT_DEBUG_PORT, debugOptions?.remoteDebuggingPort)
         assertNull(debugOptions?.debuggerReadyPort, "Without a readiness port the run must not wait for a debugger")
-        assertEquals(defaults.debuggerReadyTimeoutMillis, debugOptions?.debuggerReadyTimeoutMillis)
+        assertEquals(DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS, debugOptions?.debuggerReadyTimeoutMillis)
     }
 
     @Test
@@ -404,10 +404,9 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
         val debugOptions = spec.runners.single().debugOptions
 
-        val defaults = PwDebugOptions()
-        assertEquals(defaults.remoteDebuggingPort, debugOptions?.remoteDebuggingPort, "An unset debug port must fall back to the default")
+        assertEquals(DEFAULT_DEBUG_PORT, debugOptions?.remoteDebuggingPort, "An unset debug port must fall back to the default")
         assertEquals(54321, debugOptions?.debuggerReadyPort)
-        assertEquals(defaults.debuggerReadyTimeoutMillis, debugOptions?.debuggerReadyTimeoutMillis)
+        assertEquals(DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS, debugOptions?.debuggerReadyTimeoutMillis)
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -34,7 +34,10 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwRunnerSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERSION
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
 import org.jetbrains.kotlin.gradle.testing.prettyPrinted
+import org.jetbrains.kotlin.gradle.util.assertLogContains
+import org.jetbrains.kotlin.gradle.util.assertLogDoesNotContain
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import org.jetbrains.kotlin.gradle.util.withGradleLogCapture
 import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions.Companion.processLaunchOptions
 import java.net.ServerSocket
 import org.junit.jupiter.api.io.TempDir
@@ -100,9 +103,24 @@ class KotlinPlaywrightTestFrameworkWiringTest {
 
         // Karma debugging comes from the IDE init script, so these options must not switch it on.
         // Building a real Karma spec would write karma.conf.js, which is not what we test here.
-        setup.jsBrowserTestTask.configureBrowserDebug()
+        val logs = withGradleLogCapture { setup.jsBrowserTestTask.configureBrowserDebug() }
 
         assertFalse(setup.jsBrowserTestTask.debug)
+        logs.assertLogContains("Browser debug options are not supported by this test framework")
+    }
+
+    @Test
+    fun `a Karma task debugged by the IDE is not reported as unsupported`() {
+        val setup = buildBrowserTestProject {}
+        assertIs<KotlinKarma>(setup.jsBrowserTestTask.testFramework)
+
+        setup.jsBrowserTestTask.browserDebug.set(true)
+        // The IDE init script turns this on for a Karma debug session before the task runs.
+        setup.jsBrowserTestTask.debug = true
+
+        val logs = withGradleLogCapture { setup.jsBrowserTestTask.configureBrowserDebug() }
+
+        logs.assertLogDoesNotContain("Browser debug options are not supported by the test framework")
     }
 
     @Test
@@ -332,6 +350,7 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         )
 
         val debuggerReadyPort = ServerSocket(0).use { it.localPort }
+        testTask.browserDebug.set(true)
         testTask.browserDebugPort.set("32123")
         testTask.browserDebugReadyPort.set(debuggerReadyPort.toString())
         testTask.browserDebugReadyTimeout.set("45000")
@@ -399,6 +418,7 @@ class KotlinPlaywrightTestFrameworkWiringTest {
             writeText("")
         }
         framework.npmToolingEnvDir.set(npmToolingEnv)
+        setup.jsBrowserTestTask.browserDebug.set(true)
         setup.jsBrowserTestTask.browserDebugReadyPort.set("54321")
 
         val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
@@ -467,24 +487,25 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     }
 
     @Test
-    fun `browser debug port implies browser debug`() {
+    fun `the debug ports alone do not enable browser debug`() {
         val setup = buildBrowserTestProject { chromium() }
-
+        setup.prepareExecutableFramework()
+        // The IDE also sends these through the environment, where they reach every task of the build,
+        // so only --browser-debug may switch a task to debugging.
         setup.jsBrowserTestTask.browserDebugPort.set("32123")
+        setup.jsBrowserTestTask.browserDebugReadyPort.set("54321")
+        setup.jsBrowserTestTask.browserDebugReadyTimeout.set("45000")
 
-        assertTrue(setup.jsBrowserTestTask.browserDebugRequested.get())
-    }
+        val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
 
-    @Test
-    fun `browser debug is off when no option is passed`() {
-        val setup = buildBrowserTestProject { chromium() }
-
-        assertFalse(setup.jsBrowserTestTask.browserDebugRequested.get())
+        assertFalse(setup.jsBrowserTestTask.debug)
+        assertNull(spec.runners.single().debugOptions)
     }
 
     @Test
     fun `invalid browser debug port is rejected`() {
         val setup = buildBrowserTestProject { chromium() }
+        setup.jsBrowserTestTask.browserDebug.set(true)
         setup.jsBrowserTestTask.browserDebugPort.set("70000")
 
         val failure = assertFailsWith<GradleException> {
@@ -500,6 +521,7 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     @Test
     fun `invalid browser debug readiness timeout is rejected`() {
         val setup = buildBrowserTestProject { chromium() }
+        setup.jsBrowserTestTask.browserDebug.set(true)
         setup.jsBrowserTestTask.browserDebugReadyTimeout.set("0")
 
         val failure = assertFailsWith<GradleException> {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -7,8 +7,10 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
+import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.tasks.testing.TestExecutionSpec
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
@@ -22,6 +24,7 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.WebpackBundleKotlinJsTests
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
+import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwExecutionSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERSION
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
@@ -29,6 +32,7 @@ import org.jetbrains.kotlin.gradle.testing.prettyPrinted
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
 import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions.Companion.processLaunchOptions
 import java.io.File
+import java.net.ServerSocket
 import org.junit.jupiter.api.io.TempDir
 import java.net.URI
 import java.net.URLDecoder
@@ -37,6 +41,7 @@ import java.nio.file.Path
 import java.time.Duration
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -44,7 +49,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.seconds
 
 class KotlinPlaywrightTestFrameworkWiringTest {
 
@@ -80,6 +84,21 @@ class KotlinPlaywrightTestFrameworkWiringTest {
             bundleTask.onlyIf.isSatisfiedBy(bundleTask),
             "Expected the bundle task to be skipped, as no browser runners are declared"
         )
+    }
+
+    @Test
+    fun `browser debug options are ignored by the Karma task`() {
+        val setup = buildBrowserTestProject {}
+        assertIs<KotlinKarma>(setup.jsBrowserTestTask.testFramework)
+
+        setup.jsBrowserTestTask.browserDebug.set(true)
+        setup.jsBrowserTestTask.browserDebugPort.set("32123")
+
+        // Karma debugging comes from the IDE init script, so these options must not switch it on.
+        // Building a real Karma spec would write karma.conf.js, which is not what we test here.
+        setup.jsBrowserTestTask.configureBrowserDebug()
+
+        assertFalse(setup.jsBrowserTestTask.debug)
     }
 
     @Test
@@ -279,44 +298,9 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         assertEquals(mockLocation4, webkit2Runner.testsLocation.get())
     }
 
-    // These tests pin the IDE debug contract without launching a real Playwright browser.
+    // Checks the browser debug wiring without starting a real browser.
     @Test
-    fun `playwright debug url uses runtime url`() {
-        val setup = buildBrowserTestProject {
-            chromium()
-        }
-        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
-        val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
-        framework.frameworkTaskInputs.chromiumRunners.get().single().testsLocation.set(location)
-
-        val debugUrl = framework.buildDebugUrl(setup.jsBrowserTestTask)
-
-        assertEquals("http://localhost:12345/test.html", debugUrl.toString().substringBefore("?"))
-    }
-
-    @Test
-    fun `playwright debug url uses configured runner timeout`() {
-        val timeout = 42L.seconds
-        val setup = buildBrowserTestProject {
-            firefox {
-                it.timeout.set(timeout)
-            }
-        }
-        val expectedTimeoutInMilliseconds = timeout.inWholeMilliseconds
-        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
-        val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
-        framework.frameworkTaskInputs.firefoxRunners.get().single().testsLocation.set(location)
-
-        val debugUrl = framework.buildDebugUrl(setup.jsBrowserTestTask)
-
-        assertTrue(
-            decodeKotlinTestConfig(debugUrl).contains("\"mochaSetupOptions\":{\"timeout\":\"${expectedTimeoutInMilliseconds}\"}"),
-            "Expected the debug URL to contain the configured runner timeout",
-        )
-    }
-
-    @Test
-    fun `playwright intellij debug uses default chromium for firefox runner`() {
+    fun `playwright debug uses default chromium for firefox runner`() {
         val setup = buildBrowserTestProject {
             firefox("selected") {
                 it.launchArgs.set(listOf("-devtools"))
@@ -332,7 +316,10 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         )
         assertEquals(setOf("firefox"), installTask.browsers.get().toSet())
 
-        setup.jsBrowserTestTask.debug = true
+        val debuggerReadyPort = ServerSocket(0).use { it.localPort }
+        setup.jsBrowserTestTask.browserDebugPort.set("32123")
+        setup.jsBrowserTestTask.browserDebugReadyPort.set(debuggerReadyPort.toString())
+        setup.jsBrowserTestTask.browserDebugReadyTimeout.set("45000")
 
         assertEquals(setOf("firefox", "chromium"), installTask.browsers.get().toSet())
 
@@ -342,15 +329,8 @@ class KotlinPlaywrightTestFrameworkWiringTest {
             writeText("")
         }
         framework.npmToolingEnvDir.set(npmToolingEnv)
-        framework.prepareDebugSession(setup.jsBrowserTestTask)
-        framework.configureRemoteDebuggingPort(32123)
 
-        val spec = framework.createTestExecutionSpec(
-            task = setup.jsBrowserTestTask,
-            launchOpts = setup.project.objects.processLaunchOptions(),
-            nodeJsArgs = mutableListOf(),
-            debug = setup.jsBrowserTestTask.debug,
-        )
+        val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
         val runner = spec.runners.single()
 
         assertEquals("chromium", runner.name)
@@ -358,8 +338,119 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         assertEquals(emptyList(), runner.launchArgs)
         assertEquals(emptyMap(), runner.launchEnvironmentVariables)
         assertEquals(32123, runner.debugOptions?.remoteDebuggingPort)
-        runner.debugOptions?.debuggerReadySocket?.close()
+        assertEquals(debuggerReadyPort, runner.debugOptions?.debuggerReadyPort)
+        assertEquals(45000, runner.debugOptions?.debuggerReadyTimeoutMillis)
     }
+
+    @Test
+    fun `browser debug option uses default port and does not wait without a readiness port`() {
+        val setup = buildBrowserTestProject {
+            chromium()
+        }
+        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
+        val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
+        framework.frameworkTaskInputs.chromiumRunners.get().single().testsLocation.set(location)
+        val npmToolingEnv = setup.project.layout.buildDirectory.dir("test-npm-tooling").get().asFile
+        npmToolingEnv.resolve("node_modules/playwright-core/cli.js").apply {
+            parentFile.mkdirs()
+            writeText("")
+        }
+        framework.npmToolingEnvDir.set(npmToolingEnv)
+        setup.jsBrowserTestTask.browserDebug.set(true)
+
+        val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
+        val debugOptions = spec.runners.single().debugOptions
+
+        assertEquals(9222, debugOptions?.remoteDebuggingPort)
+        assertNull(debugOptions?.debuggerReadyPort, "Without a readiness port the run must not wait for a debugger")
+        assertEquals(30_000, debugOptions?.debuggerReadyTimeoutMillis)
+    }
+
+    @Test
+    fun `browser debug readiness port without a timeout keeps the default timeout`() {
+        val setup = buildBrowserTestProject {
+            chromium()
+        }
+        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
+        val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
+        framework.frameworkTaskInputs.chromiumRunners.get().single().testsLocation.set(location)
+        val npmToolingEnv = setup.project.layout.buildDirectory.dir("test-npm-tooling").get().asFile
+        npmToolingEnv.resolve("node_modules/playwright-core/cli.js").apply {
+            parentFile.mkdirs()
+            writeText("")
+        }
+        framework.npmToolingEnvDir.set(npmToolingEnv)
+        setup.jsBrowserTestTask.browserDebugReadyPort.set("54321")
+
+        val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
+        val debugOptions = spec.runners.single().debugOptions
+
+        assertEquals(9222, debugOptions?.remoteDebuggingPort, "An unset debug port must fall back to the default")
+        assertEquals(54321, debugOptions?.debuggerReadyPort)
+        assertEquals(30_000, debugOptions?.debuggerReadyTimeoutMillis)
+    }
+
+    @Test
+    fun `browser debug port implies browser debug`() {
+        val setup = buildBrowserTestProject { chromium() }
+
+        setup.jsBrowserTestTask.browserDebugPort.set("32123")
+
+        assertTrue(setup.jsBrowserTestTask.browserDebugRequested.get())
+    }
+
+    @Test
+    fun `browser debug is off when no option is passed`() {
+        val setup = buildBrowserTestProject { chromium() }
+
+        assertFalse(setup.jsBrowserTestTask.browserDebugRequested.get())
+    }
+
+    @Test
+    fun `invalid browser debug port is rejected`() {
+        val setup = buildBrowserTestProject { chromium() }
+        setup.jsBrowserTestTask.browserDebugPort.set("70000")
+
+        val failure = assertFailsWith<GradleException> {
+            setup.jsBrowserTestTask.configureBrowserDebug()
+        }
+
+        assertEquals(
+            "--browser-debug-port must be an integer between 1 and 65535, but was '70000'",
+            failure.message,
+        )
+    }
+
+    @Test
+    fun `invalid browser debug readiness timeout is rejected`() {
+        val setup = buildBrowserTestProject { chromium() }
+        setup.jsBrowserTestTask.browserDebugReadyTimeout.set("0")
+
+        val failure = assertFailsWith<GradleException> {
+            setup.jsBrowserTestTask.configureBrowserDebug()
+        }
+
+        assertEquals(
+            "--browser-debug-ready-timeout must be a positive number of milliseconds, but was '0'",
+            failure.message,
+        )
+    }
+}
+
+// Mirrors KotlinJsTest.createTestExecutionSpec without its protected entry point.
+private fun KotlinJsTest.buildExecutionSpec(project: ProjectInternal): TestExecutionSpec {
+    configureBrowserDebug()
+    val framework = testFramework!!
+    val launchOptions = project.objects.processLaunchOptions {
+        workingDir.set(framework.workingDir)
+        executable.set(framework.executable)
+    }
+    return framework.createTestExecutionSpec(
+        task = this,
+        launchOpts = launchOptions,
+        nodeJsArgs = mutableListOf(),
+        debug = debug,
+    )
 }
 
 private class BrowserTestProject(
@@ -404,12 +495,4 @@ private fun mockLocation(project: ProjectInternal, uri: URI): KotlinJsTestsLocat
 
     override val url: Provider<URI>
         get() = project.providers.provider { uri }
-}
-
-private fun decodeKotlinTestConfig(uri: URI): String {
-    val encodedConfig = uri.rawQuery
-        .split("&")
-        .single { it.startsWith("kotlinTestConfig=") }
-        .substringAfter("=")
-    return URLDecoder.decode(encodedConfig, StandardCharsets.UTF_8)
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -24,9 +24,9 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.getPwInstallBrowserTaskName
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.js.testing.WebpackBundleKotlinJsTests
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
+import org.jetbrains.kotlin.gradle.targets.js.testing.DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS
+import org.jetbrains.kotlin.gradle.targets.js.testing.DEFAULT_DEBUG_PORT
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
-import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.DEFAULT_DEBUGGER_READY_TIMEOUT_MILLIS
-import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.DEFAULT_DEBUG_PORT
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwExecutionSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwRunnerSpec

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -44,6 +44,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
 
 class KotlinPlaywrightTestFrameworkWiringTest {
 
@@ -291,6 +292,27 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val debugUrl = framework.buildDebugUrl(setup.jsBrowserTestTask)
 
         assertEquals("http://localhost:12345/test.html", debugUrl.toString().substringBefore("?"))
+    }
+
+    @Test
+    fun `playwright debug url uses configured runner timeout`() {
+        val timeout = 42L.seconds
+        val setup = buildBrowserTestProject {
+            firefox {
+                it.timeout.set(timeout)
+            }
+        }
+        val expectedTimeoutInMilliseconds = timeout.inWholeMilliseconds
+        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
+        val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
+        framework.frameworkTaskInputs.firefoxRunners.get().single().testsLocation.set(location)
+
+        val debugUrl = framework.buildDebugUrl(setup.jsBrowserTestTask)
+
+        assertTrue(
+            decodeKotlinTestConfig(debugUrl).contains("\"mochaSetupOptions\":{\"timeout\":\"${expectedTimeoutInMilliseconds}\"}"),
+            "Expected the debug URL to contain the configured runner timeout",
+        )
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -342,7 +342,8 @@ class KotlinPlaywrightTestFrameworkWiringTest {
             writeText("")
         }
         framework.npmToolingEnvDir.set(npmToolingEnv)
-        framework.debugPort.set(32123)
+        framework.prepareDebugSession(setup.jsBrowserTestTask)
+        framework.configureRemoteDebuggingPort(32123)
 
         val spec = framework.createTestExecutionSpec(
             task = setup.jsBrowserTestTask,
@@ -357,6 +358,7 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         assertEquals(emptyList(), runner.launchArgs)
         assertEquals(emptyMap(), runner.launchEnvironmentVariables)
         assertEquals(32123, runner.debugOptions?.remoteDebuggingPort)
+        runner.debugOptions?.debuggerReadySocket?.close()
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -316,7 +316,7 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     }
 
     @Test
-    fun `playwright intellij debug falls back to chromium for firefox runner`() {
+    fun `playwright intellij debug uses default chromium for firefox runner`() {
         val setup = buildBrowserTestProject {
             firefox("selected") {
                 it.launchArgs.set(listOf("-devtools"))
@@ -352,7 +352,7 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         )
         val runner = spec.runners.single()
 
-        assertEquals("selected", runner.name)
+        assertEquals("chromium", runner.name)
         assertEquals(PwBrowserKind.CHROMIUM, runner.browserKind)
         assertEquals(emptyList(), runner.launchArgs)
         assertEquals(emptyMap(), runner.launchEnvironmentVariables)

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -27,16 +27,12 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwExecutionSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERSION
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
-import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
 import org.jetbrains.kotlin.gradle.testing.prettyPrinted
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
 import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions.Companion.processLaunchOptions
-import java.io.File
 import java.net.ServerSocket
 import org.junit.jupiter.api.io.TempDir
 import java.net.URI
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.test.Test
@@ -311,17 +307,32 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
         framework.frameworkTaskInputs.firefoxRunners.get().single().testsLocation.set(location)
 
-        val installTask = assertIs<PlaywrightBrowserInstall>(
-            setup.project.tasks.getByName("kotlinInstallPlaywrightBrowsers")
+        val firefoxInstallTask = assertIs<PlaywrightBrowserInstall>(
+            setup.project.tasks.getByName(PwBrowserKind.FIREFOX.getPwInstallBrowserTaskName())
         )
-        assertEquals(setOf("firefox"), installTask.browsers.get().toSet())
+        assertEquals(setOf("firefox"), firefoxInstallTask.browsers.get().toSet())
+
+        val chromiumInstallTask = assertIs<PlaywrightBrowserInstall>(
+            setup.project.tasks.getByName(PwBrowserKind.CHROMIUM.getPwInstallBrowserTaskName())
+        )
+        assertEquals(setOf("chromium"), chromiumInstallTask.browsers.get().toSet())
+
+        val testTask = setup.jsBrowserTestTask
+        assertFalse(
+            testTask.taskDependencies.getDependencies(testTask).contains(chromiumInstallTask),
+            "Expected no Chromium install dependency without browser debugging"
+        )
 
         val debuggerReadyPort = ServerSocket(0).use { it.localPort }
-        setup.jsBrowserTestTask.browserDebugPort.set("32123")
-        setup.jsBrowserTestTask.browserDebugReadyPort.set(debuggerReadyPort.toString())
-        setup.jsBrowserTestTask.browserDebugReadyTimeout.set("45000")
+        testTask.browserDebugPort.set("32123")
+        testTask.browserDebugReadyPort.set(debuggerReadyPort.toString())
+        testTask.browserDebugReadyTimeout.set("45000")
 
-        assertEquals(setOf("firefox", "chromium"), installTask.browsers.get().toSet())
+        // The option is only set once the task is selected, so the dependency has to resolve lazily.
+        assertTrue(
+            testTask.taskDependencies.getDependencies(testTask).contains(chromiumInstallTask),
+            "Expected a debug run to depend on the Chromium install task"
+        )
 
         val npmToolingEnv = setup.project.layout.buildDirectory.dir("test-npm-tooling").get().asFile
         npmToolingEnv.resolve("node_modules/playwright-core/cli.js").apply {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -385,20 +385,6 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     }
 
     @Test
-    fun `a debug run does not depend on the chromium install task without browser debug`() {
-        val setup = buildBrowserTestProject { firefox("selected") }
-        val chromiumInstallTask = assertIs<PlaywrightBrowserInstall>(
-            setup.project.tasks.getByName(PwBrowserKind.CHROMIUM.getPwInstallBrowserTaskName())
-        )
-        val testTask = setup.jsBrowserTestTask
-
-        assertFalse(
-            testTask.taskDependencies.getDependencies(testTask).contains(chromiumInstallTask),
-            "Expected no Chromium install dependency without browser debugging"
-        )
-    }
-
-    @Test
     fun `browser debug option uses default port and does not wait without a readiness port`() {
         val setup = buildBrowserTestProject {
             chromium()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -7,7 +7,6 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
-import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.testing.TestExecutionSpec
@@ -505,32 +504,35 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     @Test
     fun `invalid browser debug port is rejected`() {
         val setup = buildBrowserTestProject { chromium() }
+        setup.prepareExecutableFramework()
         setup.jsBrowserTestTask.browserDebug.set(true)
         setup.jsBrowserTestTask.browserDebugPort.set("70000")
 
-        val failure = assertFailsWith<GradleException> {
-            setup.jsBrowserTestTask.configureBrowserDebug()
+        // The options are parsed lazily, so the value has to be read for the check to run.
+        val failure = assertFailsWith<Exception> {
+            setup.jsBrowserTestTask.buildExecutionSpec(setup.project)
         }
 
         assertEquals(
             "--browser-debug-port must be an integer between 1 and 65535, but was '70000'",
-            failure.message,
+            failure.cause?.message,
         )
     }
 
     @Test
     fun `invalid browser debug readiness timeout is rejected`() {
         val setup = buildBrowserTestProject { chromium() }
+        setup.prepareExecutableFramework()
         setup.jsBrowserTestTask.browserDebug.set(true)
         setup.jsBrowserTestTask.browserDebugReadyTimeout.set("0")
 
-        val failure = assertFailsWith<GradleException> {
-            setup.jsBrowserTestTask.configureBrowserDebug()
+        val failure = assertFailsWith<Exception> {
+            setup.jsBrowserTestTask.buildExecutionSpec(setup.project)
         }
 
         assertEquals(
             "--browser-debug-ready-timeout must be a positive number of milliseconds, but was '0'",
-            failure.message,
+            failure.cause?.message,
         )
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -12,6 +12,9 @@ import org.gradle.api.file.Directory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.testing.TestExecutionSpec
 import org.gradle.api.provider.Provider
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
 import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersion
@@ -26,6 +29,7 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrigh
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwDebugOptions
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwExecutionSpec
+import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwRunnerSpec
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERSION
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
 import org.jetbrains.kotlin.gradle.testing.prettyPrinted
@@ -34,6 +38,7 @@ import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions.Companio
 import java.net.ServerSocket
 import org.junit.jupiter.api.io.TempDir
 import java.net.URI
+import java.net.URLDecoder
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.test.Test
@@ -46,6 +51,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
 
 class KotlinPlaywrightTestFrameworkWiringTest {
 
@@ -405,6 +411,35 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     }
 
     @Test
+    fun `a debug run has no test runner timeout`() {
+        val setup = buildBrowserTestProject {
+            chromium {
+                it.timeout.set(30L.seconds)
+            }
+        }
+        setup.prepareExecutableFramework()
+        setup.jsBrowserTestTask.browserDebug.set(true)
+
+        val runner = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project)).runners.single()
+
+        assertEquals("0", runner.browserRunnerTimeoutMillis())
+    }
+
+    @Test
+    fun `a regular run keeps the configured test runner timeout`() {
+        val setup = buildBrowserTestProject {
+            chromium {
+                it.timeout.set(30L.seconds)
+            }
+        }
+        setup.prepareExecutableFramework()
+
+        val runner = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project)).runners.single()
+
+        assertEquals("30000", runner.browserRunnerTimeoutMillis())
+    }
+
+    @Test
     fun `browser debug port implies browser debug`() {
         val setup = buildBrowserTestProject { chromium() }
 
@@ -465,6 +500,36 @@ private fun KotlinJsTest.buildExecutionSpec(project: ProjectInternal): TestExecu
         nodeJsArgs = mutableListOf(),
         debug = debug,
     )
+}
+
+private fun BrowserTestProject.prepareExecutableFramework(): KotlinPlaywrightJsTestFramework {
+    val framework = assertIs<KotlinPlaywrightJsTestFramework>(jsBrowserTestTask.testFramework)
+    val location = mockLocation(project, URI("http://localhost:12345/test.html"))
+    with(framework.frameworkTaskInputs) {
+        (chromiumRunners.get() + firefoxRunners.get() + webkitRunners.get()).forEach { it.testsLocation.set(location) }
+    }
+
+    val npmToolingEnv = project.layout.buildDirectory.dir("test-npm-tooling").get().asFile
+    npmToolingEnv.resolve("node_modules/playwright-core/cli.js").apply {
+        parentFile.mkdirs()
+        writeText("")
+    }
+    framework.npmToolingEnvDir.set(npmToolingEnv)
+
+    return framework
+}
+
+private fun PwRunnerSpec.browserRunnerTimeoutMillis(): String {
+    val query = buildTestsExecutionerUrl(URI("http://localhost:12345/test.html")).rawQuery
+    val config = query.split("&")
+        .single { it.startsWith("kotlinTestConfig=") }
+        .substringAfter('=')
+        .let { URLDecoder.decode(it, Charsets.UTF_8) }
+
+    return Json.parseToJsonElement(config)
+        .jsonObject.getValue("mochaSetupOptions")
+        .jsonObject.getValue("timeout")
+        .jsonPrimitive.content
 }
 
 private class BrowserTestProject(

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -21,13 +21,18 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.js.testing.WebpackBundleKotlinJsTests
 import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.KotlinPlaywrightJsTestFramework
+import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERSION
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PwBrowserKind
 import org.jetbrains.kotlin.gradle.testing.prettyPrinted
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import org.jetbrains.kotlin.gradle.utils.processes.ProcessLaunchOptions.Companion.processLaunchOptions
+import java.io.File
 import org.junit.jupiter.api.io.TempDir
 import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.test.Test
@@ -273,6 +278,64 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         assertEquals(mockLocation4, webkit2Runner.testsLocation.get())
     }
 
+    // These tests pin the IDE debug contract without launching a real Playwright browser.
+    @Test
+    fun `playwright debug url uses runtime url`() {
+        val setup = buildBrowserTestProject {
+            chromium()
+        }
+        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
+        val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
+        framework.frameworkTaskInputs.chromiumRunners.get().single().testsLocation.set(location)
+
+        val debugUrl = framework.buildDebugUrl(setup.jsBrowserTestTask)
+
+        assertEquals("http://localhost:12345/test.html", debugUrl.toString().substringBefore("?"))
+    }
+
+    @Test
+    fun `playwright intellij debug falls back to chromium for firefox runner`() {
+        val setup = buildBrowserTestProject {
+            firefox("selected") {
+                it.launchArgs.set(listOf("-devtools"))
+                it.launchEnvironmentVariables.set(mapOf("FIREFOX_DEBUG" to "1"))
+            }
+        }
+        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
+        val location = mockLocation(setup.project, URI("http://localhost:12345/test.html"))
+        framework.frameworkTaskInputs.firefoxRunners.get().single().testsLocation.set(location)
+
+        val installTask = assertIs<PlaywrightBrowserInstall>(
+            setup.project.tasks.getByName("kotlinInstallPlaywrightBrowsers")
+        )
+        assertEquals(setOf("firefox"), installTask.browsers.get().toSet())
+
+        setup.jsBrowserTestTask.debug = true
+
+        assertEquals(setOf("firefox", "chromium"), installTask.browsers.get().toSet())
+
+        val npmToolingEnv = setup.project.layout.buildDirectory.dir("test-npm-tooling").get().asFile
+        npmToolingEnv.resolve("node_modules/playwright-core/cli.js").apply {
+            parentFile.mkdirs()
+            writeText("")
+        }
+        framework.npmToolingEnvDir.set(npmToolingEnv)
+        framework.debugPort.set(32123)
+
+        val spec = framework.createTestExecutionSpec(
+            task = setup.jsBrowserTestTask,
+            launchOpts = setup.project.objects.processLaunchOptions(),
+            nodeJsArgs = mutableListOf(),
+            debug = setup.jsBrowserTestTask.debug,
+        )
+        val runner = spec.runners.single()
+
+        assertEquals("selected", runner.name)
+        assertEquals(PwBrowserKind.CHROMIUM, runner.browserKind)
+        assertEquals(emptyList(), runner.launchArgs)
+        assertEquals(emptyMap(), runner.launchEnvironmentVariables)
+        assertEquals(32123, runner.debugOptions?.remoteDebuggingPort)
+    }
 }
 
 private class BrowserTestProject(
@@ -306,4 +369,23 @@ private fun buildBrowserTestProject(configure: KotlinJsBrowserTestDsl.() -> Unit
     }
     project.evaluate()
     return BrowserTestProject(project, testDsl)
+}
+
+private fun mockLocation(project: ProjectInternal, uri: URI): KotlinJsTestsLocation = object : KotlinJsTestsLocation {
+    override val bundleLocation: Provider<Directory>
+        get() = project.layout.buildDirectory.dir("mock-browser-test-bundle")
+
+    override val testHtmlFileName: Provider<String>
+        get() = project.providers.provider { "test.html" }
+
+    override val url: Provider<URI>
+        get() = project.providers.provider { uri }
+}
+
+private fun decodeKotlinTestConfig(uri: URI): String {
+    val encodedConfig = uri.rawQuery
+        .split("&")
+        .single { it.startsWith("kotlinTestConfig=") }
+        .substringAfter("=")
+    return URLDecoder.decode(encodedConfig, StandardCharsets.UTF_8)
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -440,6 +440,34 @@ class KotlinPlaywrightTestFrameworkWiringTest {
     }
 
     @Test
+    fun `a debug run launches the first of several chromium runners`() {
+        val setup = buildBrowserTestProject {
+            chromium("first")
+            chromium("second")
+        }
+        setup.prepareExecutableFramework()
+        setup.jsBrowserTestTask.browserDebug.set(true)
+
+        val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
+
+        // A debug session attaches to a single browser, so the other runners are left out.
+        assertEquals(listOf("first"), spec.runners.map { it.name })
+    }
+
+    @Test
+    fun `a regular run launches every chromium runner`() {
+        val setup = buildBrowserTestProject {
+            chromium("first")
+            chromium("second")
+        }
+        setup.prepareExecutableFramework()
+
+        val spec = assertIs<PwExecutionSpec>(setup.jsBrowserTestTask.buildExecutionSpec(setup.project))
+
+        assertEquals(listOf("first", "second"), spec.runners.map { it.name })
+    }
+
+    @Test
     fun `browser debug port implies browser debug`() {
         val setup = buildBrowserTestProject { chromium() }
 


### PR DESCRIPTION
- Expose Playwright debug URL and debugger port to IDEA
- Launch debug runs through Chromium/CDP
- Install Chromium for debug fallback when only Firefox/WebKit runners are declared

#KT-86731 Ready for Review