### PR TITLE
[K/N] ObjCName annotation support for commonizer

### DIFF
--- a/native/commonizer/src/org/jetbrains/kotlin/commonizer/core/AnnotationsCommonizer.kt
+++ b/native/commonizer/src/org/jetbrains/kotlin/commonizer/core/AnnotationsCommonizer.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.commonizer.cir.CirConstantValue
 import org.jetbrains.kotlin.commonizer.cir.CirEntityId
 import org.jetbrains.kotlin.commonizer.utils.COMMONIZER_OBJC_INTEROP_CALLABLE_ANNOTATION_ID
 import org.jetbrains.kotlin.commonizer.utils.DEPRECATED_ANNOTATION_CLASS_ID
+import org.jetbrains.kotlin.commonizer.utils.OBJC_NAME_ANNOTATION_CLASS_ID
 import org.jetbrains.kotlin.commonizer.utils.isObjCInteropCallableAnnotation
 
 private typealias Annotations = Map<CirEntityId, CirAnnotation>
@@ -24,6 +25,7 @@ object AnnotationsCommonizer : AssociativeCommonizer<List<CirAnnotation>> {
         return buildList {
             addAll(commonizedObjcCallableAnnotation(first, second))
             commonizedDeprecatedAnnotation(firstAnnotations, secondAnnotations)?.let { add(it) }
+            commonizedObjCNameAnnotation(firstAnnotations, secondAnnotations)?.let { add(it) }
             addAll(commonizedSimpleAnnotations(firstAnnotations, secondAnnotations))
         }.distinct()
     }
@@ -82,6 +84,12 @@ object AnnotationsCommonizer : AssociativeCommonizer<List<CirAnnotation>> {
         val firstDeprecation = first[DEPRECATED_ANNOTATION_CLASS_ID] ?: return null
         val secondDeprecation = second[DEPRECATED_ANNOTATION_CLASS_ID] ?: return null
         return DeprecationAnnotationCommonizer.commonize(firstDeprecation, secondDeprecation)
+    }
+
+    private fun commonizedObjCNameAnnotation(first: Annotations, second: Annotations): CirAnnotation? {
+        val firstObjCName = first[OBJC_NAME_ANNOTATION_CLASS_ID] ?: return null
+        val secondObjCName = second[OBJC_NAME_ANNOTATION_CLASS_ID] ?: return null
+        return ObjCNameAnnotationCommonizer.commonize(firstObjCName, secondObjCName)
     }
 
     private val objCCallableAnnotation = CirAnnotation.createInterned(

--- a/native/commonizer/src/org/jetbrains/kotlin/commonizer/core/ObjCNameAnnotationCommonizer.kt
+++ b/native/commonizer/src/org/jetbrains/kotlin/commonizer/core/ObjCNameAnnotationCommonizer.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.commonizer.core
+
+import org.jetbrains.kotlin.commonizer.cir.CirAnnotation
+
+/**
+ * Commonizes the `kotlin.native.ObjCName` annotation.
+ *
+ * The annotation is derived from the underlying Objective-C class/protocol name and is therefore expected
+ * to be identical across the commonized targets.
+ */
+object ObjCNameAnnotationCommonizer : AssociativeCommonizer<CirAnnotation> {
+    override fun commonize(first: CirAnnotation, second: CirAnnotation): CirAnnotation? {
+        // `first`/`second` share the same annotation class id by construction; keep it only if the arguments match.
+        return if (first == second) first else null
+    }
+}

--- a/native/commonizer/src/org/jetbrains/kotlin/commonizer/utils/names.kt
+++ b/native/commonizer/src/org/jetbrains/kotlin/commonizer/utils/names.kt
@@ -19,6 +19,8 @@ internal val DEPRECATED_ANNOTATION_CLASS_ID: CirEntityId = CirEntityId.create(DE
 internal const val ANY_CLASS_FULL_NAME: ClassName = "kotlin/Any"
 internal val ANY_CLASS_ID: CirEntityId = CirEntityId.create(ANY_CLASS_FULL_NAME)
 
+internal val OBJC_NAME_ANNOTATION_CLASS_ID: CirEntityId = CirEntityId.create("kotlin/native/ObjCName")
+
 internal val SPECIAL_CLASS_WITHOUT_SUPERTYPES_CLASS_IDS: List<CirEntityId> = listOf(
     ANY_CLASS_ID,
     CirEntityId.create("kotlin/Nothing")

--- a/native/commonizer/tests/org/jetbrains/kotlin/commonizer/core/AnnotationsCommonizerTest.kt
+++ b/native/commonizer/tests/org/jetbrains/kotlin/commonizer/core/AnnotationsCommonizerTest.kt
@@ -276,8 +276,45 @@ class AnnotationsCommonizerTest : AbstractCommonizerTest<List<CirAnnotation>, Li
         )
     )
 
+    @Test
+    fun sameObjCName() = doTestSuccess(
+        expected = listOf(mockObjCName(swiftName = "UserDefaults")),
+        listOf(mockObjCName(swiftName = "UserDefaults")),
+        listOf(mockObjCName(swiftName = "UserDefaults")),
+        listOf(mockObjCName(swiftName = "UserDefaults"))
+    )
+
+    @Test
+    fun differentObjCName() = doTestSuccess(
+        expected = emptyList(),
+        listOf(mockObjCName(swiftName = "UserDefaults")),
+        listOf(mockObjCName(swiftName = "Defaults")),
+        listOf(mockObjCName(swiftName = "UserDefaults"))
+    )
+
+    @Test
+    fun missingObjCNameOnOneTarget() = doTestSuccess(
+        expected = emptyList(),
+        listOf(mockObjCName(swiftName = "UserDefaults")),
+        emptyList(),
+        listOf(mockObjCName(swiftName = "UserDefaults"))
+    )
+
     override fun createCommonizer() = AnnotationsCommonizer.asCommonizer()
 }
+
+private fun mockObjCName(
+    name: String = "",
+    swiftName: String = "",
+    exact: Boolean = false
+): CirAnnotation = mockAnnotation(
+    classId = "kotlin/native/ObjCName",
+    constantValueArguments = HashMap<CirName, CirConstantValue>().apply {
+        if (name.isNotEmpty()) this[CirName.create("name")] = StringValue(name)
+        if (swiftName.isNotEmpty()) this[CirName.create("swiftName")] = StringValue(swiftName)
+        if (exact) this[CirName.create("exact")] = BooleanValue(true)
+    }
+)
 
 private fun mockAnnotation(
     classId: String,

--- a/native/commonizer/tests/org/jetbrains/kotlin/commonizer/hierarchical/HierarchicalObjCNameAnnotationCommonizationTest.kt
+++ b/native/commonizer/tests/org/jetbrains/kotlin/commonizer/hierarchical/HierarchicalObjCNameAnnotationCommonizationTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.commonizer.hierarchical
+
+import org.jetbrains.kotlin.commonizer.AbstractInlineSourcesCommonizationTest
+import org.jetbrains.kotlin.commonizer.assertCommonized
+import org.junit.jupiter.api.Test
+
+class HierarchicalObjCNameAnnotationCommonizationTest : AbstractInlineSourcesCommonizationTest() {
+
+    @Test
+    fun `test ObjCName on class`() {
+        val result = commonize {
+            outputTarget("(a, b)")
+
+            simpleSingleSourceTarget(
+                "a", """
+                    @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                    @kotlin.native.ObjCName(swiftName = "UserDefaults")
+                    class NSUserDefaults
+                """.trimIndent()
+            )
+
+            simpleSingleSourceTarget(
+                "b", """
+                    @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                    @kotlin.native.ObjCName(swiftName = "UserDefaults")
+                    class NSUserDefaults
+                """.trimIndent()
+            )
+        }
+
+        result.assertCommonized(
+            "(a, b)", """
+                @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                @kotlin.native.ObjCName(swiftName = "UserDefaults")
+                expect class NSUserDefaults()
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `test ObjCName on interface`() {
+        val result = commonize {
+            outputTarget("(a, b)")
+
+            simpleSingleSourceTarget(
+                "a", """
+                    @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                    @kotlin.native.ObjCName(swiftName = "URLSessionDelegate")
+                    interface NSURLSessionDelegate
+                """.trimIndent()
+            )
+
+            simpleSingleSourceTarget(
+                "b", """
+                    @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                    @kotlin.native.ObjCName(swiftName = "URLSessionDelegate")
+                    interface NSURLSessionDelegate
+                """.trimIndent()
+            )
+        }
+
+        result.assertCommonized(
+            "(a, b)", """
+                @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                @kotlin.native.ObjCName(swiftName = "URLSessionDelegate")
+                expect interface NSURLSessionDelegate
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `test ObjCName with different swiftName is dropped`() {
+        val result = commonize {
+            outputTarget("(a, b)")
+
+            simpleSingleSourceTarget(
+                "a", """
+                    @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                    @kotlin.native.ObjCName(swiftName = "UserDefaults")
+                    class NSUserDefaults
+                """.trimIndent()
+            )
+
+            simpleSingleSourceTarget(
+                "b", """
+                    @file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
+                    @kotlin.native.ObjCName(swiftName = "Defaults")
+                    class NSUserDefaults
+                """.trimIndent()
+            )
+        }
+
+        result.assertCommonized(
+            "(a, b)", """
+                expect class NSUserDefaults()
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
Class/interface `@kotlin.native.ObjCName` annotations (e.g. `@ObjCName(swiftName = "UserDefaults")` on `NSUserDefaults`) were silently dropped by the commonizer, so commonized platform libraries lost the Swift name on their declarations.

`AnnotationsCommonizer` only preserved three kinds of annotations: ObjC-callable annotations, `@Deprecated`, and argument-less "simple" annotations. This change makes `@ObjCName` preserved as well.

^ KT-81934 Fixed