### PR TITLE
[K/JS][Test] Aling maxHeapSizeMb for JS tests with Wasm tests

### DIFF
--- a/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/jsTest.kt
+++ b/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/jsTest.kt
@@ -22,6 +22,8 @@ fun ProjectTestsExtension.jsTestTask(
     body: Test.() -> Unit = {},
 ): TaskProvider<Test> = testTask(
     taskName = taskName,
+    // KTI-3248, the heap size is the same as for the Wasm tests
+    maxHeapSizeMb = 6144,
     skipInLocalBuild = skipInLocalBuild,
 ) {
 


### PR DESCRIPTION
^KTI-3248 Fixed