### PR TITLE
[CFG] Elvis exit nodes should not be marked as unreachable

### DIFF
--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extra/UnreachableCodeChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/extra/UnreachableCodeChecker.kt
@@ -49,26 +49,9 @@ object UnreachableCodeChecker : FirControlFlowChecker(MppCheckerKind.Common) {
     )
 
     private fun CFGNode<*>.skipNode(): Boolean {
-        val skipType = this is ExitNodeMarker ||
-                this is EnterNodeMarker ||
-                this is StubNode ||
-                this is SplitPostponedLambdasNode ||
-                this is PostponedLambdaExitNode ||
-                this is MergePostponedLambdaExitsNode ||
-                this is FunctionCallExitNode ||
-                this is BooleanOperatorExitLeftOperandNode ||
-                this is BooleanOperatorEnterRightOperandNode ||
-                this is WhenSyntheticElseBranchNode ||
-                this is WhenBranchResultEnterNode ||
-                this is WhenBranchResultExitNode ||
-                this is ExitSafeCallNode ||
-                this is ElvisLhsExitNode ||
-                this is ElvisLhsIsNotNullNode
-        val allowType = this is LoopEnterNode ||
-                this is LoopBlockEnterNode ||
-                this is TryExpressionEnterNode
-        return !allowType &&
-                (skipType ||
+        // Nodes which must be reachable, regardless of source key or element type.
+        return this !is MustBeReachableNodeMarker &&
+                (this is AlwaysReachableNodeMarker ||
                         sourceKindsToSkip.contains(this.fir.source?.kind) ||
                         this.fir.source?.elementType == TokenType.ERROR_ELEMENT)
     }

--- a/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNode.kt
+++ b/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/resolve/dfa/cfg/CFGNode.kt
@@ -227,11 +227,25 @@ val CFGNode<*>.previousLiveNodes: List<CFGNode<*>>
         else -> previousNodes.filter { !it.isDead }
     }
 
-interface EnterNodeMarker
-interface ExitNodeMarker
+interface EnterNodeMarker : AlwaysReachableNodeMarker
+interface ExitNodeMarker : AlwaysReachableNodeMarker
 interface GraphEnterNodeMarker : EnterNodeMarker
 interface GraphExitNodeMarker : ExitNodeMarker
 interface TailrecExitNodeMarker
+
+/**
+ * Marks nodes which should never be considered unreachable when reporting diagnostics.
+ * This usually indicates they are a synthetic node to create a proper control-flow graph,
+ * or they correspond more with the syntax of the code and not the execution.
+ */
+interface AlwaysReachableNodeMarker
+
+/**
+ * Marks nodes which must always be reachable when reporting diagnostics.
+ * This overrides the [AlwaysReachableNodeMarker] interface
+ * and any source kind or source element type checks.
+ */
+interface MustBeReachableNodeMarker
 
 // ----------------------------------- EnterNode for declaration with CFG -----------------------------------
 
@@ -323,8 +337,12 @@ class ExitValueParameterNode(owner: ControlFlowGraph, override val fir: FirValue
 
 // ----------------------------------- Anonymous function -----------------------------------
 
-class SplitPostponedLambdasNode(owner: ControlFlowGraph, override val fir: FirStatement, val lambdas: List<FirAnonymousFunction>, level: Int)
-    : CFGNodeWithSubgraphs<FirStatement>(owner, level) {
+class SplitPostponedLambdasNode(
+    owner: ControlFlowGraph,
+    override val fir: FirStatement,
+    val lambdas: List<FirAnonymousFunction>,
+    level: Int,
+) : CFGNodeWithSubgraphs<FirStatement>(owner, level), AlwaysReachableNodeMarker {
 
     override val subGraphs: List<ControlFlowGraph>
         get() = lambdas.mapNotNull { it.controlFlowGraphReference?.controlFlowGraph }
@@ -340,13 +358,15 @@ class SplitPostponedLambdasNode(owner: ControlFlowGraph, override val fir: FirSt
     }
 }
 
-class PostponedLambdaExitNode(owner: ControlFlowGraph, override val fir: FirAnonymousFunctionExpression, level: Int) : CFGNode<FirAnonymousFunctionExpression>(owner, level) {
+class PostponedLambdaExitNode(owner: ControlFlowGraph, override val fir: FirAnonymousFunctionExpression, level: Int) :
+    CFGNode<FirAnonymousFunctionExpression>(owner, level), AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitPostponedLambdaExitNode(this, data)
     }
 }
 
-class MergePostponedLambdaExitsNode(owner: ControlFlowGraph, override val fir: FirElement, level: Int) : CFGNode<FirElement>(owner, level), TailrecExitNodeMarker {
+class MergePostponedLambdaExitsNode(owner: ControlFlowGraph, override val fir: FirElement, level: Int) :
+    CFGNode<FirElement>(owner, level), TailrecExitNodeMarker, AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitMergePostponedLambdaExitsNode(this, data)
     }
@@ -559,18 +579,23 @@ class WhenBranchConditionExitNode(owner: ControlFlowGraph, override val fir: Fir
         return visitor.visitWhenBranchConditionExitNode(this, data)
     }
 }
-class WhenBranchResultEnterNode(owner: ControlFlowGraph, override val fir: FirWhenBranch, level: Int) : CFGNode<FirWhenBranch>(owner, level) {
+
+class WhenBranchResultEnterNode(owner: ControlFlowGraph, override val fir: FirWhenBranch, level: Int) :
+    CFGNode<FirWhenBranch>(owner, level), AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitWhenBranchResultEnterNode(this, data)
     }
 }
-class WhenBranchResultExitNode(owner: ControlFlowGraph, override val fir: FirWhenBranch, level: Int) : CFGNode<FirWhenBranch>(owner, level),
-    TailrecExitNodeMarker {
+
+class WhenBranchResultExitNode(owner: ControlFlowGraph, override val fir: FirWhenBranch, level: Int) :
+    CFGNode<FirWhenBranch>(owner, level), TailrecExitNodeMarker, AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitWhenBranchResultExitNode(this, data)
     }
 }
-class WhenSyntheticElseBranchNode(owner: ControlFlowGraph, override val fir: FirWhenExpression, level: Int) : CFGNode<FirWhenExpression>(owner, level) {
+
+class WhenSyntheticElseBranchNode(owner: ControlFlowGraph, override val fir: FirWhenExpression, level: Int) :
+    CFGNode<FirWhenExpression>(owner, level), AlwaysReachableNodeMarker {
     init {
         assert(!fir.isProperlyExhaustive)
     }
@@ -582,14 +607,15 @@ class WhenSyntheticElseBranchNode(owner: ControlFlowGraph, override val fir: Fir
 
 // ----------------------------------- Loop -----------------------------------
 
-class LoopEnterNode(owner: ControlFlowGraph, override val fir: FirLoop, level: Int) : CFGNode<FirLoop>(owner, level),
-    EnterNodeMarker {
+class LoopEnterNode(owner: ControlFlowGraph, override val fir: FirLoop, level: Int) :
+    CFGNode<FirLoop>(owner, level), EnterNodeMarker, MustBeReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitLoopEnterNode(this, data)
     }
 }
-class LoopBlockEnterNode(owner: ControlFlowGraph, override val fir: FirLoop, level: Int) : CFGNode<FirLoop>(owner, level),
-    EnterNodeMarker {
+
+class LoopBlockEnterNode(owner: ControlFlowGraph, override val fir: FirLoop, level: Int) :
+    CFGNode<FirLoop>(owner, level), EnterNodeMarker, MustBeReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitLoopBlockEnterNode(this, data)
     }
@@ -627,8 +653,8 @@ class LoopExitNode(owner: ControlFlowGraph, override val fir: FirLoop, level: In
 
 // ----------------------------------- Try-catch-finally -----------------------------------
 
-class TryExpressionEnterNode(owner: ControlFlowGraph, override val fir: FirTryExpression, level: Int) : CFGNode<FirTryExpression>(owner, level),
-    EnterNodeMarker {
+class TryExpressionEnterNode(owner: ControlFlowGraph, override val fir: FirTryExpression, level: Int) :
+    CFGNode<FirTryExpression>(owner, level), EnterNodeMarker, MustBeReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitTryExpressionEnterNode(this, data)
     }
@@ -690,13 +716,15 @@ class BooleanOperatorEnterNode(owner: ControlFlowGraph, override val fir: FirBoo
     }
 }
 
-class BooleanOperatorExitLeftOperandNode(owner: ControlFlowGraph, override val fir: FirBooleanOperatorExpression, level: Int) : CFGNode<FirBooleanOperatorExpression>(owner, level) {
+class BooleanOperatorExitLeftOperandNode(owner: ControlFlowGraph, override val fir: FirBooleanOperatorExpression, level: Int) :
+    CFGNode<FirBooleanOperatorExpression>(owner, level), AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitBooleanOperatorExitLeftOperandNode(this, data)
     }
 }
 
-class BooleanOperatorEnterRightOperandNode(owner: ControlFlowGraph, override val fir: FirBooleanOperatorExpression, level: Int) : CFGNode<FirBooleanOperatorExpression>(owner, level) {
+class BooleanOperatorEnterRightOperandNode(owner: ControlFlowGraph, override val fir: FirBooleanOperatorExpression, level: Int) :
+    CFGNode<FirBooleanOperatorExpression>(owner, level), AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitBooleanOperatorEnterRightOperandNode(this, data)
     }
@@ -843,8 +871,8 @@ class FunctionCallEnterNode(owner: ControlFlowGraph, fir: FirCall, level: Int)
     }
 }
 
-class FunctionCallExitNode(owner: ControlFlowGraph, fir: FirCall, level: Int)
-    : CFGNodeWithRevisableFunctionCall(owner, fir, level) {
+class FunctionCallExitNode(owner: ControlFlowGraph, fir: FirCall, level: Int) :
+    CFGNodeWithRevisableFunctionCall(owner, fir, level), AlwaysReachableNodeMarker {
     override val isUnion: Boolean
         get() = true
 
@@ -901,7 +929,8 @@ class ThrowExceptionNode(
     }
 }
 
-class StubNode(owner: ControlFlowGraph, level: Int) : CFGNode<FirStub>(owner, level) {
+class StubNode(owner: ControlFlowGraph, level: Int) :
+    CFGNode<FirStub>(owner, level), AlwaysReachableNodeMarker {
     init {
         isDead = true
     }
@@ -954,8 +983,8 @@ class EnterSafeCallNode(owner: ControlFlowGraph, override val fir: FirSafeCallEx
         return visitor.visitEnterSafeCallNode(this, data)
     }
 }
-class ExitSafeCallNode(owner: ControlFlowGraph, override val fir: FirSafeCallExpression, level: Int) : CFGNode<FirSafeCallExpression>(owner, level),
-    TailrecExitNodeMarker {
+class ExitSafeCallNode(owner: ControlFlowGraph, override val fir: FirSafeCallExpression, level: Int) :
+    CFGNode<FirSafeCallExpression>(owner, level), TailrecExitNodeMarker, AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitExitSafeCallNode(this, data)
     }
@@ -963,13 +992,15 @@ class ExitSafeCallNode(owner: ControlFlowGraph, override val fir: FirSafeCallExp
 
 // ----------------------------------- Elvis -----------------------------------
 
-class ElvisLhsExitNode(owner: ControlFlowGraph, override val fir: FirElvisExpression, level: Int) : CFGNode<FirElvisExpression>(owner, level) {
+class ElvisLhsExitNode(owner: ControlFlowGraph, override val fir: FirElvisExpression, level: Int) :
+    CFGNode<FirElvisExpression>(owner, level), AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitElvisLhsExitNode(this, data)
     }
 }
 
-class ElvisLhsIsNotNullNode(owner: ControlFlowGraph, override val fir: FirElvisExpression, level: Int) : CFGNode<FirElvisExpression>(owner, level) {
+class ElvisLhsIsNotNullNode(owner: ControlFlowGraph, override val fir: FirElvisExpression, level: Int) :
+    CFGNode<FirElvisExpression>(owner, level), AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitElvisLhsIsNotNullNode(this, data)
     }
@@ -981,8 +1012,8 @@ class ElvisRhsEnterNode(owner: ControlFlowGraph, override val fir: FirElvisExpre
     }
 }
 
-class ElvisExitNode(owner: ControlFlowGraph, override val fir: FirElvisExpression, level: Int) : CFGNode<FirElvisExpression>(owner, level),
-    TailrecExitNodeMarker {
+class ElvisExitNode(owner: ControlFlowGraph, override val fir: FirElvisExpression, level: Int) :
+    CFGNode<FirElvisExpression>(owner, level), TailrecExitNodeMarker, AlwaysReachableNodeMarker {
     override fun <R, D> accept(visitor: ControlFlowGraphVisitor<R, D>, data: D): R {
         return visitor.visitElvisExitNode(this, data)
     }

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/deadCode/deadCodeElvis.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/deadCode/deadCodeElvis.kt
@@ -23,14 +23,14 @@ fun test2(): Int {
 fun test3(a: Int?): Any? {
     a?.let {
         return a
-    } <!UNREACHABLE_CODE!>?:<!> return null
+    } ?: return null
     <!UNREACHABLE_CODE!>unreachable()<!>
 }
 
 fun test4(a: Int?) {
     a?.let {
         return
-    } <!UNREACHABLE_CODE!>?:<!> error("null a")
+    } ?: error("null a")
     <!UNREACHABLE_CODE!>unreachable()<!>
 }
 

--- a/compiler/testData/diagnostics/tests/controlFlowAnalysis/deadCode/deadCodeElvis.kt
+++ b/compiler/testData/diagnostics/tests/controlFlowAnalysis/deadCode/deadCodeElvis.kt
@@ -1,10 +1,13 @@
 // RUN_PIPELINE_TILL: BACKEND
-// DIAGNOSTICS: -DEBUG_INFO_SMARTCAST
+// ISSUE: KT-81816
 
 val nullableInt: Int? get() = null
+fun error(msg: String): Nothing = null!!
+fun unreachable() {}
 
 fun test1(): Int {
     return nullableInt?.let { return it } ?: 0
+    <!UNREACHABLE_CODE!>unreachable()<!>
 }
 
 fun test2(): Int {
@@ -14,6 +17,21 @@ fun test2(): Int {
     } else {
         0
     }
+    <!UNREACHABLE_CODE!>unreachable()<!>
+}
+
+fun test3(a: Int?): Any? {
+    a?.let {
+        return a
+    } <!UNREACHABLE_CODE!>?:<!> return null
+    <!UNREACHABLE_CODE!>unreachable()<!>
+}
+
+fun test4(a: Int?) {
+    a?.let {
+        return
+    } <!UNREACHABLE_CODE!>?:<!> error("null a")
+    <!UNREACHABLE_CODE!>unreachable()<!>
 }
 
 /* GENERATED_FIR_TAGS: elvisExpression, equalityExpression, functionDeclaration, getter, ifExpression, integerLiteral,


### PR DESCRIPTION
If the LHS of an elvis resolves to `Nothing?` and RHS resolves to
`Nothing`, the exit node of the entire elvis operator will be marked as
dead. This results in a false positive warning for unreachable code on
the exit node. The exit node of the elvis can be safely ignored for
unreachable checks, as it does not represent a real source location.

Instead of just adding another node type to the list of nodes ignored,
create two base interfaces to represent either nodes which can always
be considered reachable (`AlwaysReachableNodeMarker`) and nodes which
must always be checked for reachability (`MustBeReachableNodeMarker`).
This will hopefully make the code more maintainable and potentially
provide a small performance improvement.

^[KT-81816](https://youtrack.jetbrains.com/issue/KT-81816) Fixed