### PR TITLE
Auto code review: force default prefix for diffs

### DIFF
--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitCLI.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitCLI.kt
@@ -41,7 +41,7 @@ object GitCLI : LocalGit {
     private const val DIFF_MINUS_MINUS_GIT = "diff --git "
 
     override suspend fun getDiff(from: GitSHA1, to: GitWorkingTree): GitDiff {
-        val diffText = gitOutput(tree = to, "diff", from.sha1)
+        val diffText = gitOutput(tree = to, "diff", "--default-prefix", from.sha1)
         val diffLines = ArrayDeque(diffText.lines())
 
         val changedFiles = mutableListOf<GitDiff.ChangedFile>()


### PR DESCRIPTION
`parseChangedFile` uses `removePrefix("a/")`/`removePrefix("b/")`, which doesn't work properly in case a custom prefix is used (git config options `diff.srcPrefix`, `diff.dstPrefix`, `diff.noprefix`, `diff.mnemonicPrefix`).