### PR TITLE
2.4.20: [Gradle] Run integration tests against Gradle 9.6.1 release

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/Readme.md
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/Readme.md
@@ -159,7 +159,7 @@ pluginManagement {
         mavenLocal()
     }
 
-    val test_fixes_version: String by settings
+    val test_fixes_version: String = providers.gradleProperty("test_fixes_version").get()
     plugins {
        id("org.jetbrains.kotlin.test.fixes.android") version test_fixes_version
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -235,6 +235,7 @@ val gradleVersions = listOf(
     "9.3.1",
     "9.4.1",
     "9.5.1",
+    "9.6.1",
 )
 
 // Keep in sync with testTags.kt

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
@@ -990,7 +990,7 @@ class BuildReportsIT : KGPBaseTest() {
     @DisplayName("for build scan with develocity plugin")
     @JvmGradlePluginTests
     @GradleTestVersions(
-        minVersion = TestVersions.Gradle.G_8_4
+        minVersion = TestVersions.Gradle.G_8_14
     )
     @GradleTest
     fun testBuildScanReportWithDevelocityPlugin(gradleVersion: GradleVersion) {
@@ -1018,21 +1018,22 @@ class BuildReportsIT : KGPBaseTest() {
                         
                 develocity {
                     buildScan {
-                        termsOfUseAgree = "yes"
-                        termsOfUseUrl = "https://gradle.com/terms-of-service"
+                        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+                        termsOfUseAgree.set("yes")
 
                         tag "test"
                     }
                 }
                 """.trimIndent()
             }
+            // -Dscan.dump disables build scan publishing and instead dumps it onto disk
             build(
-                "compileKotlin", "--scan"
+                "compileKotlin", "--scan", "-Dscan.dump"
             ) {
                 assertOutputDoesNotContain("The build scan was not published due to a configuration problem.")
                 assertOutputDoesNotContain("The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin.")
                 assertOutputContains("Build metrics are stored into build scan for")
-                assertOutputContains("[com.gradle.develocity.agent.gradle.DevelocityPlugin] Publishing build scan...")
+                assertOutputContains("[com.gradle.develocity.agent.gradle.DevelocityPlugin] Build scan written to:")
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerDiagnosticsProblemsApiIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerDiagnosticsProblemsApiIT.kt
@@ -15,7 +15,8 @@ import org.jetbrains.kotlin.gradle.testbase.assertProblemsReportContainsDiagnost
 @GradleTestVersions(
     minVersion = TestVersions.Gradle.G_8_11, // This test asserts via the HTML problems report, which is available from Gradle 8.11+
     additionalVersions = [
-        TestVersions.Gradle.G_8_13
+        TestVersions.Gradle.G_8_13,
+        TestVersions.Gradle.G_9_5,
     ]
 )
 @OtherGradlePluginTests

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/FusStatisticsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/FusStatisticsIT.kt
@@ -492,6 +492,8 @@ class FusStatisticsIT : KGPBaseTest() {
     @GradleTestVersions(
         minVersion = TestVersions.Gradle.G_8_2,
         additionalVersions = [TestVersions.Gradle.G_8_2],
+        // Kover triggers deprecation in Gradle 9.6.0 https://github.com/Kotlin/kotlinx-kover/issues/813
+        maxVersion = TestVersions.Gradle.G_9_5,
     )
     fun testKotlinxPlugins(gradleVersion: GradleVersion) {
         project(

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/GradleCompatibilityIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/GradleCompatibilityIT.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.gradle.testbase.buildScriptReturn
 import org.jetbrains.kotlin.gradle.testbase.plugins
 import org.jetbrains.kotlin.gradle.testbase.project
 import org.jetbrains.kotlin.gradle.utils.setInvisibleIfSupported
-import org.jetbrains.kotlin.testFederation.SmokeTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import java.io.File
@@ -59,7 +58,7 @@ class GradleCompatibilityIT : KGPBaseTest() {
         project("kotlinProject", gradleVersion) {
             build("help") {
                 val expectedVariant = when (gradleVersion) {
-                    //GradleVersion.version(TestVersions.Gradle.G_9_6) -> "gradle96"
+                    GradleVersion.version(TestVersions.Gradle.G_9_6) -> "gradle96"
                     GradleVersion.version(TestVersions.Gradle.G_9_5) -> "gradle813"
                     GradleVersion.version(TestVersions.Gradle.G_9_4) -> "gradle813"
                     GradleVersion.version(TestVersions.Gradle.G_9_3) -> "gradle813"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.build.report.metrics.BuildAttribute
@@ -911,7 +912,11 @@ abstract class BaseIncrementalCompilationMultiProjectIT : IncrementalCompilation
             buildAndFail(":lib:$compileKotlinTaskName") {
                 assertIncrementalCompilation()
                 assertTasksFailed(":lib:$compileKotlinTaskName")
-                assertOutputContains("Compilation error. See log for more details")
+                if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_6)) {
+                    assertOutputContains("Compilation error. See log for more details")
+                } else {
+                    assertOutputContains("Kotlin compiler error")
+                }
             }
 
             // Fix the compile error in the source code
@@ -948,10 +953,20 @@ abstract class BaseIncrementalCompilationMultiProjectIT : IncrementalCompilation
             changeMethodSignatureInLib()
 
             // In the next build, compilation should be incremental and fail, then fall back to non-incremental compilation and succeed
-            build(":lib:$compileKotlinTaskName") {
-                assertIncrementalCompilationFellBackToNonIncremental(BuildAttribute.IC_FAILED_TO_COMPILE_INCREMENTALLY)
-                // Also check that the output is not deleted (regression test for KT-49780)
-                assertFileExists(lookupFile)
+            if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_6)) {
+                build(":lib:$compileKotlinTaskName") {
+                    assertIncrementalCompilationFellBackToNonIncremental(BuildAttribute.IC_FAILED_TO_COMPILE_INCREMENTALLY)
+                    // Also check that the output is not deleted (regression test for KT-49780)
+                    assertFileExists(lookupFile)
+                }
+            } else {
+                // FIXME: KT-87824 Report an exception raised during an incremental compilation as an internal compiler error
+                // IC sends diagnostic with error severity level which triggers build failure
+                buildAndFail(":lib:$compileKotlinTaskName") {
+                    assertIncrementalCompilationFellBackToNonIncremental(BuildAttribute.IC_FAILED_TO_COMPILE_INCREMENTALLY)
+                    // Also check that the output is not deleted (regression test for KT-49780)
+                    assertFileExists(lookupFile)
+                }
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
@@ -897,7 +897,7 @@ abstract class BaseIncrementalCompilationMultiProjectIT : IncrementalCompilation
     @DisplayName("Test handling of failures caused by user errors")
     @GradleTest
     fun testFailureHandling_UserError(gradleVersion: GradleVersion) {
-        defaultProject(gradleVersion) {
+        defaultProject(gradleVersion, buildOptions = defaultBuildOptions.copy(runViaBuildToolsApi = true)) {
             // Perform the first non-incremental build
             build(":lib:$compileKotlinTaskName")
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/KotlinGradlePluginIT.kt
@@ -683,9 +683,10 @@ class KotlinGradleIT : KGPBaseTest() {
                     }
                     else -> {
                         // Attributes may come in random order
+                        val projName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_6)) ":projA" else "':projA'"
                         val attributeMatchingString = output.lineSequence().find {
                             it.trimStart().startsWith(
-                                "> No matching variant of project :projA was found. " +
+                                "> No matching variant of project $projName was found. " +
                                         "The consumer was configured to find a library for use during compile-time, " +
                                         "compatible with Java 17, preferably in the form of class files, " +
                                         "preferably optimized for standard JVMs, and its dependencies declared externally, "
@@ -733,9 +734,10 @@ class KotlinGradleIT : KGPBaseTest() {
                     }
                     else -> {
                         // Attributes may come in random order
+                        val projName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_6)) ":projA" else "':projA'"
                         val attributeMatchingString = output.lineSequence().find {
                             it.contains(
-                                "No matching variant of project :projA was found. " +
+                                "No matching variant of project $projName was found. " +
                                         "The consumer was configured to find a library for use during compile-time, " +
                                         "compatible with Java 17, preferably in the form of class files, " +
                                         "preferably optimized for standard JVMs, and its dependencies declared externally, "

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MppIdeDependencyResolutionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/MppIdeDependencyResolutionIT.kt
@@ -463,14 +463,20 @@ class MppIdeDependencyResolutionIT : KGPBaseTest() {
     fun `test native project dependencies resolve leniently`(gradleVersion: GradleVersion) {
         project("kt-61466-lenient-dependency-resolution", gradleVersion) {
             resolveIdeDependencies(":consumer") { dependencies ->
+                val unresolvedProjectName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_6)) {
+                    "project :producer"
+                } else {
+                    "project ':producer'"
+                }
+
                 dependencies["commonMain"].assertMatches(
                     kotlinNativeDistributionDependencies,
-                    unresolvedDependenciesDiagnosticMatcher("project :producer"),
+                    unresolvedDependenciesDiagnosticMatcher(unresolvedProjectName),
                 )
 
                 dependencies["linuxMain"].assertMatches(
                     kotlinNativeDistributionDependencies,
-                    unresolvedDependenciesDiagnosticMatcher("project :producer"),
+                    unresolvedDependenciesDiagnosticMatcher(unresolvedProjectName),
                     dependsOnDependency(":consumer/commonMain"),
                     dependsOnDependency(":consumer/nativeMain")
                 )
@@ -1043,11 +1049,11 @@ class MppIdeDependencyResolutionIT : KGPBaseTest() {
     }
 
     @GradleTest
-    fun `KT-81973_npe_when_strange_dependency_is-added`(gradleVersions: GradleVersion) {
+    fun `KT-81973_npe_when_strange_dependency_is-added`(gradleVersion: GradleVersion) {
         // it covers this bug https://github.com/gradle/gradle/issues/36284
         // info is needed to check case when the "bad" error is logged out
         val withLogLevelInfo = defaultBuildOptions.copy(logLevel = LogLevel.INFO)
-        project("empty", gradleVersions, buildOptions = withLogLevelInfo) {
+        project("empty", gradleVersion, buildOptions = withLogLevelInfo) {
             plugins { kotlin("multiplatform") }
             buildScriptInjection {
                 kotlinMultiplatform.jvm()
@@ -1057,8 +1063,13 @@ class MppIdeDependencyResolutionIT : KGPBaseTest() {
                 }
             }
         }.resolveIdeDependencies { dependencies ->
-            val cause = "Got class org.gradle.internal.resolve.ModuleVersionResolveException error when trying to resolve Artifact, but explanation message can't be displayed because it failed with class java.lang.NullPointerException. For details please visit https://github.com/gradle/gradle/issues/36284"
-            assertOutputContains(cause)
+            if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_6)) {
+                val cause =
+                    "Got class org.gradle.internal.resolve.ModuleVersionResolveException error when trying to resolve Artifact, but " +
+                            "explanation message can't be displayed because it failed with class java.lang.NullPointerException. " +
+                            "For details please visit https://github.com/gradle/gradle/issues/36284"
+                assertOutputContains(cause)
+            }
             dependencies["commonTest"].assertMatches(
                 kotlinStdlibDependencies,
                 jetbrainsAnnotationDependencies,
@@ -1072,7 +1083,6 @@ class MppIdeDependencyResolutionIT : KGPBaseTest() {
                 IdeaKotlinDependencyMatcher("Unresolved androidx.room:room-sqlite-wrapper:2.8.3") { dependency ->
                     dependency is IdeaKotlinUnresolvedBinaryDependency
                             && dependency.coordinates.toString() == "androidx.room:room-sqlite-wrapper:2.8.3"
-                            && dependency.cause == cause
                 },
             )
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ProblemsApiIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ProblemsApiIT.kt
@@ -14,14 +14,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 @DisplayName("Problems API tests")
-@GradleTestVersions(
-    minVersion = TestVersions.Gradle.G_8_6 // Problems Api available only from Gradle 8.6
-)
 @OtherGradlePluginTests
 class ProblemsApiIT : KGPBaseTest() {
     @GradleTest
     @GradleTestVersions(
-        minVersion = TestVersions.Gradle.G_8_11 // html reports available only from Gradle 8.11
+        minVersion = TestVersions.Gradle.G_8_11, // html reports available only from Gradle 8.11
+        additionalVersions = [TestVersions.Gradle.G_9_5],
     )
     @DisplayName("Test problems emitted")
     fun testProblemsEmitted(gradleVersion: GradleVersion) {
@@ -101,7 +99,7 @@ class ProblemsApiIT : KGPBaseTest() {
                             )
                         )
                     }
-                } else {
+                } else if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_6)) {
                     buildList {
                         add(
                             ProblemsApiDiagnosticG94(
@@ -146,6 +144,65 @@ class ProblemsApiIT : KGPBaseTest() {
                                 locations = listOf(ProblemsApiLocation("org.jetbrains.kotlin.jvm")),
                                 problem = emptyList(),
                                 severity = "ERROR",
+                                problemDetails = "ATTENTION! This build uses the following Kotlin Gradle Plugin properties:\n\nkotlin.internal.compiler.arguments.log.level\nkotlin.internal.diagnostics.showStacktrace\nkotlin.internal.diagnostics.useParsableFormatting\n\nInternal properties are not recommended for production use.\nStability and future compatibility of the build is not guaranteed.",
+                                contextualLabel = "Usage of Internal Kotlin Gradle Plugin Properties Detected",
+                                problemId = listOf(
+                                    ProblemIdentifier("kotlin", "Kotlin"),
+                                    ProblemIdentifier("kgp:misconfiguration", "Kotlin Gradle Plugin Misconfiguration"),
+                                    ProblemIdentifier(
+                                        "internal-kotlin-gradle-plugin-properties-used",
+                                        "Usage of Internal Kotlin Gradle Plugin Properties Detected"
+                                    )
+                                ),
+                                solutions = listOf("Please consider using the public API instead of internal properties.")
+                            )
+                        )
+                    }
+                } else {
+                    buildList {
+                        add(
+                            ProblemsApiDiagnosticG94(
+                                locations = listOf(ProblemsApiLocation("org.jetbrains.kotlin.jvm")),
+                                problem = emptyList(),
+                                severity = "WARNING",
+                                problemDetails = "The `kotlin.internal.single.build.metrics.file` deprecated property is used in your build.",
+                                contextualLabel = "Deprecated Gradle Property 'kotlin.internal.single.build.metrics.file' Used",
+                                problemId = listOf(
+                                    ProblemIdentifier("kotlin", "Kotlin"),
+                                    ProblemIdentifier("kgp:deprecation", "Kotlin Gradle Plugin Deprecation"),
+                                    ProblemIdentifier(
+                                        "deprecated-warning-gradle-properties",
+                                        "Deprecated Gradle Property 'kotlin.internal.single.build.metrics.file' Used"
+                                    )
+                                ),
+                                solutions = listOf("It is unsupported, please stop using it.")
+                            )
+                        )
+
+                        add(
+                            ProblemsApiDiagnosticG94(
+                                locations = listOf(ProblemsApiLocation("org.jetbrains.kotlin.jvm")),
+                                problem = emptyList(),
+                                severity = "WARNING",
+                                problemDetails = "The `kotlin.build.report.dir` deprecated property is used in your build.",
+                                contextualLabel = "Deprecated Gradle Property 'kotlin.build.report.dir' Used",
+                                problemId = listOf(
+                                    ProblemIdentifier("kotlin", "Kotlin"),
+                                    ProblemIdentifier("kgp:deprecation", "Kotlin Gradle Plugin Deprecation"),
+                                    ProblemIdentifier(
+                                        "deprecated-warning-gradle-properties",
+                                        "Deprecated Gradle Property 'kotlin.build.report.dir' Used"
+                                    )
+                                ),
+                                solutions = listOf("It is unsupported, please stop using it.")
+                            )
+                        )
+
+                        add(
+                            ProblemsApiDiagnosticG94(
+                                locations = listOf(ProblemsApiLocation("org.jetbrains.kotlin.jvm")),
+                                problem = emptyList(),
+                                severity = "WARNING",
                                 problemDetails = "ATTENTION! This build uses the following Kotlin Gradle Plugin properties:\n\nkotlin.internal.compiler.arguments.log.level\nkotlin.internal.diagnostics.showStacktrace\nkotlin.internal.diagnostics.useParsableFormatting\n\nInternal properties are not recommended for production use.\nStability and future compatibility of the build is not guaranteed.",
                                 contextualLabel = "Usage of Internal Kotlin Gradle Plugin Properties Detected",
                                 problemId = listOf(

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SubpluginsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/SubpluginsIT.kt
@@ -262,7 +262,7 @@ class SubpluginsIT : KGPBaseTest() {
                 }
                 
                 buildscript {
-                    val kotlin_version: String by extra
+                    val kotlin_version = extra["kotlin_version"]
                     repositories {
                         mavenLocal()
                     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/VariantAwareDependenciesMppIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/VariantAwareDependenciesMppIT.kt
@@ -59,7 +59,7 @@ class VariantAwareDependenciesMppIT : KGPBaseTest() {
                     sourceSets.jsMain {
                         dependencies {
                             implementation(
-                                project.dependencies.create(project.rootProject)
+                                dependencies.project(mapOf("path" to ":"))
                             )
                         }
                     }
@@ -128,7 +128,7 @@ class VariantAwareDependenciesMppIT : KGPBaseTest() {
                         |    }
                         |}
                         |
-                        |dependencies { implementation rootProject }
+                        |dependencies { implementation(project(":")) }
                         |
                         """.trimMargin()
                     )
@@ -147,7 +147,7 @@ class VariantAwareDependenciesMppIT : KGPBaseTest() {
                 it.replace("kotlinOptions.jvmTarget = \"1.7\"", "kotlinOptions.jvmTarget = \"11\"") +
                         """
                         |
-                        |dependencies { implementation rootProject }
+                        |dependencies { implementation(project(":")) }
                         |
                         """.trimMargin()
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/KotlinAndroidMppCompilationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/android/KotlinAndroidMppCompilationIT.kt
@@ -125,12 +125,12 @@ class KotlinAndroidMppCompilationIT : KGPBaseTest() {
                             implementation(kotlin("stdlib-common"))
                         }
                     }
-                    val androidLibDebug by creating {
+                    val androidLibDebug = create("androidLibDebug") {
                         dependencies {
                             implementation(kotlin("reflect"))
                         }
                     }
-                    val androidLibRelease by creating {
+                    val androidLibRelease = create("androidLibRelease") {
                         dependencies {
                             implementation(kotlin("test-junit"))
                         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppDslAssociateCompilationsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppDslAssociateCompilationsIT.kt
@@ -140,7 +140,9 @@ class MppDslAssociateCompilationsIT : KGPBaseTest() {
                     "build/reports/tests/${targetName}Test/classes/com.example.HelloTest.html"
                 } else {
                     val prefix = if (targetName == "jvm") "" else "${targetName}Test."
-                    val dirName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_4)) {
+                    val dirName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_4) ||
+                        gradleVersion >= GradleVersion.version(TestVersions.Gradle.G_9_6)
+                    ) {
                         "${prefix}com.example.HelloTest"
                     } else {
                         "${prefix}com.example.HelloTest".hashTestPathSegment()
@@ -154,7 +156,9 @@ class MppDslAssociateCompilationsIT : KGPBaseTest() {
                     "build/reports/tests/${targetName}IntegrationTest/classes/com.example.HelloIntegrationTest.html"
                 } else {
                     val prefix = if (targetName == "jvm") "" else "${targetName}IntegrationTest."
-                    val dirName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_4)) {
+                    val dirName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_4) ||
+                        gradleVersion >= GradleVersion.version(TestVersions.Gradle.G_9_6)
+                    ) {
                         "${prefix}com.example.HelloIntegrationTest"
                     } else {
                         "${prefix}com.example.HelloIntegrationTest".hashTestPathSegment()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/SeparateKmpCompilationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/SeparateKmpCompilationIT.kt
@@ -44,8 +44,8 @@ class SeparateKmpCompilationIT : KGPBaseTest() {
         doTestFragmentDependenciesArg(gradleVersion, additionalProjectConfiguration = {
             applyMultiplatform {
                 sourceSets {
-                    val jvmAndJs by it.creating {
-                        dependsOn(it.commonMain.get())
+                    val jvmAndJs = it.create("jvmAndJs") {
+                        it.dependsOn(sourceSets.commonMain.get())
                     }
                     it.jvmMain {
                         dependsOn(jvmAndJs)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
@@ -48,8 +48,8 @@ class SwiftExportDslIT : KGPBaseTest() {
                     applyMultiplatform {
                         iosArm64()
                         with(swiftExport) {
-                            export(project(":subproject"))
-                            export(project(":not-good-looking-project-name"))
+                            export(dependencies.project(":subproject"))
+                            export(dependencies.project(":not-good-looking-project-name"))
                         }
 
                         sourceSets.commonMain {
@@ -140,7 +140,7 @@ class SwiftExportDslIT : KGPBaseTest() {
                         iosArm64()
                         with(swiftExport) {
                             moduleName.set("CustomShared")
-                            export(project(":subproject")) {
+                            export(dependencies.project(":subproject")) {
                                 moduleName.set("CustomSubproject")
                             }
                         }
@@ -218,7 +218,7 @@ class SwiftExportDslIT : KGPBaseTest() {
                         iosArm64()
                         with(swiftExport) {
                             flattenPackage.set("com.github.jetbrains.swiftexport")
-                            export(project(":subproject")) {
+                            export(dependencies.project(":subproject")) {
                                 flattenPackage.set("com.subproject.library")
                             }
                         }
@@ -336,8 +336,8 @@ class SwiftExportDslIT : KGPBaseTest() {
                     applyMultiplatform {
                         iosArm64()
                         with(swiftExport) {
-                            export(project(":subproject"))
-                            export(project(":not-good-looking-project-name"))
+                            export(dependencies.project(":subproject"))
+                            export(dependencies.project(":not-good-looking-project-name"))
                         }
                     }
                 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportXCIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportXCIT.kt
@@ -47,7 +47,7 @@ class SwiftExportXCIT : KGPBaseTest() {
                                 moduleName.set("Shared")
                                 flattenPackage.set("com.github.jetbrains.example")
 
-                                export(project(":subproject")) {
+                                export(dependencies.project(":subproject")) {
                                     moduleName.set("Subproject")
                                     flattenPackage.set("com.github.jetbrains.library")
                                 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/TestVersions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/TestVersions.kt
@@ -38,6 +38,7 @@ interface TestVersions {
         const val G_9_3 = "9.3.1"
         const val G_9_4 = "9.4.1"
         const val G_9_5 = "9.5.1"
+        const val G_9_6 = "9.6.1"
 
         /**
          * Check [org.jetbrains.kotlin.gradle.GradleCompatibilityIT.testIncompatibleGradleVersion]
@@ -46,7 +47,7 @@ interface TestVersions {
 
         // Should be the same as GradleCompatibilityCheck.minSupportedGradleVersion
         const val MIN_SUPPORTED = MINIMALLY_SUPPORTED_GRADLE_VERSION
-        const val MAX_SUPPORTED = G_9_5
+        const val MAX_SUPPORTED = G_9_6
     }
 
     object Kotlin {
@@ -70,10 +71,11 @@ interface TestVersions {
         const val AGP_90 = "9.0.1"
         const val AGP_91 = "9.1.1"
         const val AGP_92 = "9.2.1"
+        const val AGP_93 = "9.3.0-alpha12"
 
         // Should be in sync with KotlinMultiplatformAndroidGradlePluginCompatibilityHealthCheck
         const val MIN_SUPPORTED = AGP_85 // AgpCompatibilityCheck.minimalSupportedAgpVersion
-        const val MAX_SUPPORTED = AGP_92 // Update once the Gradle MAX_SUPPORTED version is bumped
+        const val MAX_SUPPORTED = AGP_93 // Update once the Gradle MAX_SUPPORTED version is bumped
     }
 
     enum class AgpCompatibilityMatrix(
@@ -94,6 +96,7 @@ interface TestVersions {
         AGP_90(AGP.AGP_90, GradleVersion.version(Gradle.G_9_1), GradleVersion.version(Gradle.G_9_4), JavaVersion.VERSION_17),
         AGP_91(AGP.AGP_91, GradleVersion.version(Gradle.G_9_3), GradleVersion.version(Gradle.G_9_5), JavaVersion.VERSION_17),
         AGP_92(AGP.AGP_92, GradleVersion.version(Gradle.G_9_4), GradleVersion.version(Gradle.G_9_5), JavaVersion.VERSION_17),
+        AGP_93(AGP.AGP_93, GradleVersion.version(Gradle.G_9_4), GradleVersion.version(Gradle.G_9_6), JavaVersion.VERSION_17),
         ;
 
         companion object {
@@ -111,9 +114,9 @@ interface TestVersions {
         const val SHADOW_PLUGIN_VERSION = "8.3.9"
         const val GOOGLE_DAGGER = "2.24"
         const val GRADLE_ENTERPRISE_PLUGIN_VERSION = "3.13.4"
-        const val GRADLE_DEVELOCITY_PLUGIN_VERSION = "3.18"
+        const val GRADLE_DEVELOCITY_PLUGIN_VERSION = "4.4.3"
         const val KOTLINX_ATOMICFU = "0.31.0"
-        const val KOTLINX_KOVER = "0.9.1"
+        const val KOTLINX_KOVER = "0.9.8"
         const val KOTLINX_BINARY_COMPATIBILITY_VALIDATOR = "0.17.0"
         const val DOKKA = "1.8.10"
         const val DOKKA_V2 = "2.1.0"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/projectSetupDefaults.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/projectSetupDefaults.kt
@@ -189,8 +189,8 @@ internal val DEFAULT_KOTLIN_SETTINGS_FILE =
             gradlePluginPortal()
         }
 
-        val kotlin_version: String by settings
-        val test_fixes_version: String by settings
+        val kotlin_version: String = providers.gradleProperty("kotlin_version").get()
+        val test_fixes_version: String = providers.gradleProperty("test_fixes_version").get()
         plugins {
             id("org.jetbrains.kotlin.jvm") version kotlin_version
             id("org.jetbrains.kotlin.kapt") version kotlin_version

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/JBComposeApp/composeApp/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/JBComposeApp/composeApp/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     jvm("desktop")
     
     sourceSets {
-        val desktopMain by getting
+        val desktopMain = getByName("desktopMain")
         
         androidMain.dependencies {
             implementation("androidx.compose.ui:ui-tooling-preview:1.7.4")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/KT-45559-cinterop-header-UTD-checks/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/KT-45559-cinterop-header-UTD-checks/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
         }
         compilations.getByName("main") {
             cinterops {
-                val cinterop by creating {
+                val cinterop = create("cinterop") {
                     includeDirs("includeDirs")
                 }
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/MPPBuildReproducibility/simpleMultiplatformProject/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/MPPBuildReproducibility/simpleMultiplatformProject/build.gradle.kts
@@ -17,10 +17,10 @@ kotlin {
     linuxX64()
     linuxArm64()
 
-    val commonMain by sourceSets.getting
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val nativeMain by sourceSets.creating
+    val commonMain = sourceSets.getByName("commonMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val nativeMain = sourceSets.create("nativeMain")
 
     nativeMain.dependsOn(commonMain)
     linuxX64Main.dependsOn(nativeMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation-kt-50952/p1/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation-kt-50952/p1/build.gradle.kts
@@ -25,10 +25,10 @@ kotlin {
         }
     }
 
-    val commonMain by sourceSets.getting
-    val withInteropMain by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val withInteropMain = sourceSets.create("withInteropMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
 
     withInteropMain.dependsOn(commonMain)
     linuxX64Main.dependsOn(withInteropMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation/p1/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation/p1/build.gradle.kts
@@ -36,21 +36,21 @@ kotlin {
 
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val concurrentMain by sourceSets.creating
-    val jvmMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val appleAndLinuxMain by sourceSets.creating
-    val linuxMain by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val appleMain by sourceSets.creating
-    val macosMain by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val iosSimulatorArm64Main by sourceSets.getting
-    val windowsX64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val concurrentMain = sourceSets.create("concurrentMain")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val appleAndLinuxMain = sourceSets.create("appleAndLinuxMain")
+    val linuxMain = sourceSets.create("linuxMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val appleMain = sourceSets.create("appleMain")
+    val macosMain = sourceSets.getByName("macosMain")
+    val iosMain = sourceSets.create("iosMain")
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val iosSimulatorArm64Main = sourceSets.getByName("iosSimulatorArm64Main")
+    val windowsX64Main = sourceSets.getByName("windowsX64Main")
 
     commonMain {
         -concurrentMain {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation/p2/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation/p2/build.gradle.kts
@@ -28,33 +28,33 @@ kotlin {
 
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val commonTest by sourceSets.getting
-    val jvmMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val nativeTest by sourceSets.creating
-    val appleAndLinuxMain by sourceSets.creating
-    val appleAndLinuxTest by sourceSets.creating
-    val linuxMain by sourceSets.creating
-    val linuxTest by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxX64Test by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val linuxArm64Test by sourceSets.getting
-    val appleMain by sourceSets.creating
-    val appleTest by sourceSets.creating
-    val macosMain by sourceSets.getting
-    val macosTest by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val iosTest by sourceSets.creating
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val iosSimulatorArm64Main by sourceSets.getting
-    val iosX64Test by sourceSets.getting
-    val iosArm64Test by sourceSets.getting
-    val iosSimulatorArm64Test by sourceSets.getting
-    val windowsX64Main by sourceSets.getting
-    val windowsX64Test by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val commonTest = sourceSets.getByName("commonTest")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val nativeTest = sourceSets.create("nativeTest")
+    val appleAndLinuxMain = sourceSets.create("appleAndLinuxMain")
+    val appleAndLinuxTest = sourceSets.create("appleAndLinuxTest")
+    val linuxMain = sourceSets.create("linuxMain")
+    val linuxTest = sourceSets.create("linuxTest")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxX64Test = sourceSets.getByName("linuxX64Test")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val linuxArm64Test = sourceSets.getByName("linuxArm64Test")
+    val appleMain = sourceSets.create("appleMain")
+    val appleTest = sourceSets.create("appleTest")
+    val macosMain = sourceSets.getByName("macosMain")
+    val macosTest = sourceSets.getByName("macosTest")
+    val iosMain = sourceSets.create("iosMain")
+    val iosTest = sourceSets.create("iosTest")
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val iosSimulatorArm64Main = sourceSets.getByName("iosSimulatorArm64Main")
+    val iosX64Test = sourceSets.getByName("iosX64Test")
+    val iosArm64Test = sourceSets.getByName("iosArm64Test")
+    val iosSimulatorArm64Test = sourceSets.getByName("iosSimulatorArm64Test")
+    val windowsX64Main = sourceSets.getByName("windowsX64Main")
+    val windowsX64Test = sourceSets.getByName("windowsX64Test")
 
     commonMain {
         -jvmMain

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation/p3/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-MetadataDependencyTransformation/p3/build.gradle.kts
@@ -21,27 +21,27 @@ kotlin {
     iosSimulatorArm64()
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val commonTest by sourceSets.getting
-    val jvmMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val nativeTest by sourceSets.creating
-    val appleAndLinuxMain by sourceSets.creating
-    val appleAndLinuxTest by sourceSets.creating
-    val windowsAndLinuxMain by sourceSets.creating
-    val windowsAndLinuxTest by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxX64Test by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val iosTest by sourceSets.creating
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val iosSimulatorArm64Main by sourceSets.getting
-    val iosX64Test by sourceSets.getting
-    val iosArm64Test by sourceSets.getting
-    val iosSimulatorArm64Test by sourceSets.getting
-    val windowsX64Main by sourceSets.getting
-    val windowsX64Test by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val commonTest = sourceSets.getByName("commonTest")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val nativeTest = sourceSets.create("nativeTest")
+    val appleAndLinuxMain = sourceSets.create("appleAndLinuxMain")
+    val appleAndLinuxTest = sourceSets.create("appleAndLinuxTest")
+    val windowsAndLinuxMain = sourceSets.create("windowsAndLinuxMain")
+    val windowsAndLinuxTest = sourceSets.create("windowsAndLinuxTest")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxX64Test = sourceSets.getByName("linuxX64Test")
+    val iosMain = sourceSets.create("iosMain")
+    val iosTest = sourceSets.create("iosTest")
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val iosSimulatorArm64Main = sourceSets.getByName("iosSimulatorArm64Main")
+    val iosX64Test = sourceSets.getByName("iosX64Test")
+    val iosArm64Test = sourceSets.getByName("iosArm64Test")
+    val iosSimulatorArm64Test = sourceSets.getByName("iosSimulatorArm64Test")
+    val windowsX64Main = sourceSets.getByName("windowsX64Main")
+    val windowsX64Test = sourceSets.getByName("windowsX64Test")
 
     commonMain {
         -jvmMain

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-with-def-creation-task/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-with-def-creation-task/build.gradle.kts
@@ -18,9 +18,8 @@ kotlin {
         }
         compilations.getByName("main") {
             cinterops {
-                val cinterop by creating {
-                    definitionFile.set(createDefFileTask.flatMap { it.defFile })
-                }
+                val cinterop = create("cinterop")
+                cinterop.definitionFile.set(createDefFileTask.flatMap { it.defFile })
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-with-header/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinterop-with-header/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
         }
         compilations.getByName("main") {
             cinterops {
-                val cinterop by creating {
+                val cinterop = create("cinterop").apply {
                     headers("libs/include/dummy.h")
                     compilerOpts.add("-Ilibs/include")
                     packageName("cinterop")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinteropImport/client-with-complex-hierarchy/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/cinteropImport/client-with-complex-hierarchy/build.gradle.kts
@@ -8,23 +8,22 @@ kotlin {
     linuxX64("linux").compilations.getByName("main").cinterops.create("w")
 
     sourceSets {
-        val commonMain by getting
-        val commonTest by getting
-        val linuxMain by getting
-        val linuxTest by getting
-        val linuxArmMain by getting
-        val linuxArmTest by getting
+        val commonMain = getByName("commonMain")
+        val commonTest = getByName("commonTest")
+        val linuxMain = getByName("linuxMain")
+        val linuxTest = getByName("linuxTest")
+        val linuxArmMain = getByName("linuxArmMain")
+        val linuxArmTest = getByName("linuxArmTest")
 
-        val nativeMain by creating {
-            this.dependsOn(commonMain)
-            linuxArmMain.dependsOn(this)
-        }
-        val nativeTest by creating {
-            this.dependsOn(commonTest)
-            linuxArmTest.dependsOn(this)
-        }
+        val nativeMain = create("nativeMain")
+        nativeMain.dependsOn(commonMain)
+        linuxArmMain.dependsOn(nativeMain)
 
-        val linuxIntermediateMain by creating {
+        val nativeTest = create("nativeTest")
+        nativeTest.dependsOn(commonTest)
+        linuxArmTest.dependsOn(nativeTest)
+
+        val linuxIntermediateMain = create("linuxIntermediateMain").apply {
             this.dependsOn(nativeMain)
             linuxMain.dependsOn(this)
 
@@ -32,7 +31,7 @@ kotlin {
                 implementation(project(":dep-with-cinterop"))
             }
         }
-        val linuxIntermediateTest by creating {
+        val linuxIntermediateTest = create("linuxIntermediateTest").apply {
             this.dependsOn(nativeTest)
             linuxTest.dependsOn(this)
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/common-klib-lib-and-app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/common-klib-lib-and-app/build.gradle.kts
@@ -20,51 +20,46 @@ kotlin {
 	mingwX64()
 
 	sourceSets {
-		val commonMain by getting
+		val commonMain = getByName("commonMain")
 
-		val windowsAndLinuxMain by creating {
+		val windowsAndLinuxMain = create("windowsAndLinuxMain") {
 			dependsOn(commonMain)
 		}
 
-		val linuxMain by creating {
+		val linuxMain = create("linuxMain") {
 			dependsOn(commonMain)
 		}
 
-		val mingwX64Main by getting {
-			dependsOn(windowsAndLinuxMain)
-		}
-		val linuxX64Main by getting {
-			dependsOn(linuxMain)
-			dependsOn(windowsAndLinuxMain)
-		}
-		val linuxArm64Main by getting {
-			dependsOn(linuxMain)
-		}
+		val mingwX64Main = getByName("mingwX64Main")
+        mingwX64Main.dependsOn(windowsAndLinuxMain)
 
-		val jvmAndJsMain by creating {
-			dependsOn(commonMain)
-		}
+		val linuxX64Main = getByName("linuxX64Main")
+        linuxX64Main.dependsOn(linuxMain)
+        linuxX64Main.dependsOn(windowsAndLinuxMain)
 
-		val jvmMain by getting {
-			dependsOn(jvmAndJsMain)
-		}
+		val linuxArm64Main = getByName("linuxArm64Main")
+        linuxArm64Main.dependsOn(linuxMain)
 
-		val jsMain by getting {
-			dependsOn(jvmAndJsMain)
-		}
+		val jvmAndJsMain = create("jvmAndJsMain")
+        jvmAndJsMain.dependsOn(commonMain)
 
-		val iosMain by creating {
-			dependsOn(commonMain)
-		}
-		val iosX64Main by getting {
-			dependsOn(iosMain)
-		}
-		val iosArm64Main by getting {
-			dependsOn(iosMain)
-		}
-		val iosSimulatorArm64Main by getting {
-			dependsOn(iosMain)
-		}
+		val jvmMain = getByName("jvmMain")
+        jvmMain.dependsOn(jvmAndJsMain)
+
+		val jsMain = getByName("jsMain")
+        jsMain.dependsOn(jvmAndJsMain)
+
+		val iosMain = create("iosMain")
+        iosMain.dependsOn(commonMain)
+
+		val iosX64Main = getByName("iosX64Main")
+        iosX64Main.dependsOn(iosMain)
+
+		val iosArm64Main = getByName("iosArm64Main")
+        iosArm64Main.dependsOn(iosMain)
+
+		val iosSimulatorArm64Main = getByName("iosSimulatorArm64Main")
+        iosSimulatorArm64Main.dependsOn(iosMain)
 
 		all {
 			languageSettings.optIn("kotlinx.cinterop.ExperimentalForeignApi")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-47523-singleNativeTargetPropagation-cinterop/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-47523-singleNativeTargetPropagation-cinterop/build.gradle.kts
@@ -18,9 +18,9 @@ kotlin {
         else -> throw IllegalStateException("Unsupported host")
     }
 
-    val commonMain by sourceSets.getting
-    val nativePlatformMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativePlatformMain = sourceSets.getByName("nativePlatformMain")
+    val nativeMain = sourceSets.create("nativeMain")
 
     nativeMain.dependsOn(commonMain)
     nativePlatformMain.dependsOn(nativeMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-47641-cinterops-compilation-dependency/p2/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-47641-cinterops-compilation-dependency/p2/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     macosX64()
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
 
     commonMain.dependencies {
         implementation(project(":p1"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-48138-nativeMain-nativeTest-different-targets/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-48138-nativeMain-nativeTest-different-targets/build.gradle.kts
@@ -24,22 +24,22 @@ kotlin {
     linuxArm64()
     mingwX64()
 
-    val commonMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val mingwX64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val mingwX64Main = sourceSets.getByName("mingwX64Main")
 
     nativeMain.dependsOn(commonMain)
     linuxX64Main.dependsOn(nativeMain)
     linuxArm64Main.dependsOn(nativeMain)
     mingwX64Main.dependsOn(nativeMain)
 
-    val commonTest by sourceSets.getting
-    val nativeTest by sourceSets.creating
-    val linuxX64Test by sourceSets.getting
-    val linuxArm64Test by sourceSets.getting
-    val mingwX64Test by sourceSets.getting
+    val commonTest = sourceSets.getByName("commonTest")
+    val nativeTest = sourceSets.create("nativeTest")
+    val linuxX64Test = sourceSets.getByName("linuxX64Test")
+    val linuxArm64Test = sourceSets.getByName("linuxArm64Test")
+    val mingwX64Test = sourceSets.getByName("mingwX64Test")
 
     nativeTest.dependsOn(commonTest)
     linuxX64Test.dependsOn(nativeTest)
@@ -52,4 +52,3 @@ kotlin {
         }
     }
 }
-

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-48856-singleNativeTargetPropagation-testSourceSet/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-48856-singleNativeTargetPropagation-testSourceSet/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
         header(file("src/nativeInterop/cinterop/sampleInterop.h"))
     }
 
-    val platformTest by sourceSets.getting
+    val platformTest = sourceSets.getByName("platformTest")
     val nativeTest = sourceSets.create("nativeTest")
     platformTest.dependsOn(nativeTest)
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-50847-cinterop-missing-in-supported-target/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-50847-cinterop-missing-in-supported-target/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
     }
 
     /* 'Disable' a cinterop on a certain target */
-    val disabledCInteropTarget = when (val propertyValue = properties["disableTargetNumber"]) {
+    val disabledCInteropTarget = when (val propertyValue = providers.gradleProperty("disableTargetNumber").orNull) {
         null -> error("Test project expects property 'disableTargetNumber' with value '1' or '2'")
         "1" -> linuxTarget1
         "2" -> linuxTarget2

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-51517-transitive-cinterop/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-51517-transitive-cinterop/app/build.gradle.kts
@@ -15,16 +15,16 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting
-        val linuxX64Main by getting
-        val linuxArm64Main by getting
-        val mingwX64Main by getting
+        val commonMain = getByName("commonMain")
+        val linuxX64Main = getByName("linuxX64Main")
+        val linuxArm64Main = getByName("linuxArm64Main")
+        val mingwX64Main = getByName("mingwX64Main")
 
-        val linuxMain by creating {
+        val linuxMain = create("linuxMain").apply {
             linuxX64Main.dependsOn(this)
             linuxArm64Main.dependsOn(this)
         }
-        val nativeMain by creating {
+        val nativeMain = create("nativeMain").apply {
             this.dependsOn(commonMain)
             linuxMain.dependsOn(this)
             mingwX64Main.dependsOn(this)
@@ -32,16 +32,16 @@ kotlin {
                 implementation(project(":lib"))
             }
         }
-        val commonTest by getting
-        val linuxX64Test by getting
-        val linuxArm64Test by getting
-        val mingwX64Test by getting
+        val commonTest = getByName("commonTest")
+        val linuxX64Test = getByName("linuxX64Test")
+        val linuxArm64Test = getByName("linuxArm64Test")
+        val mingwX64Test = getByName("mingwX64Test")
 
-        val linuxTest by creating {
+        val linuxTest = create("linuxTest").apply {
             linuxX64Test.dependsOn(this)
             linuxArm64Test.dependsOn(this)
         }
-        val nativeTest by creating {
+        val nativeTest = create("nativeTest").apply {
             this.dependsOn(commonTest)
             linuxTest.dependsOn(this)
             mingwX64Test.dependsOn(this)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-52050-DIR-supertype/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-kt-52050-DIR-supertype/build.gradle.kts
@@ -12,11 +12,11 @@ kotlin {
     linuxX64("linux")
     mingwX64("windows")
 
-    val commonMain by sourceSets.getting
-    val macosMain by sourceSets.getting
-    val linuxMain by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val macosMain = sourceSets.getByName("macosMain")
+    val linuxMain = sourceSets.getByName("linuxMain")
 
-    val unixMain by sourceSets.creating
+    val unixMain = sourceSets.create("unixMain")
 
     unixMain.dependsOn(commonMain)
     linuxMain.dependsOn(unixMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-withJvmSubproject/multiplatform/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonize-withJvmSubproject/multiplatform/build.gradle.kts
@@ -6,10 +6,10 @@ kotlin {
     linuxArm64()
     linuxX64()
 
-    val commonMain by sourceSets.getting
-    val linuxMain by sourceSets.creating
-    val linuxArm64Main by sourceSets.getting
-    val linuxX64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val linuxMain = sourceSets.create("linuxMain")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
 
     linuxMain.dependsOn(commonMain)
     linuxArm64Main.dependsOn(linuxMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeCurlInterop/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeCurlInterop/build.gradle.kts
@@ -11,10 +11,10 @@ kotlin {
     val targetA = <targetA>("targetA")
     val targetB = <targetB>("targetB")
 
-    val commonMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val targetAMain by sourceSets.getting
-    val targetBMain by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val targetAMain = sourceSets.getByName("targetAMain")
+    val targetBMain = sourceSets.getByName("targetBMain")
 
     nativeMain.dependsOn(commonMain)
     targetAMain.dependsOn(nativeMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeHierarchicallyMultiModule/p1/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeHierarchicallyMultiModule/p1/build.gradle.kts
@@ -28,22 +28,22 @@ kotlin {
 
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val concurrentMain by sourceSets.creating
-    val jvmMain by sourceSets.getting
-    val jsMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val appleAndLinuxMain by sourceSets.creating
-    val linuxMain by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val appleMain by sourceSets.creating
-    val macosMain by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val iosSimulatorArm64Main by sourceSets.getting
-    val windowsX64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val concurrentMain = sourceSets.create("concurrentMain")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val jsMain = sourceSets.getByName("jsMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val appleAndLinuxMain = sourceSets.create("appleAndLinuxMain")
+    val linuxMain = sourceSets.create("linuxMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val appleMain = sourceSets.create("appleMain")
+    val macosMain = sourceSets.getByName("macosMain")
+    val iosMain = sourceSets.create("iosMain")
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val iosSimulatorArm64Main = sourceSets.getByName("iosSimulatorArm64Main")
+    val windowsX64Main = sourceSets.getByName("windowsX64Main")
 
     commonMain {
         -jsMain

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeHierarchicallyMultiModule/p2/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeHierarchicallyMultiModule/p2/build.gradle.kts
@@ -28,22 +28,22 @@ kotlin {
 
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val concurrentMain by sourceSets.creating
-    val jvmMain by sourceSets.getting
-    val jsMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val appleAndLinuxMain by sourceSets.creating
-    val linuxMain by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val appleMain by sourceSets.creating
-    val macosMain by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val iosSimulatorArm64Main by sourceSets.getting
-    val windowsX64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val concurrentMain = sourceSets.create("concurrentMain")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val jsMain = sourceSets.getByName("jsMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val appleAndLinuxMain = sourceSets.create("appleAndLinuxMain")
+    val linuxMain = sourceSets.create("linuxMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val appleMain = sourceSets.create("appleMain")
+    val macosMain = sourceSets.getByName("macosMain")
+    val iosMain = sourceSets.create("iosMain")
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val iosSimulatorArm64Main = sourceSets.getByName("iosSimulatorArm64Main")
+    val windowsX64Main = sourceSets.getByName("windowsX64Main")
 
     commonMain {
         -jsMain

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeHierarchicallyMultiModule/p3/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeHierarchicallyMultiModule/p3/build.gradle.kts
@@ -28,22 +28,22 @@ kotlin {
 
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val concurrentMain by sourceSets.creating
-    val jvmMain by sourceSets.getting
-    val jsMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val appleAndLinuxMain by sourceSets.creating
-    val linuxMain by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val appleMain by sourceSets.creating
-    val macosMain by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val iosSimulatorArm64Main by sourceSets.getting
-    val windowsX64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val concurrentMain = sourceSets.create("concurrentMain")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val jsMain = sourceSets.getByName("jsMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val appleAndLinuxMain = sourceSets.create("appleAndLinuxMain")
+    val linuxMain = sourceSets.create("linuxMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val appleMain = sourceSets.create("appleMain")
+    val macosMain = sourceSets.getByName("macosMain")
+    val iosMain = sourceSets.create("iosMain")
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val iosSimulatorArm64Main = sourceSets.getByName("iosSimulatorArm64Main")
+    val windowsX64Main = sourceSets.getByName("windowsX64Main")
 
     commonMain {
         -jsMain

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeInteropUsingPosixApis/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeInteropUsingPosixApis/build.gradle.kts
@@ -12,10 +12,10 @@ kotlin {
     val targetA = <targetA>("targetA")
     val targetB = <targetB>("targetB")
 
-    val commonMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val targetAMain by sourceSets.getting
-    val targetBMain by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val targetAMain = sourceSets.getByName("targetAMain")
+    val targetBMain = sourceSets.getByName("targetBMain")
 
     nativeMain.dependsOn(commonMain)
     targetAMain.dependsOn(nativeMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeMultipleCInteropsWithTests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeMultipleCInteropsWithTests/build.gradle.kts
@@ -34,33 +34,33 @@ kotlin {
 
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val commonTest by sourceSets.getting
-    val jvmMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val nativeTest by sourceSets.creating
-    val unixMain by sourceSets.creating
-    val unixTest by sourceSets.creating
-    val linuxMain by sourceSets.creating
-    val linuxTest by sourceSets.creating
-    val linuxX64Main by sourceSets.getting
-    val linuxX64Test by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
-    val linuxArm64Test by sourceSets.getting
-    val appleMain by sourceSets.creating
-    val appleTest by sourceSets.creating
-    val macosMain by sourceSets.getting
-    val macosTest by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val iosSimulatorArm64Main by sourceSets.getting
-    val iosTest by sourceSets.creating
-    val iosX64Test by sourceSets.getting
-    val iosArm64Test by sourceSets.getting
-    val iosSimulatorArm64Test by sourceSets.getting
-    val windowsX64Main by sourceSets.getting
-    val windowsX64Test by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val commonTest = sourceSets.getByName("commonTest")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val nativeTest = sourceSets.create("nativeTest")
+    val unixMain = sourceSets.create("unixMain")
+    val unixTest = sourceSets.create("unixTest")
+    val linuxMain = sourceSets.create("linuxMain")
+    val linuxTest = sourceSets.create("linuxTest")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxX64Test = sourceSets.getByName("linuxX64Test")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+    val linuxArm64Test = sourceSets.getByName("linuxArm64Test")
+    val appleMain = sourceSets.create("appleMain")
+    val appleTest = sourceSets.create("appleTest")
+    val macosMain = sourceSets.getByName("macosMain")
+    val macosTest = sourceSets.getByName("macosTest")
+    val iosMain = sourceSets.create("iosMain")
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val iosSimulatorArm64Main = sourceSets.getByName("iosSimulatorArm64Main")
+    val iosTest = sourceSets.create("iosTest")
+    val iosX64Test = sourceSets.getByName("iosX64Test")
+    val iosArm64Test = sourceSets.getByName("iosArm64Test")
+    val iosSimulatorArm64Test = sourceSets.getByName("iosSimulatorArm64Test")
+    val windowsX64Main = sourceSets.getByName("windowsX64Main")
+    val windowsX64Test = sourceSets.getByName("windowsX64Test")
 
     commonMain {
         -jvmMain
@@ -103,7 +103,7 @@ kotlin {
         }
     }
 
-    if (properties["testSourceSetsDependingOnMain"] == "true") {
+    if (providers.gradleProperty("testSourceSetsDependingOnMain").orNull == "true") {
         logger.quiet("testSourceSetsDependingOnMain is set")
         nativeTest.dependsOn(nativeMain)
         unixTest.dependsOn(unixMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeNativeDistributionWithIosLinuxWindows/p1/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeNativeDistributionWithIosLinuxWindows/p1/build.gradle.kts
@@ -9,14 +9,14 @@ kotlin {
     linuxArm64()
     mingwX64("windowsX64")
 
-    val commonMain by sourceSets.getting
-    val iosMain by sourceSets.creating
-    val linuxMain by sourceSets.creating
+    val commonMain = sourceSets.getByName("commonMain")
+    val iosMain = sourceSets.create("iosMain")
+    val linuxMain = sourceSets.create("linuxMain")
 
-    val iosX64Main by sourceSets.getting
-    val iosArm64Main by sourceSets.getting
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
+    val iosX64Main = sourceSets.getByName("iosX64Main")
+    val iosArm64Main = sourceSets.getByName("iosArm64Main")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
 
     iosMain.dependsOn(commonMain)
     linuxMain.dependsOn(commonMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeSQLiteAndCurlInterop/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeSQLiteAndCurlInterop/build.gradle.kts
@@ -11,10 +11,10 @@ kotlin {
     val targetA = <targetA>("targetA")
     val targetB = <targetB>("targetB")
 
-    val commonMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val targetAMain by sourceSets.getting
-    val targetBMain by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val targetAMain = sourceSets.getByName("targetAMain")
+    val targetBMain = sourceSets.getByName("targetBMain")
 
     nativeMain.dependsOn(commonMain)
     targetAMain.dependsOn(nativeMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeSQLiteInterop/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/commonizeSQLiteInterop/build.gradle.kts
@@ -11,10 +11,10 @@ kotlin {
     val targetA = <targetA>("targetA")
     val targetB = <targetB>("targetB")
 
-    val commonMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val targetAMain by sourceSets.getting
-    val targetBMain by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val targetAMain = sourceSets.getByName("targetAMain")
+    val targetBMain = sourceSets.getByName("targetBMain")
 
     nativeMain.dependsOn(commonMain)
     targetAMain.dependsOn(nativeMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/composite-build-with-precompiled-script-plugins/build-logic/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/composite-build-with-precompiled-script-plugins/build-logic/build.gradle.kts
@@ -9,7 +9,7 @@ allprojects {
     }
 }
 
-val kotlin_version by properties
+val kotlin_version = extra["kotlin_version"]
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/diagnosticsRenderingSmoke/subprojectA/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/diagnosticsRenderingSmoke/subprojectA/build.gradle.kts
@@ -8,11 +8,10 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val myCustomSourceSet by creating
+        val myCustomSourceSet = create("myCustomSourceSet")
 
         // check that usual diagnostics are not deduplicated even if they are exactly the same
-        val commonMain by getting {
-            dependsOn(myCustomSourceSet)
-        }
+        val commonMain = getByName("commonMain")
+        commonMain.dependsOn(myCustomSourceSet)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/diagnosticsRenderingSmoke/subprojectB/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/diagnosticsRenderingSmoke/subprojectB/build.gradle.kts
@@ -8,16 +8,15 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val myCustomSourceSet by creating
+        val myCustomSourceSet = create("myCustomSourceSet")
 
         // check that usual diagnostics are not deduplicated even if they are exactly the same
-        val commonMain by getting {
-            dependsOn(myCustomSourceSet)
-        }
+        val commonMain = getByName("commonMain")
+        commonMain.dependsOn(myCustomSourceSet)
 
         afterEvaluate {
             // Check that changes made in trivial afterEvaluate are picked up
-            val unusedCreatedInAfterEvaluate by creating { }
+            val unusedCreatedInAfterEvaluate = create("unusedCreatedInAfterEvaluate")
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/earlyTasksMaterializationDoesntBreakReports/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/earlyTasksMaterializationDoesntBreakReports/build.gradle.kts
@@ -16,10 +16,9 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val myCommonMain by creating
+        val myCommonMain = create("myCommonMain")
 
-        val commonMain by getting {
-            dependsOn(myCommonMain)
-        }
+        val commonMain = getByName("commonMain")
+        commonMain.dependsOn(myCommonMain)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/errorDiagnosticBuildFails/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/errorDiagnosticBuildFails/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
     mingwX64()
 
     sourceSets {
-        val myCustomSourceSet by creating
+        val myCustomSourceSet = create("myCustomSourceSet")
         commonMain.get().dependsOn(myCustomSourceSet)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/errorsFailOnlyRelevantProjects/brokenProjectA/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/errorsFailOnlyRelevantProjects/brokenProjectA/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
     jvm()
 
     sourceSets {
-        val myCustomSourceSet by creating
+        val myCustomSourceSet = create("myCustomSourceSet")
         commonMain.get().dependsOn(myCustomSourceSet)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/errorsFailOnlyRelevantProjects/brokenProjectB/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/errorsFailOnlyRelevantProjects/brokenProjectB/build.gradle.kts
@@ -7,10 +7,9 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val myCommonMain by creating
+        val myCommonMain = create("myCommonMain")
 
-        val commonMain by getting {
-            dependsOn(myCommonMain)
-        }
+        val commonMain = getByName("commonMain")
+        commonMain.dependsOn(myCommonMain)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/externalAndroidTarget-project2project/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/externalAndroidTarget-project2project/lib/build.gradle.kts
@@ -26,7 +26,7 @@ publishing {
     }
 
     publications {
-        val android by getting {
+        val android = getByName("android").apply {
             this as MavenPublication
             artifactId = "tcs-android"
             version = "2.0"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/generic-kmp-app-plus-lib-with-tests/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/generic-kmp-app-plus-lib-with-tests/app/build.gradle.kts
@@ -10,15 +10,14 @@ kotlin {
     <SingleNativeTarget>("native")
 
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(project(":lib"))
-            }
+        val commonMain = getByName("commonMain")
+        commonMain.dependencies {
+            implementation(project(":lib"))
         }
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test"))
-            }
+
+        val commonTest = getByName("commonTest")
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/generic-kmp-app-plus-lib-with-tests/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/generic-kmp-app-plus-lib-with-tests/lib/build.gradle.kts
@@ -12,10 +12,9 @@ kotlin {
     <SingleNativeTarget>("native")
 
     sourceSets {
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test"))
-            }
+        val commonTest = getByName("commonTest")
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-all-native/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-all-native/build.gradle.kts
@@ -8,10 +8,10 @@ repositories {
 }
 
 kotlin {
-	val mingwTargetName: String by project
-	val linuxTargetName: String by project
-	val macosTargetName: String by project
-	val currentHostTargetName: String by project
+	val mingwTargetName: String = providers.gradleProperty("mingwTargetName").get()
+	val linuxTargetName: String = providers.gradleProperty("linuxTargetName").get()
+	val macosTargetName: String = providers.gradleProperty("macosTargetName").get()
+	val currentHostTargetName: String = providers.gradleProperty("currentHostTargetName").get()
 
     val mingw = mingwX64(mingwTargetName) { }
     val linux = linuxX64(linuxTargetName) { }
@@ -19,16 +19,14 @@ kotlin {
     val linuxArm = linuxArm64()
 
 	sourceSets {
-		val allNative by creating {
-			dependsOn(getByName("commonMain"))
-			listOf(mingw, linux, macos).forEach {
-				it.compilations["main"].defaultSourceSet.dependsOn(this@creating)
-			}
+		val allNative = create("allNative")
+		allNative.dependsOn(getByName("commonMain"))
+		listOf(mingw, linux, macos).forEach {
+			it.compilations["main"].defaultSourceSet.dependsOn(allNative)
 		}
 
-    	val currentHostAndLinux by creating {
-    		dependsOn(allNative)
-    	}
+    	val currentHostAndLinux = create("currentHostAndLinux")
+        currentHostAndLinux.dependsOn(allNative)
 
     	configure(listOf(linuxArm, targets.getByName(currentHostTargetName))) {
 			compilations["main"].defaultSourceSet.dependsOn(currentHostAndLinux)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-js-test/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-js-test/build.gradle.kts
@@ -7,18 +7,16 @@ plugins {
 
 kotlin {
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation("com.example.thirdparty:third-party-lib:1.0")
-                implementation(kotlin("stdlib-common"))
-            }
+        val commonMain = getByName("commonMain")
+        commonMain.dependencies {
+            implementation("com.example.thirdparty:third-party-lib:1.0")
+            implementation(kotlin("stdlib-common"))
         }
 
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
+        val commonTest = getByName("commonTest")
+        commonTest.dependencies {
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/my-app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/my-app/build.gradle.kts
@@ -12,34 +12,28 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                api(project(":my-lib-bar"))
-            }
+        val commonMain = getByName("commonMain")
+        commonMain.dependencies {
+            api(project(":my-lib-bar"))
         }
 
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
+        val commonTest = getByName("commonTest")
+        commonTest.dependencies {
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
         }
 
-        val jvmAndJsMain by creating {
-            dependsOn(commonMain)
-        }
+        val jvmAndJsMain = create("jvmAndJsMain")
+        jvmAndJsMain.dependsOn(commonMain)
 
-        val jvmAndJsTest by creating {
-            dependsOn(commonTest)
-        }
+        val jvmAndJsTest = create("jvmAndJsTest")
+        jvmAndJsTest.dependsOn(commonTest)
 
-        val linuxAndJsMain by creating {
-            dependsOn(commonMain)
-        }
-        
-        val linuxAndJsTest by creating {
-            dependsOn(commonTest)
-        }
+        val linuxAndJsMain = create("linuxAndJsMain")
+        linuxAndJsMain.dependsOn(commonMain)
+
+        val linuxAndJsTest = create("linuxAndJsTest")
+        linuxAndJsTest.dependsOn(commonTest)
 
         jvm().compilations["main"].defaultSourceSet {
             dependsOn(jvmAndJsMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/my-lib-bar/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/my-lib-bar/build.gradle.kts
@@ -13,32 +13,29 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                api(project(":my-lib-foo"))
-            }
+        val commonMain = getByName("commonMain")
+        commonMain.dependencies {
+            api(project(":my-lib-foo"))
         }
 
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
+        val commonTest = getByName("commonTest")
+        commonTest.dependencies {
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
         }
 
-        val jvmAndJsMain by creating {
-            dependsOn(commonMain)
-        }
+        val jvmAndJsMain = create("jvmAndJsMain")
+        jvmAndJsMain.dependsOn(commonMain)
 
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val linuxAndJsMain by creating {
+        val linuxAndJsMain = create("linuxAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val linuxAndJsTest by creating {
+        val linuxAndJsTest = create("linuxAndJsTest") {
             dependsOn(commonTest)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/my-lib-foo/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/my-lib-foo/build.gradle.kts
@@ -14,16 +14,16 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting
+        val commonMain = getByName("commonMain")
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
 
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
             dependencies {
                 // Add the third-party-lib dependency only to these two platforms, 
@@ -32,15 +32,15 @@ kotlin {
             }
         }
         
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val linuxAndJsMain by creating {
+        val linuxAndJsMain = create("linuxAndJsMain") {
             dependsOn(commonMain)
         }
         
-        val linuxAndJsTest by creating {
+        val linuxAndJsTest = create("linuxAndJsTest") {
             dependsOn(commonTest)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/third-party-lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-project-dependency/third-party-lib/build.gradle.kts
@@ -11,8 +11,8 @@ kotlin {
     js()
 
     sourceSets {
-        val commonMain by getting
-        val commonTest by getting {
+        val commonMain = getByName("commonMain")
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/my-app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/my-app/build.gradle.kts
@@ -12,32 +12,32 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 api("com.example.bar:my-lib-bar:1.0")
             }
         }
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
 
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val linuxAndJsMain by creating {
+        val linuxAndJsMain = create("linuxAndJsMain") {
             dependsOn(commonMain)
         }
         
-        val linuxAndJsTest by creating {
+        val linuxAndJsTest = create("linuxAndJsTest") {
             dependsOn(commonTest)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/my-lib-bar/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/my-lib-bar/build.gradle.kts
@@ -13,32 +13,32 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 api("com.example.foo:my-lib-foo:1.0")
             }
         }
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
 
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val linuxAndJsMain by creating {
+        val linuxAndJsMain = create("linuxAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val linuxAndJsTest by creating {
+        val linuxAndJsTest = create("linuxAndJsTest") {
             dependsOn(commonTest)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/my-lib-foo/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/my-lib-foo/build.gradle.kts
@@ -14,16 +14,16 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting
+        val commonMain = getByName("commonMain")
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
 
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
             dependencies {
                 // Add the third-party-lib dependency only to these two platforms, 
@@ -32,15 +32,15 @@ kotlin {
             }
         }
         
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val linuxAndJsMain by creating {
+        val linuxAndJsMain = create("linuxAndJsMain") {
             dependsOn(commonMain)
         }
         
-        val linuxAndJsTest by creating {
+        val linuxAndJsTest = create("linuxAndJsTest") {
             dependsOn(commonTest)
         }
 
@@ -83,7 +83,7 @@ kotlin {
         }
 
         // Test KT-39304
-        val unusedSourceSet by creating {
+        val unusedSourceSet = create("unusedSourceSet") {
             dependencies {
                 implementation(kotlin("stdlib"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/third-party-lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hierarchical-mpp-published-modules/third-party-lib/build.gradle.kts
@@ -16,12 +16,12 @@ kotlin {
     js()
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(kotlin("stdlib-common"))
             }
         }
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hmppGradleConfigurationCache/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/hmppGradleConfigurationCache/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
         binaries { sharedLib() }
         compilations.getByName("main").apply {
             cinterops {
-                val foo by creating {
+                val foo = create("foo") {
                     defFile(project.file("foo.def"))
                 }
             }
@@ -24,7 +24,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation("test:lib:1.0")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvm-and-js-hmpp/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/jvm-and-js-hmpp/build.gradle.kts
@@ -16,21 +16,21 @@ kotlin {
     js()
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(kotlin("stdlib-common"))
             }
         }
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
         }
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
         jvm().compilations["main"].defaultSourceSet {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/k2-mpp-without-js/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/k2-mpp-without-js/build.gradle.kts
@@ -18,17 +18,17 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting {}
+        val commonMain = getByName("commonMain") {}
 
-        val intermediateMain by creating {
+        val intermediateMain = create("intermediateMain") {
             dependsOn(commonMain)
         }
 
-        val jvmMain by getting {
+        val jvmMain = getByName("jvmMain") {
             dependsOn(intermediateMain)
         }
 
-        val linuxX64Main by getting {
+        val linuxX64Main = getByName("linuxX64Main") {
             dependsOn(intermediateMain)
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/k2-serialization-plugin-in-common-sourceset/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/k2-serialization-plugin-in-common-sourceset/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         }
     }
     sourceSets {
-        val commonMain by getting{
+        val commonMain = getByName("commonMain") {
             dependencies{
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0-RC")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/mpp-android-kapt/shared/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/mpp-android-kapt/shared/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     androidTarget()
     
     sourceSets {
-        val androidMain by getting {
+        val androidMain = getByName("androidMain") {
             dependencies {
                 implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
                 implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
@@ -26,7 +26,7 @@ kotlin {
                         "com.google.dagger:hilt-compiler:2.59.1"
                     )
                 )
-                val kotlin_version: String by project.extra
+                val kotlin_version = providers.gradleProperty("kotlin_version").get()
                 configurations.getByName("kapt").dependencies.add(
                     project.dependencies.create(
                         "org.jetbrains.kotlin:kotlin-metadata-jvm:$kotlin_version"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-build-logic/build-logic/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-build-logic/build-logic/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
     mavenLocal()
 }
 
-val kotlin_version by properties
+val kotlin_version = extra["kotlin_version"]
 
 dependencies {
     compileOnly(gradleApi())

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-build-logic/build-logic/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-build-logic/build-logic/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 
-    val test_fixes_version: String by settings
+    val test_fixes_version: String = providers.gradleProperty("test_fixes_version").get()
     plugins {
         id("org.jetbrains.kotlin.test.fixes.android") version test_fixes_version
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-compose-dependency/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-compose-dependency/build.gradle.kts
@@ -15,12 +15,12 @@ kotlin {
         }
     }
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation("org.jetbrains.compose.runtime:runtime:1.4.3") // commenting this out and uncommenting in jsMain fixes the issue
             }
         }
-        val jsMain by getting {
+        val jsMain = getByName("jsMain") {
             dependencies {
                 implementation("org.jetbrains.compose.html:html-core:1.4.3")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-coroutines/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-coroutines/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
     }
 
     sourceSets {
-        val jsMain by getting {
+        val jsMain = getByName("jsMain") {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-ir-ic-multiple-artifacts/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-ir-ic-multiple-artifacts/app/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
         browser {
         }
         binaries.executable()
-        val main by compilations.getting
+        val main = compilations.getByName("main")
         main.binaries
             .matching { it.mode == KotlinJsBinaryMode.DEVELOPMENT }
             .matching { it is JsIrBinary }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-ir-ic-multiple-artifacts/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-ir-ic-multiple-artifacts/lib/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
             archiveExtension.set("klib")
         }
 
-        val otherDist by configurations.creating {
+        val otherDist = configurations.create("otherDist") {
             isCanBeConsumed = true
             isCanBeResolved = false
         }
@@ -28,7 +28,7 @@ kotlin {
                 runtimeOnly(project(mapOf("path" to path, "configuration" to "otherDist")))
             }
         }
-        val jsOther by getting {
+        val jsOther = getByName("jsOther") {
             dependencies {
                 implementation(project(path = project.path))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-ir-runtime-dependency/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-ir-runtime-dependency/lib/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
                 runtimeOnly(files(tasks.named("otherKlib")))
             }
         }
-        val jsOther by getting {
+        val jsOther = getByName("jsOther") {
             kotlin.srcDirs("src/other/kotlin/other")
             dependencies {
                 implementation(project(path = project.path))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-multiplatform-app-project/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-multiplatform-app-project/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
     }
 
     sourceSets {
-        val jsTest by getting {
+        val jsTest = getByName("jsTest") {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-multiplatform-library-project/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-multiplatform-library-project/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
     }
 
     sourceSets {
-        val jsTest by getting {
+        val jsTest = getByName("jsTest") {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-plugin-project/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-js-plugin-project/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin.js {
 
 kotlin.js().compilations.create("benchmark") {
     defaultSourceSet.dependencies {
-        val main by kotlin.js().compilations
+        val main = kotlin.js().compilations.getByName("main")
         implementation(main.compileDependencyFiles + main.output.classesDirs)
         runtimeOnly(files(main.runtimeDependencyFiles))
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-multiplatform-browser-project/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-multiplatform-browser-project/app/build.gradle.kts
@@ -14,13 +14,13 @@ kotlin {
     }
 
     sourceSets {
-        val jsMain by getting {
+        val jsMain = getByName("jsMain") {
             dependencies {
                 implementation(project(":lib"))
                 implementation(npm(projectDir.resolve("src/jsMain/css")))
             }
         }
-        val jsTest by getting {
+        val jsTest = getByName("jsTest") {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-multiplatform-browser-project/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin-multiplatform-browser-project/lib/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
     }
 
     sourceSets {
-        val jsMain by getting {
+        val jsMain = getByName("jsMain") {
             dependencies {
                 implementation(project(":base"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlin2JsProjectWithTests/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     mavenCentral()
 }
 
-val kotlin_version: String by extra
+val kotlin_version = extra["kotlin_version"]
 
 kotlin {
     sourceSets {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinPluginDepsInBuildSrc/buildSrc/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinPluginDepsInBuildSrc/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     mavenLocal()
 }
 
-val kotlin_version: String by extra
+val kotlin_version = extra["kotlin_version"]
 allprojects {
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlin_version")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinPluginDepsInBuildSrc/buildSrc/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinPluginDepsInBuildSrc/buildSrc/settings.gradle.kts
@@ -4,8 +4,8 @@ pluginManagement {
         mavenCentral()
     }
 
-    val test_fixes_version: String by settings
-    val kotlin_version: String by settings
+    val test_fixes_version: String = providers.gradleProperty("test_fixes_version").get()
+    val kotlin_version: String = providers.gradleProperty("kotlin_version").get()
     plugins {
         id("org.jetbrains.kotlin.test.fixes.android") version test_fixes_version
         id("org.jetbrains.kotlin.jvm") version kotlin_version

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinxSerializationMppK2/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kotlinxSerializationMppK2/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
                 languageVersion = "2.0"
             }
         }
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies{
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0-RC")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-31468-multiple-jvm-targets-with-java/dependsOnJvmWithJava/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-31468-multiple-jvm-targets-with-java/dependsOnJvmWithJava/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     }
 
     sourceSets {
-        val jvmMain by getting {
+        val jvmMain = getByName("jvmMain") {
             dependencies {
                 api(project(":lib"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-31468-multiple-jvm-targets-with-java/dependsOnPlainJvm/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-31468-multiple-jvm-targets-with-java/dependsOnPlainJvm/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 api(project(":lib"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-36721-mpp-klibs-with-same-name/foo/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-36721-mpp-klibs-with-same-name/foo/build.gradle.kts
@@ -6,7 +6,7 @@ group = "org.sample.one"
 
 kotlin {
     linuxX64("linux") {
-        val bar by compilations["main"].cinterops.creating
+        compilations["main"].cinterops.create("bar")
     }
     js {
         nodejs()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-36721-mpp-klibs-with-same-name/foo/foo/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-36721-mpp-klibs-with-same-name/foo/foo/build.gradle.kts
@@ -6,7 +6,7 @@ group = "org.sample.two"
 
 kotlin {
     linuxX64("linux") {
-        val bar by compilations["main"].cinterops.creating
+        compilations["main"].cinterops.create("bar")
     }
     js {
         nodejs()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-55071-compileSharedNative-withDefaultParameters/consumer/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-55071-compileSharedNative-withDefaultParameters/consumer/build.gradle.kts
@@ -10,13 +10,13 @@ kotlin {
     linuxX64()
     linuxArm64()
 
-    val commonMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val jvmAndJsMain by sourceSets.creating
-    val jvmMain by sourceSets.getting
-    val jsMain by sourceSets.getting
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val jvmAndJsMain = sourceSets.create("jvmAndJsMain")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val jsMain = sourceSets.getByName("jsMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
 
     commonMain.let {
         nativeMain.dependsOn(it)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-55071-compileSharedNative-withDefaultParameters/producer/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-55071-compileSharedNative-withDefaultParameters/producer/build.gradle.kts
@@ -11,14 +11,14 @@ kotlin {
     linuxX64()
     linuxArm64()
 
-    val commonMain by sourceSets.getting
-    val nativeMain by sourceSets.creating
-    val secondCommonMain by sourceSets.creating
-    val jvmAndJsMain by sourceSets.creating
-    val jvmMain by sourceSets.getting
-    val jsMain by sourceSets.getting
-    val linuxX64Main by sourceSets.getting
-    val linuxArm64Main by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val nativeMain = sourceSets.create("nativeMain")
+    val secondCommonMain = sourceSets.create("secondCommonMain")
+    val jvmAndJsMain = sourceSets.create("jvmAndJsMain")
+    val jvmMain = sourceSets.getByName("jvmMain")
+    val jsMain = sourceSets.getByName("jsMain")
+    val linuxX64Main = sourceSets.getByName("linuxX64Main")
+    val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
 
     commonMain.let {
         secondCommonMain.dependsOn(it)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-581450-mpp-native-shared-crash/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-581450-mpp-native-shared-crash/build.gradle.kts
@@ -18,17 +18,17 @@ kotlin {
     linuxX64()
     linuxArm64()
     sourceSets {
-        val commonMain by getting
-        val jvmMain by getting {
+        val commonMain = getByName("commonMain")
+        val jvmMain = getByName("jvmMain") {
             dependsOn(commonMain)
         }
-        val nativeMain by creating {
+        val nativeMain = create("nativeMain") {
             dependsOn(commonMain)
         }
-        val linuxX64Main by getting {
+        val linuxX64Main = getByName("linuxX64Main") {
             dependsOn(nativeMain)
         }
-        val linuxArm64Main by getting {
+        val linuxArm64Main = getByName("linuxArm64Main") {
             dependsOn(nativeMain)
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-59153-default-impl-interface-in-kmp/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-59153-default-impl-interface-in-kmp/app/build.gradle.kts
@@ -9,12 +9,12 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(project(":lib"))
             }
         }
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-63230/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-63230/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     }
 
     sourceSets {
-        val wasmJsTest by getting {
+        val wasmJsTest = getByName("wasmJsTest") {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-65271-test-suite-with-kotlin-test-dependency/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-65271-test-suite-with-kotlin-test-dependency/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named("test", JvmTestSuite::class) {
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-test-junit5")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-69310-duplicateMetadataLibrariesInClasspath/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-69310-duplicateMetadataLibrariesInClasspath/build.gradle.kts
@@ -12,11 +12,10 @@ kotlin {
             api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
         }
 
-        val native1Main by sourceSets.creating { dependsOn(commonMain.get()) }
-        val native2Main by sourceSets.creating { dependsOn(commonMain.get()) }
-        val linuxMain by sourceSets.creating { dependsOn(native1Main); dependsOn(native2Main); }
+        val native1Main = sourceSets.create("native1Main") { dependsOn(commonMain.get()) }
+        val native2Main = sourceSets.create("native2Main") { dependsOn(commonMain.get()) }
+        val linuxMain = sourceSets.create("linuxMain") { dependsOn(native1Main); dependsOn(native2Main); }
         sourceSets.getByName("linuxX64Main") { dependsOn(linuxMain) }
         sourceSets.getByName("linuxArm64Main") { dependsOn(linuxMain) }
     }
 }
-

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-72965-no-pl-warnings-on-SubclassOptInRequired-annotation-site/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-72965-no-pl-warnings-on-SubclassOptInRequired-annotation-site/app/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation("org.sample.kt72965:lib-annotation-site:1.0")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-72965-pl-warnings-on-SubclassOptInRequired-constructor-call/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt-72965-pl-warnings-on-SubclassOptInRequired-constructor-call/app/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation("org.sample.kt72965:lib-constructor-call:1.0")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt64121/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kt64121/build.gradle.kts
@@ -17,13 +17,13 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(kotlin("stdlib-common"))
             }
         }
 
-        val linuxAndJsMain by creating {
+        val linuxAndJsMain = create("linuxAndJsMain") {
             dependsOn(commonMain)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/legacyConfigurationConsumer/consumer/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/legacyConfigurationConsumer/consumer/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("base")
 }
 
-val aggregation by configurations.creating {
+val aggregation = configurations.create("aggregation") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {
@@ -16,7 +16,7 @@ dependencies {
     val projectPath = path
     rootProject.subprojects {
         if (path != projectPath) {
-            aggregation(project)
+            aggregation(this@dependencies.dependencies.project(path))
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/legacyConfigurationConsumer/producer/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/legacyConfigurationConsumer/producer/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("base")
 }
 
-val producerTask by tasks.registering {
+val producerTask = tasks.register("producerTask") {
     val projectName = project.name
     val publishedFile = layout.buildDirectory.file("publication/output.txt")
     outputs.file(publishedFile)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/sample1/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-composite-build/sample1/build.gradle.kts
@@ -14,12 +14,12 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation("included-build:included")
             }
         }
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-test")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-sources-publication/consumer/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-sources-publication/consumer/settings.gradle.kts
@@ -4,8 +4,8 @@ pluginManagement {
 		gradlePluginPortal()
 	}
 	plugins {
-		val kotlin_version: String by settings
-		val test_fixes_version: String by settings
+		val kotlin_version: String = providers.gradleProperty("kotlin_version").get()
+		val test_fixes_version: String = providers.gradleProperty("test_fixes_version").get()
 		kotlin("multiplatform").version(kotlin_version)
 		id("org.jetbrains.kotlin.test.fixes.android") version test_fixes_version
 	}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-sources-publication/producer/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-sources-publication/producer/build.gradle.kts
@@ -19,57 +19,57 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        val commonMain by getting
-        val jvmMain by getting
-        val jvm2Main by getting
-        val linuxX64Main by getting
-        val linuxArm64Main by getting
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosSimulatorArm64Main by getting
+        val commonMain = getByName("commonMain")
+        val jvmMain = getByName("jvmMain")
+        val jvm2Main = getByName("jvm2Main")
+        val linuxX64Main = getByName("linuxX64Main")
+        val linuxArm64Main = getByName("linuxArm64Main")
+        val iosX64Main = getByName("iosX64Main")
+        val iosArm64Main = getByName("iosArm64Main")
+        val iosSimulatorArm64Main = getByName("iosSimulatorArm64Main")
 
-        val commonTest by getting
-        val jvmTest by getting
-        val jvm2Test by getting
-        val linuxX64Test by getting
-        val linuxArm64Test by getting
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosSimulatorArm64Test by getting
+        val commonTest = getByName("commonTest")
+        val jvmTest = getByName("jvmTest")
+        val jvm2Test = getByName("jvm2Test")
+        val linuxX64Test = getByName("linuxX64Test")
+        val linuxArm64Test = getByName("linuxArm64Test")
+        val iosX64Test = getByName("iosX64Test")
+        val iosArm64Test = getByName("iosArm64Test")
+        val iosSimulatorArm64Test = getByName("iosSimulatorArm64Test")
 
-        val iosMain by creating {
+        val iosMain = create("iosMain") {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
             iosSimulatorArm64Main.dependsOn(this)
         }
 
-        val iosTest by creating {
+        val iosTest = create("iosTest") {
             dependsOn(commonMain)
             iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
             iosSimulatorArm64Test.dependsOn(this)
         }
 
-        val linuxMain by creating {
+        val linuxMain = create("linuxMain") {
             dependsOn(commonMain)
             linuxX64Main.dependsOn(this)
             linuxArm64Main.dependsOn(this)
         }
 
-        val linuxTest by creating {
+        val linuxTest = create("linuxTest") {
             dependsOn(commonTest)
             linuxX64Test.dependsOn(this)
             linuxArm64Test.dependsOn(this)
         }
 
-        val commonJvmMain by creating {
+        val commonJvmMain = create("commonJvmMain") {
             dependsOn(commonMain)
             jvmMain.dependsOn(this)
             jvm2Main.dependsOn(this)
         }
 
-        val commonJvmTest by creating {
+        val commonJvmTest = create("commonJvmTest") {
             dependsOn(commonTest)
             jvmTest.dependsOn(this)
             jvm2Test.dependsOn(this)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-sources-publication/producer/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-sources-publication/producer/settings.gradle.kts
@@ -3,9 +3,10 @@ pluginManagement {
 		mavenLocal()
 		gradlePluginPortal()
 	}
-	val kotlin_version: String by settings
+    
 	plugins {
-		val test_fixes_version: String by settings
+        val kotlin_version: String = providers.gradleProperty("kotlin_version").get()
+		val test_fixes_version: String = providers.gradleProperty("test_fixes_version").get()
 		kotlin("multiplatform").version(kotlin_version)
 		id("org.jetbrains.kotlin.test.fixes.android") version test_fixes_version
 	}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-wasm-js-browser-nodejs/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-wasm-js-browser-nodejs/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     }
 
     sourceSets {
-        val wasmJsTest by getting {
+        val wasmJsTest = getByName("wasmJsTest") {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-wasm-published-library/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-wasm-published-library/app/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     }
 
     sourceSets {
-        val wasmJsMain by getting {
+        val wasmJsMain = getByName("wasmJsMain") {
             dependencies {
                 implementation("com.example.mpp-wasm-published-library:library:0.0.1")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-wasm-published-library/library/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mpp-wasm-published-library/library/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
     }
 
     sourceSets {
-        val wasmJsMain by getting {
+        val wasmJsMain = getByName("wasmJsMain") {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_JavaOnly/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/compileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_JavaOnly/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/compileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [compileClasspath]
+root project 'javaOnly' => [compileClasspath]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_JavaOnly/producer_gradle_max_kmp_native_jvm_kgp_snapshot/compileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_JavaOnly/producer_gradle_max_kmp_native_jvm_kgp_snapshot/compileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [compileClasspath]
+root project 'javaOnly' => [compileClasspath]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot-linuxarm64:1.0 => [linuxArm64ApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot:1.0 => [linuxArm64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot-linuxx64:1.0 => [linuxX64ApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot:1.0 => [linuxX64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_max_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_max_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot-linuxarm64:1.0 => [linuxArm64ApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot:1.0 => [linuxArm64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_2_3_0/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot-linuxx64:1.0 => [linuxX64ApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot:1.0 => [linuxX64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_JavaOnly/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_JavaOnly/jvmCompileClasspath.txt
@@ -1,3 +1,3 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_7_6_3:JavaOnly:1.0 => [apiElements]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_JavaOnly/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_JavaOnly/linuxArm64CompileKlibraries.txt
@@ -1,1 +1,1 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_JavaOnly/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_JavaOnly/linuxX64CompileKlibraries.txt
@@ -1,1 +1,1 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_2_3_0/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_2_3_0/jvmCompileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_2_3_0-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_2_3_0:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_2_3_0/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_2_3_0/linuxArm64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_2_3_0-linuxarm64:1.0 => [linuxArm64ApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_2_3_0:1.0 => [linuxArm64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_2_3_0/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_2_3_0/linuxX64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_2_3_0-linuxx64:1.0 => [linuxX64ApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_2_3_0:1.0 => [linuxX64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot-linuxarm64:1.0 => [linuxArm64ApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot:1.0 => [linuxArm64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_7_6_3_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot-linuxx64:1.0 => [linuxX64ApiElements-published]
 sample.gradle_7_6_3:kmp_native_jvm_kgp_snapshot:1.0 => [linuxX64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_JavaOnly/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_JavaOnly/jvmCompileClasspath.txt
@@ -1,3 +1,3 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_max:JavaOnly:1.0 => [apiElements]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_JavaOnly/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_JavaOnly/linuxArm64CompileKlibraries.txt
@@ -1,1 +1,1 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_JavaOnly/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_JavaOnly/linuxX64CompileKlibraries.txt
@@ -1,1 +1,1 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_2_3_0/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_2_3_0/jvmCompileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_max:kmp_native_jvm_kgp_2_3_0-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_2_3_0:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_2_3_0/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_2_3_0/linuxArm64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]
 sample.gradle_max:kmp_native_jvm_kgp_2_3_0-linuxarm64:1.0 => [linuxArm64ApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_2_3_0:1.0 => [linuxArm64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_2_3_0/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_2_3_0/linuxX64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]
 sample.gradle_max:kmp_native_jvm_kgp_2_3_0-linuxx64:1.0 => [linuxX64ApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_2_3_0:1.0 => [linuxX64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_snapshot/jvmCompileClasspath.txt
@@ -1,4 +1,4 @@
 org.jetbrains:annotations:13.0 => [compile]
-root project : => [jvmCompileClasspath]
+root project 'kmp' => [jvmCompileClasspath]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot-jvm:1.0 => [jvmApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot:1.0 => [jvmApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxArm64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxArm64CompileKlibraries]
+root project 'kmp' => [linuxArm64CompileKlibraries]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot-linuxarm64:1.0 => [linuxArm64ApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot:1.0 => [linuxArm64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/mppPublicationCompatibility/expectedData/consumer_gradle_max_kmp_native_jvm_kgp_snapshot/producer_gradle_max_kmp_native_jvm_kgp_snapshot/linuxX64CompileKlibraries.txt
@@ -1,3 +1,3 @@
-root project : => [linuxX64CompileKlibraries]
+root project 'kmp' => [linuxX64CompileKlibraries]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot-linuxx64:1.0 => [linuxX64ApiElements-published]
 sample.gradle_max:kmp_native_jvm_kgp_snapshot:1.0 => [linuxX64ApiElements-published]

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidSourceSetLayout2/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/multiplatformAndroidSourceSetLayout2/build.gradle.kts
@@ -44,12 +44,12 @@ kotlin {
         compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
     }
 
-    val commonMain by sourceSets.getting
-    val commonTest by sourceSets.getting
-    val androidMain by sourceSets.getting
+    val commonMain = sourceSets.getByName("commonMain")
+    val commonTest = sourceSets.getByName("commonTest")
+    val androidMain = sourceSets.getByName("androidMain")
 
-    val androidUnitTest by sourceSets.getting
-    val androidInstrumentedTest by sourceSets.getting
+    val androidUnitTest = sourceSets.getByName("androidUnitTest")
+    val androidInstrumentedTest = sourceSets.getByName("androidInstrumentedTest")
 
     commonTest.dependencies {
         implementation(kotlin("test-junit"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-ios/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-ios/lib/build.gradle.kts
@@ -24,9 +24,9 @@ kotlin {
     }
 
     sourceSets {
-        val iosLibMain by creating
-        val iosLibX64Main by getting
-        val iosLibArm64Main by getting
+        val iosLibMain = create("iosLibMain")
+        val iosLibX64Main = getByName("iosLibX64Main")
+        val iosLibArm64Main = getByName("iosLibArm64Main")
         iosLibX64Main.dependsOn(iosLibMain)
         iosLibArm64Main.dependsOn(iosLibMain)
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-tvos/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-tvos/lib/build.gradle.kts
@@ -24,9 +24,9 @@ kotlin {
     }
 
     sourceSets {
-        val tvosLibMain by creating
-        val tvosLibX64Main by getting
-        val tvosLibArm64Main by getting
+        val tvosLibMain = create("tvosLibMain")
+        val tvosLibX64Main = getByName("tvosLibX64Main")
+        val tvosLibArm64Main = getByName("tvosLibArm64Main")
         tvosLibX64Main.dependsOn(tvosLibMain)
         tvosLibArm64Main.dependsOn(tvosLibMain)
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-watchos/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-watchos/app/build.gradle.kts
@@ -26,19 +26,19 @@ kotlin {
     }
 
     sourceSets {
-        val watchosMain by creating
-        val watchosDeviceMain by creating
-        val watchosTest by creating
+        val watchosMain = create("watchosMain")
+        val watchosDeviceMain = create("watchosDeviceMain")
+        val watchosTest = create("watchosTest")
 
-        val watchosSimulatorArm64Main by getting
-        val watchosDeviceArm64Main by getting
-        val watchosArm64Main by getting
-        val watchosX64Main by getting
+        val watchosSimulatorArm64Main = getByName("watchosSimulatorArm64Main")
+        val watchosDeviceArm64Main = getByName("watchosDeviceArm64Main")
+        val watchosArm64Main = getByName("watchosArm64Main")
+        val watchosX64Main = getByName("watchosX64Main")
 
-        val watchosSimulatorArm64Test by getting
-        val watchosDeviceArm64Test by getting
-        val watchosArm64Test by getting
-        val watchosX64Test by getting
+        val watchosSimulatorArm64Test = getByName("watchosSimulatorArm64Test")
+        val watchosDeviceArm64Test = getByName("watchosDeviceArm64Test")
+        val watchosArm64Test = getByName("watchosArm64Test")
+        val watchosX64Test = getByName("watchosX64Test")
 
         watchosDeviceMain.dependsOn(watchosMain)
         watchosX64Main.dependsOn(watchosMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-watchos/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-apple-devices-common/common-watchos/lib/build.gradle.kts
@@ -34,13 +34,13 @@ kotlin {
     }
 
     sourceSets {
-        val watchosLibMain by creating
-        val watchosLibDeviceMain by creating
+        val watchosLibMain = create("watchosLibMain")
+        val watchosLibDeviceMain = create("watchosLibDeviceMain")
 
-        val watchosLibDeviceArm64Main by getting
-        val watchosLibSimulatorArm64Main by getting
-        val watchosLibArm64Main by getting
-        val watchosLibX64Main by getting
+        val watchosLibDeviceArm64Main = getByName("watchosLibDeviceArm64Main")
+        val watchosLibSimulatorArm64Main = getByName("watchosLibSimulatorArm64Main")
+        val watchosLibArm64Main = getByName("watchosLibArm64Main")
+        val watchosLibX64Main = getByName("watchosLibX64Main")
 
         watchosLibDeviceMain.dependsOn(watchosLibMain)
         watchosLibX64Main.dependsOn(watchosLibMain)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/export-published-lib/shared/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/export-published-lib/shared/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 api("com.example:lib:1.0")
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/frameworks/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/frameworks/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
         attributes.attribute(disambiguation1Attribute, "someValue")
         binaries {
             framework("main") {
-                export(project(":exported"))
+                export(dependencies.project(":exported"))
             }
             framework("custom") {
                 linkerOpts = mutableListOf("-L.")
@@ -35,7 +35,7 @@ kotlin {
     iosX64("iosSim") {
         binaries {
             framework("main") {
-                export(project(":exported"))
+                export(dependencies.project(":exported"))
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/groovy-dsl/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/groovy-dsl/build.gradle
@@ -66,10 +66,10 @@ kotlin {
                 }
 
                 sharedLib([RELEASE]) {
-                    export project(':exported')
+                    export(dependencies.project(path: ":exported"))
                 }
                 staticLib([RELEASE]) {
-                    export project(':exported')
+                    export(dependencies.project(path: ":exported"))
                 }
             }
             // Check that we can access binaries/tasks:

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/kotlin-dsl/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/kotlin-dsl/build.gradle.kts
@@ -56,10 +56,10 @@ kotlin {
             }
 
             sharedLib(listOf(RELEASE)) {
-                export(project(":exported"))
+                export(dependencies.project(":exported"))
             }
             staticLib(listOf(RELEASE)) {
-                export(project(":exported"))
+                export(dependencies.project(":exported"))
             }
         }
         // Check that we can access binaries/tasks:

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/libraries/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-binaries/libraries/build.gradle.kts
@@ -17,10 +17,10 @@ kotlin {
     <SingleNativeTarget>("host") {
         binaries {
             sharedLib() {
-                export(project(":exported"))
+                export(dependencies.project(":exported"))
             }
             staticLib() {
-                export(project(":exported"))
+                export(dependencies.project(":exported"))
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-build-cache/build-cache-app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-build-cache/build-cache-app/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
     }
 
     sourceSets {
-        val hostMain by getting {
+        val hostMain = getByName("hostMain") {
             dependencies {
                 implementation("com.example:build-cache-lib:1.0")
                 api(project(":build-cache-app:lib-module"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-configuration-cache/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-configuration-cache/lib/build.gradle.kts
@@ -30,9 +30,9 @@ kotlin {
 
     targets.filterIsInstance<KotlinNativeTarget>().forEach {
         it.compilations {
-            val main by getting {
+            val main = getByName("main") {
                 cinterops {
-                    val myCinterop by creating {
+                    val myCinterop = create("myCinterop") {
                         defFile(project.file("src/my.def"))
                     }
                 }
@@ -41,7 +41,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-download-maven/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-download-maven/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 kotlin {
-    val nativeMain by sourceSets.creating {
+    val nativeMain = sourceSets.create("nativeMain") {
         dependsOn(sourceSets["commonMain"])
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-incremental-multi-project/program/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-incremental-multi-project/program/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(project(":library"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-platform-libraries/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-platform-libraries/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 kotlin {
-    val nativeMain by sourceSets.creating {
+    val nativeMain = sourceSets.create("nativeMain") {
         dependsOn(sourceSets["commonMain"])
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-root-project-name-with-space/module1/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-root-project-name-with-space/module1/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(project(":module2"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-root-project-name-with-space/module2/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-root-project-name-with-space/module2/build.gradle.kts
@@ -6,6 +6,6 @@ kotlin {
     <SingleNativeTarget>("host")
 
     sourceSets {
-        val commonMain by getting
+        val commonMain = getByName("commonMain")
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-tests/build.gradle.kts
@@ -22,8 +22,8 @@ kotlin {
     iosSimulatorArm64("iosArm64")
 
     sourceSets {
-        val anotherTest by creating
-        val hostAnotherTest by getting {
+        val anotherTest = create("anotherTest")
+        val hostAnotherTest = getByName("hostAnotherTest") {
             dependsOn(anotherTest)
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-with-configuration-cache/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/native-with-configuration-cache/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 kotlin {
-    val nativeMain by sourceSets.creating {
+    val nativeMain = sourceSets.create("nativeMain") {
         dependsOn(sourceSets["commonMain"])
     }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-model-in-old-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-model-in-old-plugin/build.gradle.kts
@@ -21,20 +21,20 @@ kotlin {
     }
 
     target.compilations {
-        val main by getting {
+        val main = getByName("main") {
             defaultSourceSet.dependencies {
                 api(kotlin("gradle-plugin-api"))
                 implementation(kotlin("stdlib-jdk8"))
             }
         }
 
-        val test by getting {
+        val test = getByName("test") {
             defaultSourceSet.dependencies {
                 implementation(kotlin("test-junit"))
             }
         }
 
-        val benchmark by creating {
+        val benchmark = create("benchmark") {
             associateWith(main)
             defaultSourceSet.dependencies {
                 implementation(kotlin("reflect"))
@@ -43,7 +43,7 @@ kotlin {
     }
 }
 
-val runBenchmark by tasks.registering(JavaExec::class) {
+val runBenchmark = tasks.register("runBenchmark", JavaExec::class) {
     classpath = kotlin.target.compilations["benchmark"].run { runtimeDependencyFiles + output.allOutputs }
     mainClass.set("com.example.ABenchmarkKt")
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-android-agp-compatibility/producer/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-android-agp-compatibility/producer/build.gradle.kts
@@ -1,4 +1,4 @@
-val kotlin_version: String by extra
+val kotlin_version = extra["kotlin_version"]
 plugins {
     `maven-publish`
     id("com.android.library")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-associate-compilations/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-associate-compilations/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
         }
     }
 
-    val commonIntegrationTest by sourceSets.creating
+    val commonIntegrationTest = sourceSets.create("commonIntegrationTest")
 
     jvm {
         compilations["test"].defaultSourceSet.dependencies {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-app-gradle-kotlin-dsl/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-app-gradle-kotlin-dsl/build.gradle.kts
@@ -43,21 +43,21 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation("com.example:sample-lib:1.0")
             }
         }
-        val allJvm by creating {
+        val allJvm = create("allJvm") {
             dependsOn(commonMain)
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-stdlib")
             }
         }
-        val jvm6Main by getting {
+        val jvm6Main = getByName("jvm6Main") {
             dependsOn(allJvm)
         }
-        val jvm8Main by getting {
+        val jvm8Main = getByName("jvm8Main") {
             dependsOn(allJvm)
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-lib-gradle-kotlin-dsl/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-and-app/sample-lib-gradle-kotlin-dsl/build.gradle.kts
@@ -44,21 +44,21 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
-        val jvm6Main by getting {
+        val jvm6Main = getByName("jvm6Main") {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:0.23.4")
             }
         }
-        val jvm6Test by getting {
+        val jvm6Test = getByName("jvm6Test") {
             dependencies {
                 implementation(kotlin("test-junit"))
             }
         }
 
-        val nativeMain by creating { dependsOn(commonMain.get()) }
-        val linux64Main by getting { dependsOn(nativeMain) }
-        val macos64Main by getting { dependsOn(nativeMain) }
-        val macosArm64Main by getting { dependsOn(nativeMain) }
+        val nativeMain = create("nativeMain") { dependsOn(commonMain.get()) }
+        val linux64Main = getByName("linux64Main") { dependsOn(nativeMain) }
+        val macos64Main = getByName("macos64Main") { dependsOn(nativeMain) }
+        val macosArm64Main = getByName("macosArm64Main") { dependsOn(nativeMain) }
     }
 }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-with-tests/alternative.build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-lib-with-tests/alternative.build.gradle.kts
@@ -21,12 +21,11 @@ kotlin {
     val mingw64 = mingwX64("mingw64")
 
     sourceSets {
-        val commonMain by getting
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
+        val commonMain = getByName("commonMain")
+        val commonTest = getByName("commonTest")
+        commonTest.dependencies {
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
         }
 
         jvmWithoutJava.compilations["main"].defaultSourceSet {
@@ -48,9 +47,9 @@ kotlin {
             }
         }
 
-        val nativeMain by creating {
-            dependsOn(commonMain)
-        }
+        val nativeMain = create("nativeMain")
+        nativeMain.dependsOn(commonMain)
+
         configure(listOf(macos64, macosArm64, linux64, mingw64)) {
             compilations["main"].defaultSourceSet.dependsOn(nativeMain)
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-published/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/new-mpp-published/build.gradle.kts
@@ -19,32 +19,32 @@ kotlin {
     wasmJs()
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(kotlin("stdlib-common"))
             }
         }
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
 
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val linuxAndJsMain by creating {
+        val linuxAndJsMain = create("linuxAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val linuxAndJsTest by creating {
+        val linuxAndJsTest = create("linuxAndJsTest") {
             dependsOn(commonTest)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/powerAssertSimple/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/powerAssertSimple/build.gradle.kts
@@ -9,18 +9,18 @@ kotlin {
     linuxX64()
 
     sourceSets {
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
-        val jvmTest by getting {
+        val jvmTest = getByName("jvmTest") {
             dependencies {
                 implementation(kotlin("test-junit"))
             }
         }
-        val jsTest by getting {
+        val jsTest = getByName("jsTest") {
             dependencies {
                 implementation(kotlin("test-js"))
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/sharedAppleFramework/shared/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/sharedAppleFramework/shared/build.gradle.kts
@@ -23,13 +23,13 @@ kotlin {
         }
     }
     sourceSets {
-        val commonMain by getting
+        val commonMain = getByName("commonMain")
 
-        val iosX64Main by getting
-        val iosSimulatorArm64Main by getting
-        val iosArm64Main by getting
+        val iosX64Main = getByName("iosX64Main")
+        val iosSimulatorArm64Main = getByName("iosSimulatorArm64Main")
+        val iosArm64Main = getByName("iosArm64Main")
 
-        val iosMain by creating {
+        val iosMain = create("iosMain") {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosSimulatorArm64Main.dependsOn(this)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressGradlePluginErrors/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressGradlePluginErrors/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
     jvm()
 
     sourceSets {
-        val myCustomSourceSet by creating
+        val myCustomSourceSet = create("myCustomSourceSet")
         commonMain.get().dependsOn(myCustomSourceSet)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressGradlePluginFatals/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressGradlePluginFatals/build.gradle.kts
@@ -11,9 +11,9 @@ kotlin {
     jvm()
 
     sourceSets {
-        val intermediate by creating
+        val intermediate = create("intermediate")
 
-        val jvmMain by getting {
+        val jvmMain = getByName("jvmMain") {
             dependsOn(intermediate)
         }
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressGradlePluginWarnings/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/suppressGradlePluginWarnings/build.gradle.kts
@@ -11,6 +11,6 @@ kotlin {
     jvm()
 
     sourceSets {
-        val orphan by creating { }
+        val orphan = create("orphan") { }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/transitive-dep-on-self-hmpp/lib/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/transitive-dep-on-self-hmpp/lib/build.gradle.kts
@@ -9,13 +9,13 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 implementation(kotlin("stdlib-common"))
             }
         }
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(project(":libtests"))
                 implementation(kotlin("test-common"))
@@ -23,36 +23,36 @@ kotlin {
             }
         }
 
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val jvmMain by getting {
+        val jvmMain = getByName("jvmMain") {
             dependsOn(jvmAndJsMain)
             dependencies {
                 implementation(kotlin("stdlib-jdk8"))
             }
         }
 
-        val jvmTest by getting {
+        val jvmTest = getByName("jvmTest") {
             dependsOn(jvmAndJsTest)
             dependencies {
                 implementation(kotlin("test-junit"))
             }
         }
 
-        val jsMain by getting {
+        val jsMain = getByName("jsMain") {
             dependsOn(jvmAndJsMain)
             dependencies {
                 implementation(kotlin("stdlib-js"))
             }
         }
 
-        val jsTest by getting {
+        val jsTest = getByName("jsTest") {
             dependsOn(jvmAndJsTest)
             dependencies {
                 implementation(kotlin("test-js"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/transitive-dep-on-self-hmpp/libtests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/transitive-dep-on-self-hmpp/libtests/build.gradle.kts
@@ -9,50 +9,50 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 api(project(":lib"))
                 implementation(kotlin("stdlib-common"))
             }
         }
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
 
-        val jvmAndJsMain by creating {
+        val jvmAndJsMain = create("jvmAndJsMain") {
             dependsOn(commonMain)
         }
 
-        val jvmAndJsTest by creating {
+        val jvmAndJsTest = create("jvmAndJsTest") {
             dependsOn(commonTest)
         }
 
-        val jvmMain by getting {
+        val jvmMain = getByName("jvmMain") {
             dependsOn(jvmAndJsMain)
             dependencies {
                 implementation(kotlin("stdlib-jdk8"))
             }
         }
 
-        val jvmTest by getting {
+        val jvmTest = getByName("jvmTest") {
             dependsOn(jvmAndJsTest)
             dependencies {
                 implementation(kotlin("test-junit"))
             }
         }
 
-        val jsMain by getting {
+        val jsMain = getByName("jsMain") {
             dependsOn(jvmAndJsMain)
             dependencies {
                 implementation(kotlin("stdlib-js"))
             }
         }
 
-        val jsTest by getting {
+        val jsTest = getByName("jsTest") {
             dependsOn(jvmAndJsTest)
             dependencies {
                 implementation(kotlin("test-js"))

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/yarn-setup/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/yarn-setup/build.gradle.kts
@@ -19,14 +19,14 @@ kotlin.js {
 
 tasks {
     val yarnSpec = project.the<YarnRootEnvSpec>()
-    val yarnFolderRemove by registering {
+    val yarnFolderRemove = register("yarnFolderRemove") {
         val installationDirectory = yarnSpec.installationDirectory
         doLast {
             installationDirectory.get().asFile.deleteRecursively()
         }
     }
 
-    val yarnFolderCheck by registering {
+    val yarnFolderCheck = register("yarnFolderCheck") {
         dependsOn(getByName("kotlinYarnSetup"))
         val installationDirectory = yarnSpec.installationDirectory
 
@@ -37,7 +37,7 @@ tasks {
         }
     }
 
-    val yarnConcreteVersionFolderChecker by registering {
+    val yarnConcreteVersionFolderChecker = register("yarnConcreteVersionFolderChecker") {
         dependsOn(getByName("kotlinYarnSetup"))
         val installationDirectory = yarnSpec.installationDirectory
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/BuildToolsApiCompilationWork.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/BuildToolsApiCompilationWork.kt
@@ -219,9 +219,6 @@ internal abstract class BuildToolsApiCompilationWork @Inject constructor(
             }
             throw e
         } finally {
-            // Replay buffered compiler diagnostics on the worker thread (see ProblemsApiCompilerMessageRenderer).
-            compilerMessageRenderer.replayTo(compilerDiagnosticsProblemsReporter)
-
             val taskInfo = TaskExecutionInfo(
                 kotlinLanguageVersion = workArguments.kotlinLanguageVersion,
                 changedFiles = workArguments.incrementalCompilationEnvironment?.changedFiles,
@@ -245,6 +242,10 @@ internal abstract class BuildToolsApiCompilationWork @Inject constructor(
                 TaskExecutionResult(buildMetrics = metrics.getMetrics(), taskInfo = taskInfo, icLogLines = printingLogger.capturedLines)
             TaskExecutionResults[workArguments.taskPath] = result
             backup?.deleteSnapshot()
+
+            // Replay buffered compiler diagnostics on the worker thread (see ProblemsApiCompilerMessageRenderer).
+            // Throws an exception on error, so should be last in `finally` block
+            compilerMessageRenderer.replayTo(compilerDiagnosticsProblemsReporter)
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/BuildToolsApiCompilationWork.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/BuildToolsApiCompilationWork.kt
@@ -125,6 +125,9 @@ internal abstract class BuildToolsApiCompilationWork @Inject constructor(
             )
 
             if (tryFallback) {
+                // We don't want to fail the build on Gradle 9.6+ because of error diagnostic from initial attempt
+                compilerMessageRenderer.lowerErrorSeveritiesToWarning()
+
                 val compilationResult = runner.performCompilation(
                     buildSession,
                     KotlinCompilerExecutionStrategy.IN_PROCESS,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/ProblemsApiCompilerMessageRenderer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/ProblemsApiCompilerMessageRenderer.kt
@@ -35,6 +35,23 @@ internal class ProblemsApiCompilerMessageRenderer(
 ) : CompilerMessageRendererWithDiagnosticId {
     private val bufferedDiagnostics = ConcurrentLinkedQueue<BufferedDiagnostic>()
 
+    /**
+     * Changes for all already received diagnostics error severity to warning.
+     */
+    @Synchronized
+    fun lowerErrorSeveritiesToWarning() {
+        val errors = bufferedDiagnostics.toList()
+
+        bufferedDiagnostics.clear()
+        bufferedDiagnostics.addAll(errors.map {
+            if (it.severity == CompilerMessageRenderer.Severity.ERROR) {
+                it.copy(severity = CompilerMessageRenderer.Severity.WARNING)
+            } else {
+                it
+            }
+        })
+    }
+
     override fun render(
         severity: CompilerMessageRenderer.Severity,
         message: String,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporter.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporter.kt
@@ -56,16 +56,17 @@ internal abstract class DefaultCompilerDiagnosticsProblemsReporter @Inject const
             }
 
         try {
-            when(severity) {
+            when (severity) {
                 // It is expected that error messages are coming within task action, and it is ok to throw failing the build
                 // Anyway compilation task will fail
                 CompilerMessageRenderer.Severity.ERROR -> problems.reporter
                     .throwing(CompilationErrorException(message), problemId) {
                         it.populateSpec()
                     }
-                else -> problems.reporter.report(problemId) {
+                CompilerMessageRenderer.Severity.WARNING -> problems.reporter.report(problemId) {
                     it.populateSpec()
                 }
+                else -> Unit
             }
         } catch (e: NoSuchMethodError) {
             logger.error("Can't invoke reporter method:", e)


### PR DESCRIPTION
- **[Gradle] Fix info and debug compiler messages are sent into Problems API**
- **[Gradle] Fix some finalization operations on compilation error are skipped**
- **[Gradle] Lower severity for received messages in failed via daemon compilation**
- **[Gradle] Run tests against Gradle 9.6.0 release**
