### PR TITLE
KT-77692 [AFU] Fix IrTypeOperatorCall handling

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
@@ -132,7 +132,7 @@ class Fir2IrImplicitCastInserter(c: Fir2IrComponents, private val conversionScop
         argumentType: ConeKotlinType,
         expectedType: ConeKotlinType,
     ): IrExpression {
-        return insertCastForIntersectionTypeOrNull(argumentType, expectedType, forReceiver = true)
+        return insertCastForIntersectionTypeOrNull(argumentType, expectedType)
         // When we generate an implicit this receiver, we assign it the type of the IR declaration.
         // However, dataframe generates FIR and IR anonymous functions with different receiver types
         // and then relies on the fact that FIR2IR generates an implicit cast from the one to the other.
@@ -146,28 +146,21 @@ class Fir2IrImplicitCastInserter(c: Fir2IrComponents, private val conversionScop
         argumentType: ConeKotlinType,
         expectedType: ConeKotlinType,
     ): IrExpression {
-        return insertCastForIntersectionTypeOrNull(argumentType, expectedType, forReceiver = false)
+        return insertCastForIntersectionTypeOrNull(argumentType, expectedType)
             ?: this
     }
 
     private fun IrExpression.insertCastForIntersectionTypeOrNull(
         argumentType: ConeKotlinType,
         expectedType: ConeKotlinType,
-        forReceiver: Boolean,
     ): IrExpression? {
         val argumentTypeLowerBound = argumentType.lowerBoundIfFlexible()
         if (argumentTypeLowerBound !is ConeIntersectionType) return null
 
         val approximatedExpectedType = expectedType.approximateForIrOrSelf()
 
-        // An intersection type like `Foo<Any?> & Foo<Bar>` is approximated to `Foo<out Any?>`.
-        // However, atomic-fu relies on the fact that receivers don't have projections in their type arguments.
-        // See plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/UncheckedCastTest.kt
-        // TODO(KT-77692) Remove if fixed on the plugin side.
-        if (!forReceiver) {
-            val approximatedArgumentType = argumentTypeLowerBound.approximateForIrOrNull() ?: argumentTypeLowerBound
-            if (approximatedArgumentType.isSubtypeOf(approximatedExpectedType, session)) return null
-        }
+        val approximatedArgumentType = argumentTypeLowerBound.approximateForIrOrNull() ?: argumentTypeLowerBound
+        if (approximatedArgumentType.isSubtypeOf(approximatedExpectedType, session)) return null
 
         return argumentTypeLowerBound.intersectedTypes
             .firstOrNull { it.isSubtypeOf(approximatedExpectedType, session) }

--- a/compiler/testData/ir/irText/expressions/atomicFuUncheckedCast.ir.txt
+++ b/compiler/testData/ir/irText/expressions/atomicFuUncheckedCast.ir.txt
@@ -83,7 +83,7 @@ FILE fqName:<root> fileName:/atomicFuUncheckedCast.kt
             ARG arg0: CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=<root>.Box origin=GET_ARRAY_ELEMENT
               ARG <this>: CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Array<<root>.Box> origin=GET_ARRAY_ELEMENT
                 ARG <this>: CALL 'public final fun <get-value> (): T of <root>.AtomicRef declared in <root>.AtomicRef' type=kotlin.Array<kotlin.Array<<root>.Box>> origin=GET_PROPERTY
-                  ARG <this>: TYPE_OP type=<root>.AtomicRef<kotlin.Array<kotlin.Array<<root>.Box>>> origin=IMPLICIT_CAST typeOperand=<root>.AtomicRef<kotlin.Array<kotlin.Array<<root>.Box>>>
+                  ARG <this>: TYPE_OP type=<root>.AtomicRef<out kotlin.Any?> origin=IMPLICIT_CAST typeOperand=<root>.AtomicRef<out kotlin.Any?>
                     GET_VAR 'bs: <root>.AtomicRef<kotlin.Any?> declared in <root>.test' type=<root>.AtomicRef<kotlin.Any?> origin=null
                 ARG index: CONST Int type=kotlin.Int value=0
               ARG index: CONST Int type=kotlin.Int value=1

--- a/compiler/testData/ir/irText/expressions/atomicFuUncheckedCast.kt.txt
+++ b/compiler/testData/ir/irText/expressions/atomicFuUncheckedCast.kt.txt
@@ -27,5 +27,6 @@ class Box {
 
 fun test(bs: AtomicRef<Any?>) {
   bs as AtomicRef<Array<Array<Box>>> /*~> Unit */
-  CHECK_NOT_NULL<Box>(arg0 = bs /*as AtomicRef<Array<Array<Box>>> */.<get-value>().get(index = 0).get(index = 1)).<get-b>() /*~> Unit */
+  CHECK_NOT_NULL<Box>(arg0 = bs /*as AtomicRef<out Any?> */.<get-value>().get(index = 0).get(index = 1)).<get-b>() /*~> Unit */
 }
+

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
@@ -81,7 +81,7 @@ abstract class AbstractAtomicfuIrBuilder(
         functionName: String,
         valueArguments: List<IrExpression?>,
         valueType: IrType,
-    ): IrCall {
+    ): IrExpression {
         val atomicHandlerClassSymbol = (getAtomicHandler.type as IrSimpleType).classOrNull
             ?: error("Failed to obtain the ClassSymbol of the type ${getAtomicHandler.render()}.")
         val functionSymbol = when (functionName) {
@@ -99,7 +99,9 @@ abstract class AbstractAtomicfuIrBuilder(
             functionSymbol,
             listOf(getAtomicHandler) + modifiedArgs,
             valueType
-        )
+        ).let {
+            if (functionName == "plusAssign" || functionName == "minusAssign") it.coerceToUnit() else it
+        }
     }
 
     abstract fun invokeFunctionOnAtomicHandler(
@@ -108,7 +110,7 @@ abstract class AbstractAtomicfuIrBuilder(
         functionName: String,
         valueArguments: List<IrExpression?>,
         valueType: IrType,
-    ): IrCall
+    ): IrExpression
 
     fun irGetProperty(property: IrProperty, dispatchReceiver: IrExpression?) =
         irCall(property.getter?.symbol ?: error("Getter is not defined for the property ${property.atomicfuRender()}")).apply {
@@ -627,5 +629,15 @@ abstract class AbstractAtomicfuIrBuilder(
     private fun IrType.getFunctionReturnType(): IrType {
         require(isFunction()) { "Expected FunctionN type, but got: ${this.render()}" }
         return (this as IrSimpleType).arguments.last().typeOrFail
+    }
+
+    protected fun IrCall.coerceToUnit(): IrTypeOperatorCall {
+        return IrTypeOperatorCallImpl(
+            startOffset, endOffset,
+            irBuiltIns.unitType,
+            IrTypeOperator.IMPLICIT_COERCION_TO_UNIT,
+            irBuiltIns.unitType,
+            this
+        )
     }
 }

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuTransformer.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuTransformer.kt
@@ -20,13 +20,13 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.utils.addToStdlib.assignFrom
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
 import org.jetbrains.kotlinx.atomicfu.compiler.backend.*
@@ -402,12 +402,18 @@ abstract class AbstractAtomicfuTransformer(
             val receiver = requireNotNull(expression.arguments[receiverParameter.indexInParameters]) {
                 "Expected receiver of the call ${expression.render()}, but found null."
             }
-            val receiverProperty = if (receiver is IrTypeOperatorCallImpl) receiver.argument else receiver // <get-_a>()
+            // With casts there are three things we need to worry about:
+            // - the actual receiver that was casted (findOriginalExpression looks it up)
+            // - the type of the cast
+            // - the expression type (which may differ from the cast type's type parameter)
+            // The latter may differ when receiver's cast has a projection type (`AtomicRef<out Any?>`),
+            // but the expression has an expanded type (`Array<Array<Any>>` instead of `out Any?`).
+            val receiverProperty = if (receiver is IrTypeOperatorCall) receiver.findOriginalExpression() else receiver // <get-_a>()
             if (!receiverProperty.type.isAtomicType()) return super.visitCall(expression, data)
-            val valueType = if (receiver is IrTypeOperatorCallImpl) {
+            val valueType = if (receiver is IrTypeOperatorCall) {
                 // val a = atomic<Any?>(null)
                 // (a as AtomicReference<Array<String>?>).getAndSet(arrayOf("aaa", "bbb"))
-                (receiver.type as IrSimpleType).arguments[0] as IrSimpleType
+                receiver.extractTypeFromCast()
             } else {
                 atomicfuSymbols.atomicToPrimitiveType(receiverProperty.type as IrSimpleType)
             }
@@ -434,7 +440,10 @@ abstract class AbstractAtomicfuTransformer(
                         functionName = functionName,
                         parentFunction = data
                     )
-                    return super.visitCall(loopCall, data)
+                    // If receiver type (valueType) and expression type don't match,
+                    // cast function type (which will be valueType, or Unit,
+                    // but in the latter case expression will have Unit type too) to the expression type.
+                    return super.visitExpression(builder.castOnTypeMismatch(loopCall, expression.type), data)
                 }
                 val atomicCall = builder.transformAtomicFunctionCall(
                     atomicHandler = atomicHandler,
@@ -444,7 +453,9 @@ abstract class AbstractAtomicfuTransformer(
                     callValueArguments = expression.nonDispatchArguments,
                     functionName = functionName
                 )
-                return super.visitExpression(atomicCall, data)
+                // If receiver type (valueType) and expression type don't match,
+                // cast function type (which will be valueType) to expression type.
+                return super.visitExpression(builder.castOnTypeMismatch(atomicCall, expression.type), data)
             }
             if (expression.symbol.owner.isInline && expression.symbol.owner.parameters.find { it.kind == IrParameterKind.ExtensionReceiver } != null) {
                 requireNotNull(data) { "Expected containing function of the call ${expression.render()}, but found null." }
@@ -458,6 +469,7 @@ abstract class AbstractAtomicfuTransformer(
                     originalAtomicExtension = declaration,
                     parentFunction = data
                 )
+                // Note that irCall always has an expression's type
                 return super.visitCall(irCall, data)
             }
             return super.visitCall(expression, data)
@@ -603,11 +615,53 @@ abstract class AbstractAtomicfuTransformer(
             return generateAtomicExtensionSignatureForAtomicHandler(atomicHandlerType, declaration)
         }
 
+        private fun IrTypeOperatorCall.extractTypeFromCast(): IrType {
+            val type = type as? IrSimpleType ?: error("Cast has unexpected type: ${render()}")
+            return when (val typeArgument = type.arguments[0]) {
+                is IrSimpleType -> typeArgument
+                is IrStarProjection -> irBuiltIns.anyNType
+                is IrTypeProjection -> if (typeArgument.variance == Variance.IN_VARIANCE) {
+                    irBuiltIns.anyType
+                } else {
+                    typeArgument.type
+                }
+            }
+        }
+
+        private fun IrTypeOperatorCall.findOriginalExpression(): IrExpression {
+            var expr = this.argument
+            while (expr is IrTypeOperatorCall) {
+                expr = expr.argument
+            }
+            return expr
+        }
+
+        private fun AbstractAtomicfuIrBuilder.castOnTypeMismatch(call: IrExpression, expectedType: IrType): IrExpression {
+            if (call.type == expectedType) return call
+            return irAs(call, expectedType)
+        }
+
         private fun getOrBuildAtomicHandler(atomicCallReceiver: IrExpression, parentFunction: IrFunction?): AtomicHandler<*> =
             when {
                 atomicCallReceiver is IrCall -> {
                     val isArrayReceiver = atomicCallReceiver.isArrayElementGetter()
-                    val getAtomicProperty = if (isArrayReceiver) atomicCallReceiver.arguments[0] as IrCall else atomicCallReceiver
+                    val getAtomicProperty = if (isArrayReceiver) {
+                        // That's an operation on an atomic array's element.
+                        // Instead of loading an element and calling an operation on it (which is impossible),
+                        // let's find an array's property and delegate a call to it.
+                        val argument0 = atomicCallReceiver.arguments[0]
+                        val receiver = if (argument0 is IrTypeOperatorCall) {
+                            argument0.findOriginalExpression()
+                        } else {
+                            argument0
+                        }
+                        check(receiver is IrCall) {
+                            "Expected IrCall receiver for the expression '${argument0?.render()}', got: ${receiver?.render()}"
+                        }
+                        receiver
+                    } else {
+                        atomicCallReceiver
+                    }
                     val atomicProperty = getAtomicProperty.getCorrespondingProperty()
                     /**
                      * NOTE about JVM backend incremental compilation:

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
@@ -64,7 +64,7 @@ class JvmAtomicfuIrBuilder(
         functionName: String,
         valueArguments: List<IrExpression?>,
         valueType: IrType,
-    ): IrCall {
+    ): IrExpression {
         require(
             atomicHandlerType == AtomicHandlerType.ATOMIC_ARRAY ||
                     atomicHandlerType == AtomicHandlerType.ATOMIC_FIELD_UPDATER ||

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/native/NativeAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/native/NativeAtomicfuIrBuilder.kt
@@ -62,7 +62,7 @@ class NativeAtomicfuIrBuilder(
         functionName: String,
         valueArguments: List<IrExpression?>,
         valueType: IrType,
-    ): IrCall =
+    ): IrExpression =
         when (atomicHandlerType) {
             AtomicHandlerType.ATOMIC_ARRAY -> {
                 invokeFunctionOnAtomicHandlerClass(getAtomicHandler, functionName, valueArguments, valueType)
@@ -79,8 +79,8 @@ class NativeAtomicfuIrBuilder(
                     "addAndGet" -> addAndGetField(getAtomicHandler, valueType, valueArguments[0])
                     "incrementAndGet" -> incrementAndGetField(getAtomicHandler, valueType)
                     "decrementAndGet" -> decrementAndGetField(getAtomicHandler, valueType)
-                    "plusAssign" -> getAndAddField(getAtomicHandler, valueType, valueArguments[0])
-                    "minusAssign" -> getAndAddField(getAtomicHandler, valueType, irUnaryMinus(valueArguments[0]))
+                    "plusAssign" -> getAndAddField(getAtomicHandler, valueType, valueArguments[0]).coerceToUnit()
+                    "minusAssign" -> getAndAddField(getAtomicHandler, valueType, irUnaryMinus(valueArguments[0])).coerceToUnit()
                     else -> error("Unsupported atomic function name $functionName")
                 }
             }

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/CastWithTypeProjections.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/CastWithTypeProjections.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/CastWithTypeProjections.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/CastWithTypeProjections.kt
@@ -1,0 +1,29 @@
+// ISSUE: KT-77692
+
+import kotlinx.atomicfu.*
+import kotlin.test.*
+
+private val ref: AtomicRef<String?> = atomic(null)
+private val refArray: AtomicArray<String?> = atomicArrayOfNulls(1)
+
+fun test() {
+    assertEquals(null, (ref as AtomicRef<*>).value as Any?)
+    assertTrue((ref as AtomicRef<in String?>).compareAndSet(null, "projected"))
+    assertEquals("projected", (ref as AtomicRef<out String>).value)
+
+    assertEquals(null, (refArray as AtomicArray<*>)[0].value)
+    assertTrue((refArray as AtomicArray<in String?>)[0].compareAndSet(null, "projected"))
+    assertEquals("projected", (refArray as AtomicArray<out String>)[0].value)
+
+    assertEquals("projected", (((ref as AtomicRef<*>) as AtomicRef<String?>) as AtomicRef<Any?>).value)
+    assertEquals("projected", (((refArray as AtomicArray<*>) as AtomicArray<String?>) as AtomicArray<Any?>)[0].value)
+
+    assertEquals("projected",
+        ((((refArray as AtomicArray<*>) as AtomicArray<Any?>)[0] as AtomicRef<in String?>) as AtomicRef<*>).value
+    )
+}
+
+fun box(): String {
+    test()
+    return "OK"
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/CastWithTypeProjections.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/CastWithTypeProjections.txt
@@ -1,0 +1,11 @@
+@kotlin.Metadata
+public final class CastWithTypeProjectionsKt {
+    // source: 'CastWithTypeProjections.kt'
+    private synthetic final static field ref: java.util.concurrent.atomic.AtomicReference
+    private synthetic final static field refArray: java.util.concurrent.atomic.AtomicReferenceArray
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    private synthetic final static method getRef(): java.util.concurrent.atomic.AtomicReference
+    private synthetic final static method getRefArray(): java.util.concurrent.atomic.AtomicReferenceArray
+    public final static method test(): void
+}

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/UncheckedCastTest.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/UncheckedCastTest.kt
@@ -3,6 +3,8 @@ import kotlin.test.*
 
 private val topLevelS = atomic<Any>(arrayOf("A", "B"))
 
+private inline fun <T> AtomicRef<T>.loadViaExtension(): T = value
+
 class UncheckedCastTest {
     private val s = atomic<Any>("AAA")
     private val bs = atomic<Any?>(null)
@@ -53,7 +55,7 @@ class UncheckedCastTest {
     fun testAtomicRefUncheckedCastGetAndUpdate() {
         bs.lazySet(arrayOf(arrayOf(Box(1), Box(2)), arrayOf(Box(3))))
         val res = (bs as AtomicRef<Array<Array<Box>>>).getAndUpdate { arrayOf(arrayOf(Box(4), Box(5)), arrayOf(Box(6))) }
-        assertEquals(2, (res as Array<Array<Box>>)[0][1]!!.b)
+        assertEquals(2, res[0][1]!!.b)
         assertEquals(5, bs.value[0][1]!!.b)
     }
 
@@ -62,8 +64,14 @@ class UncheckedCastTest {
         bs.lazySet(arrayOf(arrayOf(Box(1), Box(2)), arrayOf(Box(3))))
         assertEquals(2, (bs as AtomicRef<Array<Array<Box>>>).value[0][1]!!.b)
         val res = (bs as AtomicRef<Array<Array<Box>>>).updateAndGet { arrayOf(arrayOf(Box(4), Box(5)), arrayOf(Box(6))) }
-        assertEquals(6, (res as Array<Array<Box>>)[1][0]!!.b)
+        assertEquals(6, res[1][0]!!.b)
         assertEquals(6, bs.value[1][0]!!.b)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun testAtomicRefUncheckedCastExtensionCall() {
+        bs.lazySet(arrayOf(arrayOf(Box(1), Box(2)), arrayOf(Box(3))))
+        assertEquals(2, (bs as AtomicRef<Array<Array<Box>>>).loadViaExtension()[0][1].b)
     }
 }
 
@@ -77,5 +85,6 @@ fun box(): String {
     testClass.testAtomicRefUncheckedCastUpdate()
     testClass.testAtomicRefUncheckedCastGetAndUpdate()
     testClass.testAtomicRefUncheckedCastUpdateAndGet()
+    testClass.testAtomicRefUncheckedCastExtensionCall()
     return "OK"
 }

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/UncheckedCastTest.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/atomics_basic/UncheckedCastTest.txt
@@ -36,6 +36,7 @@ public final class UncheckedCastTest {
     private synthetic final method setS$volatile(p0: java.lang.Object): void
     public final method testArrayValueUncheckedCast(): void
     public final method testArrayValueUncheckedCastInlineFunc(): void
+    public final method testAtomicRefUncheckedCastExtensionCall(): void
     public final method testAtomicRefUncheckedCastGetAndUpdate(): void
     public final method testAtomicRefUncheckedCastUpdate(): void
     public final method testAtomicRefUncheckedCastUpdateAndGet(): void
@@ -55,4 +56,7 @@ public final class UncheckedCastTestKt {
     public synthetic final static method access$getTopLevelS(): java.util.concurrent.atomic.AtomicReference
     public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
     private synthetic final static method getTopLevelS(): java.util.concurrent.atomic.AtomicReference
+    private synthetic final static method loadViaExtension$atomicfu$ATOMIC_ARRAY$Any(p0: java.util.concurrent.atomic.AtomicReferenceArray, p1: int): java.lang.Object
+    private synthetic final static method loadViaExtension$atomicfu$ATOMIC_FIELD_UPDATER$Any(p0: java.util.concurrent.atomic.AtomicReferenceFieldUpdater, p1: java.lang.Object): java.lang.Object
+    private synthetic final static method loadViaExtension$atomicfu$BOXED_ATOMIC$Any(p0: java.util.concurrent.atomic.AtomicReference): java.lang.Object
 }

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestGenerated.java
@@ -146,6 +146,12 @@ public class AtomicfuNativeTestGenerated extends AbstractNativeCodegenBoxTest {
     }
 
     @Test
+    @TestMetadata("CastWithTypeProjections.kt")
+    public void testCastWithTypeProjections() {
+      run("CastWithTypeProjections.kt");
+    }
+
+    @Test
     @TestMetadata("IndexArrayElementGetterTest.kt")
     public void testIndexArrayElementGetterTest() {
       run("IndexArrayElementGetterTest.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlin/konan/test/blackbox/AtomicfuNativeTestWithInlinedFunInKlibGenerated.java
@@ -149,6 +149,12 @@ public class AtomicfuNativeTestWithInlinedFunInKlibGenerated extends AbstractNat
     }
 
     @Test
+    @TestMetadata("CastWithTypeProjections.kt")
+    public void testCastWithTypeProjections() {
+      run("CastWithTypeProjections.kt");
+    }
+
+    @Test
     @TestMetadata("IndexArrayElementGetterTest.kt")
     public void testIndexArrayElementGetterTest() {
       run("IndexArrayElementGetterTest.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsTestGenerated.java
@@ -134,6 +134,12 @@ public class AtomicfuJsTestGenerated extends AbstractAtomicfuJsTest {
     }
 
     @Test
+    @TestMetadata("CastWithTypeProjections.kt")
+    public void testCastWithTypeProjections() {
+      run("CastWithTypeProjections.kt");
+    }
+
+    @Test
     @TestMetadata("IndexArrayElementGetterTest.kt")
     public void testIndexArrayElementGetterTest() {
       run("IndexArrayElementGetterTest.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJsWithInlinedFunInKlibTestGenerated.java
@@ -134,6 +134,12 @@ public class AtomicfuJsWithInlinedFunInKlibTestGenerated extends AbstractAtomicf
     }
 
     @Test
+    @TestMetadata("CastWithTypeProjections.kt")
+    public void testCastWithTypeProjections() {
+      run("CastWithTypeProjections.kt");
+    }
+
+    @Test
     @TestMetadata("IndexArrayElementGetterTest.kt")
     public void testIndexArrayElementGetterTest() {
       run("IndexArrayElementGetterTest.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuJvmFirLightTreeTestGenerated.java
@@ -134,6 +134,12 @@ public class AtomicfuJvmFirLightTreeTestGenerated extends AbstractAtomicfuJvmFir
     }
 
     @Test
+    @TestMetadata("CastWithTypeProjections.kt")
+    public void testCastWithTypeProjections() {
+      run("CastWithTypeProjections.kt");
+    }
+
+    @Test
     @TestMetadata("IndexArrayElementGetterTest.kt")
     public void testIndexArrayElementGetterTest() {
       run("IndexArrayElementGetterTest.kt");

--- a/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
+++ b/plugins/atomicfu/atomicfu-compiler/tests-gen/org/jetbrains/kotlinx/atomicfu/runners/AtomicfuNativeKlibSyntheticAccessorTestGenerated.java
@@ -157,6 +157,12 @@ public class AtomicfuNativeKlibSyntheticAccessorTestGenerated extends AbstractAt
     }
 
     @Test
+    @TestMetadata("CastWithTypeProjections.kt")
+    public void testCastWithTypeProjections() {
+      run("CastWithTypeProjections.kt");
+    }
+
+    @Test
     @TestMetadata("IndexArrayElementGetterTest.kt")
     public void testIndexArrayElementGetterTest() {
       run("IndexArrayElementGetterTest.kt");


### PR DESCRIPTION
There were generally two issues:
- AFU transformer expected type to be `IrSimpleType` (which is not the case if there's a projection type)
- In case of the receiver's type cast, `IrTypeOperatorCall`'s type argument's type argument may be a projection type, and expression's return type could be an expanded type. 
  AFU transformer was losing expression's return type which led to errors down the compilation pipeline.

This change adds projection type support and also set correct type for all operations.

^Fixes KT-77692