### PR TITLE
[NI] Update reachability metadata

### DIFF
--- a/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
+++ b/prepare/compiler-native-image/resources/META-INF/native-image/org/jetbrains/kotlin/kotlin-compiler-embeddable/reachability-metadata.json
@@ -506,6 +506,15 @@
       "type": "org.jetbrains.kotlin.com.intellij.codeInsight.multiverse.MultiverseEnabler"
     },
     {
+      "type": "org.jetbrains.kotlin.com.intellij.concurrency.VarHandleWrapperImpl",
+      "methods": [
+        {
+          "name": "useVarHandlesInConcurrentCollections",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "org.jetbrains.kotlin.com.intellij.java.syntax.JavaSyntaxBundle"
     },
     {


### PR DESCRIPTION
Recent changes in master caused Native Image CI tests to fail. This commits updates reachability metadata for the native image to fix the tests.

[CI run](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_NativeImageTestsAggregate/1008781790) with new metadata