### PR TITLE
[K/N] Tests: Fix flakiness in the kt56402 test (KT-87458)

### DIFF
--- a/native/native.tests/testData/interop/objc/kt56402/kt56402.kt
+++ b/native/native.tests/testData/interop/objc/kt56402/kt56402.kt
@@ -7,6 +7,7 @@
 import kt56402.*
 
 import kotlin.concurrent.AtomicInt
+import kotlin.concurrent.AtomicReference
 import kotlin.native.concurrent.*
 import kotlin.native.internal.test.testLauncherEntryPoint
 import kotlin.system.exitProcess
@@ -45,11 +46,18 @@ class OnDestroyHookSub(onDestroy: (ULong) -> Unit) : OnDestroyHook(onDestroy)
 
 val aliveObjectIds = LockedSet<ULong>()
 
-@NoInline fun alloc(ctor: ((ULong) -> Unit) -> ULong): ULong = autoreleasepool {
-    val id = ctor {
+// Keeps the last allocated object strongly reachable until it is registered in `aliveObjectIds`.
+// Otherwise the GC may collect it and run `onDestroy` (which removes the id from the set)
+// on the finalizer thread before `add` happens, failing the assertion in `LockedSet.remove`.
+val keepAlive = AtomicReference<Any?>(null)
+
+@NoInline fun alloc(ctor: ((ULong) -> Unit) -> Pair<Any, ULong>): ULong = autoreleasepool {
+    val (obj, id) = ctor {
         aliveObjectIds.remove(it)
     }
+    keepAlive.value = obj
     aliveObjectIds.add(id)
+    keepAlive.value = null
     id
 }
 
@@ -73,10 +81,11 @@ fun waitDestruction(id: ULong) {
 fun testOnMainThread() {
     assertTrue(isMainThread())
     val id = alloc { onDestroy ->
-        OnDestroyHook {
+        val obj = OnDestroyHook {
             assertTrue(isMainThread())
             onDestroy(it)
-        }.identity()
+        }
+        obj to obj.identity()
     }
     waitDestruction(id)
 }
@@ -87,10 +96,11 @@ fun testOnSecondaryThread() {
         execute(TransferMode.SAFE, {}) {
             assertFalse(isMainThread())
             alloc { onDestroy ->
-                OnDestroyHook {
+                val obj = OnDestroyHook {
                     assertFalse(isMainThread())
                     onDestroy(it)
-                }.identity()
+                }
+                obj to obj.identity()
             }
         }.result
     }
@@ -101,10 +111,11 @@ fun testOnSecondaryThread() {
 fun testSubOnMainThread() {
     assertTrue(isMainThread())
     val id = alloc { onDestroy ->
-        OnDestroyHookSub {
+        val obj = OnDestroyHookSub {
             assertTrue(isMainThread())
             onDestroy(it)
-        }.identity()
+        }
+        obj to obj.identity()
     }
     waitDestruction(id)
 }
@@ -115,10 +126,11 @@ fun testSubOnSecondaryThread() {
         execute(TransferMode.SAFE, {}) {
             assertFalse(isMainThread())
             alloc { onDestroy ->
-                OnDestroyHookSub {
+                val obj = OnDestroyHookSub {
                     assertFalse(isMainThread())
                     onDestroy(it)
-                }.identity()
+                }
+                obj to obj.identity()
             }
         }.result
     }
@@ -134,7 +146,7 @@ fun testGlobalOnMainThread() {
             onDestroy(it)
         }!!
         clearGlobal()
-        obj.identity()
+        obj to obj.identity()
     }
     waitDestruction(id)
 }
@@ -150,7 +162,7 @@ fun testGlobalOnSecondaryThread() {
                     onDestroy(it)
                 }!!
                 clearGlobal()
-                obj.identity()
+                obj to obj.identity()
             }
         }.result
     }
@@ -161,10 +173,11 @@ fun testGlobalOnSecondaryThread() {
 fun testProtocolOnMainThread() {
     assertTrue(isMainThread())
     val id = alloc { onDestroy ->
-        newOnDestroyHook {
+        val obj = newOnDestroyHook {
             assertTrue(isMainThread())
             onDestroy(it)
-        }!!.identity()
+        }!!
+        obj to obj.identity()
     }
     waitDestruction(id)
 }
@@ -175,10 +188,11 @@ fun testProtocolOnSecondaryThread() {
         execute(TransferMode.SAFE, {}) {
             assertFalse(isMainThread())
             alloc { onDestroy ->
-                newOnDestroyHook {
+                val obj = newOnDestroyHook {
                     assertFalse(isMainThread())
                     onDestroy(it)
-                }!!.identity()
+                }!!
+                obj to obj.identity()
             }
         }.result
     }


### PR DESCRIPTION
Fixes [KT-87458](https://youtrack.jetbrains.com/issue/KT-87458) 
(`ComplexCInteropTest.testKt56402` is flaky).

**Root cause:**
the test registers each object's id in `aliveObjectIds` only after the constructor returns, but the objects were temporaries (`OnDestroyHook { ... }.identity()`) whose last reference dies as soon as `identity()` returns. If the GC finalizes the object in that window, the ObjC `dealloc` hook runs `LockedSet.remove` on the finalizer thread before `add`, tripping the `assertTrue(id in impl)` assertion — exactly the trace in the issue.

**Fix:** keep the allocated object strongly reachable in a global `keepAlive` sink until it's registered. (maybe should be in separate memory space?)

**Verification** (macOS aarch64): 
made the race deterministic by inserting `kotlin.native.runtime.GC.collect()` between construction and registration.
Unmodified test: fails every run (5/5) with the exact KT-87458 stack, and only the secondary-thread tests fail — matching the issue (`testSubOnSecondaryThread`), since main-thread objects are finalized on the main run loop after registration. With the fix: passes every run with the forced collection (10/10) and without it (20/20).