### PR TITLE
[Kapt] Use decimal FP values for stubs in direct mode

### DIFF
--- a/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/stubs/KaptStubConverter.kt
+++ b/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/stubs/KaptStubConverter.kt
@@ -1733,7 +1733,7 @@ class KaptStubConverter(val kaptContext: KaptContextForStubGeneration, val gener
                 treeMaker.Literal(value)
             }
             is Float if value.isFinite() -> {
-                sb.append(java.lang.Float.toHexString(value)).append("F")
+                sb.append(value.toString()).append("F")
                 treeMaker.Literal(value)
             }
             is Float -> {
@@ -1745,7 +1745,7 @@ class KaptStubConverter(val kaptContext: KaptContextForStubGeneration, val gener
                 )
             }
             is Double if value.isFinite() -> {
-                sb.append(java.lang.Double.toHexString(value))
+                sb.append(value.toString())
                 treeMaker.Literal(value)
             }
             is Double -> {


### PR DESCRIPTION
Previously, KaptStubGenerator emitted exact hexadecimal FP values
in `direct` mode. However, in most cases the original literals in Kotlin
sources are decimal, so it makes sense to emit the decimal ones for
the sake of easier manual inspection. JVM-based toString() guarantees
for finite FP numbers that parsing of the resulting String will yield
exactly the same number.