### PR TITLE
[Swift Export][Tests] Enable simple test suite for iOS

### DIFF
--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/NativeTestSupport.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/NativeTestSupport.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.konan.test.blackbox.support
 
 import org.jetbrains.kotlin.config.PartialLinkageConfig
 import org.jetbrains.kotlin.config.PartialLinkageLogLevel
+import org.jetbrains.kotlin.config.nativeBinaryOptions.BinaryOptions
 import org.jetbrains.kotlin.config.nativeBinaryOptions.GC
 import org.jetbrains.kotlin.config.nativeBinaryOptions.GCSchedulerType
 import org.jetbrains.kotlin.konan.target.Distribution
@@ -252,7 +253,7 @@ object NativeTestSupport {
         output += computeCompilerOutputInterceptor(enforcedProperties)
         output += computeBinaryLibraryKind(enforcedProperties)
         output += computeCInterfaceMode(enforcedProperties)
-        output += computeXCTestRunner(enforcedProperties, nativeTargets)
+        output += computeXCTestRunner(enforcedProperties, nativeTargets, binaryOptions)
         output += computeKlibIrInlinerMode(tags)
         // Compute tests timeouts with regard to already calculated properties that may affect execution time
         output += computeTimeouts(enforcedProperties, output)
@@ -431,13 +432,18 @@ object NativeTestSupport {
         return Timeouts(executionTimeout)
     }
 
-    private fun computeXCTestRunner(enforcedProperties: EnforcedProperties, nativeTargets: KotlinNativeTargets) = XCTestRunner(
+    private fun computeXCTestRunner(
+        enforcedProperties: EnforcedProperties,
+        nativeTargets: KotlinNativeTargets,
+        binaryOptions: ExplicitBinaryOptions,
+    ) = XCTestRunner(
         ClassLevelProperty.XCTEST_FRAMEWORK.readValue(
             enforcedProperties,
             String::toBooleanStrictOrNull,
             default = false
         ),
-        nativeTargets
+        nativeTargets,
+        isMacabi = binaryOptions.getOrNull(BinaryOptions.macabi) ?: false,
     )
 
     private fun computePlatformLibs(enforcedProperties: EnforcedProperties): PlatformLibs {

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/TestProcessSettings.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/TestProcessSettings.kt
@@ -312,7 +312,10 @@ internal enum class CInterfaceMode(val compilerFlag: String) {
     NONE("-Xbinary=cInterfaceMode=none")
 }
 
-internal class XCTestRunner(val isEnabled: Boolean, private val nativeTargets: KotlinNativeTargets) {
+internal class XCTestRunner(
+    val isEnabled: Boolean,
+    private val nativeTargets: KotlinNativeTargets,
+    private val isMacabi: Boolean) {
     /**
      * Path to the developer frameworks directory.
      */
@@ -335,11 +338,14 @@ internal class XCTestRunner(val isEnabled: Boolean, private val nativeTargets: K
     }
 
     private fun targetPlatform(): String {
-        val xcodeTarget = when (val target = nativeTargets.testTarget) {
-            KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64 -> "macosx"
-            KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64 -> "iphonesimulator"
-            KonanTarget.IOS_ARM64 -> "iphoneos"
-            else -> error("Target $target is not supported buy the executor")
+        val xcodeTarget = when {
+            isMacabi -> "macosx"
+            else -> when (val target = nativeTargets.testTarget) {
+                KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64 -> "macosx"
+                KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64 -> "iphonesimulator"
+                KonanTarget.IOS_ARM64 -> "iphoneos"
+                else -> error("Target $target is not supported buy the executor")
+            }
         }
 
         val result = try {

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/closures/closures.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/closures/closures.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // MODULE: Main
 // FILE: closures.kt

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/coroutines/coroutines.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/coroutines/coroutines.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // MODULE: Main
 // FILE: coroutines.kt

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/inheritance/inheritance.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/inheritance/inheritance.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
 // MODULE: Main

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/sequences/sequences.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/execution/sequences/sequences.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // MODULE: Main
 // FILE: sequences.kt

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/closures/closures.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/closures/closures.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // APPLE_ONLY_VALIDATION
 // MODULE: main

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/coroutines.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/coroutines.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // APPLE_ONLY_VALIDATION
 // MODULE: main

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutinesWithPackageFlattening/coroutinesWithPackageFlattening.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutinesWithPackageFlattening/coroutinesWithPackageFlattening.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // APPLE_ONLY_VALIDATION
 // MODULE: main

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/crossLanguageInheritance/crossLanguageInheritance.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/crossLanguageInheritance/crossLanguageInheritance.kt
@@ -1,7 +1,3 @@
-// IGNORE_NATIVE: targetFamily=IOS
-// IGNORE_NATIVE: targetFamily=TVOS
-// IGNORE_NATIVE: targetFamily=WATCHOS
-// IGNORE_NATIVE: target=macos_x64
 // KIND: STANDALONE
 // APPLE_ONLY_VALIDATION
 // MODULE: main

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/coroutines/TestGenerator.kt
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/coroutines/TestGenerator.kt
@@ -8,10 +8,12 @@ package org.jetbrains.kotlin.swiftexport.standalone.test.coroutines
 import org.jetbrains.kotlin.generators.dsl.junit5.generateTestGroupSuiteWithJUnit5
 import org.jetbrains.kotlin.generators.model.annotation
 import org.jetbrains.kotlin.generators.tests.provider
+import org.jetbrains.kotlin.konan.target.KonanTarget.MACOS_ARM64
 import org.jetbrains.kotlin.konan.test.blackbox.support.group.UseExtTestCaseGroupProvider
 import org.jetbrains.kotlin.swiftexport.standalone.test.AbstractSwiftExportExecutionTest
 import org.jetbrains.kotlin.swiftexport.standalone.test.AbstractSwiftExportWithBinaryCompilationTest
 import org.jetbrains.kotlin.swiftexport.standalone.test.AbstractSwiftExportWithResultValidationTest
+import org.jetbrains.kotlin.swiftexport.standalone.test.EnabledOnNativeTargets
 import org.jetbrains.kotlin.swiftexport.standalone.test.SwiftExportWithCoroutinesTestSupport
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -21,13 +23,17 @@ fun main(args: Array<String>) {
 
 fun generateCoroutinesSuite(args: Array<String>, classNamePrefix: String = "") {
     val testsRoot = args[0]
+    // Coroutines/atomicfu test klibs are prebuilt for macos_arm64 only on the CI agents.
+    val targetRestrictionAnnotation = annotation(EnabledOnNativeTargets::class.java, "targets" to arrayOf(MACOS_ARM64.name))
+
     generateTestGroupSuiteWithJUnit5(args) {
         testGroup(testsRoot, "native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation") {
             testClass<AbstractSwiftExportWithResultValidationTest>(
                 suiteTestClassName = "${classNamePrefix}SwiftExportCoroutinesWithResultValidationTest",
                 annotations = listOf(
                     provider<UseExtTestCaseGroupProvider>(),
-                    annotation(ExtendWith::class.java, SwiftExportWithCoroutinesTestSupport::class.java)
+                    annotation(ExtendWith::class.java, SwiftExportWithCoroutinesTestSupport::class.java),
+                    targetRestrictionAnnotation,
                 ),
             ) {
                 model("", extension = null, recursive = false)
@@ -38,7 +44,8 @@ fun generateCoroutinesSuite(args: Array<String>, classNamePrefix: String = "") {
                 suiteTestClassName = "${classNamePrefix}SwiftExportCoroutinesWithBinaryCompilationTest",
                 annotations = listOf(
                     provider<UseExtTestCaseGroupProvider>(),
-                    annotation(ExtendWith::class.java, SwiftExportWithCoroutinesTestSupport::class.java)
+                    annotation(ExtendWith::class.java, SwiftExportWithCoroutinesTestSupport::class.java),
+                    targetRestrictionAnnotation,
                 ),
             ) {
                 model("", extension = null, recursive = false)
@@ -49,7 +56,8 @@ fun generateCoroutinesSuite(args: Array<String>, classNamePrefix: String = "") {
                 suiteTestClassName = "${classNamePrefix}SwiftExportCoroutinesExecutionTestGenerated",
                 annotations = listOf(
                     provider<UseExtTestCaseGroupProvider>(),
-                    annotation(ExtendWith::class.java, SwiftExportWithCoroutinesTestSupport::class.java)
+                    annotation(ExtendWith::class.java, SwiftExportWithCoroutinesTestSupport::class.java),
+                    targetRestrictionAnnotation,
                 ),
             ) {
                 model(pattern = "^([^_](.+))$", recursive = false)

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectExecutionTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectExecutionTest.kt
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.swiftexport.standalone.runSwiftExport
 import org.junit.jupiter.api.Test
 import java.io.File
 
+// Uses external project klibs prebuilt for macos_arm64 only on the CI agents.
+@EnabledOnNativeTargets(targets = ["macos_arm64"])
 abstract class AbstractExternalProjectExecutionTest : AbstractSwiftExportExecutionTest() {
 
     @Test

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectGenerationTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectGenerationTest.kt
@@ -17,6 +17,8 @@ import org.jetbrains.kotlin.swiftexport.standalone.runSwiftExport
 import org.junit.jupiter.api.Test
 import java.io.File
 
+// Uses external project klibs prebuilt for macos_arm64 only on the CI agents.
+@EnabledOnNativeTargets(targets = ["macos_arm64"])
 abstract class AbstractExternalProjectGenerationTest : AbstractSwiftExportWithBinaryCompilationTest(), SwiftExportValidator {
 
     private val tmpdir = FileUtil.createTempDirectory("SwiftExportIntegrationTests", null, false)

--- a/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.swiftexport.standalone.test
 
 import com.intellij.testFramework.TestDataFile
 import org.jetbrains.kotlin.konan.target.Distribution
+import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.test.blackbox.support.*
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.SwiftCompilation
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact
@@ -24,6 +25,9 @@ import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftExportConfig
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
 import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertTrue
 import org.jetbrains.kotlin.utils.KotlinNativePaths
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import java.io.File
 import java.nio.file.Path
@@ -44,6 +48,26 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
     * */
     var givenModules: Set<TestModule.Given> = emptySet()
     var minOSVersion: String? = null
+
+    /**
+     * Single target gate for all Swift Export suites: skips (does not fail) the test when its `testTarget`
+     * is not allowed by the [EnabledOnNativeTargets] annotation on the test class. Suites with no annotation
+     * are unconstrained.
+     */
+    @BeforeEach
+    fun assumeTestTargetEnabled(testInfo: TestInfo) {
+        val annotation = testInfo.testClass.get().getAnnotation(EnabledOnNativeTargets::class.java) ?: return
+        val unknownTargets = annotation.targets.filterNot(KonanTarget.predefinedTargets::containsKey)
+        check(unknownTargets.isEmpty()) {
+            "Unknown native targets in ${annotation.annotationClass.simpleName}: $unknownTargets"
+        }
+
+        val testTarget = targets.testTarget
+        val enabled = testTarget.family in annotation.families || testTarget.name in annotation.targets
+        Assumptions.assumeTrue(enabled) {
+            "Ignored: test target '${testTarget.name}' is not enabled by ${annotation.annotationClass.simpleName}"
+        }
+    }
 
     /**
      * Additional options appended verbatim to every `swiftc` invocation made by the test harness. Tests that

--- a/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportWithBinaryCompilationTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportWithBinaryCompilationTest.kt
@@ -26,6 +26,8 @@ import java.io.File
 @AffectedByNative
 @AffectedByAnalysisApi
 @ExtendWith(UpdateTestDataSupport::class)
+// TODO: KT-75530 — extend beyond OSX/IOS once other Apple families can build these apps.
+@EnabledOnNativeTargets(families = [Family.OSX, Family.IOS])
 abstract class AbstractSwiftExportWithBinaryCompilationTest : AbstractSwiftExportTest() {
     protected open fun runCompiledTest(
         testPathFull: File,
@@ -38,9 +40,9 @@ abstract class AbstractSwiftExportWithBinaryCompilationTest : AbstractSwiftExpor
 
     @BeforeEach
     fun checkHost() {
+        // Swift export compilation/execution requires an Apple host (swiftc/Xcode). The *target* gate
+        // lives in @EnabledOnNativeTargets on this class (see AbstractSwiftExportTest.assumeTestTargetEnabled).
         Assumptions.assumeTrue(testRunSettings.get<KotlinNativeTargets>().hostTarget.family.isAppleFamily)
-        // TODO: KT-75530
-        Assumptions.assumeTrue(testRunSettings.get<KotlinNativeTargets>().testTarget.family == Family.OSX)
     }
 
     protected fun runTest(@TestDataFile testDir: String) {

--- a/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/EnabledOnNativeTargets.kt
+++ b/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/EnabledOnNativeTargets.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.swiftexport.standalone.test
+
+import org.jetbrains.kotlin.konan.target.Family
+
+/**
+ * Restricts a Swift Export test class to the given native targets. Evaluated once per test by
+ * [AbstractSwiftExportTest.assumeTestTargetEnabled]; a test whose `testTarget` is not allowed is
+ * skipped (JUnit "ignored"), not failed.
+ *
+ * A target is enabled when its [Family] is listed in [families] **or** its canonical name
+ * (e.g. `"macos_arm64"`) is listed in [targets]. Use [families] for family-wide constraints
+ * (e.g. "any Apple mobile/desktop target") and [targets] to pin an exact target (e.g. suites that
+ * consume prebuilt klibs that only exist for `macos_arm64` on the CI agents).
+ *
+ * `@Inherited` so a generated concrete suite picks up the annotation from its abstract base; a suite may
+ * also carry its own annotation (e.g. added by a test generator, as the coroutines suites do), which
+ * shadows the inherited one.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+@java.lang.annotation.Inherited
+annotation class EnabledOnNativeTargets(
+    val families: Array<Family> = [],
+    val targets: Array<String> = [],
+)


### PR DESCRIPTION
Previously all swift-export-standalone-integration-tests were disabled for non-macOS targets. That is expected for tests relying on prebuilt klibs on the CI agents (e.g. coroutines, external modules), but the simple module doesn't have such dependencies and should run on iOS.
Use single @EnabledOnNativeTargets annotation to define target restrictions for test suites.

^KT-75530