### PR TITLE
[Wasm] Support callable references with context parameters

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/AbstractFunctionReferenceLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/AbstractFunctionReferenceLowering.kt
@@ -322,3 +322,51 @@ abstract class AbstractFunctionReferenceLowering<C : CommonBackendContext>(val c
     protected abstract fun getInvokeMethodOrigin(reference: IrRichFunctionReference): IrDeclarationOrigin
     protected abstract fun getConstructorCallOrigin(reference: IrRichFunctionReference): IrStatementOrigin?
 }
+
+fun CommonBackendContext.addBoundValueAtOverride(
+    functionReferenceClass: IrClass,
+    fields: List<IrField>,
+    overrideOrigin: IrDeclarationOrigin = IrDeclarationOrigin.DEFINED,
+) {
+    val overridden = functionReferenceClass.superTypes.mapNotNull { superType ->
+        superType.getClass()
+            ?.declarations
+            ?.filterIsInstance<IrSimpleFunction>()
+            ?.singleOrNull { it.name.asString() == "boundValueAt" }
+            ?.symbol
+    }
+    if (overridden.isEmpty()) return
+
+    val function = functionReferenceClass.addFunction {
+        startOffset = SYNTHETIC_OFFSET
+        endOffset = SYNTHETIC_OFFSET
+        name = Name.identifier("boundValueAt")
+        origin = overrideOrigin
+        returnType = overridden[0].owner.returnType
+    }
+    function.parameters += function.createDispatchReceiverParameterWithClassParent()
+    overridden[0].owner.parameters
+        .filter { it.kind == IrParameterKind.Regular }
+        .forEach { function.parameters += it.copyTo(function) }
+    function.overriddenSymbols += overridden
+
+    val anyNType = irBuiltIns.anyNType
+    function.body = createIrBuilder(function.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
+        +irReturn(irBoundValueAt(function, fields, anyNType))
+    }
+}
+
+private fun IrBuilderWithScope.irBoundValueAt(function: IrFunction, fields: List<IrField>, resultType: IrType): IrExpression {
+    val dispatchReceiver = function.dispatchReceiverParameter!!
+    fun boundValue(field: IrField) = irGetField(irGet(dispatchReceiver), field)
+
+    if (fields.size == 1) {
+        return boundValue(fields[0])
+    }
+
+    val indexParameter = function.parameters.single { it.kind == IrParameterKind.Regular }
+    val branches = (0..<fields.lastIndex).map { index ->
+        irBranch(irEquals(irGet(indexParameter), irInt(index)), boundValue(fields[index]))
+    } + irElseBranch(boundValue(fields.last()))
+    return irWhen(resultType, branches)
+}

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/BackendWasmSymbols.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/BackendWasmSymbols.kt
@@ -52,8 +52,8 @@ class BackendWasmSymbols(
         val isSupportedInterface by CallableIds.isSupportedInterface.functionSymbol()
         val getInterfaceVTable by CallableIds.getInterfaceVTable.functionSymbol()
         val wasmGetInterfaceVTableBodyImpl by CallableIds.wasmGetInterfaceVTableBodyImpl.functionSymbol()
-        // XXX To be changed after bootstrap.
-        val kFunctionImpl: IrClassSymbol = ClassIds.KFunctionImplNew.classSymbolOrNull() ?: ClassIds.KFunctionImpl.classSymbol()
+        // XXX Drop fallback to KFunctionImplNew (now it is older than KFunctionImpl) after bootstrap.
+        val kFunctionImpl: IrClassSymbol = ClassIds.KFunctionImpl.classSymbolOrNull() ?: ClassIds.KFunctionImplNew.classSymbol()
         val kFunctionErrorImpl: IrClassSymbol = ClassIds.KFunctionErrorImpl.classSymbol()
     }
 

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmCallableReferenceLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmCallableReferenceLowering.kt
@@ -241,7 +241,7 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
                     makeValueParameter("flags", context.irBuiltIns.intType),
                     makeValueParameter("arity", context.irBuiltIns.intType),
                     makeValueParameter("id", context.irBuiltIns.stringType),
-                    makeValueParameter("receiver", context.irBuiltIns.anyNType),
+                    makeValueParameter("boundValueCount", context.irBuiltIns.intType),
                     makeValueParameter("name", context.irBuiltIns.stringType),
                 )
             }
@@ -254,7 +254,6 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
     private fun IrBuilderWithScope.getExtraConstructorArgument(
         parameter: IrValueParameter,
         reference: IrRichFunctionReference,
-        receiverTemp: IrVariable?,
     ): IrExpression {
         val linkerError = reference.getLinkageErrorIfAny(backendContext)
         val reflectionTargetSymbol = reference.reflectionTargetSymbol
@@ -278,13 +277,8 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
                     "id" -> {
                         reference.getId(backendContext).toIrConst(context.irBuiltIns.stringType)
                     }
-                    "receiver" -> {
-                        // Use the temporary variable if provided, otherwise null
-                        if (receiverTemp != null) {
-                            irGet(receiverTemp)
-                        } else {
-                            irNull()
-                        }
+                    "boundValueCount" -> {
+                        reference.boundValues.size.toIrConst(context.irBuiltIns.intType)
                     }
                     "name" -> {
                         name.toIrConst(context.irBuiltIns.stringType)
@@ -565,6 +559,10 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
             postprocessInvoke(this, functionReference.secondFunctionInterface)
         }
 
+        if (fields.isNotEmpty()) {
+            addBoundValueAtOverride(functionReferenceClass, fields)
+        }
+
         val superInterfaceClass = superInterfaceType.classOrFail.owner
 
         functionReferenceClass.addFakeOverrides(
@@ -582,62 +580,22 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
         constructor: IrConstructor,
         irBuilder: DeclarationIrBuilder,
         bridgedFunction: IrSimpleFunction,
-    ): IrExpression {
-        val boundReceiverIndex = if (reference.reflectionTargetSymbol != null) {
-            val boundReceiverParameters = reference.invokeFunction.parameters.filter {
-                // This is a total hack, but by the time we get to IR,
-                // apparently coerced to unit function references already
-                // have introduced receiver parameters (as `receiver', and
-                // not as `<this>' like everywhere else. This makes things
-                // fairly brittle.
-                val name = it.name.asString()
-                name == "<this>" || name == "receiver"
+    ): IrExpression =
+        irBuilder.irCallConstructor(constructor.symbol, emptyList()).apply {
+            origin = JsStatementOrigins.CALLABLE_REFERENCE_CREATE
+            arguments[0] = IrRawFunctionReferenceImpl(
+                startOffset = reference.startOffset,
+                endOffset = reference.endOffset,
+                type = reference.type,
+                symbol = bridgedFunction.symbol,
+            )
+            for ((index, value) in reference.boundValues.withIndex()) {
+                arguments[index + 1] = value
             }
-            require(boundReceiverParameters.size <= 1) { "Code generation for references with more than one bound receiver is not supported yet" }
-            if (boundReceiverParameters.isEmpty())
-                null
-            else
-                reference.invokeFunction.parameters.indexOf(boundReceiverParameters.first())
-        } else {
-            null
+            for (index in (reference.boundValues.size + 1) until arguments.size) {
+                arguments[index] = irBuilder.getExtraConstructorArgument(constructor.parameters[index], reference)
+            }
         }
-
-        fun DeclarationIrBuilder.buildConstructorCall(receiverTemp: IrVariable?) =
-            irCallConstructor(constructor.symbol, emptyList()).apply {
-                origin = JsStatementOrigins.CALLABLE_REFERENCE_CREATE
-                arguments[0] = IrRawFunctionReferenceImpl(
-                    startOffset = reference.startOffset,
-                    endOffset = reference.endOffset,
-                    type = reference.type,
-                    symbol = bridgedFunction.symbol,
-                )
-                for ((index, value) in reference.boundValues.withIndex()) {
-                    arguments[index + 1] = if (receiverTemp != null && index == boundReceiverIndex) {
-                        irGet(receiverTemp)
-                    } else {
-                        value
-                    }
-                }
-                for (index in (reference.boundValues.size + 1) until arguments.size) {
-                    arguments[index] = getExtraConstructorArgument(
-                        constructor.parameters[index],
-                        reference,
-                        receiverTemp
-                    )
-                }
-            }
-
-        return if (boundReceiverIndex != null) {
-            // Create a temporary for the receiver to avoid duplicate IR nodes
-            irBuilder.irBlock {
-                val receiverTemp = irTemporary(reference.boundValues[boundReceiverIndex], nameHint = "receiver")
-                +irBuilder.buildConstructorCall(receiverTemp)
-            }
-        } else {
-            // No receiver reuse needed, use simple constructor call
-            irBuilder.buildConstructorCall(null)
-        }
-    }
 
     private fun IrBuilderWithScope.irUnit() =
         IrGetObjectValueImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, context.irBuiltIns.unitType, context.irBuiltIns.unitClass)
@@ -806,6 +764,48 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
         }
     }
 
+    private fun addBoundValueAtOverride(functionReferenceClass: IrClass, fields: List<IrField>) {
+        val overridden = functionReferenceClass.superTypes.mapNotNull { superType ->
+            superType.getClass()
+                ?.declarations
+                ?.filterIsInstance<IrSimpleFunction>()
+                ?.singleOrNull { it.name.asString() == "boundValueAt" }
+                ?.symbol
+        }
+        if (overridden.isEmpty()) return
+
+        val function = functionReferenceClass.addFunction {
+            startOffset = SYNTHETIC_OFFSET
+            endOffset = SYNTHETIC_OFFSET
+            name = Name.identifier("boundValueAt")
+            origin = GENERATED_MEMBER_IN_CALLABLE_REFERENCE
+            returnType = overridden[0].owner.returnType
+        }
+        function.parameters += function.createDispatchReceiverParameterWithClassParent()
+        overridden[0].owner.parameters
+            .filter { it.kind == IrParameterKind.Regular }
+            .forEach { function.parameters += it.copyTo(function) }
+        function.overriddenSymbols += overridden
+        function.body = context.createIrBuilder(function.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
+            +irReturn(irBoundValueAt(function, fields))
+        }
+    }
+
+    private fun IrBuilderWithScope.irBoundValueAt(function: IrFunction, fields: List<IrField>): IrExpression {
+        val dispatchReceiver = function.dispatchReceiverParameter!!
+        fun boundValue(field: IrField) = irGetField(irGet(dispatchReceiver), field)
+
+        if (fields.size == 1) {
+            return boundValue(fields[0])
+        }
+
+        val indexParameter = function.parameters.single { it.kind == IrParameterKind.Regular }
+        val branches = (0..<fields.lastIndex).map { index ->
+            irBranch(irEquals(irGet(indexParameter), irInt(index)), boundValue(fields[index]))
+        } + irElseBranch(boundValue(fields.last()))
+        return irWhen(context.irBuiltIns.anyNType, branches)
+    }
+
     private fun generateSuperClassConstructorCall(
         irBuilder: IrBuilderWithScope,
         constructor: IrConstructor,
@@ -827,7 +827,7 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
                     arguments[0] = getConstructorArg("flags")
                     arguments[1] = getConstructorArg("arity")
                     arguments[2] = getConstructorArg("id")
-                    arguments[3] = getConstructorArg("receiver")
+                    arguments[3] = getConstructorArg("boundValueCount")
                     arguments[4] = getConstructorArg("name")
                 }
             }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmCallableReferenceLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/WasmCallableReferenceLowering.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.linkage.partial.reflectionTargetLinkageError
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.VariableRemapper
+import org.jetbrains.kotlin.backend.common.lower.addBoundValueAtOverride
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.declarationsAtFunctionReferenceLowering
 import org.jetbrains.kotlin.backend.wasm.WasmBackendContext
@@ -560,7 +561,7 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
         }
 
         if (fields.isNotEmpty()) {
-            addBoundValueAtOverride(functionReferenceClass, fields)
+            context.addBoundValueAtOverride(functionReferenceClass, fields, GENERATED_MEMBER_IN_CALLABLE_REFERENCE)
         }
 
         val superInterfaceClass = superInterfaceType.classOrFail.owner
@@ -762,48 +763,6 @@ class WasmCallableReferenceLowering(val backendContext: WasmBackendContext) : Fi
                 )
             }
         }
-    }
-
-    private fun addBoundValueAtOverride(functionReferenceClass: IrClass, fields: List<IrField>) {
-        val overridden = functionReferenceClass.superTypes.mapNotNull { superType ->
-            superType.getClass()
-                ?.declarations
-                ?.filterIsInstance<IrSimpleFunction>()
-                ?.singleOrNull { it.name.asString() == "boundValueAt" }
-                ?.symbol
-        }
-        if (overridden.isEmpty()) return
-
-        val function = functionReferenceClass.addFunction {
-            startOffset = SYNTHETIC_OFFSET
-            endOffset = SYNTHETIC_OFFSET
-            name = Name.identifier("boundValueAt")
-            origin = GENERATED_MEMBER_IN_CALLABLE_REFERENCE
-            returnType = overridden[0].owner.returnType
-        }
-        function.parameters += function.createDispatchReceiverParameterWithClassParent()
-        overridden[0].owner.parameters
-            .filter { it.kind == IrParameterKind.Regular }
-            .forEach { function.parameters += it.copyTo(function) }
-        function.overriddenSymbols += overridden
-        function.body = context.createIrBuilder(function.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
-            +irReturn(irBoundValueAt(function, fields))
-        }
-    }
-
-    private fun IrBuilderWithScope.irBoundValueAt(function: IrFunction, fields: List<IrField>): IrExpression {
-        val dispatchReceiver = function.dispatchReceiverParameter!!
-        fun boundValue(field: IrField) = irGetField(irGet(dispatchReceiver), field)
-
-        if (fields.size == 1) {
-            return boundValue(fields[0])
-        }
-
-        val indexParameter = function.parameters.single { it.kind == IrParameterKind.Regular }
-        val branches = (0..<fields.lastIndex).map { index ->
-            irBranch(irEquals(irGet(indexParameter), irInt(index)), boundValue(fields[index]))
-        } + irElseBranch(boundValue(fields.last()))
-        return irWhen(context.irBuiltIns.anyNType, branches)
     }
 
     private fun generateSuperClassConstructorCall(

--- a/compiler/testData/codegen/box/callableReference/equality/unboundVsNullBoundReceiver.kt
+++ b/compiler/testData/codegen/box/callableReference/equality/unboundVsNullBoundReceiver.kt
@@ -1,6 +1,5 @@
-// IGNORE_BACKEND: WASM_JS, WASM_WASI
-// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.3,2.4
-// ^ Fixed in 2.5 by KT-87445
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native,Wasm-JS:2.3,2.4
+// ^ Fixed in 2.5 by KT-87445 (Native) and KT-87447 (Wasm)
 // ISSUE: KT-87625
 
 fun checkNotEqual(x: Any, y: Any) {

--- a/compiler/testData/codegen/box/contextParameters/contextualCallableReferenceEquality.kt
+++ b/compiler/testData/codegen/box/contextParameters/contextualCallableReferenceEquality.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +ContextParameters +CallableReferencesToContextual
-// IGNORE_BACKEND: JVM_IR, WASM_JS, WASM_WASI
+// IGNORE_BACKEND: JVM_IR
 // ^KT-86452, KT-87390
 
 import kotlin.reflect.KFunction

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeFunctionReferenceLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeFunctionReferenceLowering.kt
@@ -8,16 +8,14 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.linkage.partial.PartialLinkageCase
 import org.jetbrains.kotlin.backend.common.linkage.partial.reflectionTargetLinkageError
 import org.jetbrains.kotlin.backend.common.lower.AbstractFunctionReferenceLowering
-import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.lower.addBoundValueAtOverride
 import org.jetbrains.kotlin.backend.common.customNameInReflection
 import org.jetbrains.kotlin.backend.common.linkage.partial.PartialLinkageIssueSignificance
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.llvm.computeFullName
-import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.builders.*
-import org.jetbrains.kotlin.ir.builders.declarations.addFunction
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.irFlag
@@ -99,51 +97,11 @@ internal class NativeFunctionReferenceLowering(val generationState: NativeGenera
 
     override fun generateExtraMethods(functionReferenceClass: IrClass, reference: IrRichFunctionReference) {
         if (reference.reflectionTargetSymbol == null) return
-        fun addOverrideInner(name: String, value: IrBuilderWithScope.(IrFunction) -> IrExpression) {
-            val overridden = functionReferenceClass.superTypes.mapNotNull { superType ->
-                superType.getClass()
-                        ?.declarations
-                        ?.filterIsInstance<IrSimpleFunction>()
-                        ?.singleOrNull { it.name.asString() == name }
-                        ?.symbol
-            }
-            require(overridden.isNotEmpty())
-            val function = functionReferenceClass.addFunction {
-                startOffset = SYNTHETIC_OFFSET
-                endOffset = SYNTHETIC_OFFSET
-                this.name = Name.identifier(name)
-                modality = Modality.FINAL
-                returnType = overridden[0].owner.returnType
-            }
-            function.parameters += function.createDispatchReceiverParameterWithClassParent()
-            overridden[0].owner.parameters
-                    .filter { it.kind == IrParameterKind.Regular }
-                    .forEach { function.parameters += it.copyTo(function) }
-            function.overriddenSymbols += overridden
-            function.body = context.createIrBuilder(function.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
-                +irReturn(value(function))
-            }
-        }
 
         val fields = functionReferenceClass.fields.toList()
         if (fields.isEmpty()) return
 
-        addOverrideInner("boundValueAt") { function -> irBoundValueAt(function, fields) }
-    }
-
-    private fun IrBuilderWithScope.irBoundValueAt(function: IrFunction, fields: List<IrField>): IrExpression {
-        val dispatchReceiver = function.dispatchReceiverParameter!!
-        fun boundValue(field: IrField) = irGetField(irGet(dispatchReceiver), field)
-
-        if (fields.size == 1) {
-            return boundValue(fields[0])
-        }
-
-        val indexParameter = function.parameters.single { it.kind == IrParameterKind.Regular }
-        val branches = (0..<fields.lastIndex).map { index ->
-            irBranch(irEquals(irGet(indexParameter), irInt(index)), boundValue(fields[index]))
-        } + irElseBranch(boundValue(fields.last()))
-        return irWhen(context.irBuiltIns.anyNType, branches)
+        context.addBoundValueAtOverride(functionReferenceClass, fields)
     }
 
     private fun IrBuilderWithScope.irKFunctionDescription(functionReference: IrRichFunctionReference, description: KFunctionDescription, reflectionTargetLinkageError: PartialLinkageCase?): IrConstantValue {

--- a/libraries/stdlib/wasm/internal/KFunctionImpl.kt
+++ b/libraries/stdlib/wasm/internal/KFunctionImpl.kt
@@ -9,30 +9,39 @@ import kotlin.reflect.KFunction
 import kotlin.internal.throwIrLinkageError
 import kotlin.internal.UsedFromCompilerGeneratedCode
 
-// Old version to be removed once bootstrap compiler gets updated.
 @UsedFromCompilerGeneratedCode
-internal abstract class KFunctionImpl(val flags: Int, val arity: Int, val id: String) {
-    protected open fun computeReceiver(): Any? = null
+internal abstract class KFunctionImpl<out R>(val flags: Int, val arity: Int, val id: String, val boundValueCount: Int, override val name: String) : KFunction<R> {
+    open fun boundValueAt(index: Int): Any? = null
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        return other is KFunctionImpl &&
-                this.flags == other.flags &&
-                this.arity == other.arity &&
-                this.id == other.id &&
-                this.computeReceiver() == other.computeReceiver()
+        if (other !is KFunctionImpl<*>) return false
+        if (this.flags != other.flags || this.arity != other.arity ||
+            this.id != other.id || this.boundValueCount != other.boundValueCount
+        ) return false
+
+        repeat(boundValueCount) { index ->
+            if (boundValueAt(index) != other.boundValueAt(index)) return false
+        }
+
+        return true
     }
 
     override fun hashCode(): Int {
         var result = flags
         result = 31 * result + arity
         result = 31 * result + id.hashCode()
-        result = 31 * result + computeReceiver().hashCode()
+
+        repeat(boundValueCount) { index ->
+            result = 31 * result + boundValueAt(index).hashCode()
+        }
+        // name does not need to be hashed explicitly, since id is a
+        // hash of fqName which contains name.
         return result
     }
 }
 
-// To be renamed to KFunctionImpl after bootstrap.
+// Old (contrary to its name) version to be removed once bootstrap compiler gets updated.
 @UsedFromCompilerGeneratedCode
 internal abstract class KFunctionImplNew<out R>(val flags: Int, val arity: Int, val id: String, val receiver: Any?, override val name: String) : KFunction<R> {
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
References to callable references with context parameters bind several values (context arguments and receiver), which the Wasm runtime and reference lowering didn't handle.

Replace the single `receiver` field with indexed
`boundValueCount`/`boundValueAt(index)` pair.

^KT-87447 Fixed
^KT-87625 Fixed