### PR TITLE
Start initializing the fields of `ComposableSingletons` objects lazily

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ClassStabilityTransformTests/testLocalParameterBasedTypeParameterSubstitution.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ClassStabilityTransformTests/testLocalParameterBasedTypeParameterSubstitution.txt
@@ -118,23 +118,29 @@ fun C(items: List<String>, %composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1463567948: Function3<String, Composer, Int, Unit> = composableLambdaInstance(<>, false) { item: String, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(item)12@440L7,13@468L16:Test.kt'")
-    val %dirty = %changed
-    if (%changed and 0b0110 == 0) {
-      %dirty = %dirty or if (%composer.changed(item)) 0b0100 else 0b0010
-    }
-    if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %dirty, -1, <>)
+  val lambda%1463567948: Function3<String, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { item: String, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(item)12@440L7,13@468L16:Test.kt'")
+          val %dirty = %changed
+          if (%changed and 0b0110 == 0) {
+            %dirty = %dirty or if (%composer.changed(item)) 0b0100 else 0b0010
+          }
+          if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %dirty, -1, <>)
+            }
+            A(item, %composer, 0b1110 and %dirty)
+            A(Wrapper(item), %composer, Wrapper.%stable)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      A(item, %composer, 0b1110 and %dirty)
-      A(Wrapper(item), %composer, Wrapper.%stable)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamSignatureTests/testBasicLambda.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamSignatureTests/testBasicLambda.txt
@@ -14,7 +14,7 @@ val foo = @Composable { x: Int -> print(x)  }
 public final class ComposableSingletons%TestKt {
   public <init>()V
   public final getLambda%-112788585%test_module()Lkotlin/jvm/functions/Function3;
-  private final static lambda__112788585%lambda%0(ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+  private final static _get_lambda__112788585_%lambda%0(ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
   static <clinit>()V
   public final static LComposableSingletons%TestKt; INSTANCE
   private static Lkotlin/jvm/functions/Function3; lambda%-112788585

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamSignatureTests/testLocalLambda.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamSignatureTests/testLocalLambda.txt
@@ -15,7 +15,7 @@
 public final class ComposableSingletons%TestKt {
   public <init>()V
   public final getLambda%505024483%test_module()Lkotlin/jvm/functions/Function3;
-  private final static lambda_505024483%lambda%0(ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+  private final static _get_lambda_505024483_%lambda%0(ILandroidx/compose/runtime/Composer;I)Lkotlin/Unit;
   static <clinit>()V
   public final static LComposableSingletons%TestKt; INSTANCE
   private static Lkotlin/jvm/functions/Function3; lambda%505024483

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamSignatureTests/testParameterlessChildrenLambdasReused.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamSignatureTests/testParameterlessChildrenLambdasReused.txt
@@ -15,7 +15,7 @@
 public final class ComposableSingletons%TestKt {
   public <init>()V
   public final getLambda%-420233864%test_module()Lkotlin/jvm/functions/Function2;
-  private final static lambda__420233864%lambda%0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+  private final static _get_lambda__420233864_%lambda%0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
   static <clinit>()V
   public final static LComposableSingletons%TestKt; INSTANCE
   private static Lkotlin/jvm/functions/Function2; lambda%-420233864

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamTransformTests/composableLocalFunctionInsideLocalClass.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ComposerParamTransformTests/composableLocalFunctionInsideLocalClass.txt
@@ -62,18 +62,24 @@ fun test() {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-951912229: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-951912229: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ContextParametersTransformTests/testMemoizationContextParameters.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ContextParametersTransformTests/testMemoizationContextParameters.txt
@@ -103,27 +103,33 @@ fun App(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1203334793: @[ExtensionFunctionType] Function4<BoxScope, A, Composer, Int, Unit> = composableLambdaInstance(<>, false) { <unused var>: BoxScope, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text(t...>:Test.kt")
-    val %dirty = %changed
-    if (%changed and 0b00110000 == 0) {
-      %dirty = %dirty or if (if (%changed and 0b01000000 == 0) {
-        %composer.changed(%this%TypeCrossfade)
-      } else {
-        %composer.changedInstance(%this%TypeCrossfade)
+  val lambda%-1203334793: @[ExtensionFunctionType] Function4<BoxScope, A, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { <unused var>: BoxScope, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text(t...>:Test.kt")
+          val %dirty = %changed
+          if (%changed and 0b00110000 == 0) {
+            %dirty = %dirty or if (if (%changed and 0b01000000 == 0) {
+              %composer.changed(%this%TypeCrossfade)
+            } else {
+              %composer.changedInstance(%this%TypeCrossfade)
+            }
+            ) 0b00100000 else 0b00010000
+          }
+          if (%composer.shouldExecute(%dirty and 0b10010001 != 0b10010000, %dirty and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %dirty, -1, <>)
+            }
+            Text(%this%TypeCrossfade.toString(), %composer, 0)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      ) 0b00100000 else 0b00010000
+      return field
     }
-    if (%composer.shouldExecute(%dirty and 0b10010001 != 0b10010000, %dirty and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %dirty, -1, <>)
-      }
-      Text(%this%TypeCrossfade.toString(), %composer, 0)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
-    }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testCallingAWrapperComposable.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testCallingAWrapperComposable.txt
@@ -40,18 +40,24 @@ fun Test(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1773251756: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<A()>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1773251756: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<A()>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            A(%composer, 0)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      A(%composer, 0)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testNothingBody.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testNothingBody.txt
@@ -62,18 +62,24 @@ fun Test3(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%125591635: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%125591635: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            TODO()
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      TODO()
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testRepeatedCallsToEffects.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testRepeatedCallsToEffects.txt
@@ -39,42 +39,48 @@ fun Test(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1846889279: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<{>,<effect>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
-      }
-      %composer.startReplaceGroup(<>)
-      sourceInformation(%composer, "*<{>,<effect>")
-      repeat(number) { it: Int ->
-        effects[it] = effect(<block>{
-          sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-          val tmp0_group = %composer.cache(false) {
-            {
-              0
+  val lambda%-1846889279: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<{>,<effect>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
             }
-          }
-          sourceInformationMarkerEnd(%composer)
-          tmp0_group
-        }, %composer, 0b0110)
-      }
-      %composer.endReplaceGroup()
-      outside = effect(<block>{
-        sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-        val tmp0_group = %composer.cache(false) {
-          {
-            "0"
+            %composer.startReplaceGroup(<>)
+            sourceInformation(%composer, "*<{>,<effect>")
+            repeat(number) { it: Int ->
+              effects[it] = effect(<block>{
+                sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
+                val tmp0_group = %composer.cache(false) {
+                  {
+                    0
+                  }
+                }
+                sourceInformationMarkerEnd(%composer)
+                tmp0_group
+              }, %composer, 0b0110)
+            }
+            %composer.endReplaceGroup()
+            outside = effect(<block>{
+              sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
+              val tmp0_group = %composer.cache(false) {
+                {
+                  "0"
+                }
+              }
+              sourceInformationMarkerEnd(%composer)
+              tmp0_group
+            }, %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
           }
         }
-        sourceInformationMarkerEnd(%composer)
-        tmp0_group
-      }, %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
       }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testSourceLineInformationForNormalInline.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTests/testSourceLineInformationForNormalInline.txt
@@ -42,29 +42,35 @@ fun Test(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1773251756: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<IW>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, "ComposableSingletons%TestKt.lambda%1773251756.<anonymous> (Test.kt:6)")
-      }
-      IW({ %composer: Composer?, %changed: Int ->
-        sourceInformationMarkerStart(%composer, <>, "C<T(2)>,<T(4)>:Test.kt")
-        T(2, %composer, 0b0110)
-        %composer.startReplaceGroup(<>)
-        sourceInformation(%composer, "*<T(3)>")
-        repeat(3) { it: Int ->
-          T(3, %composer, 0b0110)
+  val lambda%1773251756: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<IW>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, "ComposableSingletons%TestKt.<get-lambda%1773251756>.<anonymous> (Test.kt:6)")
+            }
+            IW({ %composer: Composer?, %changed: Int ->
+              sourceInformationMarkerStart(%composer, <>, "C<T(2)>,<T(4)>:Test.kt")
+              T(2, %composer, 0b0110)
+              %composer.startReplaceGroup(<>)
+              sourceInformation(%composer, "*<T(3)>")
+              repeat(3) { it: Int ->
+                T(3, %composer, 0b0110)
+              }
+              %composer.endReplaceGroup()
+              T(4, %composer, 0b0110)
+              sourceInformationMarkerEnd(%composer)
+            }, %composer, 0)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
         }
-        %composer.endReplaceGroup()
-        T(4, %composer, 0b0110)
-        sourceInformationMarkerEnd(%composer)
-      }, %composer, 0)
-      if (isTraceInProgress()) {
-        traceEventEnd()
       }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTestsNoSource/testCallingAWrapperComposable.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ControlFlowTransformTestsNoSource/testCallingAWrapperComposable.txt
@@ -33,11 +33,17 @@ fun Test(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1773251756: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      A(%composer, 0)
-    } else {
-      %composer.skipToGroupEnd()
+  val lambda%1773251756: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            A(%composer, 0)
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
+      }
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/defaultParamVarargs.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/defaultParamVarargs.txt
@@ -144,32 +144,44 @@ fun VarargWContent(values: IntArray?, content: Function2<Composer, Int, Unit>, %
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1963231897: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1963231897: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-168993022: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-168993022: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testAbstractDefaultParamComposableLambda.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testAbstractDefaultParamComposableLambda.txt
@@ -116,32 +116,44 @@ private interface DefaultParamInterface {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1800837504: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1800837504: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("default", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("default", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1311305486: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1311305486: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("default", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("default", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testOpenDefaultParamComposableLambda.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.DefaultParamTransformTests/testOpenDefaultParamComposableLambda.txt
@@ -138,32 +138,44 @@ private interface DefaultParamInterface {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1800837504: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1800837504: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("default", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("default", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1311305486: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1311305486: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("default", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("default", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testAnnotationChecker.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testAnnotationChecker.txt
@@ -36,18 +36,24 @@ fun Example(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%160586029: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%160586029: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambda.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambda.txt
@@ -17,22 +17,28 @@ val test = @Composable { x: Int ->
 
 val test: Function3<Int, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-302707801
 internal object ComposableSingletons%TestKt {
-  val lambda%-302707801: Function3<Int, Composer, Int, Unit> = composableLambdaInstance(<>, false) { x: Int, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(x)6@192L4:Test.kt'")
-    val %dirty = %changed
-    if (%changed and 0b0110 == 0) {
-      %dirty = %dirty or if (%composer.changed(x)) 0b0100 else 0b0010
-    }
-    if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %dirty, -1, <>)
+  val lambda%-302707801: Function3<Int, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { x: Int, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(x)6@192L4:Test.kt'")
+          val %dirty = %changed
+          if (%changed and 0b0110 == 0) {
+            %dirty = %dirty or if (%composer.changed(x)) 0b0100 else 0b0010
+          }
+          if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %dirty, -1, <>)
+            }
+            A(x, 0, %composer, 0b1110 and %dirty, 0b0010)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      A(x, 0, %composer, 0b1110 and %dirty, 0b0010)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambdaWithStableParams.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambdaWithStableParams.txt
@@ -18,26 +18,32 @@ val foo = @Composable { x: Int, y: Foo ->
 
 val foo: Function4<Int, Foo, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%529523933
 internal object ComposableSingletons%TestKt {
-  val lambda%529523933: Function4<Int, Foo, Composer, Int, Unit> = composableLambdaInstance(<>, false) { x: Int, y: Foo, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(x,y)6@199L4,7@208L4:Test.kt'")
-    val %dirty = %changed
-    if (%changed and 0b0110 == 0) {
-      %dirty = %dirty or if (%composer.changed(x)) 0b0100 else 0b0010
-    }
-    if (%changed and 0b00110000 == 0) {
-      %dirty = %dirty or if (%composer.changed(y)) 0b00100000 else 0b00010000
-    }
-    if (%composer.shouldExecute(%dirty and 0b10010011 != 0b10010010, %dirty and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %dirty, -1, <>)
+  val lambda%529523933: Function4<Int, Foo, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { x: Int, y: Foo, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(x,y)6@199L4,7@208L4:Test.kt'")
+          val %dirty = %changed
+          if (%changed and 0b0110 == 0) {
+            %dirty = %dirty or if (%composer.changed(x)) 0b0100 else 0b0010
+          }
+          if (%changed and 0b00110000 == 0) {
+            %dirty = %dirty or if (%composer.changed(y)) 0b00100000 else 0b00010000
+          }
+          if (%composer.shouldExecute(%dirty and 0b10010011 != 0b10010010, %dirty and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %dirty, -1, <>)
+            }
+            A(x, %composer, 0b1110 and %dirty)
+            B(y, %composer, 0b1110 and %dirty shr 0b0011)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      A(x, %composer, 0b1110 and %dirty)
-      B(y, %composer, 0b1110 and %dirty shr 0b0011)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambdaWithStableParamsAndReturnValue.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambdaWithStableParamsAndReturnValue.txt
@@ -66,20 +66,26 @@ fun Example(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-431064669: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-431064669: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            val id = <block>{
+              object
+            }
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      val id = <block>{
-        object
-      }
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambdaWithUnstableParams.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableLambdaWithUnstableParams.txt
@@ -67,15 +67,21 @@ fun B(y: Foo, %composer: Composer?, %changed: Int) {
 }
 val foo: Function4<Int, Foo, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%529523933
 internal object ComposableSingletons%TestKt {
-  val lambda%529523933: Function4<Int, Foo, Composer, Int, Unit> = composableLambdaInstance(<>, false) { x: Int, y: Foo, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(x,y)10@288L4,11@297L4:Test.kt'")
-    if (isTraceInProgress()) {
-      traceEventStart(<>, %changed, -1, <>)
+  val lambda%529523933: Function4<Int, Foo, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { x: Int, y: Foo, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(x,y)10@288L4,11@297L4:Test.kt'")
+          if (isTraceInProgress()) {
+            traceEventStart(<>, %changed, -1, <>)
+          }
+          A(x, %composer, 0b1110 and %changed)
+          B(y, %composer, 0b1110 and %changed shr 0b0011)
+          if (isTraceInProgress()) {
+            traceEventEnd()
+          }
+        }
+      }
+      return field
     }
-    A(x, %composer, 0b1110 and %changed)
-    B(y, %composer, 0b1110 and %changed shr 0b0011)
-    if (isTraceInProgress()) {
-      traceEventEnd()
-    }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableSingletonsAreStatic.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testComposableSingletonsAreStatic.txt
@@ -49,18 +49,24 @@ fun Example(content: Function2<Composer, Int, Unit>?, %composer: Composer?, %cha
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1401779980: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1401779980: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testDefaultsIssue.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testDefaultsIssue.txt
@@ -74,18 +74,24 @@ fun Box2(modifier: Modifier?, paddingStart: Dp, content: Function2<Composer, Int
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%494899680: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%494899680: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testExtensionReceiver.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testExtensionReceiver.txt
@@ -55,31 +55,37 @@ fun MaybeStable.example(x: Int, %composer: Composer?, %changed: Int) {
 }
 val example: @[ExtensionFunctionType] Function4<MaybeStable, Int, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-2119615962
 internal object ComposableSingletons%TestKt {
-  val lambda%-2119615962: @[ExtensionFunctionType] Function4<MaybeStable, Int, Composer, Int, Unit> = composableLambdaInstance(<>, false) { it: Int, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(it):Test.kt'")
-    val %dirty = %changed
-    if (%changed and 0b0110 == 0) {
-      %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
-        %composer.changed(<this>)
-      } else {
-        %composer.changedInstance(<this>)
+  val lambda%-2119615962: @[ExtensionFunctionType] Function4<MaybeStable, Int, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { it: Int, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(it):Test.kt'")
+          val %dirty = %changed
+          if (%changed and 0b0110 == 0) {
+            %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+              %composer.changed(<this>)
+            } else {
+              %composer.changedInstance(<this>)
+            }
+            ) 0b0100 else 0b0010
+          }
+          if (%changed and 0b00110000 == 0) {
+            %dirty = %dirty or if (%composer.changed(it)) 0b00100000 else 0b00010000
+          }
+          if (%composer.shouldExecute(%dirty and 0b10010011 != 0b10010010, %dirty and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %dirty, -1, <>)
+            }
+            used(<this>)
+            used(it)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      ) 0b0100 else 0b0010
+      return field
     }
-    if (%changed and 0b00110000 == 0) {
-      %dirty = %dirty or if (%composer.changed(it)) 0b00100000 else 0b00010000
-    }
-    if (%composer.shouldExecute(%dirty and 0b10010011 != 0b10010010, %dirty and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %dirty, -1, <>)
-      }
-      used(<this>)
-      used(it)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
-    }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testLambdaSkipping.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testLambdaSkipping.txt
@@ -21,18 +21,24 @@ fun LazyListScope.Example(items: LazyPagingItems<User>) {
   itemsIndexed(items, ComposableSingletons%TestKt.lambda%-2123538558)
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-2123538558: @[ExtensionFunctionType] Function5<LazyItemScope, Int, User?, Composer, Int, Unit> = composableLambdaInstance(<>, false) { index: Int, user: User?, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(index,user):Test.kt'")
-    if (%composer.shouldExecute(%changed and 0b010000000001 != 0b010000000000, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-2123538558: @[ExtensionFunctionType] Function5<LazyItemScope, Int, User?, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { index: Int, user: User?, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(index,user):Test.kt'")
+          if (%composer.shouldExecute(%changed and 0b010000000001 != 0b010000000000, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("Hello World")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("Hello World")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testReceiverLambdaCall.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testReceiverLambdaCall.txt
@@ -27,73 +27,97 @@ val unstableUsed: @[ExtensionFunctionType] Function3<Foo, Composer, Int, Unit> =
 val stableUnused: @[ExtensionFunctionType] Function3<StableFoo, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-1723802896
 val stableUsed: @[ExtensionFunctionType] Function3<StableFoo, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-1402105449
 internal object ComposableSingletons%TestKt {
-  val lambda%-1652029138: @[ExtensionFunctionType] Function3<Foo, Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1652029138: @[ExtensionFunctionType] Function3<Foo, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1351038805: @[ExtensionFunctionType] Function3<Foo, Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    val %dirty = %changed
-    if (%changed and 0b0110 == 0) {
-      %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
-        %composer.changed(<this>)
-      } else {
-        %composer.changedInstance(<this>)
+  val lambda%1351038805: @[ExtensionFunctionType] Function3<Foo, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          val %dirty = %changed
+          if (%changed and 0b0110 == 0) {
+            %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+              %composer.changed(<this>)
+            } else {
+              %composer.changedInstance(<this>)
+            }
+            ) 0b0100 else 0b0010
+          }
+          if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %dirty, -1, <>)
+            }
+            used(x)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      ) 0b0100 else 0b0010
+      return field
     }
-    if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %dirty, -1, <>)
+  val lambda%-1723802896: @[ExtensionFunctionType] Function3<StableFoo, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      used(x)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1723802896: @[ExtensionFunctionType] Function3<StableFoo, Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1402105449: @[ExtensionFunctionType] Function3<StableFoo, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          val %dirty = %changed
+          if (%changed and 0b0110 == 0) {
+            %dirty = %dirty or if (%composer.changed(<this>)) 0b0100 else 0b0010
+          }
+          if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %dirty, -1, <>)
+            }
+            used(x)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1402105449: @[ExtensionFunctionType] Function3<StableFoo, Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    val %dirty = %changed
-    if (%changed and 0b0110 == 0) {
-      %dirty = %dirty or if (%composer.changed(<this>)) 0b0100 else 0b0010
-    }
-    if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %dirty, -1, <>)
-      }
-      used(x)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
-    }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testSimpleBox.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testSimpleBox.txt
@@ -57,18 +57,24 @@ fun SimpleBox(modifier: Modifier?, content: Function2<Composer, Int, Unit>?, %co
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1760563718: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1760563718: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testStaticDetection.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTests/testStaticDetection.txt
@@ -108,18 +108,24 @@ fun B(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1004593700: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1004593700: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/testIfStatementGroups.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/testIfStatementGroups.txt
@@ -62,15 +62,21 @@ fun Test(level: Int, %composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%867304610: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      used(<block>{
-        %composer.cache(false) {
-          "Middle"
+  val lambda%867304610: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            used(<block>{
+              %composer.cache(false) {
+                "Middle"
+              }
+            })
+          } else {
+            %composer.skipToGroupEnd()
+          }
         }
-      })
-    } else {
-      %composer.skipToGroupEnd()
+      }
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/test_ComposableLambdaWithUnusedParameter.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionBodySkippingTransformTestsNoSource/test_ComposableLambdaWithUnusedParameter.txt
@@ -14,11 +14,17 @@ val layoutLambda = @Composable { _: Int ->
 
 val layoutLambda: Function3<Int, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-739046490
 internal object ComposableSingletons%TestKt {
-  val lambda%-739046490: Function3<Int, Composer, Int, Unit> = composableLambdaInstance(<>, false) { <unused var>: Int, %composer: Composer?, %changed: Int ->
-    if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
-      Layout(%composer, 0)
-    } else {
-      %composer.skipToGroupEnd()
+  val lambda%-739046490: Function3<Int, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { <unused var>: Int, %composer: Composer?, %changed: Int ->
+          if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
+            Layout(%composer, 0)
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
+      }
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionKeyMetaAnnotationsTests/testComposableLambda.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionKeyMetaAnnotationsTests/testComposableLambda.txt
@@ -25,8 +25,8 @@ ComposableSingletons$TestKt {
     <init> ()V null
     getLambda$-420233864$test_module ()Lkotlin/jvm/functions/Function2; null
     getLambda$511230191$test_module ()Lkotlin/jvm/functions/Function2; null
-    lambda__420233864$lambda$0 (Landroidx/compose/runtime/Composer;I)Lkotlin/Unit; [key=-420233864, startOffset=143, endOffset=170]
-    lambda_511230191$lambda$0 (Landroidx/compose/runtime/Composer;I)Lkotlin/Unit; [key=511230191, startOffset=180, endOffset=206]
+    _get_lambda__420233864_$lambda$0 (Landroidx/compose/runtime/Composer;I)Lkotlin/Unit; [key=-420233864, startOffset=143, endOffset=170]
+    _get_lambda_511230191_$lambda$0 (Landroidx/compose/runtime/Composer;I)Lkotlin/Unit; [key=511230191, startOffset=180, endOffset=206]
     <clinit> ()V null
 }
 

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionalInterfaceTransformTests/testComposableFunInterfaceWComposableLambda.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionalInterfaceTransformTests/testComposableFunInterfaceWComposableLambda.txt
@@ -121,18 +121,24 @@ interface Decoration {
   abstract fun Decoration(content: Function2<Composer, Int, Unit>, %composer: Composer?, %changed: Int)
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1716229609: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1716229609: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionalInterfaceTransformTests/testComposableFunInterfaceWComposableLambdaCaptureVariable.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.FunctionalInterfaceTransformTests/testComposableFunInterfaceWComposableLambdaCaptureVariable.txt
@@ -123,18 +123,24 @@ interface Decoration {
   abstract fun Decoration(content: Function2<Composer, Int, Unit>, %composer: Composer?, %changed: Int)
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1716229609: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1716229609: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=false].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=false].txt
@@ -30,7 +30,7 @@ private fun contentOf(
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda_412467906$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda_412467906_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 21 }
 }
 
@@ -51,7 +51,7 @@ TestKt {
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda_412467906$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda_412467906_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 21 }
 }
 
@@ -72,7 +72,7 @@ TestKt {
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda_412467906$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda_412467906_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 21 }
 }
 
@@ -90,7 +90,7 @@ TestKt {
 ========= FunctionMeta: false, OptimizeGroups: false =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda_412467906$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda_412467906_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 21 }
 }
 

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/contentOf[mapping=true].txt
@@ -29,7 +29,7 @@ private fun contentOf(
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda_412467906_$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
@@ -42,7 +42,7 @@ ComposeStackTrace -> $$compose:
     1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda_412467906_$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
@@ -55,7 +55,7 @@ ComposeStackTrace -> $$compose:
     1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
 ========= FunctionMeta: true, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda_412467906_$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>
@@ -65,7 +65,7 @@ ComposeStackTrace -> $$compose:
     1:1:void ExtraKt.SubcomposeAsyncImageContent(androidx.compose.runtime.Composer,int):11:11 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: false =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda_412467906$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda_412467906_$lambda$0(androidx.compose.runtime.Composer,int):21:21 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):11:11 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):12:12 -> m$<key>
     1:1:kotlin.Unit TestKt.contentOf$lambda$0(kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,kotlin.jvm.functions.Function3,androidx.compose.runtime.Composer,int):13:13 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaInField[mapping=false].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaInField[mapping=false].txt
@@ -15,13 +15,13 @@ class Test {
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda__1246884903$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda__1246884903_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 6 }
 }
 
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda__1246884903$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda__1246884903_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 6 }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaInField[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambdaInField[mapping=true].txt
@@ -14,7 +14,7 @@ class Test {
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__1246884903$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda__1246884903_$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__1246884903$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda__1246884903_$lambda$0(androidx.compose.runtime.Composer,int):6:6 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambda[mapping=false].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambda[mapping=false].txt
@@ -11,13 +11,13 @@ val a = @Composable {}
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda__486040309$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda__486040309_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 4 }
 }
 
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposableSingletons$TestKt {
     file: Test.kt
-    lambda__486040309$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
+    _get_lambda__486040309_$lambda$0(Landroidx/compose/runtime/Composer;I)Lkotlin/Unit;
         Root { key: <key>, line: 4 }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambda[mapping=true].txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.GroupAnalysisCompilerTest/lambda[mapping=true].txt
@@ -10,7 +10,7 @@ val a = @Composable {}
 
 ========= FunctionMeta: true, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__486040309$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda__486040309_$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
 ========= FunctionMeta: false, OptimizeGroups: true =========
 ComposeStackTrace -> $$compose:
-    1:1:kotlin.Unit ComposableSingletons$TestKt.lambda__486040309$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>
+    1:1:kotlin.Unit ComposableSingletons$TestKt._get_lambda__486040309_$lambda$0(androidx.compose.runtime.Composer,int):4:4 -> m$<key>

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testJvmNameComposableSingletons.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testJvmNameComposableSingletons.txt
@@ -13,18 +13,24 @@ val x = @Composable {}
 
 val x: Function2<Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-1017214942
 internal object ComposableSingletons%TestKt {
-  val lambda%-1017214942: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1017214942: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testMemoizationIsDisabledInTryExpressions002.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testMemoizationIsDisabledInTryExpressions002.txt
@@ -21,34 +21,40 @@ fun test() {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%652858494: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
-      }
-      if (true) {
-        %composer.startReplaceGroup(<>)
-        sourceInformation(%composer, "<{}>")
-        foo(<block>{
-          sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-          val tmp0_group = %composer.cache(false) {
-            {
+  val lambda%652858494: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
             }
+            if (true) {
+              %composer.startReplaceGroup(<>)
+              sourceInformation(%composer, "<{}>")
+              foo(<block>{
+                sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
+                val tmp0_group = %composer.cache(false) {
+                  {
+                  }
+                }
+                sourceInformationMarkerEnd(%composer)
+                tmp0_group
+              })
+              %composer.endReplaceGroup()
+            } else {
+              %composer.startReplaceGroup(<>)
+              %composer.endReplaceGroup()
+            }
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
           }
-          sourceInformationMarkerEnd(%composer)
-          tmp0_group
-        })
-        %composer.endReplaceGroup()
-      } else {
-        %composer.startReplaceGroup(<>)
-        %composer.endReplaceGroup()
+        }
       }
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testMemoizationIsDisabledInTryExpressions003.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testMemoizationIsDisabledInTryExpressions003.txt
@@ -20,24 +20,30 @@ fun test() {
   val f = ComposableSingletons%TestKt.lambda%-867510614
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-867510614: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
-      }
-      try {
-        if (true) {
-          foo {
+  val lambda%-867510614: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            try {
+              if (true) {
+                foo {
+                }
+              }
+            } finally {
+            }
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
           }
         }
-      } finally {
       }
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testMemoizationIsDisabledInTryExpressions004.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testMemoizationIsDisabledInTryExpressions004.txt
@@ -22,26 +22,32 @@ fun test() {
   val f = ComposableSingletons%TestKt.lambda%-867510614
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-867510614: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
-      }
-      try {
-        repeat(3) { it: Int ->
-          if (true) {
-            foo {
+  val lambda%-867510614: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
             }
+            try {
+              repeat(3) { it: Int ->
+                if (true) {
+                  foo {
+                  }
+                }
+              }
+            } finally {
+            }
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
           }
         }
-      } finally {
       }
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testNestedComposableSingletonsClass.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testNestedComposableSingletonsClass.txt
@@ -21,18 +21,24 @@ class A {
     }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-749522881: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-749522881: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testNestedComposableSingletonsClass2.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/testNestedComposableSingletonsClass2.txt
@@ -30,18 +30,24 @@ class A {
     }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-508024995: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-508024995: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/composableLambdaInInlineDefaultParam.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/composableLambdaInInlineDefaultParam.txt
@@ -29,20 +29,26 @@ fun <T: Any> NavGraphBuilder.bottomSheet(noinline dragHandle: Function2<Composer
 }
 ) { }
 internal object ComposableSingletons%TestKt {
-  val lambda%-355041365: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<DragHa...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-355041365: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<DragHa...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            BottomSheetDefaults.DragHandle(%composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      BottomSheetDefaults.DragHandle(%composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-1: Function2<Composer, Int, Unit>
     get() {
       return lambda%-355041365

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testCallingInlineFunction.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testCallingInlineFunction.txt
@@ -123,20 +123,26 @@ fun Test(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1390967652: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1390967652: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("a")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("a")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-1: Function2<Composer, Int, Unit>
     get() {
       return lambda%-1390967652

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testComposableInlineFunction.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testComposableInlineFunction.txt
@@ -57,34 +57,46 @@ fun Inlined(%composer: Composer?, %changed: Int) {
   sourceInformationMarkerEnd(%composer)
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-193164677: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-193164677: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1918458719: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1918458719: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-2: Function2<Composer, Int, Unit>
     get() {
       return lambda%1918458719

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testComposableLambdaPropertyUsedInTwoFunctions.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testComposableLambdaPropertyUsedInTwoFunctions.txt
@@ -52,32 +52,44 @@ fun Bar(%composer: Composer?, %changed: Int) {
   sourceInformationMarkerEnd(%composer)
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-486040309: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-486040309: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1731717644: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1731717644: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testComposableSingletonInInlineFunction.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testComposableSingletonInInlineFunction.txt
@@ -261,138 +261,186 @@ internal fun Test4(block: Function3<Function2<Composer, Int, Unit>, Composer, In
   sourceInformationMarkerEnd(%composer)
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1027889013: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1027889013: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-1: Function2<Composer, Int, Unit>
     get() {
       return lambda%-1027889013
     }
-  val lambda%1629446639: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1629446639: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            "Hello"
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      "Hello"
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-2: Function2<Composer, Int, Unit>
     get() {
       return lambda%1629446639
     }
-  val lambda%-1268429142: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1268429142: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1388906510: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1388906510: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            "Hello"
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      "Hello"
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1508969271: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1508969271: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-5: Function2<Composer, Int, Unit>
     get() {
       return lambda%-1508969271
     }
-  val lambda%1148366381: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1148366381: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            "Hello"
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      "Hello"
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-6: Function2<Composer, Int, Unit>
     get() {
       return lambda%1148366381
     }
-  val lambda%-1749509400: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1749509400: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-7: Function2<Composer, Int, Unit>
     get() {
       return lambda%-1749509400
     }
-  val lambda%907826252: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%907826252: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            "Hello"
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      "Hello"
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
   val lambda-8: Function2<Composer, Int, Unit>
     get() {
       return lambda%907826252

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testDifferentLambdaTypes.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testDifferentLambdaTypes.txt
@@ -40,60 +40,84 @@ fun Foo(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-901944135: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-901944135: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%869170273: Function3<Int, Composer, Int, Unit> = composableLambdaInstance(<>, false) { it: Int, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(it):Test.kt'")
-    if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%869170273: Function3<Int, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { it: Int, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(it):Test.kt'")
+          if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1917317994: Function3<String, Composer, Int, Unit> = composableLambdaInstance(<>, false) { it: String, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(it):Test.kt'")
-    if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1917317994: Function3<String, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { it: String, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(it):Test.kt'")
+          if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-406468707: @[ExtensionFunctionType] Function3<Int, Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-406468707: @[ExtensionFunctionType] Function3<Int, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b00010001 != 0b00010000, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testGetterAndSetter.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testGetterAndSetter.txt
@@ -30,88 +30,124 @@ var foo: Function2<Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-69
     field = ComposableSingletons%TestKt.lambda%1005617485
   }
 internal object ComposableSingletons%TestKt {
-  val lambda%-2145061552: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-2145061552: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("field")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("field")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-697646928: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Box>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-697646928: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Box>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Box(ComposableSingletons%TestKt.lambda%-2145061552, %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Box(ComposableSingletons%TestKt.lambda%-2145061552, %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1813956673: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1813956673: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("get")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("get")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1418399519: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Box>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1418399519: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Box>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Box(ComposableSingletons%TestKt.lambda%1813956673, %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Box(ComposableSingletons%TestKt.lambda%1813956673, %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1028503379: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1028503379: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("set")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("set")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1005617485: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Box>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1005617485: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Box>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Box(ComposableSingletons%TestKt.lambda%-1028503379, %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Box(ComposableSingletons%TestKt.lambda%-1028503379, %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testLambdasNextToEachOther.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testLambdasNextToEachOther.txt
@@ -38,46 +38,64 @@ fun root(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%308868616: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%308868616: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("1")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("1")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%266925745: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%266925745: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("2")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("2")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1728505744: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1728505744: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("2")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("2")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testLocalVariableComposableLambdas.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testLocalVariableComposableLambdas.txt
@@ -39,32 +39,44 @@ fun A(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1189050887: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1189050887: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%2106561222: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%2106561222: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testMemoizingDifferentlyScopedLambdas.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testMemoizingDifferentlyScopedLambdas.txt
@@ -113,60 +113,84 @@ class ClassScope {
     }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-548887921: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-548887921: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            println("topLevelScope")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      println("topLevelScope")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1567063066: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1567063066: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("functionScope")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("functionScope")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%665899684: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%665899684: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("classScope")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("classScope")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-959936766: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-959936766: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("nestedClassScope")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("nestedClassScope")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testMemoizingNestedLambdas.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testMemoizingNestedLambdas.txt
@@ -51,78 +51,108 @@ fun root(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-960236888: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-960236888: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("root/1/1")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("root/1/1")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-553294081: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-553294081: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("root/1/2/1")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("root/1/2/1")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%618064424: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%618064424: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("root/1/2/2")
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("root/1/2/2")
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%2026723231: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Box>,<Box>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%2026723231: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Box>,<Box>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("root/1/2")
+            Box(ComposableSingletons%TestKt.lambda%-553294081, %composer, 0b0110)
+            Box(ComposableSingletons%TestKt.lambda%618064424, %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("root/1/2")
-      Box(ComposableSingletons%TestKt.lambda%-553294081, %composer, 0b0110)
-      Box(ComposableSingletons%TestKt.lambda%618064424, %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%308868616: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Box>,<Box>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%308868616: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Box>,<Box>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            print("root/1")
+            Box(ComposableSingletons%TestKt.lambda%-960236888, %composer, 0b0110)
+            Box(ComposableSingletons%TestKt.lambda%2026723231, %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      print("root/1")
-      Box(ComposableSingletons%TestKt.lambda%-960236888, %composer, 0b0110)
-      Box(ComposableSingletons%TestKt.lambda%2026723231, %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testOverloads.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testOverloads.txt
@@ -105,60 +105,84 @@ fun Foo(x: String, %composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-255600592: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-255600592: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1034946783: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1034946783: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%-1717614383: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1717614383: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%2015267231: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%2015267231: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testParameterComposableLambdas.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testParameterComposableLambdas.txt
@@ -33,18 +33,24 @@ fun A(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%345062178: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%345062178: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testTopLevelComposableLambdaProperties.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationTransformTests/testTopLevelComposableLambdaProperties.txt
@@ -14,32 +14,44 @@ val bar: @Composable () -> Unit = {}
 val foo: Function2<Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%-697646928
 val bar: Function2<Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%1674893565
 internal object ComposableSingletons%TestKt {
-  val lambda%-697646928: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-697646928: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%1674893565: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1674893565: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.RememberIntrinsicTransformTests/testRememberInALoop.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.RememberIntrinsicTransformTests/testRememberInALoop.txt
@@ -28,36 +28,42 @@ class SomeUnstableClass(val a: Any = "abc") {
 }
 val content: Function3<@[ParameterName(name = 'a')] SomeUnstableClass, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%613241577
 internal object ComposableSingletons%TestKt {
-  val lambda%613241577: Function3<SomeUnstableClass, Composer, Int, Unit> = composableLambdaInstance(<>, false) { it: SomeUnstableClass, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(it)10@339L14:Test.kt'")
-    if (isTraceInProgress()) {
-      traceEventStart(<>, %changed, -1, <>)
-    }
-    %composer.startReplaceGroup(<>)
-    sourceInformation(%composer, "*<rememb...>")
-    val <iterator> = 0 until count.iterator()
-    while (<iterator>.hasNext()) {
-      val index = <iterator>.next()
-      val i = <block>{
-        sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-        val tmp0_group = %composer.cache(false) {
-          index
+  val lambda%613241577: Function3<SomeUnstableClass, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { it: SomeUnstableClass, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(it)10@339L14:Test.kt'")
+          if (isTraceInProgress()) {
+            traceEventStart(<>, %changed, -1, <>)
+          }
+          %composer.startReplaceGroup(<>)
+          sourceInformation(%composer, "*<rememb...>")
+          val <iterator> = 0 until count.iterator()
+          while (<iterator>.hasNext()) {
+            val index = <iterator>.next()
+            val i = <block>{
+              sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
+              val tmp0_group = %composer.cache(false) {
+                index
+              }
+              sourceInformationMarkerEnd(%composer)
+              tmp0_group
+            }
+          }
+          %composer.endReplaceGroup()
+          val a = <block>{
+            sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
+            val tmp1_group = %composer.cache(false) {
+              1
+            }
+            sourceInformationMarkerEnd(%composer)
+            tmp1_group
+          }
+          if (isTraceInProgress()) {
+            traceEventEnd()
+          }
         }
-        sourceInformationMarkerEnd(%composer)
-        tmp0_group
       }
+      return field
     }
-    %composer.endReplaceGroup()
-    val a = <block>{
-      sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-      val tmp1_group = %composer.cache(false) {
-        1
-      }
-      sourceInformationMarkerEnd(%composer)
-      tmp1_group
-    }
-    if (isTraceInProgress()) {
-      traceEventEnd()
-    }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.RememberIntrinsicTransformTests/testRememberInALoop_NoTrailingRemember.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.RememberIntrinsicTransformTests/testRememberInALoop_NoTrailingRemember.txt
@@ -27,25 +27,31 @@ class SomeUnstableClass(val a: Any = "abc") {
 }
 val content: Function3<@[ParameterName(name = 'a')] SomeUnstableClass, Composer, Int, Unit> = ComposableSingletons%TestKt.lambda%613241577
 internal object ComposableSingletons%TestKt {
-  val lambda%613241577: Function3<SomeUnstableClass, Composer, Int, Unit> = composableLambdaInstance(<>, false) { it: SomeUnstableClass, %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "invalid source info at 1: 'CN(it)*8@278L18:Test.kt'")
-    if (isTraceInProgress()) {
-      traceEventStart(<>, %changed, -1, <>)
-    }
-    val <iterator> = 0 until count.iterator()
-    while (<iterator>.hasNext()) {
-      val index = <iterator>.next()
-      val i = <block>{
-        sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
-        val tmp0_group = %composer.cache(false) {
-          index
+  val lambda%613241577: Function3<SomeUnstableClass, Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { it: SomeUnstableClass, %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "invalid source info at 1: 'CN(it)*8@278L18:Test.kt'")
+          if (isTraceInProgress()) {
+            traceEventStart(<>, %changed, -1, <>)
+          }
+          val <iterator> = 0 until count.iterator()
+          while (<iterator>.hasNext()) {
+            val index = <iterator>.next()
+            val i = <block>{
+              sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
+              val tmp0_group = %composer.cache(false) {
+                index
+              }
+              sourceInformationMarkerEnd(%composer)
+              tmp0_group
+            }
+          }
+          if (isTraceInProgress()) {
+            traceEventEnd()
+          }
         }
-        sourceInformationMarkerEnd(%composer)
-        tmp0_group
       }
+      return field
     }
-    if (isTraceInProgress()) {
-      traceEventEnd()
-    }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testCallingComposableParameterWithComposableParameter.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testCallingComposableParameterWithComposableParameter.txt
@@ -41,18 +41,24 @@ fun Test(decorator: Function3<@[ParameterName(name = 'content')] Function2<Compo
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1254334145: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1254334145: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("Some text", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("Some text", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testCanInferWithGeneric.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testCanInferWithGeneric.txt
@@ -37,18 +37,24 @@ fun Test(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%682646544: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%682646544: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("test", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("test", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testCompositionLocalsProvider.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testCompositionLocalsProvider.txt
@@ -42,18 +42,24 @@ fun Test(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%1643529656: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%1643529656: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("test", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("test", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testInferLambdaParameter.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testInferLambdaParameter.txt
@@ -37,18 +37,24 @@ fun Test(content: Function2<Composer, Int, Unit>, %composer: Composer?, %changed
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-886022036: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Text("...>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-886022036: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Text("...>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Text("test", %composer, 0b0110)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Text("test", %composer, 0b0110)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testOptionalParameters.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.TargetAnnotationsTransformTests/testOptionalParameters.txt
@@ -265,32 +265,44 @@ fun UseOptional(%composer: Composer?, %changed: Int) {
   }
 }
 internal object ComposableSingletons%TestKt {
-  val lambda%-1761910897: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%-1761910897: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Unit
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Unit
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
-  val lambda%449031748: Function2<Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
-    sourceInformation(%composer, "C<Leaf()>:Test.kt")
-    if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
-      if (isTraceInProgress()) {
-        traceEventStart(<>, %changed, -1, <>)
+  val lambda%449031748: Function2<Composer, Int, Unit>?
+    get() {
+      if (field == null) {
+        field = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+          sourceInformation(%composer, "C<Leaf()>:Test.kt")
+          if (%composer.shouldExecute(%changed and 0b0011 != 0b0010, %changed and 0b0001)) {
+            if (isTraceInProgress()) {
+              traceEventStart(<>, %changed, -1, <>)
+            }
+            Leaf(%composer, 0)
+            if (isTraceInProgress()) {
+              traceEventEnd()
+            }
+          } else {
+            %composer.skipToGroupEnd()
+          }
+        }
       }
-      Leaf(%composer, 0)
-      if (isTraceInProgress()) {
-        traceEventEnd()
-      }
-    } else {
-      %composer.skipToGroupEnd()
+      return field
     }
-  }
 }

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ComposeBytecodeCodegenTest.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ComposeBytecodeCodegenTest.kt
@@ -761,7 +761,7 @@ class ComposeBytecodeCodegenTest : AbstractCodegenTest() {
             """,
             validate = { bytecode ->
                 val invokeMethod = run {
-                    val staticLambdaFunctionRegex = Regex("private final static lambda.*lambda%0[\\S\\s]*?\\v\\v", RegexOption.MULTILINE)
+                    val staticLambdaFunctionRegex = Regex("private final static _get_lambda.*lambda%0[\\S\\s]*?\\v\\v", RegexOption.MULTILINE)
                     val matches = staticLambdaFunctionRegex.findAll(bytecode)
                     matches.single().value
                 }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -39,6 +39,9 @@ import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeBuilder
 import org.jetbrains.kotlin.ir.types.impl.buildSimpleType
 import org.jetbrains.kotlin.ir.types.impl.toBuilder
 import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
 /**
@@ -384,7 +387,6 @@ class ComposableTargetAnnotationsTransformer(
         get() = when (this) {
             is IrFunctionExpression -> function.isComposable
             is IrCall -> isComposableSingletonGetter() || hasTransformedLambda
-            is IrGetField -> symbol.owner.initializer?.findTransformedLambda() != null
             else -> false
         }
 
@@ -394,15 +396,27 @@ class ComposableTargetAnnotationsTransformer(
             else -> false
         }
 
-    private fun IrElement.findTransformedLambda(): IrFunctionExpression? =
-        when (this) {
-            is IrCall -> targetArguments.firstNotNullOfOrNull { it?.findTransformedLambda() }
-            is IrGetField -> symbol.owner.initializer?.findTransformedLambda()
-            is IrBody -> statements.firstNotNullOfOrNull { it.findTransformedLambda() }
-            is IrReturn -> value.findTransformedLambda()
-            is IrFunctionExpression -> if (isTransformedLambda) this else null
-            else -> null
-        }
+    private fun IrElement.findTransformedLambda(): IrFunctionExpression? {
+        var result: IrFunctionExpression? = null
+        acceptVoid(object : IrVisitorVoid() {
+            override fun visitElement(element: IrElement) {
+                if (result == null) {
+                    element.acceptChildrenVoid(this)
+                }
+            }
+
+            override fun visitFunctionExpression(expression: IrFunctionExpression) {
+                if (result == null) {
+                    if (expression.isTransformedLambda) {
+                        result = expression
+                    } else {
+                        super.visitFunctionExpression(expression)
+                    }
+                }
+            }
+        })
+        return result
+    }
 
     internal fun IrElement.transformedLambda(): IrFunctionExpression =
         findTransformedLambda() ?: error("Could not find the lambda for ${dump()}")

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -42,6 +42,8 @@ import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.isUnit
 import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.types.makeNullable
+import org.jetbrains.kotlin.ir.builders.declarations.addFunction
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.kotlin.PackagePartClassUtils
 import org.jetbrains.kotlin.name.Name
@@ -820,25 +822,32 @@ class ComposerLambdaMemoization(
                 startOffset = SYNTHETIC_OFFSET
                 endOffset = SYNTHETIC_OFFSET
                 name = Name.identifier(lambdaName)
-                type = lambdaType
+                type = lambdaType.makeNullable()
                 visibility = DescriptorVisibilities.PRIVATE
                 isStatic = context.platform.isJvm()
             }.also { f ->
                 f.correspondingPropertySymbol = p.symbol
                 f.parent = clazz
-                f.initializer = DeclarationIrBuilder(context, clazz.symbol)
-                    .irExprBody(lambdaExpression.markIsTransformedLambda())
             }
             val getter = p.addGetter {
                 returnType = lambdaType
                 visibility = DescriptorVisibilities.INTERNAL
-                origin = IrDeclarationOrigin.DEFAULT_PROPERTY_ACCESSOR
+                origin = IrDeclarationOrigin.GeneratedByPlugin(ComposeCompilerKey)
             }.also { fn ->
                 val thisParam = clazz.thisReceiver!!.copyTo(fn)
                 fn.parent = clazz
                 fn.parameters += thisParam
                 fn.body = DeclarationIrBuilder(context, fn.symbol).irBlockBody {
-                    +irReturn(irGetField(irGet(thisParam), p.backingField!!))
+                    val backingField = p.backingField!!
+                    +irIf(
+                        condition = irEqualsNull(irGetField(irGet(thisParam), backingField)),
+                        body = irSetField(
+                            irGet(thisParam),
+                            backingField,
+                            lambdaExpression.markIsTransformedLambda()
+                        )
+                    )
+                    +irReturn(irGetField(irGet(thisParam), backingField))
                 }
             }
 
@@ -860,7 +869,7 @@ class ComposerLambdaMemoization(
                         fn.parent = clazz
                         fn.parameters += thisParam
                         fn.body = DeclarationIrBuilder(context, fn.symbol).irBlockBody {
-                            +irReturn(irCall(getter))
+                            +irReturn(irCall(getter).apply { dispatchReceiver = irGet(thisParam) })
                         }
                     }
                 }

--- a/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.ir.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.ir.txt
@@ -3,63 +3,70 @@ MODULE_FRAGMENT
     CLASS OBJECT name:ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt modality:FINAL visibility:internal superTypes:[kotlin.Any]
       thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt
       PROPERTY name:lambda$-1010009659 visibility:internal modality:FINAL [val]
-        FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static]
-          EXPRESSION_BODY
-            CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
-              ARG key: CONST Int type=kotlin.Int value=-1010009659
-              ARG tracked: CONST Boolean type=kotlin.Boolean value=false
-              ARG block: FUN_EXPR type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
-                FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
-                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:0 type:kotlin.Function0<kotlin.Unit>
-                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:1 type:kotlin.Function0<kotlin.Unit>
-                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:2 type:kotlin.Function0<kotlin.Unit>
-                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:3 type:kotlin.Function0<kotlin.Unit>
-                  VALUE_PARAMETER kind:Regular name:$composer index:4 type:androidx.compose.runtime.Composer? [assignable]
-                  VALUE_PARAMETER kind:Regular name:$changed index:5 type:kotlin.Int
-                  annotations:
-                    Composable
-                    FunctionKeyMeta(key = -1010009659, startOffset = 134, endOffset = 151)
-                  BLOCK_BODY
-                    CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                      ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-                      ARG sourceInformation: CONST String type=kotlin.String value="C:module_main_composableTypeRemappingOfExternalAccessors.kt"
-                    WHEN type=kotlin.Unit origin=IF
-                      BRANCH
-                        if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
-                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-                          ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
-                            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
-                              ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
-                                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=kotlin.Int origin=null
-                                ARG other: CONST Int type=kotlin.Int value=8193
-                              ARG arg1: CONST Int type=kotlin.Int value=8192
-                          ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
-                            ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=kotlin.Int origin=null
-                            ARG other: CONST Int type=kotlin.Int value=1
-                        then: BLOCK type=kotlin.Unit origin=null
-                          WHEN type=kotlin.Unit origin=IF
-                            BRANCH
-                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
-                              then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                                ARG key: CONST Int type=kotlin.Int value=-1010009659
-                                ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=kotlin.Int origin=null
-                                ARG dirty2: CONST Int type=kotlin.Int value=-1
-                                ARG info: CONST String type=kotlin.String value="ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous> (module_main_composableTypeRemappingOfExternalAccessors.kt:20)"
-                          GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-                          WHEN type=kotlin.Unit origin=IF
-                            BRANCH
-                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
-                              then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                      BRANCH
-                        if: CONST Boolean type=kotlin.Boolean value=true
-                        then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
-                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-lambda$-1010009659> visibility:internal modality:FINAL returnType:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+        FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static]
+        FUN GENERATED[androidx.compose.compiler.plugins.kotlin.lower.ComposeCompilerKey] name:<get-lambda$-1010009659> visibility:internal modality:FINAL returnType:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
           VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt
           correspondingProperty: PROPERTY name:lambda$-1010009659 visibility:internal modality:FINAL [val]
           BLOCK_BODY
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
+                    receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>' type=<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>' type=<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt origin=null
+                  value: CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
+                    ARG key: CONST Int type=kotlin.Int value=-1010009659
+                    ARG tracked: CONST Boolean type=kotlin.Boolean value=false
+                    ARG block: FUN_EXPR type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                        VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:0 type:kotlin.Function0<kotlin.Unit>
+                        VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:1 type:kotlin.Function0<kotlin.Unit>
+                        VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:2 type:kotlin.Function0<kotlin.Unit>
+                        VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:3 type:kotlin.Function0<kotlin.Unit>
+                        VALUE_PARAMETER kind:Regular name:$composer index:4 type:androidx.compose.runtime.Composer? [assignable]
+                        VALUE_PARAMETER kind:Regular name:$changed index:5 type:kotlin.Int
+                        annotations:
+                          Composable
+                          FunctionKeyMeta(key = -1010009659, startOffset = 134, endOffset = 151)
+                        BLOCK_BODY
+                          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG sourceInformation: CONST String type=kotlin.String value="C:module_main_composableTypeRemappingOfExternalAccessors.kt"
+                          WHEN type=kotlin.Unit origin=IF
+                            BRANCH
+                              if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                                ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                                  ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                                    ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                      ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG other: CONST Int type=kotlin.Int value=8193
+                                    ARG arg1: CONST Int type=kotlin.Int value=8192
+                                ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                  ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>.<anonymous>' type=kotlin.Int origin=null
+                                  ARG other: CONST Int type=kotlin.Int value=1
+                              then: BLOCK type=kotlin.Unit origin=null
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                                      ARG key: CONST Int type=kotlin.Int value=-1010009659
+                                      ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG dirty2: CONST Int type=kotlin.Int value=-1
+                                      ARG info: CONST String type=kotlin.String value="ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>.<anonymous> (module_main_composableTypeRemappingOfExternalAccessors.kt:20)"
+                                GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            BRANCH
+                              if: CONST Boolean type=kotlin.Boolean value=true
+                              then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
             RETURN type=kotlin.Nothing from='internal final fun <get-lambda$-1010009659> (): kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt'
-              GET_FIELD 'FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+              GET_FIELD 'FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
                 receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>' type=<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt origin=null
       CONSTRUCTOR visibility:public returnType:<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt [primary]
         BLOCK_BODY

--- a/plugins/compose/compiler-hosted/testData/codegen/inlineFuncWithExposedComposableSingleton.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/inlineFuncWithExposedComposableSingleton.txt
@@ -34,12 +34,12 @@ public final class compose/ui/ComposableSingletons$BarKt {
     private static field lambda$2013108129: kotlin.jvm.functions.Function2
     static method <clinit>(): void
     public method <init>(): void
+    private final static method _get_lambda_2013108129_$lambda$0(p0: androidx.compose.runtime.Composer, p1: int): kotlin.Unit
+    private final static method _get_lambda__1754416646_$lambda$0(p0: androidx.compose.runtime.Composer, p1: int): kotlin.Unit
     public final method getLambda$-1754416646$main(): kotlin.jvm.functions.Function2
     public final method getLambda$2013108129$main(): kotlin.jvm.functions.Function2
     public final method getLambda-1$main(): kotlin.jvm.functions.Function2
     public final method getLambda-2$main(): kotlin.jvm.functions.Function2
-    private final static method lambda_2013108129$lambda$0(p0: androidx.compose.runtime.Composer, p1: int): kotlin.Unit
-    private final static method lambda__1754416646$lambda$0(p0: androidx.compose.runtime.Composer, p1: int): kotlin.Unit
 }
 
 public final class compose/ui/ComposableSingletons$FooKt {
@@ -48,9 +48,9 @@ public final class compose/ui/ComposableSingletons$FooKt {
     private static field lambda$-1798180840: kotlin.jvm.functions.Function2
     static method <clinit>(): void
     public method <init>(): void
+    private final static method _get_lambda__1798180840_$lambda$0(p0: androidx.compose.runtime.Composer, p1: int): kotlin.Unit
     public final method getLambda$-1798180840$main(): kotlin.jvm.functions.Function2
     public final method getLambda-1$main(): kotlin.jvm.functions.Function2
-    private final static method lambda__1798180840$lambda$0(p0: androidx.compose.runtime.Composer, p1: int): kotlin.Unit
 }
 
 public final class compose/ui/FooKt$FooHelp$localFooHelp$1 {

--- a/plugins/compose/compiler-hosted/testData/codegen/multiModulesWithComposableFunction.ir.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/multiModulesWithComposableFunction.ir.txt
@@ -3,59 +3,66 @@ MODULE_FRAGMENT
     CLASS OBJECT name:ComposableSingletons$MainKt modality:FINAL visibility:internal superTypes:[kotlin.Any]
       thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:home.ComposableSingletons$MainKt
       PROPERTY name:lambda$-1263890955 visibility:internal modality:FINAL [val]
-        FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static]
-          EXPRESSION_BODY
-            CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
-              ARG key: CONST Int type=kotlin.Int value=-1263890955
-              ARG tracked: CONST Boolean type=kotlin.Boolean value=false
-              ARG block: FUN_EXPR type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
-                FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
-                  VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer? [assignable]
-                  VALUE_PARAMETER kind:Regular name:$changed index:1 type:kotlin.Int
-                  annotations:
-                    Composable
-                    FunctionKeyMeta(key = -1263890955, startOffset = 396, endOffset = 407)
-                  BLOCK_BODY
-                    CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                      ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-                      ARG sourceInformation: CONST String type=kotlin.String value="C:main.kt#1wrmn"
-                    WHEN type=kotlin.Unit origin=IF
-                      BRANCH
-                        if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
-                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-                          ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
-                            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
-                              ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
-                                ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=kotlin.Int origin=null
-                                ARG other: CONST Int type=kotlin.Int value=3
-                              ARG arg1: CONST Int type=kotlin.Int value=2
-                          ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
-                            ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=kotlin.Int origin=null
-                            ARG other: CONST Int type=kotlin.Int value=1
-                        then: BLOCK type=kotlin.Unit origin=null
-                          WHEN type=kotlin.Unit origin=IF
-                            BRANCH
-                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
-                              then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                                ARG key: CONST Int type=kotlin.Int value=-1263890955
-                                ARG dirty1: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=kotlin.Int origin=null
-                                ARG dirty2: CONST Int type=kotlin.Int value=-1
-                                ARG info: CONST String type=kotlin.String value="home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous> (main.kt:60)"
-                          GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-                          WHEN type=kotlin.Unit origin=IF
-                            BRANCH
-                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
-                              then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                      BRANCH
-                        if: CONST Boolean type=kotlin.Boolean value=true
-                        then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
-                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-lambda$-1263890955> visibility:internal modality:FINAL returnType:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+        FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static]
+        FUN GENERATED[androidx.compose.compiler.plugins.kotlin.lower.ComposeCompilerKey] name:<get-lambda$-1263890955> visibility:internal modality:FINAL returnType:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
           VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:home.ComposableSingletons$MainKt
           correspondingProperty: PROPERTY name:lambda$-1263890955 visibility:internal modality:FINAL [val]
           BLOCK_BODY
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
+                    receiver: GET_VAR '<this>: home.ComposableSingletons$MainKt declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>' type=home.ComposableSingletons$MainKt origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: home.ComposableSingletons$MainKt declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>' type=home.ComposableSingletons$MainKt origin=null
+                  value: CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
+                    ARG key: CONST Int type=kotlin.Int value=-1263890955
+                    ARG tracked: CONST Boolean type=kotlin.Boolean value=false
+                    ARG block: FUN_EXPR type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                        VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer? [assignable]
+                        VALUE_PARAMETER kind:Regular name:$changed index:1 type:kotlin.Int
+                        annotations:
+                          Composable
+                          FunctionKeyMeta(key = -1263890955, startOffset = 396, endOffset = 407)
+                        BLOCK_BODY
+                          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG sourceInformation: CONST String type=kotlin.String value="C:main.kt#1wrmn"
+                          WHEN type=kotlin.Unit origin=IF
+                            BRANCH
+                              if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                                ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                                  ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                                    ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                      ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG other: CONST Int type=kotlin.Int value=3
+                                    ARG arg1: CONST Int type=kotlin.Int value=2
+                                ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                  ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=kotlin.Int origin=null
+                                  ARG other: CONST Int type=kotlin.Int value=1
+                              then: BLOCK type=kotlin.Unit origin=null
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                                      ARG key: CONST Int type=kotlin.Int value=-1263890955
+                                      ARG dirty1: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG dirty2: CONST Int type=kotlin.Int value=-1
+                                      ARG info: CONST String type=kotlin.String value="home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous> (main.kt:60)"
+                                GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            BRANCH
+                              if: CONST Boolean type=kotlin.Boolean value=true
+                              then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
             RETURN type=kotlin.Nothing from='internal final fun <get-lambda$-1263890955> (): kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in home.ComposableSingletons$MainKt'
-              GET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+              GET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
                 receiver: GET_VAR '<this>: home.ComposableSingletons$MainKt declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>' type=home.ComposableSingletons$MainKt origin=null
       CONSTRUCTOR visibility:public returnType:home.ComposableSingletons$MainKt [primary]
         BLOCK_BODY

--- a/plugins/compose/compiler-hosted/testData/codegen/nestedLambda.ir.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/nestedLambda.ir.txt
@@ -161,59 +161,66 @@ MODULE_FRAGMENT
     CLASS OBJECT name:ComposableSingletons$MainKt modality:FINAL visibility:internal superTypes:[kotlin.Any]
       thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:home.ComposableSingletons$MainKt
       PROPERTY name:lambda$-1263890955 visibility:internal modality:FINAL [val]
-        FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static]
-          EXPRESSION_BODY
-            CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
-              ARG key: CONST Int type=kotlin.Int value=-1263890955
-              ARG tracked: CONST Boolean type=kotlin.Boolean value=false
-              ARG block: FUN_EXPR type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
-                FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
-                  VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer? [assignable]
-                  VALUE_PARAMETER kind:Regular name:$changed index:1 type:kotlin.Int
-                  annotations:
-                    Composable
-                    FunctionKeyMeta(key = -1263890955, startOffset = 1075, endOffset = 1086)
-                  BLOCK_BODY
-                    CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                      ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-                      ARG sourceInformation: CONST String type=kotlin.String value="C:main.kt#1wrmn"
-                    WHEN type=kotlin.Unit origin=IF
-                      BRANCH
-                        if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
-                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-                          ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
-                            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
-                              ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
-                                ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=kotlin.Int origin=null
-                                ARG other: CONST Int type=kotlin.Int value=3
-                              ARG arg1: CONST Int type=kotlin.Int value=2
-                          ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
-                            ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=kotlin.Int origin=null
-                            ARG other: CONST Int type=kotlin.Int value=1
-                        then: BLOCK type=kotlin.Unit origin=null
-                          WHEN type=kotlin.Unit origin=IF
-                            BRANCH
-                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
-                              then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                                ARG key: CONST Int type=kotlin.Int value=-1263890955
-                                ARG dirty1: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=kotlin.Int origin=null
-                                ARG dirty2: CONST Int type=kotlin.Int value=-1
-                                ARG info: CONST String type=kotlin.String value="home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous> (main.kt:44)"
-                          GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-                          WHEN type=kotlin.Unit origin=IF
-                            BRANCH
-                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
-                              then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
-                      BRANCH
-                        if: CONST Boolean type=kotlin.Boolean value=true
-                        then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
-                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.lambda$-1263890955.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-lambda$-1263890955> visibility:internal modality:FINAL returnType:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+        FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static]
+        FUN GENERATED[androidx.compose.compiler.plugins.kotlin.lower.ComposeCompilerKey] name:<get-lambda$-1263890955> visibility:internal modality:FINAL returnType:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
           VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:home.ComposableSingletons$MainKt
           correspondingProperty: PROPERTY name:lambda$-1263890955 visibility:internal modality:FINAL [val]
           BLOCK_BODY
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
+                    receiver: GET_VAR '<this>: home.ComposableSingletons$MainKt declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>' type=home.ComposableSingletons$MainKt origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: home.ComposableSingletons$MainKt declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>' type=home.ComposableSingletons$MainKt origin=null
+                  value: CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
+                    ARG key: CONST Int type=kotlin.Int value=-1263890955
+                    ARG tracked: CONST Boolean type=kotlin.Boolean value=false
+                    ARG block: FUN_EXPR type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                        VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer? [assignable]
+                        VALUE_PARAMETER kind:Regular name:$changed index:1 type:kotlin.Int
+                        annotations:
+                          Composable
+                          FunctionKeyMeta(key = -1263890955, startOffset = 1075, endOffset = 1086)
+                        BLOCK_BODY
+                          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG sourceInformation: CONST String type=kotlin.String value="C:main.kt#1wrmn"
+                          WHEN type=kotlin.Unit origin=IF
+                            BRANCH
+                              if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                                ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                                  ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                                    ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                      ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG other: CONST Int type=kotlin.Int value=3
+                                    ARG arg1: CONST Int type=kotlin.Int value=2
+                                ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                  ARG <this>: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=kotlin.Int origin=null
+                                  ARG other: CONST Int type=kotlin.Int value=1
+                              then: BLOCK type=kotlin.Unit origin=null
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                                      ARG key: CONST Int type=kotlin.Int value=-1263890955
+                                      ARG dirty1: GET_VAR '$changed: kotlin.Int declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG dirty2: CONST Int type=kotlin.Int value=-1
+                                      ARG info: CONST String type=kotlin.String value="home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous> (main.kt:44)"
+                                GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            BRANCH
+                              if: CONST Boolean type=kotlin.Boolean value=true
+                              then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
             RETURN type=kotlin.Nothing from='internal final fun <get-lambda$-1263890955> (): kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in home.ComposableSingletons$MainKt'
-              GET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+              GET_FIELD 'FIELD name:lambda$-1263890955 type:kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in home.ComposableSingletons$MainKt' type=kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
                 receiver: GET_VAR '<this>: home.ComposableSingletons$MainKt declared in home.ComposableSingletons$MainKt.<get-lambda$-1263890955>' type=home.ComposableSingletons$MainKt origin=null
       CONSTRUCTOR visibility:public returnType:home.ComposableSingletons$MainKt [primary]
         BLOCK_BODY


### PR DESCRIPTION
Test: Used this version of the compiler (via `./gradlew install`) and R8 to compile the example from b/530458587 and verified that the lambda containing `ExamplePickerContent(option = "brass-lantern-preview-fixture")` now gets optimized out, and so does the lambda containing that lambda.
Bug: 530458587