### PR TITLE
[Wasm, Test] Only run debug/ tests in dev mode

### DIFF
--- a/compiler/testData/debug/stepping/multiModule.kt
+++ b/compiler/testData/debug/stepping/multiModule.kt
@@ -1,4 +1,3 @@
-// WASM_IGNORE_FOR: mode=multi-module
 // MODULE: lib
 // FILE: a.kt
 
@@ -17,34 +16,34 @@ fun box() {
 }
 
 // EXPECTATIONS JVM_IR
+// test.kt:14 box
+// a.kt:4 a
+// test.kt:14 box
 // test.kt:15 box
-// a.kt:5 a
+// b.kt:8 b
 // test.kt:15 box
 // test.kt:16 box
-// b.kt:9 b
-// test.kt:16 box
-// test.kt:17 box
 
 // EXPECTATIONS NATIVE
+// test.kt:14 box
+// a.kt:4 a
+// test.kt:14 box
 // test.kt:15 box
-// a.kt:5 a
-// test.kt:15 box
+// b.kt:8 b
 // test.kt:16 box
-// b.kt:9 b
-// test.kt:17 box
 
 // EXPECTATIONS JS_IR
+// test.kt:14 box
+// a.kt:4 a
 // test.kt:15 box
-// a.kt:5 a
+// b.kt:8 b
 // test.kt:16 box
-// b.kt:9 b
-// test.kt:17 box
 
 // EXPECTATIONS WASM
+// test.kt:14 $box (4)
+// a.kt:4 $a (10, 13)
+// test.kt:14 $box (4)
 // test.kt:15 $box (4)
-// a.kt:5 $a (10, 13)
+// b.kt:8 $b (10, 13)
 // test.kt:15 $box (4)
-// test.kt:16 $box (4)
-// b.kt:9 $b (10, 13)
-// test.kt:16 $box (4)
-// test.kt:17 $box (1)
+// test.kt:16 $box (1)

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/handlers/WasmDebugRunner.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/handlers/WasmDebugRunner.kt
@@ -33,10 +33,10 @@ open class WasmDebugRunner(testServices: TestServices, includeLocalVariableInfor
     override fun processAfterAllModules(someAssertionWasFailed: Boolean) {
         if (!someAssertionWasFailed) {
             val artifacts = modulesToArtifact.values.single() as WasmCompilationSetsBinaryArtifact
+            // run debug tests only in dev (non-DCE) compilation, as DCE:
+            // - is not a supported debug mode in general, and
+            // - can slightly degrade source maps, which can lead to different stepping behavior between dev and dce, which doesn't work with unified EXPECTATIONS blocks
             processCompilationSet(artifacts.compilation, "dev")
-            artifacts.dceCompilation?.let {
-                processCompilationSet(it, "dce")
-            }
         }
     }
 }


### PR DESCRIPTION
Remove dce compilation from `WasmDebugRunner`.