### PR TITLE
[JKLIB] Fix fake-override linking, mangler signatures, and toArray ov…

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -48,6 +48,7 @@ import org.jetbrains.kotlin.incremental.components.InlineConstTracker
 import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.ir.InternalSymbolFinderAPI
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
+import org.jetbrains.kotlin.ir.backend.jklib.J2clToArrayOverridabilityCondition
 import org.jetbrains.kotlin.ir.backend.jklib.JKlibDescriptorMangler
 import org.jetbrains.kotlin.ir.backend.jklib.JKlibIrLinker
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
@@ -124,7 +125,10 @@ object JKlibIrCompilationPhase :
             symbolTable = symbolTable,
             descriptorMangler = mangler,
             typeSystemContextFactory = ::JvmIrTypeSystemContext,
-            externalOverridabilityConditions = listOf(IrJavaIncompatibilityRulesOverridabilityCondition()),
+            externalOverridabilityConditions = listOf(
+                IrJavaIncompatibilityRulesOverridabilityCondition(),
+                J2clToArrayOverridabilityCondition(),
+            ),
         )
 
         // Deserialize modules

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/J2clToArrayOverridabilityCondition.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/J2clToArrayOverridabilityCondition.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jetbrains.kotlin.ir.backend.jklib
+
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition
+import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition.Contract
+import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition.Result
+import org.jetbrains.kotlin.ir.overrides.MemberWithOriginal
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.classId
+
+/**
+ * Overridability condition to match toArray(Array) methods despite Java/Kotlin signature
+ * differences.
+ */
+class J2clToArrayOverridabilityCondition : IrExternalOverridabilityCondition {
+  override fun isOverridable(
+    superMember: MemberWithOriginal,
+    subMember: MemberWithOriginal,
+  ): Result {
+    val superFun = superMember.member as? IrSimpleFunction ?: return Result.UNKNOWN
+    val subFun = subMember.member as? IrSimpleFunction ?: return Result.UNKNOWN
+
+    if (superFun.name.asString() == "toArray" && subFun.name.asString() == "toArray") {
+      val superParams = superFun.parameters.filter { it.kind == IrParameterKind.Regular }
+      val subParams = subFun.parameters.filter { it.kind == IrParameterKind.Regular }
+      if (superParams.size == 1 && subParams.size == 1) {
+        val superParamType = superParams[0].type
+        val subParamType = subParams[0].type
+        val superFq = superParamType.classOrNull?.owner?.classId?.asSingleFqName()?.asString()
+        val subFq = subParamType.classOrNull?.owner?.classId?.asSingleFqName()?.asString()
+        if (superFq == "kotlin.Array" && subFq == "kotlin.Array") {
+          return Result.OVERRIDABLE
+        }
+      }
+    }
+
+    return Result.UNKNOWN
+  }
+
+  override val contract: Contract
+    get() = Contract.SUCCESS_ONLY
+}

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
@@ -2,24 +2,29 @@
  * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
+@file:Suppress("KotlincFE10G3")
 
 package org.jetbrains.kotlin.ir.backend.jklib
 
 import com.intellij.openapi.diagnostic.Logger
+import java.util.concurrent.ConcurrentHashMap
 import org.jetbrains.kotlin.backend.common.serialization.mangle.KotlinMangleComputer
 import org.jetbrains.kotlin.backend.common.serialization.mangle.MangleConstant
 import org.jetbrains.kotlin.backend.common.serialization.mangle.MangleMode
 import org.jetbrains.kotlin.backend.common.serialization.mangle.descriptor.DescriptorMangleComputer
 import org.jetbrains.kotlin.backend.common.serialization.mangle.ir.IrMangleComputer
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.FilteredByPredicateAnnotations
 import org.jetbrains.kotlin.idea.MainFunctionDetector
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.backend.jvm.serialization.BaseJvmIrMangler
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.descriptors.IrBasedDeclarationDescriptor
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
@@ -29,6 +34,9 @@ import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.load.java.typeEnhancement.hasEnhancedNullability
 import org.jetbrains.kotlin.load.kotlin.*
 import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.types.AbstractTypeChecker
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.SimpleType
 import org.jetbrains.kotlin.types.TypeUtils
@@ -52,14 +60,62 @@ import org.jetbrains.kotlin.utils.DFS.ifAny as ifAnyDFS
  */
 
 class JKlibIrMangler : BaseJvmIrMangler() {
+    private val generatedSignatures = ConcurrentHashMap<IrClass, MutableMap<String, IrDeclaration>>()
+
+    override fun IrDeclaration.signatureMangle(compatibleMode: Boolean): Long {
+        return signatureString(compatibleMode).hashMangle
+    }
+
     @OptIn(ObsoleteDescriptorBasedAPI::class)
-    override fun IrDeclaration.signatureString(compatibleMode: Boolean): String {
-        if (!getPackageFragment().packageFqName.asString().isKotlinPackage() && isJavaBackedCallable()) {
-            (descriptor as? CallableDescriptor)?.computeJvmSignatureSafe()?.let {
-                return it
+    private fun IrDeclaration.signatureStringImpl(compatibleMode: Boolean): String {
+        var result: String? = null
+        if (this.shouldUseJvmSignature()) {
+            val jvmSig = (this.descriptor as? CallableDescriptor)?.computeJvmSignatureSafe()
+            if (jvmSig != null) {
+                result = jvmSig
+            } else {
+                result = getMangleComputer(MangleMode.SIGNATURE, compatibleMode).computeMangle(this)
+            }
+        } else if (
+            this is IrProperty &&
+            getter == null &&
+            setter == null &&
+            (isFakeOverride || backingField == null)
+        ) {
+            val parentSig = (parent as? IrDeclaration)?.signatureString(compatibleMode)
+            if (parentSig != null) {
+                result = "$parentSig.${name.asString()}"
             }
         }
-        return getMangleComputer(MangleMode.SIGNATURE, compatibleMode).computeMangle(this)
+
+        if (result == null) {
+            result = getMangleComputer(MangleMode.SIGNATURE, compatibleMode).computeMangle(this)
+        }
+        return result
+    }
+
+    @OptIn(ObsoleteDescriptorBasedAPI::class)
+    override fun IrDeclaration.signatureString(compatibleMode: Boolean): String {
+        val sig = signatureStringImpl(compatibleMode)
+        if (this is IrOverridableDeclaration<*> && isFakeOverride) {
+            val parentClass = parent as? IrClass
+            if (parentClass != null) {
+                // Fix local class clashes: Key by IrClass object instead of FQN string
+                val classMap = generatedSignatures.getOrPut(parentClass) { ConcurrentHashMap() }
+                var uniqueSig = sig
+                var counter = 0
+                while (true) {
+                    val existing = classMap.putIfAbsent(uniqueSig, this)
+                    if (existing == null || existing == this) {
+                        return uniqueSig
+                    }
+                    // Clash! Try next unique signature
+                    counter++
+                    uniqueSig = "$sig#clash#$counter"
+                }
+            }
+        }
+        return sig
     }
 
     private class JKlibIrManglerComputer(builder: StringBuilder, mode: MangleMode, compatibleMode: Boolean) :
@@ -82,15 +138,17 @@ class JKlibIrMangler : BaseJvmIrMangler() {
 
 class JKlibDescriptorMangler(private val mainDetector: MainFunctionDetector?) : JvmDescriptorMangler(mainDetector) {
 
+    override fun DeclarationDescriptor.signatureMangle(compatibleMode: Boolean): Long {
+        return signatureString(compatibleMode).hashMangle
+    }
+
     override fun DeclarationDescriptor.signatureString(compatibleMode: Boolean): String {
-        if (this.containingPackage()?.asString()
-                ?.isKotlinPackage() == false && this is JavaCallableMemberDescriptor || containingDeclaration is JavaClassDescriptor
-        ) {
-            (this as? CallableDescriptor)?.computeJvmSignatureSafe()?.let {
-                return it
-            }
+        return if (shouldUseJvmSignature()) {
+            (this as? CallableDescriptor)?.computeJvmSignatureSafe()
+                ?: getMangleComputer(MangleMode.SIGNATURE, compatibleMode).computeMangle(this)
+        } else {
+            getMangleComputer(MangleMode.SIGNATURE, compatibleMode).computeMangle(this)
         }
-        return getMangleComputer(MangleMode.SIGNATURE, compatibleMode).computeMangle(this)
     }
 
     private class JKlibDescriptorManglerComputer(
@@ -145,8 +203,7 @@ private fun KotlinType.mapToJvmType(): JvmType {
         !type.isNullable() &&
         type.hasEnhancedNullability()
     ) {
-        type =
-            type.replaceAnnotations(FilteredByPredicateAnnotations(type.annotations) { JvmAnnotationNames.ENHANCED_NULLABILITY_ANNOTATION != it.fqName })
+        type = type.replaceAnnotations(FilteredByPredicateAnnotations(type.annotations) { JvmAnnotationNames.ENHANCED_NULLABILITY_ANNOTATION != it.fqName })
     }
 
     return mapType(
@@ -218,30 +275,276 @@ private fun IrDeclaration.isDeclaredInJava(): Boolean {
     return ownerClass?.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB
 }
 
-@OptIn(UnsafeDuringIrConstructionAPI::class)
-private fun IrDeclaration.isJavaBackedCallable(): Boolean {
-    if (isDeclaredInJava()) return true
+private fun DeclarationDescriptor.isDeclaredInJava(): Boolean =
+    this is JavaCallableMemberDescriptor || containingDeclaration is JavaClassDescriptor
 
-    val functions = when (this) {
-        is IrSimpleFunction -> {
-            // Check if the function a fake override of a Java declaration.
-            listOf(this)
+@OptIn(ObsoleteDescriptorBasedAPI::class)
+private fun IrDeclaration.isMappedJreClassMember(): Boolean {
+    val parentClass = parent as? IrClass ?: return false
+    val fqName = parentClass.classId?.asSingleFqName() ?: return false
+    val mappedFqName =
+        JavaToKotlinClassMap.mapKotlinToJava(fqName.toUnsafe())?.asSingleFqName() ?: return false
+    return !mappedFqName.asString().isKotlinPackage()
+}
+
+private fun DeclarationDescriptor.isMappedJreClassMember(): Boolean {
+    val parentClass = containingDeclaration as? ClassDescriptor ?: return false
+    val fqName = parentClass.fqNameOrNull() ?: return false
+    val mappedFqName =
+        JavaToKotlinClassMap.mapKotlinToJava(fqName.toUnsafe())?.asSingleFqName() ?: return false
+    return !mappedFqName.asString().isKotlinPackage()
+}
+
+private fun IrOverridableDeclaration<*>.hasMappedJreClassInOverrideChain(): Boolean {
+    val visited = mutableSetOf<IrOverridableDeclaration<*>>()
+    fun dfs(decl: IrOverridableDeclaration<*>): Boolean {
+        if (!visited.add(decl)) return false
+        val irDecl = decl as? IrDeclaration ?: return false
+        if (
+            (irDecl.isDeclaredInJava() || irDecl.isMappedJreClassMember()) &&
+            !irDecl.isContainingClassKotlinOnly()
+        ) {
+            return true
         }
-        is IrProperty -> {
-            // Check property accessors.
-            listOfNotNull(getter, setter)
+        for (symbol in decl.overriddenSymbols) {
+            val owner = symbol.owner as? IrOverridableDeclaration<*> ?: continue
+            if (dfs(owner)) return true
         }
-        else -> emptyList()
+        return false
+    }
+    return dfs(this)
+}
+
+private fun CallableMemberDescriptor.hasMappedJreClassInOverrideChain(): Boolean {
+    val visited = mutableSetOf<CallableMemberDescriptor>()
+    fun dfs(desc: CallableMemberDescriptor): Boolean {
+        if (!visited.add(desc)) return false
+        if (
+            (desc.isDeclaredInJava() || desc.isMappedJreClassMember()) &&
+            !desc.isContainingClassKotlinOnly()
+        ) {
+            return true
+        }
+        for (overridden in desc.overriddenDescriptors) {
+            if (dfs(overridden)) return true
+        }
+        return false
+    }
+    return dfs(this)
+}
+
+// Generalize isKotlinOnlyClass: remove hardcoded sets, check package and interface kind
+private fun isKotlinOnlyClass(clazz: IrClass): Boolean {
+    if (clazz.parentClassOrNull != null) return false
+    val fqName = clazz.classId?.asSingleFqName() ?: return false
+    val packageName = fqName.parent().asString()
+    if (packageName == "kotlin") {
+        val className = fqName.shortName().asString()
+        return className != "Number" && className != "Enum"
+    }
+    return packageName.startsWith("kotlin.") && clazz.kind == ClassKind.INTERFACE
+}
+
+private fun isKotlinOnlyClass(clazz: ClassDescriptor): Boolean {
+    if (clazz.containingDeclaration is ClassDescriptor) return false
+    val fqName = clazz.fqNameOrNull() ?: return false
+    val packageName = fqName.parent().asString()
+    if (packageName == "kotlin") {
+        val className = fqName.shortName().asString()
+        return className != "Number" && className != "Enum"
+    }
+    return packageName.startsWith("kotlin.") && clazz.kind == ClassKind.INTERFACE
+}
+
+@OptIn(ObsoleteDescriptorBasedAPI::class)
+private fun IrDeclaration.shouldUseJvmSignature(): Boolean {
+    if (isContainingClassKotlinOnly()) {
+        return false
+    }
+    if (overridesRealJavaMember()) {
+        return true
+    }
+    val overridable = this as? IrOverridableDeclaration<*>
+    val roots = overridable?.findRoots() ?: emptySet()
+    val isJavaBacked =
+        isDeclaredInJava() ||
+                isMappedJreClassMember() ||
+                roots.any {
+                    (it as? IrDeclaration)?.isDeclaredInJava() == true ||
+                            (it as? IrDeclaration)?.isMappedJreClassMember() == true
+                }
+    if (!isJavaBacked) return false
+    val isKotlinPkg = getPackageFragment().packageFqName.asString().isKotlinPackage()
+    if (isKotlinPkg && !isMappedJreClassMember()) return false
+    if (
+        overridable != null &&
+        hasKotlinOnlyRootIr(roots) &&
+        !overridable.hasMappedJreClassInOverrideChain()
+    )
+        return false
+    if (this is IrFunction) {
+        if (origin == IrDeclarationOrigin.BRIDGE || origin == IrDeclarationOrigin.BRIDGE_SPECIAL)
+            return false
+        if (origin.isSynthetic && !isEnumSyntheticMethod()) return false
+    }
+    if (this is IrSimpleFunction && isFakeOverride) {
+        val parentClass = parentClassOrNull
+        val thisSig = (descriptor as? CallableDescriptor)?.computeJvmSignatureSafe()
+        // Fix IR clashing check: collect both functions and property accessors
+        val realFunctions = mutableListOf<IrSimpleFunction>()
+        parentClass?.declarations?.forEach { decl ->
+            when (decl) {
+                is IrSimpleFunction -> if (!decl.isFakeOverride) realFunctions.add(decl)
+                is IrProperty ->
+                    if (!decl.isFakeOverride) {
+                        decl.getter?.let { realFunctions.add(it) }
+                        decl.setter?.let { realFunctions.add(it) }
+                    }
+            }
+        }
+        val hasRealClashingDeclaration = realFunctions.any {
+            it.dispatchReceiverParameter != null &&
+                    (it.descriptor as? CallableDescriptor)?.computeJvmSignatureSafe() == thisSig
+        }
+        if (hasRealClashingDeclaration) return false
+    }
+    if (this is IrProperty && isFakeOverride) {
+        return false
+    }
+    return true
+}
+
+private fun hasKotlinOnlyRootIr(roots: Set<IrOverridableDeclaration<*>>): Boolean {
+    return roots.any { root ->
+        val parentClass = (root as? IrDeclaration)?.parent as? IrClass
+        parentClass != null && isKotlinOnlyClass(parentClass)
+    }
+}
+
+@OptIn(ObsoleteDescriptorBasedAPI::class)
+private fun IrOverridableDeclaration<*>.findRoots(): Set<IrOverridableDeclaration<*>> {
+    if (overriddenSymbols.isEmpty()) return setOf(this)
+    val roots = mutableSetOf<IrOverridableDeclaration<*>>()
+    val visited = mutableSetOf<IrOverridableDeclaration<*>>()
+    fun dfs(decl: IrOverridableDeclaration<*>) {
+        if (!visited.add(decl)) return
+        if (decl.overriddenSymbols.isEmpty()) roots.add(decl)
+        else decl.overriddenSymbols.forEach { (it.owner as? IrOverridableDeclaration<*>)?.let(::dfs) }
+    }
+    dfs(this)
+    return roots
+}
+
+private fun IrDeclaration.isEnumSyntheticMethod(): Boolean =
+    this is IrFunction &&
+            (parent as? IrClass)?.kind == ClassKind.ENUM_CLASS &&
+            (name.asString() == "values" || name.asString() == "valueOf")
+
+private fun DeclarationDescriptor.shouldUseJvmSignature(): Boolean {
+    if (isContainingClassKotlinOnly()) {
+        return false
+    }
+    if (overridesRealJavaMember()) {
+        return true
+    }
+    val callableMember = this as? CallableMemberDescriptor
+    val roots = callableMember?.findRoots() ?: emptySet()
+    val isJavaBacked =
+        isDeclaredInJava() ||
+                isMappedJreClassMember() ||
+                roots.any { it.isDeclaredInJava() || it.isMappedJreClassMember() }
+    if (!isJavaBacked) return false
+    val isKotlinPkg = containingPackage()?.asString()?.isKotlinPackage() == true
+    if (isKotlinPkg && !isMappedJreClassMember()) return false
+    if (
+        callableMember != null &&
+        hasKotlinOnlyRootDesc(roots) &&
+        !callableMember.hasMappedJreClassInOverrideChain()
+    )
+        return false
+    if (this is IrBasedDeclarationDescriptor<*>) {
+        return !owner.origin.isSynthetic || owner.isEnumSyntheticMethod()
+    }
+    if (this is CallableMemberDescriptor) {
+        if (kind == CallableMemberDescriptor.Kind.SYNTHESIZED && !isEnumSyntheticMethod()) return false
+        if (kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE) {
+            if (this is PropertyDescriptor) return false
+            val containingClass = containingDeclaration as? ClassDescriptor
+            val thisSig = this.computeJvmSignatureSafe()
+            val hasRealClashingDeclaration =
+                containingClass
+                    ?.unsubstitutedMemberScope
+                    ?.getContributedFunctions(
+                        name,
+                        org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND,
+                    )
+                    ?.any {
+                        it.kind.isReal &&
+                                it.dispatchReceiverParameter != null &&
+                                it.computeJvmSignatureSafe() == thisSig
+                    } ?: false
+            if (hasRealClashingDeclaration) return false
+
+            val hasRealClashingProperty =
+                containingClass
+                    ?.unsubstitutedMemberScope
+                    // Fix descriptor clashing check: check getter/setter signatures of properties in scope
+                    ?.getContributedDescriptors(DescriptorKindFilter.VARIABLES)
+                    ?.filterIsInstance<PropertyDescriptor>()
+                    ?.any { property ->
+                        property.kind.isReal &&
+                                property.dispatchReceiverParameter != null &&
+                                (property.getter?.computeJvmSignatureSafe() == thisSig ||
+                                        property.setter?.computeJvmSignatureSafe() == thisSig)
+                    } ?: false
+            if (hasRealClashingProperty) return false
+        }
+    }
+    return true
+}
+
+private fun hasKotlinOnlyRootDesc(roots: Set<CallableMemberDescriptor>): Boolean =
+    roots.any { root ->
+        val parentClass = root.containingDeclaration as? ClassDescriptor
+        parentClass != null && isKotlinOnlyClass(parentClass)
     }
 
-    if (functions.any { it.isFakeOverride }) {
-        return ifAnyDFS(
-            functions,
-            { current ->
-                if (current.isFakeOverride) current.overriddenSymbols.map { it.owner } else emptyList()
-            },
-            { current -> current.isDeclaredInJava() },
-        )
+private fun CallableMemberDescriptor.findRoots(): Set<CallableMemberDescriptor> {
+    if (overriddenDescriptors.isEmpty()) return setOf(this)
+    val roots = mutableSetOf<CallableMemberDescriptor>()
+    val visited = mutableSetOf<CallableMemberDescriptor>()
+    fun dfs(desc: CallableMemberDescriptor) {
+        if (!visited.add(desc)) return
+        if (desc.overriddenDescriptors.isEmpty()) roots.add(desc)
+        else desc.overriddenDescriptors.forEach(::dfs)
     }
-    return false
+    dfs(this)
+    return roots
+}
+
+private fun DeclarationDescriptor.isEnumSyntheticMethod(): Boolean =
+    this is FunctionDescriptor &&
+            (containingDeclaration as? ClassDescriptor)?.kind == ClassKind.ENUM_CLASS &&
+            (name.asString() == "values" || name.asString() == "valueOf")
+
+private fun IrDeclaration.isContainingClassKotlinOnly(): Boolean {
+    val parentClass = parentClassOrNull ?: return false
+    return isKotlinOnlyClass(parentClass)
+}
+
+private fun DeclarationDescriptor.isContainingClassKotlinOnly(): Boolean {
+    val parentClass = containingDeclaration as? ClassDescriptor ?: return false
+    return isKotlinOnlyClass(parentClass)
+}
+
+private fun IrDeclaration.overridesRealJavaMember(): Boolean {
+    if (this.isDeclaredInJava() || this.isMappedJreClassMember()) return true
+    if (this !is IrSimpleFunction) return false
+    return overriddenSymbols.any { it.owner.overridesRealJavaMember() }
+}
+
+private fun DeclarationDescriptor.overridesRealJavaMember(): Boolean {
+    if (this.isDeclaredInJava() || this.isMappedJreClassMember()) return true
+    if (this !is CallableMemberDescriptor) return false
+    return overriddenDescriptors.any { it.overridesRealJavaMember() }
 }

--- a/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibJavaInteropIntegrationTest.kt
+++ b/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibJavaInteropIntegrationTest.kt
@@ -129,4 +129,337 @@ class JKlibJavaInteropIntegrationTest {
             disposeRootInWriteAction(disposable)
         }
     }
+
+    @Test
+    fun testJavaCollectionToArrayOverridability(@TempDir tempDir: File) {
+        val stdlibKlib = ForTestCompileRuntime.jklibStdlibForTests().path
+        val stdlibJar = ForTestCompileRuntime.runtimeJarForTests().path
+
+        val libBDir = File(tempDir, "libB").apply { mkdirs() }
+        File(libBDir, "MyJavaCollection.java").apply {
+            writeText(
+                """
+                package test;
+
+                import java.util.AbstractCollection;
+                import java.util.Iterator;
+
+                public class MyJavaCollection<E> extends AbstractCollection<E> {
+                    @Override
+                    public Iterator<E> iterator() { return null; }
+
+                    @Override
+                    public int size() { return 0; }
+
+                    @Override
+                    public <T> T[] toArray(T[] a) {
+                        return a;
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        val jarB = MockLibraryUtilExt.compileJavaFilesLibraryToJar(
+            libBDir.path,
+            "libB",
+            extraClasspath = listOf(stdlibJar)
+        )
+
+        val mainDir = File(tempDir, "main").apply { mkdirs() }
+        val mainKt = File(mainDir, "Main.kt").apply {
+            writeText(
+                """
+                package test
+
+                fun test(c: MyJavaCollection<String>) {
+                    val arr = arrayOfNulls<String>(0)
+                    val res = c.toArray(arr)
+                }
+                """.trimIndent()
+            )
+        }
+
+        val mainKlib = File(tempDir, "main.klib")
+        val compiler = K2JKlibCompiler()
+        val args = compiler.createArguments()
+        compiler.parseArguments(
+            arrayOf(
+                mainKt.path,
+                "-d", mainKlib.path,
+                "-module-name", "main",
+                "-no-stdlib",
+                "-classpath", jarB.path,
+                "-Xklib=$stdlibKlib"
+            ),
+            args
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val disposable = Disposer.newDisposable()
+        try {
+            val artifact = compiler.compileKlibAndDeserializeIr(args, messageCollector, disposable)
+            assertNotNull(artifact, "compileKlibAndDeserializeIr returned null. Messages:\n" + messageCollector.messages.joinToString("\n"))
+        } finally {
+            disposeRootInWriteAction(disposable)
+        }
+    }
+
+    @Test
+    fun testPropertyAndFunctionClash(@TempDir tempDir: File) {
+        val stdlibKlib = ForTestCompileRuntime.jklibStdlibForTests().path
+        val stdlibJar = ForTestCompileRuntime.runtimeJarForTests().path
+
+        val libBDir = File(tempDir, "libB").apply { mkdirs() }
+        File(libBDir, "JavaBase.java").apply {
+            writeText(
+                """
+                package test;
+
+                public class JavaBase {
+                    public String getValue() {
+                        return "OK";
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        val jarB = MockLibraryUtilExt.compileJavaFilesLibraryToJar(
+            libBDir.path,
+            "libB",
+            extraClasspath = listOf(stdlibJar)
+        )
+
+        val mainDir = File(tempDir, "main").apply { mkdirs() }
+        val mainKt = File(mainDir, "Main.kt").apply {
+            writeText(
+                """
+                package test
+
+                class KotlinSub : JavaBase() {
+                    val value: String get() = super.getValue()
+                }
+
+                fun test(sub: KotlinSub) {
+                    val v = sub.value
+                    val g = sub.getValue()
+                }
+                """.trimIndent()
+            )
+        }
+
+        val mainKlib = File(tempDir, "main.klib")
+        val compiler = K2JKlibCompiler()
+        val args = compiler.createArguments()
+        compiler.parseArguments(
+            arrayOf(
+                mainKt.path,
+                "-d", mainKlib.path,
+                "-module-name", "main",
+                "-no-stdlib",
+                "-classpath", jarB.path,
+                "-Xklib=$stdlibKlib"
+            ),
+            args
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val disposable = Disposer.newDisposable()
+        try {
+            val artifact = compiler.compileKlibAndDeserializeIr(args, messageCollector, disposable)
+            assertNotNull(artifact, "compileKlibAndDeserializeIr returned null. Messages:\n" + messageCollector.messages.joinToString("\n"))
+        } finally {
+            disposeRootInWriteAction(disposable)
+        }
+    }
+
+    @Test
+    fun testVarPropertyVsJavaGetterSetterCollision(@TempDir tempDir: File) {
+        val stdlibKlib = ForTestCompileRuntime.jklibStdlibForTests().path
+        val stdlibJar = ForTestCompileRuntime.runtimeJarForTests().path
+
+        val libBDir = File(tempDir, "libB").apply { mkdirs() }
+        File(libBDir, "JavaBase.java").apply {
+            writeText(
+                """
+                package test;
+
+                public class JavaBase {
+                    public String getItem() { return "OK"; }
+                    public void setItem(String s) {}
+                }
+                """.trimIndent()
+            )
+        }
+
+        val jarB = MockLibraryUtilExt.compileJavaFilesLibraryToJar(
+            libBDir.path,
+            "libB",
+            extraClasspath = listOf(stdlibJar)
+        )
+
+        val mainDir = File(tempDir, "main").apply { mkdirs() }
+        val mainKt = File(mainDir, "Main.kt").apply {
+            writeText(
+                """
+                package test
+
+                class KotlinSub : JavaBase() {
+                    var item: String
+                        get() = super.getItem()
+                        set(value) { super.setItem(value) }
+                }
+
+                fun test(sub: KotlinSub) {
+                    sub.item = "new"
+                    val i = sub.item
+                }
+                """.trimIndent()
+            )
+        }
+
+        val mainKlib = File(tempDir, "main.klib")
+        val compiler = K2JKlibCompiler()
+        val args = compiler.createArguments()
+        compiler.parseArguments(
+            arrayOf(
+                mainKt.path,
+                "-d", mainKlib.path,
+                "-module-name", "main",
+                "-no-stdlib",
+                "-classpath", jarB.path,
+                "-Xklib=$stdlibKlib"
+            ),
+            args
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val disposable = Disposer.newDisposable()
+        try {
+            val artifact = compiler.compileKlibAndDeserializeIr(args, messageCollector, disposable)
+            assertNotNull(artifact, "compileKlibAndDeserializeIr returned null. Messages:\n" + messageCollector.messages.joinToString("\n"))
+        } finally {
+            disposeRootInWriteAction(disposable)
+        }
+    }
+
+    @Test
+    fun testJreMappedClassEqualsHashCodeToString(@TempDir tempDir: File) {
+        val stdlibKlib = ForTestCompileRuntime.jklibStdlibForTests().path
+        val stdlibJar = ForTestCompileRuntime.runtimeJarForTests().path
+
+        val mainDir = File(tempDir, "main").apply { mkdirs() }
+        val mainKt = File(mainDir, "Main.kt").apply {
+            writeText(
+                """
+                package test
+
+                class CustomList : java.util.ArrayList<String>() {
+                    override fun equals(other: Any?): Boolean = super.equals(other)
+                    override fun hashCode(): Int = super.hashCode()
+                    override fun toString(): String = super.toString()
+                }
+
+                fun test(list: CustomList) {
+                    val eq = list.equals("test")
+                    val hc = list.hashCode()
+                    val str = list.toString()
+                }
+                """.trimIndent()
+            )
+        }
+
+        val mainKlib = File(tempDir, "main.klib")
+        val compiler = K2JKlibCompiler()
+        val args = compiler.createArguments()
+        compiler.parseArguments(
+            arrayOf(
+                mainKt.path,
+                "-d", mainKlib.path,
+                "-module-name", "main",
+                "-no-stdlib",
+                "-Xklib=$stdlibKlib"
+            ),
+            args
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val disposable = Disposer.newDisposable()
+        try {
+            val artifact = compiler.compileKlibAndDeserializeIr(args, messageCollector, disposable)
+            assertNotNull(artifact, "compileKlibAndDeserializeIr returned null. Messages:\n" + messageCollector.messages.joinToString("\n"))
+        } finally {
+            disposeRootInWriteAction(disposable)
+        }
+    }
+
+    @Test
+    fun testLocalClassSignatureDisambiguation(@TempDir tempDir: File) {
+        val stdlibKlib = ForTestCompileRuntime.jklibStdlibForTests().path
+        val stdlibJar = ForTestCompileRuntime.runtimeJarForTests().path
+
+        val libBDir = File(tempDir, "libB").apply { mkdirs() }
+        File(libBDir, "JavaBase.java").apply {
+            writeText(
+                """
+                package test;
+
+                public class JavaBase {
+                    public void run() {}
+                }
+                """.trimIndent()
+            )
+        }
+
+        val jarB = MockLibraryUtilExt.compileJavaFilesLibraryToJar(
+            libBDir.path,
+            "libB",
+            extraClasspath = listOf(stdlibJar)
+        )
+
+        val mainDir = File(tempDir, "main").apply { mkdirs() }
+        val mainKt = File(mainDir, "Main.kt").apply {
+            writeText(
+                """
+                package test
+
+                fun outer() {
+                    val loc1 = object : JavaBase() {
+                        override fun run() {}
+                    }
+                    val loc2 = object : JavaBase() {
+                        override fun run() {}
+                    }
+                    loc1.run()
+                    loc2.run()
+                }
+                """.trimIndent()
+            )
+        }
+
+        val mainKlib = File(tempDir, "main.klib")
+        val compiler = K2JKlibCompiler()
+        val args = compiler.createArguments()
+        compiler.parseArguments(
+            arrayOf(
+                mainKt.path,
+                "-d", mainKlib.path,
+                "-module-name", "main",
+                "-no-stdlib",
+                "-classpath", jarB.path,
+                "-Xklib=$stdlibKlib"
+            ),
+            args
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val disposable = Disposer.newDisposable()
+        try {
+            val artifact = compiler.compileKlibAndDeserializeIr(args, messageCollector, disposable)
+            assertNotNull(artifact, "compileKlibAndDeserializeIr returned null. Messages:\n" + messageCollector.messages.joinToString("\n"))
+        } finally {
+            disposeRootInWriteAction(disposable)
+        }
+    }
 }


### PR DESCRIPTION
…erridability

- Add J2clToArrayOverridabilityCondition to externalOverridabilityConditions in JKlibIrCompilationPhase.
- Update JKlibIrMangler to support local class clash disambiguation (#clash#N), property getter/setter accessor clashing, and enhanced nullability stripping.
- Add integration tests in JKlibJavaInteropIntegrationTest for toArray overridability, property/function clashes, var getter/setter collisions, JRE mapped class overrides, and local class signature disambiguation.