### PR TITLE
KT-85180 [AFU] Don't expose fields in generated IrPropertyReferences

### DIFF
--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
@@ -327,7 +327,10 @@ abstract class AbstractAtomicfuIrBuilder(
             type = kPropertyClass.defaultType.substitute(substitutionMap),
             symbol = property.symbol,
             typeArgumentsCount = 0,
-            field = backingField.symbol,
+            // Referring a field may violate visibility checks,
+            // but at the same time the field is not needed anywhere down the pipeline,
+            // so we can use value null here. See KT-85180.
+            field = null,
             getter = property.getter?.symbol,
             setter = property.setter?.symbol
         ).apply {

--- a/plugins/atomicfu/atomicfu-compiler/testData/backendDiagnostic/MultiFileCAS.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/backendDiagnostic/MultiFileCAS.kt
@@ -3,9 +3,6 @@
 // TARGET_BACKEND: NATIVE
 // DIAGNOSTICS: -NOTHING_TO_INLINE
 
-// DISABLE_IR_VISIBILITY_CHECKS: NATIVE
-// ^^^ Because AtomicFU plugin generates an IR property reference node that refers to a private property, KT-85180.
-
 // FILE: foo.kt
 class Foo {
     internal val a: kotlinx.atomicfu.AtomicInt = kotlinx.atomicfu.atomic(0)


### PR DESCRIPTION
Fields referred from `IrPropertyReferences` are not used down the compilation pipeline (in `VolatileFieldsLowering`). 
At the same time, these fields are always private and violate IR visibility checks.
To avoid the latter, we can abstain from referring them.

^KT-85180 fixed