### PR TITLE
[JVM] Turn `JvmIrSpecialAnnotationSymbolProvider` into a class

### DIFF
--- a/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirCompilerFacility.kt
+++ b/analysis/analysis-api-fir/src/org/jetbrains/kotlin/analysis/api/fir/components/KaFirCompilerFacility.kt
@@ -1095,7 +1095,7 @@ internal class KaFirCompilerFacility(
             visibilityConverter = FirJvmVisibilityConverter,
             kotlinBuiltIns = DefaultBuiltIns.Instance,
             typeSystemContextProvider = ::JvmIrTypeSystemContext,
-            specialAnnotationsProvider = JvmIrSpecialAnnotationSymbolProvider,
+            specialAnnotationsProvider = JvmIrSpecialAnnotationSymbolProvider(),
             extraActualDeclarationExtractorsInitializer = {
                 error(
                     "extraActualDeclarationExtractorsInitializer should never be called, because outputs is a list of a single element. " +

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
@@ -307,7 +307,7 @@ private fun AllModulesFrontendOutput.convertToIrAndActualize(
         FirJvmVisibilityConverter,
         DefaultBuiltIns.Instance,
         ::JvmIrTypeSystemContext,
-        JvmIrSpecialAnnotationSymbolProvider,
+        JvmIrSpecialAnnotationSymbolProvider(),
         if (configuration.languageVersionSettings.getFlag(AnalysisFlags.stdlibCompilation)) {
             { emptyList() }
         } else {

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JvmGeneratorExtensionsImpl.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JvmGeneratorExtensionsImpl.kt
@@ -148,17 +148,20 @@ open class JvmGeneratorExtensionsImpl(
     override val shouldPreventDeprecatedIntegerValueTypeLiteralConversion: Boolean
         get() = true
 
+    private val specialAnnotations: JvmIrSpecialAnnotationSymbolProvider =
+        JvmIrSpecialAnnotationSymbolProvider()
+
     override fun generateFlexibleNullabilityAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateFlexibleNullabilityAnnotation()
+        specialAnnotations.generateFlexibleNullabilityAnnotation()
 
     override fun generateFlexibleMutabilityAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateFlexibleMutabilityAnnotation()
+        specialAnnotations.generateFlexibleMutabilityAnnotation()
 
     override fun generateEnhancedNullabilityAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateEnhancedNullabilityAnnotation()
+        specialAnnotations.generateEnhancedNullabilityAnnotation()
 
     override fun generateRawTypeAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateRawTypeAnnotation()
+        specialAnnotations.generateRawTypeAnnotation()
 
     override fun unwrapSyntheticJavaProperty(descriptor: PropertyDescriptor): Pair<FunctionDescriptor, FunctionDescriptor?>? {
         if (descriptor is SyntheticJavaPropertyDescriptor) {

--- a/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmFir2IrPipelinePhase.kt
+++ b/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/pipeline/jvm/JvmFir2IrPipelinePhase.kt
@@ -92,7 +92,7 @@ object JvmFir2IrPipelinePhase : PipelinePhase<JvmFrontendPipelineArtifact, JvmFi
             FirJvmVisibilityConverter,
             DefaultBuiltIns.Instance,
             ::JvmIrTypeSystemContext,
-            JvmIrSpecialAnnotationSymbolProvider,
+            JvmIrSpecialAnnotationSymbolProvider(),
             if (configuration.languageVersionSettings.getFlag(AnalysisFlags.stdlibCompilation)) {
                 { emptyList() }
             } else {

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/FunctionReferenceLowering.kt
@@ -103,7 +103,7 @@ internal class FunctionReferenceLowering(private val context: JvmBackendContext)
             if (setIndyDataIfPossible(expression, plainLambda = false)) return expression
         }
 
-        val samSuperType = runIf(expression.isSamConversion()) { expression.type.erasedUpperBound.rawType() }
+        val samSuperType = runIf(expression.isSamConversion()) { expression.type.erasedUpperBound.rawType(context.specialAnnotationsProvider) }
 
         return FunctionReferenceBuilder(expression, samSuperType).build()
     }

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmSingleAbstractMethodLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/JvmSingleAbstractMethodLowering.kt
@@ -35,6 +35,8 @@ internal class JvmSingleAbstractMethodLowering(context: JvmBackendContext) : Sin
     private val isJavaSamConversionWithEqualsHashCode =
         context.config.languageVersionSettings.supportsFeature(LanguageFeature.JavaSamConversionEqualsHashCode)
 
+    private val specialAnnotations = context.specialAnnotationsProvider
+
     override val inInlineFunctionScope: Boolean
         get() = allScopes.any { (it.irElement as? IrDeclaration)?.isInPublicInlineScope == true }
 
@@ -42,10 +44,10 @@ internal class JvmSingleAbstractMethodLowering(context: JvmBackendContext) : Sin
         if (inInlineFunctionScope) DescriptorVisibilities.PUBLIC else JavaDescriptorVisibilities.PACKAGE_VISIBILITY
 
     override fun getSuperTypeForWrapper(typeOperand: IrType): IrType =
-        typeOperand.erasedUpperBound.rawType()
+        typeOperand.erasedUpperBound.rawType(specialAnnotations)
 
     override fun getWrappedFunctionType(klass: IrClass): IrType =
-        klass.rawType()
+        klass.rawType(specialAnnotations)
 
     override fun getSuspendFunctionWithoutContinuation(function: IrSimpleFunction): IrSimpleFunction =
         function.suspendFunctionOriginal()

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmBackendContext.kt
@@ -59,6 +59,8 @@ class JvmBackendContext(
 
     override val irFactory: IrFactory = IrFactoryImpl
 
+    val specialAnnotationsProvider: JvmIrSpecialAnnotationSymbolProvider =
+        JvmIrSpecialAnnotationSymbolProvider()
     override val typeSystem: IrTypeSystemContext = JvmIrTypeSystemContext(irBuiltIns)
     val defaultTypeMapper = IrTypeMapper(this)
     val defaultMethodSignatureMapper = MethodSignatureMapper(this, defaultTypeMapper)

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrSpecialAnnotationSymbolProvider.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrSpecialAnnotationSymbolProvider.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.name.StandardClassIds.Annotations.RawTypeAnnotation
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
 import kotlin.apply
 
-object JvmIrSpecialAnnotationSymbolProvider : IrSpecialAnnotationsProvider() {
+class JvmIrSpecialAnnotationSymbolProvider : IrSpecialAnnotationsProvider() {
     private val kotlinJvmInternalPackage: IrExternalPackageFragmentImpl =
         IrExternalPackageFragmentImpl(DescriptorlessExternalPackageFragmentSymbol(), JvmAnnotationNames.KOTLIN_JVM_INTERNAL)
 

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrTypeSystemContext.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/JvmIrTypeSystemContext.kt
@@ -20,8 +20,11 @@ import org.jetbrains.kotlin.ir.types.isMarkedNullable as irIsMarkedNullable
 class JvmIrTypeSystemContext(override val irBuiltIns: IrBuiltIns) : IrTypeSystemContext {
     override val treatFullValueClassesWithOneFieldAsBasic: Boolean get() = false
 
+    private val specialAnnotations: JvmIrSpecialAnnotationSymbolProvider =
+        JvmIrSpecialAnnotationSymbolProvider()
+
     override fun KotlinTypeMarker.asFlexibleType(): FlexibleTypeMarker? =
-        (this as IrType).asJvmFlexibleType(irBuiltIns, JvmIrSpecialAnnotationSymbolProvider)
+        (this as IrType).asJvmFlexibleType(irBuiltIns, specialAnnotations)
 
     override fun FlexibleTypeMarker.upperBound(): IrSimpleType {
         return when (this) {

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/ir/JvmIrUtils.kt
@@ -266,8 +266,8 @@ private fun IrDeclaration.isFunctionWhichCanBeExposed(isPropagatedOrImplicit: Bo
     return parentClassOrNull?.isFileClass == false || annotations.hasAnnotation(JVM_EXPOSE_BOXED_ANNOTATION_FQ_NAME)
 }
 
-fun IrClass.rawType(): IrType =
-    defaultType.addAnnotations(listOf(JvmIrSpecialAnnotationSymbolProvider.generateRawTypeAnnotation()))
+fun IrClass.rawType(specialAnnotations: JvmIrSpecialAnnotationSymbolProvider): IrType =
+    defaultType.addAnnotations(listOf(specialAnnotations.generateRawTypeAnnotation()))
 
 fun IrSimpleType.isRawType(): Boolean =
     hasAnnotation(JvmSymbols.RAW_TYPE_ANNOTATION_FQ_NAME)

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/Fir2IrJvmResultsConverter.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/Fir2IrJvmResultsConverter.kt
@@ -51,7 +51,7 @@ internal class Fir2IrJvmResultsConverter(testServices: TestServices) : AbstractF
     }
 
     override fun createSpecialAnnotationsProvider(): IrSpecialAnnotationsProvider {
-        return JvmIrSpecialAnnotationSymbolProvider
+        return JvmIrSpecialAnnotationSymbolProvider()
     }
 
     override fun createExtraActualDeclarationExtractorInitializer(): (Fir2IrComponents) -> List<IrExtraActualDeclarationExtractor> {

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/JvmGeneratorExtensionsImpl.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/repl/JvmGeneratorExtensionsImpl.kt
@@ -151,17 +151,20 @@ open class JvmGeneratorExtensionsImpl(
     override val shouldPreventDeprecatedIntegerValueTypeLiteralConversion: Boolean
         get() = true
 
+    private val specialAnnotations: JvmIrSpecialAnnotationSymbolProvider =
+        JvmIrSpecialAnnotationSymbolProvider()
+
     override fun generateFlexibleNullabilityAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateFlexibleNullabilityAnnotation()
+        specialAnnotations.generateFlexibleNullabilityAnnotation()
 
     override fun generateFlexibleMutabilityAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateFlexibleMutabilityAnnotation()
+        specialAnnotations.generateFlexibleMutabilityAnnotation()
 
     override fun generateEnhancedNullabilityAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateEnhancedNullabilityAnnotation()
+        specialAnnotations.generateEnhancedNullabilityAnnotation()
 
     override fun generateRawTypeAnnotation(): IrAnnotation =
-        JvmIrSpecialAnnotationSymbolProvider.generateRawTypeAnnotation()
+        specialAnnotations.generateRawTypeAnnotation()
 
     override fun unwrapSyntheticJavaProperty(descriptor: PropertyDescriptor): Pair<FunctionDescriptor, FunctionDescriptor?>? {
         if (descriptor is SyntheticJavaPropertyDescriptor) {


### PR DESCRIPTION
This is a non-functional preparation for passing the built-ins module to the provider, so the `kotlinJvmInternalPackage` can be created with the right parent module: https://github.com/JetBrains/kotlin/pull/6493#pullrequestreview-4733458667

KT-87198