### PR TITLE
[Gradle] Skip multiple KGP check when project isolation is on

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING
 import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.util.checkedReplace
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.DisplayName
 import kotlin.io.path.appendText
 import kotlin.test.assertEquals
@@ -93,23 +94,19 @@ class DifferentClassloadersIT : KGPBaseTest() {
             "differentClassloaders",
             gradleVersion,
         ) {
+            assumeTrue(buildOptions.isolatedProjects.toBooleanFlag(gradleVersion))
+
             setupDifferentClassloadersProject()
 
-            if (buildOptions.isolatedProjects.toBooleanFlag(gradleVersion)) {
-                // Web plugins generally don't support project isolation (see KT-75899), so there are many build failure reasons.
-                // We're using a heuristic to validate that the build didn't fail because of different classloader detection logic:
-                // KotlinPluginInMultipleProjectsHolder stores paths of projects that apply the KGP in the root project's extras,
-                // which is not allowed with project isolation.
-                buildAndFail("publish", "-PmppProjectDependency=true") {
-                    assertOutputDoesNotContain(
-                        "Plugin class 'org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin': " +
-                                "Project ':mpp-lib' cannot access 'Project.extensions' functionality on another project ':'"
-                    )
-                }
-            } else {
-                build("publish", "-PmppProjectDependency=true") {
-                    assertOutputContains(MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING)
-                }
+            // Web plugins generally don't support project isolation (see KT-75899), so there are many build failure reasons.
+            // We're using a heuristic to validate that the build didn't fail because of different classloader detection logic:
+            // KotlinPluginInMultipleProjectsHolder stores paths of projects that apply the KGP in the root project's extras,
+            // which is not allowed with project isolation.
+            buildAndFail("publish", "-PmppProjectDependency=true") {
+                assertOutputDoesNotContain(
+                    "Plugin class 'org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin': " +
+                            "Project ':mpp-lib' cannot access 'Project.extensions' functionality on another project ':'"
+                )
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING
 import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_SPECIFIC_PROJECTS_WARNING
+import org.jetbrains.kotlin.gradle.targets.js.MULTIPLE_PLUGIN_DETECTION_DISABLED_WITH_PROJECT_ISOLATION_INFO
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.gradle.util.checkedReplace
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -98,15 +99,8 @@ class DifferentClassloadersIT : KGPBaseTest() {
 
             setupDifferentClassloadersProject()
 
-            // Web plugins generally don't support project isolation (see KT-75899), so there are many build failure reasons.
-            // We're using a heuristic to validate that the build didn't fail because of different classloader detection logic:
-            // KotlinPluginInMultipleProjectsHolder stores paths of projects that apply the KGP in the root project's extras,
-            // which is not allowed with project isolation.
             buildAndFail("publish", "-PmppProjectDependency=true") {
-                assertOutputDoesNotContain(
-                    "Plugin class 'org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin': " +
-                            "Project ':mpp-lib' cannot access 'Project.extensions' functionality on another project ':'"
-                )
+                assertOutputContains(MULTIPLE_PLUGIN_DETECTION_DISABLED_WITH_PROJECT_ISOLATION_INFO)
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/DifferentClassloadersIT.kt
@@ -86,6 +86,34 @@ class DifferentClassloadersIT : KGPBaseTest() {
         }
     }
 
+    @DisplayName("KT-87840: Different classloader detection is turned off in web targets when project isolation is enabled")
+    @GradleTest
+    fun testDetectingDifferentClassLoadersInWebTargetsTurnedOffInIsolatedProjects(gradleVersion: GradleVersion) {
+        project(
+            "differentClassloaders",
+            gradleVersion,
+        ) {
+            setupDifferentClassloadersProject()
+
+            if (buildOptions.isolatedProjects.toBooleanFlag(gradleVersion)) {
+                // Web plugins generally don't support project isolation (see KT-75899), so there are many build failure reasons.
+                // We're using a heuristic to validate that the build didn't fail because of different classloader detection logic:
+                // KotlinPluginInMultipleProjectsHolder stores paths of projects that apply the KGP in the root project's extras,
+                // which is not allowed with project isolation.
+                buildAndFail("publish", "-PmppProjectDependency=true") {
+                    assertOutputDoesNotContain(
+                        "Plugin class 'org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin': " +
+                                "Project ':mpp-lib' cannot access 'Project.extensions' functionality on another project ':'"
+                    )
+                }
+            } else {
+                build("publish", "-PmppProjectDependency=true") {
+                    assertOutputContains(MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING)
+                }
+            }
+        }
+    }
+
     private fun TestProject.setupDifferentClassloadersProject() {
         // Specify the plugin versions in the subprojects with different plugin sets –
         // this will make Gradle use separate class loaders

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/differentClassloaders/mpp-lib/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/differentClassloaders/mpp-lib/build.gradle
@@ -8,7 +8,9 @@ version = "1.0"
 
 kotlin {
     jvm()
-    js()
+    js {
+        nodejs()
+    }
 }
 
 publishing {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/MultiplePluginDeclarationDetector.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/MultiplePluginDeclarationDetector.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.BuildFinishedListenerService
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginInMultipleProjectsHolder
 import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING
+import org.jetbrains.kotlin.gradle.plugin.internal.isProjectIsolationEnabled
 
 internal class MultiplePluginDeclarationDetector
 private constructor() {
@@ -17,6 +18,8 @@ private constructor() {
     )
 
     fun detect(project: Project) {
+        if (project.isProjectIsolationEnabled) return
+
         pluginInMultipleProjectsHolder
             .addProject(project)
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/MultiplePluginDeclarationDetector.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/MultiplePluginDeclarationDetector.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.js
 
 import org.gradle.api.Project
+import org.gradle.api.logging.Logging
 import org.jetbrains.kotlin.gradle.plugin.BuildFinishedListenerService
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginInMultipleProjectsHolder
 import org.jetbrains.kotlin.gradle.plugin.MULTIPLE_KOTLIN_PLUGINS_LOADED_WARNING
@@ -16,9 +17,13 @@ private constructor() {
     private val pluginInMultipleProjectsHolder = KotlinPluginInMultipleProjectsHolder(
         trackPluginVersionsSeparately = false
     )
+    private val logger by lazy { Logging.getLogger(MultiplePluginDeclarationDetector::class.java) }
 
     fun detect(project: Project) {
-        if (project.isProjectIsolationEnabled) return
+        if (project.isProjectIsolationEnabled) {
+            logger.info(MULTIPLE_PLUGIN_DETECTION_DISABLED_WITH_PROJECT_ISOLATION_INFO)
+            return
+        }
 
         pluginInMultipleProjectsHolder
             .addProject(project)
@@ -54,3 +59,6 @@ private constructor() {
         }
     }
 }
+
+const val MULTIPLE_PLUGIN_DETECTION_DISABLED_WITH_PROJECT_ISOLATION_INFO = "MultiplePluginDeclarationDetector is disabled because " +
+        "project isolation is enabled."

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/yarn/WasmYarnRootExtensionTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/yarn/WasmYarnRootExtensionTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.wasm.yarn
 
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 import org.jetbrains.kotlin.internal.KgpBuildConstants
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -15,6 +16,9 @@ class WasmYarnRootExtensionTest {
     @Test
     fun checkDefaultYarnVersion() {
         val project = ProjectBuilder.builder().build()
+        // Apply the KotlinMultiplatformPluginWrapper first so the necessary wiring takes places,
+        // consistent with how WasmYarnPlugin is applied in real projects.
+        project.plugins.apply(KotlinMultiplatformPluginWrapper::class.java)
         val yarnRootExtension = WasmYarnPlugin.apply(project)
         assertEquals(
             KgpBuildConstants.DEFAULT_YARN_VERSION,

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/web/yarn/YarnRootExtensionTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/web/yarn/YarnRootExtensionTest.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.web.yarn
 
 import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.internal.KgpBuildConstants
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,7 +17,10 @@ class YarnRootExtensionTest {
     @Test
     fun checkDefaultYarnVersion() {
         val project = ProjectBuilder.builder().build()
-        val yarnRootExtension = YarnPlugin.Companion.apply(project)
+        // Apply the KotlinMultiplatformPluginWrapper first so the necessary wiring takes places,
+        // consistent with how WasmYarnPlugin is applied in real projects.
+        project.plugins.apply(KotlinMultiplatformPluginWrapper::class.java)
+        val yarnRootExtension = YarnPlugin.apply(project)
         assertEquals(
             KgpBuildConstants.DEFAULT_YARN_VERSION,
             yarnRootExtension.versionProperty.orNull,


### PR DESCRIPTION
MultiplePluginDeclarationDetector (or rather
KotlinPluginInMultipleProjectsHolder it uses under the hood) is not compatible with project isolation, so it needs to exit early if project isolation is enabled.

^KT-87840 Verification Pending