### PR TITLE
[JKLIB] add support for -XheaderModeType compilation

### DIFF
--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsConfigurator.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArgumentsConfigurator.kt
@@ -59,7 +59,10 @@ open class CommonCompilerArgumentsConfigurator {
             putAnalysisFlag(AnalysisFlags.dontWarnOnErrorSuppression, dontWarnOnErrorSuppression)
             putAnalysisFlag(AnalysisFlags.lenientMode, lenientMode)
             putAnalysisFlag(AnalysisFlags.headerMode, headerMode)
-            putAnalysisFlag(AnalysisFlags.headerModeType, headerModeType)
+            HeaderMode.fromString(headerModeType)?.also { putAnalysisFlag(AnalysisFlags.headerModeType, it) }
+                ?: reporter.reportError(
+                    "Unknown value for parameter -Xheader-mode-type: '$headerModeType'. Value should be one of ${HeaderMode.availableValues()}"
+                )
             putAnalysisFlag(AnalysisFlags.firAggressivePruning, firAggressivePruning ?: headerMode)
             putAnalysisFlag(AnalysisFlags.hierarchicalMultiplatformCompilation, separateKmpCompilationScheme && multiPlatform)
             putAnalysisFlag(AnalysisFlags.kmpJvmIncrementalCompilationEnabled, fragmentIncrementalClasspath.isNotEmpty() && multiPlatform)

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibCliPipeline.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibCliPipeline.kt
@@ -6,11 +6,17 @@
 package org.jetbrains.kotlin.cli.jklib.pipeline
 
 import org.jetbrains.kotlin.backend.common.phaser.then
+import org.jetbrains.kotlin.backend.common.phaser.thenIf
 import org.jetbrains.kotlin.cli.common.arguments.K2JKlibCompilerArguments
 import org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline
 import org.jetbrains.kotlin.cli.pipeline.ArgumentsPipelineArtifact
 import org.jetbrains.kotlin.cli.pipeline.PipelineContext
+import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.HeaderMode
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.config.phaser.CompilerPhase
+import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.pipeline.AllModulesFrontendOutput
 import org.jetbrains.kotlin.util.PerformanceManager
 
 class JKlibCliPipeline(
@@ -21,14 +27,49 @@ class JKlibCliPipeline(
     ): CompilerPhase<PipelineContext, ArgumentsPipelineArtifact<K2JKlibCompilerArguments>, *> {
         val phases =
             JKlibConfigurationPhase then
-                    JKlibFrontendPipelinePhase then
-                    JKlibFir2IrPipelinePhase then
-                    JKlibKlibSerializationPhase
+                JKlibFrontendPipelinePhase.thenIf(
+                    condition = ::skipIrGeneration,
+                    onTrue = JKlibMetadataSerializationPhase,
+                    onFalse = JKlibFir2IrPipelinePhase then JKlibKlibSerializationPhase,
+                )
 
         return if (arguments.compileIr) {
             phases then JKlibIrCompilationPhase
         } else {
             phases
+        }
+    }
+
+    /**
+     * Skips IR generation when running header mode with -Xheader-mode and
+     * -Xheader-mode-type=compilation, unless the module contains declarations that require IR
+     * (inline functions, inline property accessors, or value classes).
+     */
+    private fun skipIrGeneration(artifact: JKlibFrontendPipelineArtifact): Boolean {
+        val configuration = artifact.configuration
+        return configuration.languageVersionSettings.getFlag(AnalysisFlags.headerMode) &&
+                configuration.languageVersionSettings.getFlag(AnalysisFlags.headerModeType) == HeaderMode.COMPILATION &&
+                !requireIrForHeaderCompilationMode(artifact.frontendOutput)
+    }
+
+    @OptIn(DirectDeclarationsAccess::class)
+    private fun requireIrForHeaderCompilationMode(frontendOutput: AllModulesFrontendOutput): Boolean {
+        return frontendOutput.outputs.any { output ->
+            output.fir.any { file ->
+                requireIrForHeaderCompilationMode(file.declarations)
+            }
+        }
+    }
+
+    @OptIn(DirectDeclarationsAccess::class)
+    private fun requireIrForHeaderCompilationMode(declarations: List<FirDeclaration>): Boolean {
+        return declarations.any { declaration ->
+            when (declaration) {
+                is FirFunction -> declaration.status.isInline
+                is FirProperty -> declaration.getter?.status?.isInline == true || declaration.setter?.status?.isInline == true
+                is FirClass -> declaration.status.isValue || requireIrForHeaderCompilationMode(declaration.declarations)
+                else -> false
+            }
         }
     }
 }

--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibPipelinePhases.kt
@@ -378,3 +378,63 @@ object JKlibKlibSerializationPhase : PipelinePhase<JKlibFir2IrPipelineArtifact, 
     }
 }
 
+object JKlibMetadataSerializationPhase : PipelinePhase<JKlibFrontendPipelineArtifact, JKlibSerializationArtifact>(
+    name = "JKlibMetadataSerializationPhase",
+    postActions = setOf(CheckCompilationErrors.CheckDiagnosticCollector)
+) {
+    override fun executePhase(input: JKlibFrontendPipelineArtifact): JKlibSerializationArtifact {
+        val configuration = input.configuration
+        val diagnosticsReporter = configuration.diagnosticsCollector
+        val destination = Path(configuration.jklibOutputDestination ?: "result.klib").absolute()
+
+        val rawModuleName = configuration.moduleName ?: JvmProtoBufUtil.DEFAULT_MODULE_NAME
+        val moduleName = Name.special("<$rawModuleName>").asString()
+
+        val serializerOutput = serializeModuleIntoKlib(
+            moduleName = moduleName,
+            irModuleFragment = null,
+            configuration = configuration,
+            diagnosticReporter = KtDiagnosticReporterWithImplicitIrBasedContext(
+                diagnosticsReporter.deduplicating(),
+                configuration.languageVersionSettings
+            ),
+            cleanFiles = emptyList(),
+            dependencies = emptyList(),
+            createModuleSerializer = { error("createModuleSerializer should not be called for metadata-only serialization") },
+            metadataSerializer = Fir2KlibMetadataSerializer(
+                configuration,
+                input.frontendOutput.outputs,
+                fir2IrActualizedResult = null,
+                exportKDoc = false,
+                produceHeaderKlib = true,
+            ),
+        )
+
+        val versions = KotlinLibraryVersioning(
+            abiVersion = KotlinAbiVersion.CURRENT,
+            compilerVersion = KotlinCompilerVersion.getVersion(),
+            metadataVersion = configuration.metadataVersion(),
+        )
+
+        KlibWriter {
+            format(KlibFormat.ZipArchive)
+            manifest {
+                moduleName(rawModuleName)
+                versions(versions)
+                platformAndTargets(BuiltInsPlatform.JKLIB, emptyList())
+                metadataFlags(configuration.languageVersionSettings)
+            }
+            includeMetadata(serializerOutput.serializedMetadata ?: error("expected serialized metadata"))
+            // serializedIr is null for metadata-only serialization; includeIr(null) is a no-op.
+            includeIr(serializerOutput.serializedIr)
+        }.writeTo(destination)
+
+        return JKlibSerializationArtifact(
+            destination.pathString,
+            configuration,
+            input.projectEnvironment,
+            input.rootDisposable,
+        )
+    }
+}
+

--- a/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibHeaderModeTest.kt
+++ b/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibHeaderModeTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.jklib.test
+
+import org.jetbrains.kotlin.cli.AbstractCliTest
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.jklib.K2JKlibCompiler
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.zip.ZipFile
+
+class JKlibHeaderModeTest {
+
+    private val stdlibKlib: String
+        get() = ForTestCompileRuntime.jklibStdlibForTests().path
+
+    private fun compile(
+        srcFile: File,
+        outputKlib: File,
+        moduleName: String,
+        vararg extraArgs: String
+    ): Pair<String, ExitCode> {
+        val args = mutableListOf(
+            srcFile.path,
+            "-d", outputKlib.path,
+            "-module-name", moduleName,
+            "-no-stdlib",
+            "-Xklib=$stdlibKlib"
+        ).apply { addAll(extraArgs) }
+        return AbstractCliTest.executeCompilerGrabOutput(K2JKlibCompiler(), args)
+    }
+
+    private fun File.hasAnyIrEntries(): Boolean {
+        return ZipFile(this).use { zip ->
+            zip.entries().asSequence().any { 
+                it.name.contains("/ir/") || it.name.contains("/ir_inlinable_functions") || it.name.startsWith("ir/")
+            }
+        }
+    }
+
+    private fun File.getAllEntryNames(): List<String> {
+        return ZipFile(this).use { zip ->
+            zip.entries().asSequence().map { it.name }.toList()
+        }
+    }
+
+    @Test
+    fun testHeaderModeKlibWithoutInlinesOmitsIr(@TempDir tempDir: File) {
+        val libSrc = File(tempDir, "Lib.kt").apply {
+            writeText(
+                """
+                package test
+
+                class Service {
+                    fun serve(): String = "OK"
+                }
+                """.trimIndent()
+            )
+        }
+        val outputKlib = File(tempDir, "libNoIr.klib")
+
+        val result = compile(libSrc, outputKlib, "libNoIr", "-Xheader-mode", "-Xheader-mode-type=compilation")
+        assertEquals(ExitCode.OK, result.second) { "Compilation failed: ${result.first}" }
+
+        assertTrue(outputKlib.exists(), "Output KLIB file does not exist")
+        assertFalse(outputKlib.hasAnyIrEntries()) {
+            "KLIB compiled without inline functions should NOT contain IR entries. Found entries: ${outputKlib.getAllEntryNames()}"
+        }
+    }
+
+    @Test
+    fun testHeaderModeKlibWithInlineFunctionPreservesIr(@TempDir tempDir: File) {
+        val libSrc = File(tempDir, "LibInline.kt").apply {
+            writeText(
+                """
+                package test
+
+                inline fun inlineHelper(): String = "OK"
+                """.trimIndent()
+            )
+        }
+        val outputKlib = File(tempDir, "libWithIr.klib")
+
+        val result = compile(libSrc, outputKlib, "libWithIr", "-Xheader-mode", "-Xheader-mode-type=compilation")
+        assertEquals(ExitCode.OK, result.second) { "Compilation failed: ${result.first}" }
+
+        assertTrue(outputKlib.exists(), "Output KLIB file does not exist")
+        assertTrue(outputKlib.hasAnyIrEntries()) {
+            "KLIB compiled with inline functions MUST contain IR entries. Found entries: ${outputKlib.getAllEntryNames()}"
+        }
+    }
+
+    @Test
+    fun testHeaderModeKlibWithInlinePropertyAccessorPreservesIr(@TempDir tempDir: File) {
+        val libSrc = File(tempDir, "LibInlineProp.kt").apply {
+            writeText(
+                """
+                package test
+
+                val inlineProp: String
+                    inline get() = "OK"
+                """.trimIndent()
+            )
+        }
+        val outputKlib = File(tempDir, "libInlineProp.klib")
+
+        val result = compile(libSrc, outputKlib, "libInlineProp", "-Xheader-mode", "-Xheader-mode-type=compilation")
+        assertEquals(ExitCode.OK, result.second) { "Compilation failed: ${result.first}" }
+
+        assertTrue(outputKlib.exists(), "Output KLIB file does not exist")
+        assertTrue(outputKlib.hasAnyIrEntries()) {
+            "KLIB compiled with inline property accessors MUST contain IR entries. Found entries: ${outputKlib.getAllEntryNames()}"
+        }
+    }
+
+    @Test
+    fun testHeaderModeKlibWithValueClassPreservesIr(@TempDir tempDir: File) {
+        val libSrc = File(tempDir, "LibValueClass.kt").apply {
+            writeText(
+                """
+                package test
+
+                @JvmInline
+                value class MyValue(val value: Int)
+                """.trimIndent()
+            )
+        }
+        val outputKlib = File(tempDir, "libValueClass.klib")
+
+        val result = compile(libSrc, outputKlib, "libValueClass", "-Xheader-mode", "-Xheader-mode-type=compilation")
+        assertEquals(ExitCode.OK, result.second) { "Compilation failed: ${result.first}" }
+
+        assertTrue(outputKlib.exists(), "Output KLIB file does not exist")
+        assertTrue(outputKlib.hasAnyIrEntries()) {
+            "KLIB compiled with value classes MUST contain IR entries. Found entries: ${outputKlib.getAllEntryNames()}"
+        }
+    }
+
+    @Test
+    fun testDownstreamCompilationAgainstHeaderKlib(@TempDir tempDir: File) {
+        val libSrc = File(tempDir, "Lib.kt").apply {
+            writeText(
+                """
+                package test
+
+                class Service {
+                    fun serve(): String = "OK"
+                }
+
+                inline fun helper(): String = "OK"
+                """.trimIndent()
+            )
+        }
+        val libKlib = File(tempDir, "libHeader.klib")
+
+        val libResult = compile(libSrc, libKlib, "libHeader", "-Xheader-mode", "-Xheader-mode-type=compilation")
+        assertEquals(ExitCode.OK, libResult.second) { "Compilation of library failed: ${libResult.first}" }
+
+        val appSrc = File(tempDir, "App.kt").apply {
+            writeText(
+                """
+                package app
+
+                import test.Service
+                import test.helper
+
+                fun useService() {
+                    val s = Service()
+                    s.serve()
+                    helper()
+                }
+                """.trimIndent()
+            )
+        }
+        val appKlib = File(tempDir, "app.klib")
+
+        val appResult = AbstractCliTest.executeCompilerGrabOutput(
+            K2JKlibCompiler(),
+            listOf(
+                appSrc.path,
+                "-d", appKlib.path,
+                "-module-name", "app",
+                "-no-stdlib",
+                "-Xklib=$stdlibKlib${File.pathSeparator}${libKlib.path}"
+            )
+        )
+        assertEquals(ExitCode.OK, appResult.second) { "Downstream compilation against header KLIB failed: ${appResult.first}" }
+    }
+
+    @Test
+    fun testInvalidHeaderModeTypeReportsError(@TempDir tempDir: File) {
+        val libSrc = File(tempDir, "Lib.kt").apply {
+            writeText("package test\nclass Service")
+        }
+        val outputKlib = File(tempDir, "lib.klib")
+
+        val result = compile(libSrc, outputKlib, "lib", "-Xheader-mode", "-Xheader-mode-type=invalid_type")
+        assertEquals(ExitCode.COMPILATION_ERROR, result.second) {
+            "Expected COMPILATION_ERROR for invalid -Xheader-mode-type, but got exit code ${result.second}"
+        }
+    }
+}


### PR DESCRIPTION
Implementing -XheaderModeType="compilation" in jklib based on native's implementation.
This headerModeType skips IR whenever possible.
The exception being:
inline functions, inline property accesors and value classes