### PR TITLE
[BTA] Allow BTA version generation on TeamCity

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/Main.kt
+++ b/compiler/build-tools/kotlin-build-tools-generator/src/org/jetbrains/kotlin/buildtools/generator/Main.kt
@@ -167,6 +167,7 @@ private fun generateBtaVersion(localArgs: Array<String>, genDir: Path, kotlinVer
             file = genFile.toFile(),
             newText = content,
             logNotChanged = false,
+            forbidGenerationOnTeamcity = false
         )
         generatedFiles.add(genFile)
     }


### PR DESCRIPTION
The only valid case for regenerating the BTA version is when bumping the Kotlin version. To avoid blocking releases, this class should be generated automatically on CI.