### PR TITLE
Move the only test from diagnostics/testsWithJvmBackend to diagnostics/tests/jvm

### DIFF
--- a/compiler/testData/diagnostics/tests/jvm/companionBlocksAndExtensions/conflictsStatic.kt
+++ b/compiler/testData/diagnostics/tests/jvm/companionBlocksAndExtensions/conflictsStatic.kt
@@ -15,3 +15,6 @@ class A {
     }
 
 }
+
+/* GENERATED_FIR_TAGS: classDeclaration, companionObject, functionDeclaration, objectDeclaration, propertyDeclaration,
+stringLiteral */


### PR DESCRIPTION
The inclusion of companionBlocksAndExtensions/conflictsStatic.kt and the migration from testsWithJvmBackend to tests/jvm happened almost at the same time, which lead to conflictsStatic.kt being the only test in testsWithJvmBackend.