### PR TITLE
[K/N] Remove eager GlobalData initialization

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -322,13 +322,6 @@ class NativeSecondStageCompilationConfig(
             configuration.get(BinaryOptions.forceNativeThreadStateForFunctions)?.toSet()
                     ?: defaultForceNativeThreadStateForFunctions
 
-    val globalDataLazyInit: Boolean
-        get() = configuration.get(BinaryOptions.globalDataLazyInit)?.also {
-            if (!it) {
-                configuration.report(CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING, "Eager Global Data initialization is deprecated")
-            }
-        } ?: true
-
     private val defaultGenericSafeCasts = !optimizationsEnabled // For now disabled in -opt due to performance penalty.
     val genericSafeCasts: Boolean by lazy {
         configuration.get(BinaryOptions.genericSafeCasts)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
@@ -324,6 +324,14 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
 
     putIfNotNull(LLVM_MODULE_PASSES, arguments.llvmModulePasses)
     putIfNotNull(LLVM_LTO_PASSES, arguments.llvmLTOPasses)
+
+    get(BinaryOptions.globalDataLazyInit)?.let {
+        if (!it) {
+            report(KONAN_ARGUMENT_ERROR, "Eager Global Data initialization is no longer supported")
+        } else {
+            report(KONAN_ARGUMENT_STRONG_WARNING, "Binary option globalDataLazyInit is deprecated and will be removed in a future release")
+        }
+    }
 }
 
 private fun String.absoluteNormalizedFile() = java.io.File(this).absoluteFile.normalize()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -2671,7 +2671,6 @@ internal class CodeGeneratorVisitor(
             overrideRuntimeGlobal(NativeRuntimeOverridableConstants.OBJC_DSIPOSE_WITH_RUN_LOOP, context.config.objcDisposeWithRunLoop.toLlvmConstInt32())
 
             overrideRuntimeGlobal(NativeRuntimeOverridableConstants.ENABLE_SAFEPOINT_SIGNPOSTS, context.config.enableSafepointSignposts.toLlvmConstInt32())
-            overrideRuntimeGlobal(NativeRuntimeOverridableConstants.GLOBAL_DATA_LAZY_INIT, context.config.globalDataLazyInit.toLlvmConstInt32())
             overrideRuntimeGlobal(NativeRuntimeOverridableConstants.SWIFT_EXPORT, context.config.swiftExport.toLlvmConstInt32())
             overrideRuntimeGlobal(NativeRuntimeOverridableConstants.LATIN1_STRINGS, context.config.latin1Strings.toLlvmConstInt32())
             overrideRuntimeGlobal(NativeRuntimeOverridableConstants.MMAP_TAG, context.config.mmapTag.toLlvmConstUInt8())

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/NativeRuntimeOverridableConstants.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/NativeRuntimeOverridableConstants.kt
@@ -34,7 +34,6 @@ object NativeRuntimeOverridableConstants {
     const val OBJC_DSIPOSE_WITH_RUN_LOOP: String = "Kotlin_objcDisposeWithRunLoop"
 
     const val ENABLE_SAFEPOINT_SIGNPOSTS: String = "Kotlin_enableSafepointSignposts"
-    const val GLOBAL_DATA_LAZY_INIT: String = "Kotlin_globalDataLazyInit"
     const val SWIFT_EXPORT: String = "Kotlin_swiftExport"
     const val LATIN1_STRINGS: String = "Kotlin_latin1Strings"
     const val MMAP_TAG: String = "Kotlin_mmapTag"

--- a/kotlin-native/runtime/src/main/cpp/CompilerConstants.cpp
+++ b/kotlin-native/runtime/src/main/cpp/CompilerConstants.cpp
@@ -34,7 +34,6 @@ RUNTIME_WEAK int32_t Kotlin_appStateTracking = 0;
 RUNTIME_WEAK int32_t Kotlin_objcDisposeOnMain = 0;
 RUNTIME_WEAK int32_t Kotlin_objcDisposeWithRunLoop = 1;
 RUNTIME_WEAK int32_t Kotlin_enableSafepointSignposts = 0;
-RUNTIME_WEAK int32_t Kotlin_globalDataLazyInit = 1;
 RUNTIME_WEAK int32_t Kotlin_swiftExport = 0;
 RUNTIME_WEAK int32_t Kotlin_latin1Strings = 0;
 RUNTIME_WEAK uint8_t Kotlin_mmapTag = 0;
@@ -90,10 +89,6 @@ ALWAYS_INLINE bool compiler::objcDisposeWithRunLoop() noexcept {
 
 ALWAYS_INLINE bool compiler::enableSafepointSignposts() noexcept {
     return Kotlin_enableSafepointSignposts != 0;
-}
-
-ALWAYS_INLINE bool compiler::globalDataLazyInit() noexcept {
-    return Kotlin_globalDataLazyInit != 0;
 }
 
 ALWAYS_INLINE bool compiler::swiftExport() noexcept {

--- a/kotlin-native/runtime/src/main/cpp/CompilerConstants.hpp
+++ b/kotlin-native/runtime/src/main/cpp/CompilerConstants.hpp
@@ -95,7 +95,6 @@ bool coreSymbolicationUseOnlyKotlinImage() noexcept;
 bool objcDisposeOnMain() noexcept;
 bool objcDisposeWithRunLoop() noexcept;
 bool enableSafepointSignposts() noexcept;
-bool globalDataLazyInit() noexcept;
 bool swiftExport() noexcept;
 bool latin1Strings() noexcept;
 uint8_t mmapTag() noexcept;

--- a/kotlin-native/runtime/src/mm/cpp/GlobalData.cpp
+++ b/kotlin-native/runtime/src/mm/cpp/GlobalData.cpp
@@ -51,30 +51,6 @@ SpinLock globalDataInitMutex;
 [[clang::no_destroy]] std::condition_variable globalDataInitCV;
 #endif
 
-void constructGlobalDataInstance() noexcept {
-    std::unique_lock guard{globalDataInitMutex};
-    auto initialState = InitState::kUninitialized;
-    globalDataInitState.compare_exchange_strong(initialState, InitState::kInitializing, std::memory_order_acq_rel);
-    RuntimeAssert(initialState == InitState::kUninitialized, "Expected state %s, but was %s", initStateToString(InitState::kUninitialized), initStateToString(initialState));
-    globalDataInitializingThread.store(std::this_thread::get_id(), std::memory_order_relaxed);
-
-    globalDataInstance.construct();
-
-    auto initializingState = InitState::kInitializing;
-    globalDataInitState.compare_exchange_strong(initializingState, InitState::kInitialized, std::memory_order_acq_rel);
-    RuntimeAssert(initializingState == InitState::kInitializing, "Expected state %s, but was %s", initStateToString(InitState::kInitializing), initStateToString(initializingState));
-    guard.unlock();
-    globalDataInitCV.notify_all();
-}
-
-[[maybe_unused]] struct GlobalDataEagerInit {
-    GlobalDataEagerInit() noexcept {
-        if (!compiler::globalDataLazyInit()) {
-            constructGlobalDataInstance();
-        }
-    }
-} globalDataEagerInit;
-
 }
 
 // static
@@ -89,9 +65,19 @@ mm::GlobalData& mm::GlobalData::Instance() noexcept {
 
 // static
 void mm::GlobalData::init() noexcept {
-    if (compiler::globalDataLazyInit()) {
-        constructGlobalDataInstance();
-    }
+    std::unique_lock guard{globalDataInitMutex};
+    auto initialState = InitState::kUninitialized;
+    globalDataInitState.compare_exchange_strong(initialState, InitState::kInitializing, std::memory_order_acq_rel);
+    RuntimeAssert(initialState == InitState::kUninitialized, "Expected state %s, but was %s", initStateToString(InitState::kUninitialized), initStateToString(initialState));
+    globalDataInitializingThread.store(std::this_thread::get_id(), std::memory_order_relaxed);
+
+    globalDataInstance.construct();
+
+    auto initializingState = InitState::kInitializing;
+    globalDataInitState.compare_exchange_strong(initializingState, InitState::kInitialized, std::memory_order_acq_rel);
+    RuntimeAssert(initializingState == InitState::kInitializing, "Expected state %s, but was %s", initStateToString(InitState::kInitializing), initStateToString(initializingState));
+    guard.unlock();
+    globalDataInitCV.notify_all();
 }
 
 void mm::waitGlobalDataInitialized() noexcept {


### PR DESCRIPTION
globalDataLazyInit=false was deprecated with a warning in 2.3.0-Beta1.

This commit:
- promotes deprecation to an error
- deprecates the binary option itself with a warning
- removes eager initialization paths

^KT-80005