### PR TITLE
Build: Don't allow tests ending with ' (apostrophe) symbol

### DIFF
--- a/compiler/util-klib/test/org/jetbrains/kotlin/library/NativeKlibPlatformCheckerTest.kt
+++ b/compiler/util-klib/test/org/jetbrains/kotlin/library/NativeKlibPlatformCheckerTest.kt
@@ -24,7 +24,7 @@ class NativeKlibPlatformCheckerTest {
     private lateinit var tmpDir: Path
 
     @Test
-    fun `No or empty 'native_targets', no or empty 'commonizer_native_targets'`() {
+    fun `No or empty native_targets, no or empty commonizer_native_targets`() {
         listOf(
             mockKlib(nativeTargets = null, nativeCommonizerTargets = null),
             mockKlib(nativeTargets = emptyList(), nativeCommonizerTargets = null),
@@ -44,7 +44,7 @@ class NativeKlibPlatformCheckerTest {
     }
 
     @Test
-    fun `Non-empty 'native_targets', no or empty 'commonizer_native_targets'`() {
+    fun `Non-empty native_targets, no or empty commonizer_native_targets`() {
         listOf(
             mockKlib(nativeTargets = listOf("target_a", "target_b"), nativeCommonizerTargets = null),
             mockKlib(nativeTargets = listOf("target_a", "target_b"), nativeCommonizerTargets = emptyList()),
@@ -62,7 +62,7 @@ class NativeKlibPlatformCheckerTest {
     }
 
     @Test
-    fun `No or empty 'native_targets', non-empty 'commonizer_native_targets'`() {
+    fun `No or empty native_targets, non-empty commonizer_native_targets`() {
         listOf(
             mockKlib(nativeTargets = null, nativeCommonizerTargets = listOf("target_a", "target_b")),
             mockKlib(nativeTargets = emptyList(), nativeCommonizerTargets = listOf("target_a", "target_b")),
@@ -80,7 +80,7 @@ class NativeKlibPlatformCheckerTest {
     }
 
     @Test
-    fun `Non-empty 'native_targets', non-empty 'commonizer_native_targets'`() {
+    fun `Non-empty native_targets, non-empty commonizer_native_targets`() {
         val klib = mockKlib(nativeTargets = listOf("target_a", "target_b"), nativeCommonizerTargets = listOf("target_c", "target_d"))
 
         klib.assertLoadedWith(KlibPlatformChecker.Native())

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/FutureTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/FutureTest.kt
@@ -157,7 +157,7 @@ class FutureTest {
     }
 
     @Test
-    fun `test - future with CoroutineStart 'Default'`() = project.runLifecycleAwareTest {
+    fun `test - future with CoroutineStart Default`() = project.runLifecycleAwareTest {
         val future = project.future(CoroutineStart.Default) {}
         assertFailsWith<IllegalLifecycleException> { future.getOrThrow() }
         future.await()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/sources/android/MultiplatformAndroidSourceSetLayoutV2Test.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/sources/android/MultiplatformAndroidSourceSetLayoutV2Test.kt
@@ -40,7 +40,7 @@ class MultiplatformAndroidSourceSetLayoutV2Test {
     }
 
     @Test
-    fun `test - main SourceSet - is called 'androidMain'`() {
+    fun `test - main SourceSet - is called androidMain`() {
         @Suppress("DEPRECATION")
         kotlin.androidTarget()
         assertEquals("androidMain", project.getKotlinSourceSetOrFail(android.sourceSets.main).name)
@@ -54,7 +54,7 @@ class MultiplatformAndroidSourceSetLayoutV2Test {
     }
 
     @Test
-    fun `test - unitTest SourceSet - is called 'androidUnitTest'`() {
+    fun `test - unitTest SourceSet - is called androidUnitTest`() {
         @Suppress("DEPRECATION")
         kotlin.androidTarget()
         assertEquals("androidUnitTest", project.getKotlinSourceSetOrFail(android.sourceSets.test).name)
@@ -68,7 +68,7 @@ class MultiplatformAndroidSourceSetLayoutV2Test {
     }
 
     @Test
-    fun `test - instrumentedTest SourceSet - is called 'androidInstrumentedTest'`() {
+    fun `test - instrumentedTest SourceSet - is called androidInstrumentedTest`() {
         @Suppress("DEPRECATION")
         kotlin.androidTarget()
         assertEquals("androidInstrumentedTest", project.getKotlinSourceSetOrFail(android.sourceSets.androidTest).name)

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/NativeKlibWriterTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/NativeKlibWriterTest.kt
@@ -30,7 +30,7 @@ class NativeKlibWriterTest : AbstractNativeKlibWriterTest<NewNativeKlibWriterPar
     }
 
     @Test
-    fun `Writing a klib with different 'targets for manifest'`() {
+    fun `Writing a klib with different targetsForManifest`() {
         listOf(
             listOf(KonanTarget.IOS_ARM64, KonanTarget.MACOS_ARM64, KonanTarget.WATCHOS_ARM64),
             listOf(KonanTarget.LINUX_ARM64, KonanTarget.MACOS_X64),

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/TestInventoryListener.kt
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/TestInventoryListener.kt
@@ -61,6 +61,11 @@ class TestInventoryListener(private val taskName: String, buildDir: Provider<Fil
         val duration = result.endTime - result.startTime
         val testName = testDescriptor.getTestName()
         val leaf = className?.let { "$it.$testName" } ?: testName
+
+        if (leaf.endsWith("'")) {
+            error("Test $leaf ends with ' (apostrophe) symbol and may be processed incorrectly by TeamCity (TW-101796)")
+        }
+
         val fullName = (suites + leaf).joinToString(": ").replace(WHITESPACE, " ")
         records += "$fullName\t$status\t$duration"
     }

--- a/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/TestFederationFunctionalTest.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/TestFederationFunctionalTest.kt
@@ -128,7 +128,7 @@ class TestFederationFunctionalTest {
      * If the test task is marked as 'isSmokeTest', then we expect all tests to be executed, always
      */
     @Test
-    fun `test - smokeTestConfig 'RunAllTests'`() {
+    fun `test - smokeTestConfig RunAllTests`() {
         val result = runTestBuild(TestFederationMode.Smoke, smokeTestConfig = "RunAllTests")
         assertEquals(
             setOf(
@@ -147,7 +147,7 @@ class TestFederationFunctionalTest {
      * If the test task is marked as 'isSmokeTest = false', then we expect it to be skipped in smoke test mode.
      */
     @Test
-    fun `test - smokeTestConfig 'Disabled'`() {
+    fun `test - smokeTestConfig Disabled`() {
         val result = runTestBuild(TestFederationMode.Smoke, smokeTestConfig = "Disabled")
         assertEquals(
             emptySet(),


### PR DESCRIPTION
Tests ending with apostrophe ' (apostrophe) symbol are processed incorrectly by TeamCity