### PR TITLE
[BTA] Refactor: move buildIdToSessionFlagFile to daemon ExecutionPolicy

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
@@ -51,7 +51,6 @@ import java.rmi.RemoteException
 
 internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCompilerArgumentsImpl, CompilerArgs : CommonCompilerArguments>(
     override val compilerArguments: BtaCompilerArgs,
-    protected val buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
 ) : CancellableBuildOperationImpl<CompilationResult>(), BaseCompilationOperation, BaseCompilationOperation.Builder {
 
     @UseFromImplModuleRestricted
@@ -72,7 +71,12 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
 
     class Option<V>(id: String, default: V) : BaseOptionWithDefault<V>(id, defaultValue = default)
 
-    override fun executeCancellableImpl(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger?): CompilationResult {
+    override fun executeCancellableImpl(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>
+    ): CompilationResult {
         val compilerMessageRenderer = this[COMPILER_MESSAGE_RENDERER]
         val kotlinLogger = logger ?: DefaultKotlinLogger
         compilerArguments.reportRestrictedViolations(kotlinLogger)
@@ -87,7 +91,7 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
                 compileInProcess(loggerAdapter)
             }
             is DaemonExecutionPolicyImpl -> {
-                compileWithDaemon(projectId, executionPolicy, loggerAdapter)
+                compileWithDaemon(executionPolicy, loggerAdapter, sessionIsAliveFlagFile)
             }
             else -> {
                 CompilationResult.COMPILATION_ERROR.also {
@@ -142,15 +146,12 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
     }
 
     private fun compileWithDaemon(
-        projectId: ProjectId,
         executionPolicy: DaemonExecutionPolicyImpl,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        sessionIsAliveFlagFile: Lazy<File>,
     ): CompilationResult {
         loggerAdapter.kotlinLogger.debug("Compiling using the daemon strategy")
         val compilerId = CompilerId.makeCompilerId(getCurrentClasspath())
-        val sessionIsAliveFlagFile = buildIdToSessionFlagFile.computeIfAbsent(projectId) {
-            createSessionIsAliveFlagFile()
-        }
 
         val daemonLogOptions = DaemonLogOptions(
             logsPath = executionPolicy[LOGS_PATH].absolutePathStringOrThrow(),
@@ -187,7 +188,7 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
             KotlinCompilerRunnerUtils.newDaemonConnection(
                 compilerId,
                 clientIsAliveFile,
-                sessionIsAliveFlagFile,
+                sessionIsAliveFlagFile.value,
                 loggerAdapter,
                 loggerAdapter.kotlinLogger.isDebugEnabled || System.getProperty("kotlin.daemon.debug.log")?.toBooleanStrictOrNull() ?: true,
                 daemonJVMOptions = jvmOptions,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.buildtools.api.ExecutionPolicy
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.trackers.BuildMetricsCollector
+import java.io.File
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -27,14 +28,24 @@ internal abstract class BuildOperationImpl<R> : BuildOperation<R>, BuildOperatio
         options[key] = value
     }
 
-    fun execute(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger? = null): R {
+    fun execute(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger? = null,
+        sessionIsAliveFlagFile: Lazy<File>
+    ): R {
         check(executionStarted.compareAndSet(expectedValue = false, newValue = true)) {
             "Build operation $this already started execution."
         }
-        return executeImpl(projectId, executionPolicy, logger)
+        return executeImpl(projectId, executionPolicy, logger, sessionIsAliveFlagFile)
     }
 
-    abstract fun executeImpl(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger? = null): R
+    abstract fun executeImpl(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger? = null,
+        sessionIsAliveFlagFile: Lazy<File>
+    ): R
 
     operator fun <V> get(key: Option<V>): V = options[key]
 

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/CancellableBuildOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/CancellableBuildOperationImpl.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.buildtools.api.OperationCancelledException
 import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.progress.CompilationCanceledException
 import org.jetbrains.kotlin.progress.CompilationCanceledStatus
+import java.io.File
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
@@ -52,10 +53,16 @@ internal abstract class CancellableBuildOperationImpl<R> : BuildOperationImpl<R>
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>,
     ): R
 
-    final override fun executeImpl(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger?): R {
-        val returnValue = executeCancellableImpl(projectId, executionPolicy, logger)
+    final override fun executeImpl(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>,
+    ): R {
+        val returnValue = executeCancellableImpl(projectId, executionPolicy, logger, sessionIsAliveFlagFile)
         return if (isCancelled.load()) {
             throw OperationCancelledException()
         } else {

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
@@ -22,24 +22,19 @@ import org.jetbrains.kotlin.buildtools.internal.wasm.WasmPlatformToolchainImpl
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.incremental.clearJarCaches
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
-import java.io.File
 import java.util.concurrent.*
 
 internal class KotlinToolchainsImpl() : KotlinToolchains {
-    private val buildIdToSessionFlagFile: MutableMap<ProjectId, File> = ConcurrentHashMap()
     val toolchains: ConcurrentHashMap<Class<*>, KotlinToolchains.Toolchain> = ConcurrentHashMap()
 
     override fun <T : KotlinToolchains.Toolchain> getToolchain(type: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
         return toolchains.computeIfAbsent(type) { type ->
             when (type) {
-                JvmPlatformToolchain::class.java -> JvmPlatformToolchainImpl(getCompilerVersion(), buildIdToSessionFlagFile)
-                JsPlatformToolchain::class.java -> JsPlatformToolchainImpl(getCompilerVersion(), buildIdToSessionFlagFile)
-                WasmPlatformToolchain::class.java -> WasmPlatformToolchainImpl(getCompilerVersion(), buildIdToSessionFlagFile)
-                KotlinMetadataPlatformToolchain::class.java -> KotlinMetadataPlatformToolchainImpl(
-                    getCompilerVersion(),
-                    buildIdToSessionFlagFile
-                )
+                JvmPlatformToolchain::class.java -> JvmPlatformToolchainImpl(getCompilerVersion())
+                JsPlatformToolchain::class.java -> JsPlatformToolchainImpl(getCompilerVersion())
+                WasmPlatformToolchain::class.java -> WasmPlatformToolchainImpl(getCompilerVersion())
+                KotlinMetadataPlatformToolchain::class.java -> KotlinMetadataPlatformToolchainImpl(getCompilerVersion())
                 CriToolchain::class.java -> CriToolchainImpl()
                 AbiValidationToolchain::class.java -> AbiValidationToolchainImpl()
                 else -> error("Unsupported platform toolchain type: $type.")
@@ -61,14 +56,14 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
     override fun getCompilerVersion(): String = KotlinCompilerVersion.VERSION
 
     override fun createBuildSession(): KotlinToolchains.BuildSession {
-        return BuildSessionImpl(this, RandomProjectUUID(), buildIdToSessionFlagFile)
+        return BuildSessionImpl(this, RandomProjectUUID())
     }
 
     private class BuildSessionImpl(
         override val kotlinToolchains: KotlinToolchains,
         override val projectId: ProjectId,
-        private val buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
     ) : KotlinToolchains.BuildSession {
+        private val sessionIsAliveFlagFile = lazy { createSessionIsAliveFlagFile() }
         private val executorDelegate = lazy {
             Executors.newCachedThreadPool()
         }
@@ -84,7 +79,7 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
             logger: KotlinLogger?,
         ): R {
             check(operation is BuildOperationImpl<R>) { "Unknown operation type: ${operation::class.qualifiedName}" }
-            val operationBody: Callable<R> = { operation.execute(projectId, executionPolicy, logger) }
+            val operationBody: Callable<R> = { operation.execute(projectId, executionPolicy, logger, sessionIsAliveFlagFile) }
             return if (executionPolicy is ExecutionPolicy.InProcess) {
                 unwrapExecutionException(executor.submit(operationBody))
             } else {
@@ -109,8 +104,9 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
             if (executorDelegate.isInitialized()) {
                 executor.shutdown()
             }
-            val file = buildIdToSessionFlagFile.remove(projectId) ?: return
-            file.delete()
+            if (sessionIsAliveFlagFile.isInitialized()) {
+                sessionIsAliveFlagFile.value.delete()
+            }
         }
     }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/CompareAbiTextFilesOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/CompareAbiTextFilesOperationImpl.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.DeepCopyable
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
+import java.io.File
 import java.nio.file.Path
 
 internal class CompareAbiTextFilesOperationImpl private constructor(
@@ -35,7 +36,12 @@ internal class CompareAbiTextFilesOperationImpl private constructor(
         initializeOptions(this::class, options)
     }
 
-    override fun executeImpl(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger?) {
+    override fun executeImpl(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>
+    ) {
         val diff = abiTools.filesDiff(
             expectedDumpFile.toFile(),
             actualDumpFile.toFile(),

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpJvmAbiToStringOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpJvmAbiToStringOperationImpl.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.buildtools.internal.UseFromImplModuleRestricted
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiFiltersImpl
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiValidationUtils
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
+import java.io.File
 import java.nio.file.Path
 
 internal class DumpJvmAbiToStringOperationImpl private constructor(
@@ -38,7 +39,12 @@ internal class DumpJvmAbiToStringOperationImpl private constructor(
         initializeOptions(this::class, options)
     }
 
-    override fun executeImpl(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger?) {
+    override fun executeImpl(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>
+    ) {
         val filters = options[PATTERN_FILTERS]?.let { AbiValidationUtils.convert(it) } ?: org.jetbrains.kotlin.abi.tools.AbiFilters.EMPTY
         abiTools.printJvmDump(appendable, inputFiles.map { it.toFile() }, filters)
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpKlibAbiToStringOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpKlibAbiToStringOperationImpl.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.buildtools.internal.UseFromImplModuleRestricted
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiFiltersImpl
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiValidationUtils
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
+import java.io.File
 import java.nio.file.Path
 
 internal class DumpKlibAbiToStringOperationImpl private constructor(
@@ -39,7 +40,12 @@ internal class DumpKlibAbiToStringOperationImpl private constructor(
         initializeOptions(this::class, options)
     }
 
-    override fun executeImpl(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger?) {
+    override fun executeImpl(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>
+    ) {
         val filters = options[PATTERN_FILTERS]?.let { AbiValidationUtils.convert(it) } ?: org.jetbrains.kotlin.abi.tools.AbiFilters.EMPTY
 
         val mergedDump = abiTools.createKlibDump()

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriFileIdToPathDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriFileIdToPathDataDeserializationOperationImpl.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.buildtools.api.cri.FileIdToPathEntry
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
+import java.io.File
 
 internal class CriFileIdToPathDataDeserializationOperationImpl(
     private val deserializer: CriDataDeserializerImpl,
@@ -28,6 +29,7 @@ internal class CriFileIdToPathDataDeserializationOperationImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>,
     ): Iterable<FileIdToPathEntry> {
         return deserializer.deserializeFileIdToPathData(data)
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriLookupDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriLookupDataDeserializationOperationImpl.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.buildtools.api.cri.LookupEntry
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
+import java.io.File
 
 internal class CriLookupDataDeserializationOperationImpl(
     private val deserializer: CriDataDeserializerImpl,
@@ -28,6 +29,7 @@ internal class CriLookupDataDeserializationOperationImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>,
     ): Iterable<LookupEntry> {
         return deserializer.deserializeLookupData(data)
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriSubtypeDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriSubtypeDataDeserializationOperationImpl.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.buildtools.api.cri.SubtypeEntry
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
+import java.io.File
 
 internal class CriSubtypeDataDeserializationOperationImpl(
     private val deserializer: CriDataDeserializerImpl,
@@ -28,6 +29,7 @@ internal class CriSubtypeDataDeserializationOperationImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>,
     ): Iterable<SubtypeEntry> {
         return deserializer.deserializeSubtypeData(data)
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/executionPolicyImpls.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/executionPolicyImpls.kt
@@ -15,10 +15,13 @@ import kotlin.io.path.Path
 
 internal object InProcessExecutionPolicyImpl : ExecutionPolicy.InProcess
 
-internal class DaemonExecutionPolicyImpl private constructor(private val options: Options = Options(ExecutionPolicy.WithDaemon::class)) :
-    ExecutionPolicy.WithDaemon, ExecutionPolicy.WithDaemon.Builder, DeepCopyable<DaemonExecutionPolicyImpl> {
+internal class DaemonExecutionPolicyImpl private constructor(
+    private val options: Options = Options(ExecutionPolicy.WithDaemon::class),
+) : ExecutionPolicy.WithDaemon, ExecutionPolicy.WithDaemon.Builder, DeepCopyable<DaemonExecutionPolicyImpl> {
 
-    constructor() : this(Options(ExecutionPolicy.WithDaemon::class)) {
+    constructor() : this(
+        Options(ExecutionPolicy.WithDaemon::class),
+    ) {
         initializeOptions(this::class, options)
     }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/JsPlatformToolchainImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/JsPlatformToolchainImpl.kt
@@ -5,19 +5,17 @@
 
 package org.jetbrains.kotlin.buildtools.internal.js
 
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsKlibCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsLinkingOperation
 import org.jetbrains.kotlin.buildtools.internal.js.operations.JsKlibCompilationOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.js.operations.JsLinkingOperationImpl
-import java.io.File
 import java.nio.file.Path
 
-internal class JsPlatformToolchainImpl(private val compilerVersion: String, private val buildIdToSessionFlagFile: MutableMap<ProjectId, File>) : JsPlatformToolchain {
+internal class JsPlatformToolchainImpl(private val compilerVersion: String) : JsPlatformToolchain {
     override fun jsLinkingOperationBuilder(klib: Path, destination: Path): JsLinkingOperation.Builder =
-        JsLinkingOperationImpl(klib, destination, buildIdToSessionFlagFile = buildIdToSessionFlagFile)
+        JsLinkingOperationImpl(klib, destination)
 
     override fun jsKlibCompilationOperationBuilder(sources: List<Path>, destination: Path): JsKlibCompilationOperation.Builder =
-        JsKlibCompilationOperationImpl(sources, destination, buildIdToSessionFlagFile = buildIdToSessionFlagFile, compilerVersion = compilerVersion)
+        JsKlibCompilationOperationImpl(sources, destination, compilerVersion = compilerVersion)
 }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsKlibCompilationOperationImpl.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.build.report.BuildReporter
 import org.jetbrains.kotlin.build.report.metrics.endMeasureGc
 import org.jetbrains.kotlin.build.report.metrics.startMeasureGc
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.js.IncrementalModule
@@ -44,7 +43,6 @@ import org.jetbrains.kotlin.daemon.common.MultiModuleICSettings
 import org.jetbrains.kotlin.incremental.*
 import org.jetbrains.kotlin.incremental.multiproject.ModulesApiHistoryJs
 import org.jetbrains.kotlin.incremental.storage.FileLocations
-import java.io.File
 import java.nio.file.Path
 
 internal class JsKlibCompilationOperationImpl private constructor(
@@ -52,23 +50,20 @@ internal class JsKlibCompilationOperationImpl private constructor(
     override val sources: List<Path>,
     override val destination: Path,
     compilerArguments: JsArgumentsImpl = JsArgumentsImpl(),
-    buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
     private val compilerVersion: String,
-) : BaseCompilationOperationImpl<JsArgumentsImpl, K2JSCompilerArguments>(compilerArguments, buildIdToSessionFlagFile),
+) : BaseCompilationOperationImpl<JsArgumentsImpl, K2JSCompilerArguments>(compilerArguments),
     JsKlibCompilationOperation, JsKlibCompilationOperation.Builder,
     DeepCopyable<JsKlibCompilationOperationImpl> {
     constructor(
         sources: List<Path>,
         destination: Path,
         compilerArguments: JsArgumentsImpl = JsArgumentsImpl(),
-        buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
         compilerVersion: String,
     ) : this(
         options = Options(JsKlibCompilationOperation::class),
         sources = sources,
         destination = destination,
         compilerArguments = compilerArguments,
-        buildIdToSessionFlagFile = buildIdToSessionFlagFile,
         compilerVersion = compilerVersion,
     ) {
         initializeOptions(this::class, options)
@@ -91,7 +86,6 @@ internal class JsKlibCompilationOperationImpl private constructor(
             sources,
             destination,
             compilerArguments.deepCopy(),
-            buildIdToSessionFlagFile,
             compilerVersion
         )
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsLinkingOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsLinkingOperationImpl.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.buildtools.internal.js.operations
 
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsKlibCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsLinkingOperation
@@ -27,21 +26,18 @@ internal class JsLinkingOperationImpl private constructor(
     override val klib: Path,
     override val destination: Path,
     compilerArguments: JsArgumentsImpl = JsArgumentsImpl(),
-    buildIdToSessionFlagFile: MutableMap<ProjectId, java.io.File>,
-) : BaseCompilationOperationImpl<JsArgumentsImpl, K2JSCompilerArguments>(compilerArguments, buildIdToSessionFlagFile),
+) : BaseCompilationOperationImpl<JsArgumentsImpl, K2JSCompilerArguments>(compilerArguments),
     JsLinkingOperation, JsLinkingOperation.Builder,
     DeepCopyable<JsLinkingOperationImpl> {
     constructor(
         klib: Path,
         destination: Path,
         compilerArguments: JsArgumentsImpl = JsArgumentsImpl(),
-        buildIdToSessionFlagFile: MutableMap<ProjectId, java.io.File>,
     ) : this(
         options = Options(JsKlibCompilationOperation::class),
         klib = klib,
         destination = destination,
         compilerArguments = compilerArguments,
-        buildIdToSessionFlagFile = buildIdToSessionFlagFile
     ) {
         initializeOptions(this::class, options)
     }
@@ -54,7 +50,6 @@ internal class JsLinkingOperationImpl private constructor(
             klib,
             destination,
             compilerArguments.deepCopy(),
-            buildIdToSessionFlagFile,
         )
     }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/JvmPlatformToolchainImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/JvmPlatformToolchainImpl.kt
@@ -5,19 +5,16 @@
 
 package org.jetbrains.kotlin.buildtools.internal.jvm
 
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshottingOperation
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
 import org.jetbrains.kotlin.buildtools.internal.jvm.operations.DiscoverScriptExtensionsOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmClasspathSnapshottingOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.jvm.operations.JvmCompilationOperationImpl
-import java.io.File
 import java.nio.file.Path
 
 internal class JvmPlatformToolchainImpl(
     private val compilerVersion: String,
-    private val buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
 ) : JvmPlatformToolchain {
     @Deprecated(
         "Use jvmCompilationOperationBuilder instead",
@@ -28,13 +25,13 @@ internal class JvmPlatformToolchainImpl(
         sources: List<Path>,
         destinationDirectory: Path,
     ): JvmCompilationOperation =
-        JvmCompilationOperationImpl(sources, destinationDirectory, buildIdToSessionFlagFile = buildIdToSessionFlagFile, compilerVersion = compilerVersion)
+        JvmCompilationOperationImpl(sources, destinationDirectory, compilerVersion = compilerVersion)
 
     override fun jvmCompilationOperationBuilder(
         sources: List<Path>,
         destinationDirectory: Path,
     ): JvmCompilationOperation.Builder =
-        JvmCompilationOperationImpl(sources, destinationDirectory, buildIdToSessionFlagFile = buildIdToSessionFlagFile, compilerVersion = compilerVersion)
+        JvmCompilationOperationImpl(sources, destinationDirectory, compilerVersion = compilerVersion)
 
     @Deprecated(
         "Use `classpathSnapshottingOperationBuilder` instead",

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/DiscoverScriptExtensionsOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/DiscoverScriptExtensionsOperationImpl.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.buildtools.api.jvm.operations.DiscoverScriptExtensio
 import org.jetbrains.kotlin.buildtools.internal.*
 import org.jetbrains.kotlin.scripting.compiler.plugin.impl.reporter
 import org.jetbrains.kotlin.scripting.definitions.ScriptDefinitionsFromClasspathDiscoverySource
+import java.io.File
 import java.nio.file.Path
 import kotlin.script.experimental.jvm.defaultJvmScriptingHostConfiguration
 
@@ -30,6 +31,7 @@ internal class DiscoverScriptExtensionsOperationImpl private constructor(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>,
     ): Collection<String> {
         // KT-84096 BTA: support daemon execution for script discovery operation
         check(executionPolicy is ExecutionPolicy.InProcess) { "Only in-process execution policy is supported for this operation." }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmClasspathSnapshottingOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmClasspathSnapshottingOperationImpl.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshotti
 import org.jetbrains.kotlin.buildtools.internal.*
 import org.jetbrains.kotlin.buildtools.internal.trackers.getMetricsReporter
 import org.jetbrains.kotlin.incremental.classpathDiff.ClasspathEntrySnapshotter
+import java.io.File
 import java.nio.file.Path
 
 internal class JvmClasspathSnapshottingOperationImpl private constructor(
@@ -45,7 +46,12 @@ internal class JvmClasspathSnapshottingOperationImpl private constructor(
         options[key] = value
     }
 
-    override fun executeImpl(projectId: ProjectId, executionPolicy: ExecutionPolicy, logger: KotlinLogger?): ClasspathEntrySnapshot {
+    override fun executeImpl(
+        projectId: ProjectId,
+        executionPolicy: ExecutionPolicy,
+        logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>
+    ): ClasspathEntrySnapshot {
         val granularity: ClassSnapshotGranularity = get(GRANULARITY)
         val parseInlinedLocalClasses: Boolean = get(PARSE_INLINED_LOCAL_CLASSES)
         val origin = ClasspathEntrySnapshotter.snapshot(

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.build.report.metrics.BuildTimeMetric
 import org.jetbrains.kotlin.build.report.metrics.endMeasureGc
 import org.jetbrains.kotlin.build.report.metrics.startMeasureGc
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmIncrementalCompilationConfiguration
@@ -49,7 +48,6 @@ import org.jetbrains.kotlin.daemon.common.CompilerMode
 import org.jetbrains.kotlin.daemon.common.IncrementalCompilationOptions
 import org.jetbrains.kotlin.incremental.*
 import org.jetbrains.kotlin.incremental.storage.FileLocations
-import java.io.File
 import java.nio.file.Path
 
 internal class JvmCompilationOperationImpl private constructor(
@@ -57,9 +55,8 @@ internal class JvmCompilationOperationImpl private constructor(
     override val sources: List<Path>,
     override val destinationDirectory: Path,
     compilerArguments: JvmCompilerArgumentsImpl = JvmCompilerArgumentsImpl(JvmCompilerArgumentValueAdapter.getOrNull()),
-    buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
     private val compilerVersion: String,
-) : BaseCompilationOperationImpl<JvmCompilerArgumentsImpl, K2JVMCompilerArguments>(compilerArguments, buildIdToSessionFlagFile),
+) : BaseCompilationOperationImpl<JvmCompilerArgumentsImpl, K2JVMCompilerArguments>(compilerArguments),
     JvmCompilationOperation,
     JvmCompilationOperation.Builder,
     DeepCopyable<JvmCompilationOperationImpl> {
@@ -68,14 +65,12 @@ internal class JvmCompilationOperationImpl private constructor(
         sources: List<Path>,
         destinationDirectory: Path,
         compilerArguments: JvmCompilerArgumentsImpl = JvmCompilerArgumentsImpl(JvmCompilerArgumentValueAdapter.getOrNull()),
-        buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
         compilerVersion: String,
     ) : this(
         options = Options(JvmCompilationOperation::class),
         sources = sources,
         destinationDirectory = destinationDirectory,
         compilerArguments = compilerArguments,
-        buildIdToSessionFlagFile = buildIdToSessionFlagFile,
         compilerVersion = compilerVersion,
     ) {
         initializeOptions(this::class, options)
@@ -91,7 +86,6 @@ internal class JvmCompilationOperationImpl private constructor(
             sources,
             destinationDirectory,
             compilerArguments.deepCopy(),
-            buildIdToSessionFlagFile,
             compilerVersion,
         )
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/metadata/KotlinMetadataPlatformToolchainImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/metadata/KotlinMetadataPlatformToolchainImpl.kt
@@ -5,19 +5,19 @@
 
 package org.jetbrains.kotlin.buildtools.internal.metadata
 
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.metadata.KotlinMetadataKlibCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.metadata.KotlinMetadataPlatformToolchain
 import org.jetbrains.kotlin.buildtools.internal.metadata.operations.KotlinMetadataKlibCompilationOperationImpl
-import java.io.File
 import java.nio.file.Path
 
-internal class KotlinMetadataPlatformToolchainImpl(private val compilerVersion: String, private val buildIdToSessionFlagFile: MutableMap<ProjectId, File>) : KotlinMetadataPlatformToolchain {
-    override fun metadataKlibCompilationOperationBuilder(sources: List<Path>, destination: Path): KotlinMetadataKlibCompilationOperation.Builder =
+internal class KotlinMetadataPlatformToolchainImpl(private val compilerVersion: String) : KotlinMetadataPlatformToolchain {
+    override fun metadataKlibCompilationOperationBuilder(
+        sources: List<Path>,
+        destination: Path,
+    ): KotlinMetadataKlibCompilationOperation.Builder =
         KotlinMetadataKlibCompilationOperationImpl(
             sources,
             destination,
-            buildIdToSessionFlagFile = buildIdToSessionFlagFile,
             compilerVersion = compilerVersion
         )
 }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/metadata/operations/KotlinMetadataKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/metadata/operations/KotlinMetadataKlibCompilationOperationImpl.kt
@@ -8,7 +8,6 @@
 package org.jetbrains.kotlin.buildtools.internal.metadata.operations
 
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.metadata.KotlinMetadataKlibCompilationOperation
 import org.jetbrains.kotlin.buildtools.internal.*
@@ -19,7 +18,6 @@ import org.jetbrains.kotlin.cli.common.arguments.K2MetadataCompilerArguments
 import org.jetbrains.kotlin.cli.metadata.KotlinMetadataCompiler
 import org.jetbrains.kotlin.daemon.common.CompileService
 import org.jetbrains.kotlin.daemon.common.IncrementalCompilationOptions
-import java.io.File
 import java.nio.file.Path
 
 internal class KotlinMetadataKlibCompilationOperationImpl private constructor(
@@ -27,23 +25,20 @@ internal class KotlinMetadataKlibCompilationOperationImpl private constructor(
     override val sources: List<Path>,
     override val destination: Path,
     compilerArguments: MetadataArgumentsImpl = MetadataArgumentsImpl(),
-    buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
     private val compilerVersion: String,
-) : BaseCompilationOperationImpl<MetadataArgumentsImpl, K2MetadataCompilerArguments>(compilerArguments, buildIdToSessionFlagFile),
+) : BaseCompilationOperationImpl<MetadataArgumentsImpl, K2MetadataCompilerArguments>(compilerArguments),
     KotlinMetadataKlibCompilationOperation, KotlinMetadataKlibCompilationOperation.Builder,
     DeepCopyable<KotlinMetadataKlibCompilationOperationImpl> {
     constructor(
         sources: List<Path>,
         destination: Path,
         compilerArguments: MetadataArgumentsImpl = MetadataArgumentsImpl(),
-        buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
         compilerVersion: String,
     ) : this(
         options = Options(KotlinMetadataKlibCompilationOperation::class),
         sources = sources,
         destination = destination,
         compilerArguments = compilerArguments,
-        buildIdToSessionFlagFile = buildIdToSessionFlagFile,
         compilerVersion = compilerVersion,
     ) {
         initializeOptions(this::class, options)
@@ -57,7 +52,6 @@ internal class KotlinMetadataKlibCompilationOperationImpl private constructor(
             sources,
             destination,
             compilerArguments.deepCopy(),
-            buildIdToSessionFlagFile,
             compilerVersion
         )
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/WasmPlatformToolchainImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/WasmPlatformToolchainImpl.kt
@@ -5,24 +5,21 @@
 
 package org.jetbrains.kotlin.buildtools.internal.wasm
 
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.wasm.WasmPlatformToolchain
 import org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmKlibCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmLinkingOperation
 import org.jetbrains.kotlin.buildtools.internal.wasm.operations.WasmKlibCompilationOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.wasm.operations.WasmLinkingOperationImpl
-import java.io.File
 import java.nio.file.Path
 
-internal class WasmPlatformToolchainImpl(private val compilerVersion: String, private val buildIdToSessionFlagFile: MutableMap<ProjectId, File>) : WasmPlatformToolchain {
+internal class WasmPlatformToolchainImpl(private val compilerVersion: String) : WasmPlatformToolchain {
     override fun wasmLinkingOperationBuilder(klib: Path, destination: Path): WasmLinkingOperation.Builder =
-        WasmLinkingOperationImpl(klib, destination, buildIdToSessionFlagFile = buildIdToSessionFlagFile)
+        WasmLinkingOperationImpl(klib, destination)
 
     override fun wasmKlibCompilationOperationBuilder(sources: List<Path>, destination: Path): WasmKlibCompilationOperation.Builder =
         WasmKlibCompilationOperationImpl(
             sources,
             destination,
-            buildIdToSessionFlagFile = buildIdToSessionFlagFile,
             compilerVersion = compilerVersion
         )
 }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmKlibCompilationOperationImpl.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.build.report.BuildReporter
 import org.jetbrains.kotlin.build.report.metrics.endMeasureGc
 import org.jetbrains.kotlin.build.report.metrics.startMeasureGc
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.wasm.IncrementalModule
@@ -44,7 +43,6 @@ import org.jetbrains.kotlin.daemon.common.MultiModuleICSettings
 import org.jetbrains.kotlin.incremental.*
 import org.jetbrains.kotlin.incremental.multiproject.ModulesApiHistoryJs
 import org.jetbrains.kotlin.incremental.storage.FileLocations
-import java.io.File
 import java.nio.file.Path
 
 internal class WasmKlibCompilationOperationImpl private constructor(
@@ -52,23 +50,20 @@ internal class WasmKlibCompilationOperationImpl private constructor(
     override val sources: List<Path>,
     override val destination: Path,
     compilerArguments: WasmArgumentsImpl = WasmArgumentsImpl(),
-    buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
     private val compilerVersion: String,
-) : BaseCompilationOperationImpl<WasmArgumentsImpl, KotlinWasmCompilerArguments>(compilerArguments, buildIdToSessionFlagFile),
+) : BaseCompilationOperationImpl<WasmArgumentsImpl, KotlinWasmCompilerArguments>(compilerArguments),
     WasmKlibCompilationOperation, WasmKlibCompilationOperation.Builder,
     DeepCopyable<WasmKlibCompilationOperationImpl> {
     constructor(
         sources: List<Path>,
         destination: Path,
         compilerArguments: WasmArgumentsImpl = WasmArgumentsImpl(),
-        buildIdToSessionFlagFile: MutableMap<ProjectId, File>,
         compilerVersion: String,
     ) : this(
         options = Options(WasmKlibCompilationOperation::class),
         sources = sources,
         destination = destination,
         compilerArguments = compilerArguments,
-        buildIdToSessionFlagFile = buildIdToSessionFlagFile,
         compilerVersion = compilerVersion,
     ) {
         initializeOptions(this::class, options)
@@ -91,7 +86,6 @@ internal class WasmKlibCompilationOperationImpl private constructor(
             sources,
             destination,
             compilerArguments.deepCopy(),
-            buildIdToSessionFlagFile,
             compilerVersion
         )
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmLinkingOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmLinkingOperationImpl.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.buildtools.internal.wasm.operations
 
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
-import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.wasm.operations.WasmLinkingOperation
 import org.jetbrains.kotlin.buildtools.internal.*
@@ -25,21 +24,18 @@ internal class WasmLinkingOperationImpl private constructor(
     override val klib: Path,
     override val destination: Path,
     compilerArguments: WasmArgumentsImpl = WasmArgumentsImpl(),
-    buildIdToSessionFlagFile: MutableMap<ProjectId, java.io.File>,
-) : BaseCompilationOperationImpl<WasmArgumentsImpl, KotlinWasmCompilerArguments>(compilerArguments, buildIdToSessionFlagFile),
+) : BaseCompilationOperationImpl<WasmArgumentsImpl, KotlinWasmCompilerArguments>(compilerArguments),
     WasmLinkingOperation, WasmLinkingOperation.Builder,
     DeepCopyable<WasmLinkingOperationImpl> {
     constructor(
         klib: Path,
         destination: Path,
         compilerArguments: WasmArgumentsImpl = WasmArgumentsImpl(),
-        buildIdToSessionFlagFile: MutableMap<ProjectId, java.io.File>,
     ) : this(
         options = Options(WasmLinkingOperation::class),
         klib = klib,
         destination = destination,
         compilerArguments = compilerArguments,
-        buildIdToSessionFlagFile = buildIdToSessionFlagFile
     ) {
         initializeOptions(this::class, options)
     }
@@ -52,7 +48,6 @@ internal class WasmLinkingOperationImpl private constructor(
             klib,
             destination,
             compilerArguments.deepCopy(),
-            buildIdToSessionFlagFile,
         )
     }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/CancellableOperationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/CancellableOperationTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.buildtools.internal.CancellableBuildOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.KotlinToolchainsImpl
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.progress.CompilationCanceledException
+import java.io.File
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -24,6 +25,7 @@ private class ExampleCancellableOperation(override val options: Options = Option
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
+        sessionIsAliveFlagFile: Lazy<File>,
     ) {
         repeat(10) {
             Thread.sleep(100)
@@ -49,7 +51,7 @@ class CancellableOperationTest {
                         operation.execute(
                             ProjectId.RandomProjectUUID(),
                             KotlinToolchainsImpl().createInProcessExecutionPolicy(),
-                            null
+                            sessionIsAliveFlagFile = lazy { File.createTempFile("session", "alive").apply { deleteOnExit() } }
                         )
                     )
                 } catch (_: CompilationCanceledException) {

--- a/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/KotlinLoggerMessageCollectorAdapterTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/KotlinLoggerMessageCollectorAdapterTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.buildtools.api.CompilerMessageRenderer
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRendererWithDiagnosticId
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRenderer.Severity
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRenderer.SourceLocation
+import org.jetbrains.kotlin.buildtools.api.KotlinCompilationProcessFailedException
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollectorWithDiagnosticId
@@ -27,7 +28,7 @@ class KotlinLoggerMessageCollectorAdapterTest {
         val call = logger.calls.single()
         assertEquals(LogMethod.ERROR_WITH_THROWABLE, call.method)
         assertEquals("crash", call.message)
-        assertIs<RuntimeException>(call.throwable)
+        assertIs<KotlinCompilationProcessFailedException>(call.throwable)
     }
 
     @Test


### PR DESCRIPTION
Since this property is only used for daemon execution, it makes more sense to live in ExecutionPolicy.WithDaemon.

This also helps making operations serializable for KT-87885.