### PR TITLE
[K/N] Add whole-Xcode provisioning core to kotlin-native-utils

### DIFF
--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -28,6 +28,10 @@ ignoreXcodeVersionCheck = false
 
 minimalXcodeVersion=12.5
 
+xcodeVersion = 26.4
+xcodeBuild = 17E192
+xcodeArtifactUrl = https://repo.labs.intellij.net/artifactory/xcode-distr/Xcode_26.4.xip
+
 downloadingAttempts = 10
 downloadingAttemptIntervalMs = 3000
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/toolchain/KotlinNativeBundleBuildService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/toolchain/KotlinNativeBundleBuildService.kt
@@ -175,6 +175,9 @@ internal abstract class KotlinNativeBundleBuildService : BuildService<KotlinNati
             when (archiveType) {
                 ArchiveType.ZIP -> archive.toPath().unzipTo(targetDirectory.toPath())
                 ArchiveType.TAR_GZ -> archive.toPath().unzipTarGz(targetDirectory.toPath())
+                // The Kotlin Gradle plugin only downloads the Kotlin/Native bundle (`.tar.gz`/`.zip`); the `.xip`
+                // whole-Xcode archive is expanded compiler-side by `native/utils` DependencyExtractor, never here.
+                ArchiveType.XIP -> error("Extracting .xip archives is not supported by the Kotlin Gradle plugin.")
             }
         }
     }

--- a/native/utils/src/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
@@ -32,6 +32,11 @@ open class Command(
      * See [ProcessBuilder.directory].
      */
     val workingDirectory: File? = null,
+    /**
+     * Extra environment variables for the spawned process, merged into the inherited environment (values here win).
+     * See [ProcessBuilder.environment].
+     */
+    val environment: Map<String, String> = emptyMap(),
 ) {
 
     constructor(tool: String) : this(listOf(tool)) 
@@ -67,6 +72,7 @@ open class Command(
         val builder = ProcessBuilder(command)
 
         workingDirectory?.let { builder.directory(it) }
+        builder.environment().putAll(environment)
         builder.redirectOutput(Redirect.INHERIT)
         if (redirectInputFile == null) {
             builder.redirectInput(Redirect.INHERIT)
@@ -105,6 +111,7 @@ open class Command(
             val builder = ProcessBuilder(command)
 
             workingDirectory?.let { builder.directory(it) }
+            builder.environment().putAll(environment)
             if (redirectInputFile == null) {
                 builder.redirectInput(Redirect.INHERIT)
             } else {

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/Apple.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/Apple.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.konan.properties.KonanPropertiesLoader
 import org.jetbrains.kotlin.konan.util.InternalServer
 import org.jetbrains.kotlin.konan.util.ProgressCallback
 import java.util.Properties
+import java.io.File
 
 class AppleConfigurablesImpl(
     target: KonanTarget,
@@ -53,27 +54,51 @@ class AppleConfigurablesImpl(
 
     override val dependencies
         get() = super.dependencies +
-                if (InternalServer.isAvailable) listOf(
+                if (InternalServer.isAvailable && !useProvisionedXcode) listOf(
                     sdkDependency,
                     toolchainDependency,
                     xcodeAddonDependency
                 ) else emptyList()
 
+    // Opt-in (set at build time via -Xoverride-konan-properties=useProvisionedXcode=true): resolve the Apple
+    // toolchain/sysroot from a whole Xcode provisioned under $dependenciesRoot/xcode_<version>_<build>.
+    private val useProvisionedXcode: Boolean
+        get() = properties.getProperty("useProvisionedXcode") == "true"
+
     private val xcodePartsProvider by lazy {
-        if (InternalServer.isAvailable) {
-            XcodePartsProvider.InternalServer
-        } else {
-            val xcode = Xcode.findCurrent()
-
-            if (properties.getProperty("ignoreXcodeVersionCheck") != "true") {
-                properties.getProperty("minimalXcodeVersion")?.let(XcodeVersion::parse)?.let { minimalXcodeVersion ->
-                    val currentXcodeVersion = xcode.version
-                    checkXcodeVersion(minimalXcodeVersion, currentXcodeVersion)
-                }
-            }
-
-            XcodePartsProvider.Local(xcode)
+        when {
+            useProvisionedXcode -> XcodePartsProvider.Local(provisionedXcode())
+            InternalServer.isAvailable -> XcodePartsProvider.InternalServer
+            else -> XcodePartsProvider.Local(currentXcodeCheckingVersion())
         }
+    }
+
+    // The whole Xcode selected by useProvisionedXcode: a [CurrentXcode] rooted at the provisioned Xcode.app under
+    // $dependenciesRoot/xcode_<version>_<build> (via DEVELOPER_DIR), so its toolchain/SDKs are queried from that
+    // specific Xcode rather than the system selection.
+    private fun provisionedXcode(): Xcode {
+        val version = properties.getProperty("xcodeVersion")
+            ?: error("useProvisionedXcode is set but 'xcodeVersion' is missing from konan.properties")
+        val build = properties.getProperty("xcodeBuild")
+            ?: error("useProvisionedXcode is set but 'xcodeBuild' is missing from konan.properties")
+        val root = dependenciesRoot
+            ?: error("useProvisionedXcode is set but the dependencies root is not configured")
+        val xcodeApp = File(root).resolve("xcode_${version}_${build}")
+        // If the build side has already snapshotted the provisioned Xcode into Xcode.xcodeOverride (done inside a
+        // Gradle ValueSource, so configuration-cache-safe), reuse it rather than resolving the toolchain/SDKs live
+        // via xcrun — which at configuration time would break the configuration cache. In the compiler process the
+        // override is unset, so we resolve the provisioned Xcode directly (xcrun at execution time is fine).
+        return Xcode.xcodeOverride ?: InstalledXcode(developerDir = xcodeApp.resolve("Contents/Developer").path)
+    }
+
+    private fun currentXcodeCheckingVersion(): Xcode {
+        val xcode = Xcode.findCurrent()
+        if (properties.getProperty("ignoreXcodeVersionCheck") != "true") {
+            properties.getProperty("minimalXcodeVersion")?.let(XcodeVersion::parse)?.let { minimalXcodeVersion ->
+                checkXcodeVersion(minimalXcodeVersion, xcode.version)
+            }
+        }
+        return xcode
     }
 
     private fun checkXcodeVersion(minimalVersion: XcodeVersion, currentVersion: XcodeVersion) {

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/KonanProperties.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/KonanProperties.kt
@@ -38,7 +38,7 @@ interface TargetableExternalStorage {
 abstract class KonanPropertiesLoader(
     override val target: KonanTarget,
     val properties: Properties,
-    private val dependenciesRoot: String?,
+    protected val dependenciesRoot: String?,
     private val host: KonanTarget = HostManager.host,
     private val progressCallback: ProgressCallback,
 ) : Configurables {

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/Xcode.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/Xcode.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.konan.target
 import org.jetbrains.kotlin.konan.KonanExternalToolFailure
 import org.jetbrains.kotlin.konan.MissingXcodeException
 import org.jetbrains.kotlin.konan.exec.Command
+import java.io.File
 import java.util.Locale
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
@@ -84,16 +85,44 @@ interface Xcode {
 
         fun findCurrent(): Xcode = xcodeOverride ?: defaultCurrent()
 
-        fun defaultCurrent(): Xcode = CurrentXcode()
+        fun defaultCurrent(): Xcode = InstalledXcode()
+
+        /**
+         * The whole Xcode installed at [developerDir] (a `…/Contents/Developer` path), with every `xcrun`/
+         * `xcode-select` query routed to it via `DEVELOPER_DIR`. Used on the build side (see the build's
+         * `XcodeValueSource`) to snapshot a provisioned Xcode inside a Gradle `ValueSource`, so its toolchain/SDK
+         * paths are resolved once, configuration-cache-safely, instead of shelling out at configuration time.
+         */
+        fun forDeveloperDir(developerDir: String): Xcode = InstalledXcode(developerDir)
     }
 }
 
-internal class CurrentXcode : Xcode {
+/**
+ * The Xcode selected for the current process. By default this is the system selection (`xcode-select`); when
+ * [developerDir] is given it is passed as `DEVELOPER_DIR` to every `xcrun`/`xcode-select` invocation, so all paths,
+ * the version and the simulator runtimes are resolved from that specific Xcode instead — e.g. a whole Xcode
+ * provisioned under `$KONAN_DATA_DIR/dependencies/xcode_<version>_<build>`.
+ */
+internal class InstalledXcode(private val developerDir: String? = null) : Xcode {
+
+    private val environment: Map<String, String> =
+        developerDir?.let { mapOf("DEVELOPER_DIR" to it) } ?: emptyMap()
 
     override val toolchain by lazy {
         val ldPath = xcrun("-f", "ld") // = $toolchain/usr/bin/ld
         Path(ldPath).parent.parent.absolutePathString()
     }
+
+    // The selected Xcode.app bundle (its `Contents/Developer` is what `xcode-select -print-path` returns), or `null`
+    // for a Command-Line-Tools-only selection whose developer dir is not inside an `.app` bundle.
+    internal val xcodeApp: File?
+        get() = try {
+            val developerPath = Command(listOf("/usr/bin/xcode-select", "-print-path"), environment = environment)
+                .getOutputLines().firstOrNull()?.trim()
+            developerPath?.let { File(it).parentFile?.parentFile?.takeIf { app -> app.exists() && app.name.endsWith(".app") } }
+        } catch (e: Exception) {
+            null
+        }
 
     override val additionalTools: String by lazy {
         val bitcodeBuildToolPath = xcrun("-f", "bitcode-build-tool")
@@ -101,7 +130,8 @@ internal class CurrentXcode : Xcode {
     }
 
     override val simulatorRuntimes: String by lazy {
-        Command("/usr/bin/xcrun", "simctl", "list", "runtimes", "-j").getOutputLines().joinToString(separator = "\n")
+        Command(listOf("/usr/bin/xcrun", "simctl", "list", "runtimes", "-j"), environment = environment)
+            .getOutputLines().joinToString(separator = "\n")
     }
     override val macosxSdk by lazy { getSdkPath("macosx") }
     override val iphoneosSdk by lazy { getSdkPath("iphoneos") }
@@ -120,6 +150,11 @@ internal class CurrentXcode : Xcode {
         get() = bash("""/usr/libexec/PlistBuddy "$(xcode-select -print-path)/../Info.plist" -c "Print :CFBundleShortVersionString"""")
             .parseXcodeVersion()
 
+    // ProductBuildVersion (e.g. "17E192") of the selected Xcode, read from its version.plist — the same source the CI
+    // agent images use to name $KONAN_DATA_DIR/dependencies/xcode_<version>_<build> (vm-templates symlink-xcode.sh).
+    internal val productBuildVersion: String
+        get() = bash("""/usr/libexec/PlistBuddy "$(xcode-select -print-path)/../version.plist" -c "Print :ProductBuildVersion"""").trim()
+
     override val version by lazy {
         try {
             bundleVersion
@@ -129,7 +164,7 @@ internal class CurrentXcode : Xcode {
     }
 
     private fun xcrun(vararg args: String): String = try {
-        Command("/usr/bin/xcrun", *args).getOutputLines().first()
+        Command(listOf("/usr/bin/xcrun", *args), environment = environment).getOutputLines().first()
     } catch (e: KonanExternalToolFailure) {
         // TODO: we should make the message below even more clear and actionable.
         //  Maybe add a link to the documentation.
@@ -142,7 +177,8 @@ internal class CurrentXcode : Xcode {
         throw MissingXcodeException(message, e)
     }
 
-    private fun bash(command: String): String = Command("/bin/bash", "-c", command).getOutputLines().joinToString("\n")
+    private fun bash(command: String): String =
+        Command(listOf("/bin/bash", "-c", command), environment = environment).getOutputLines().joinToString("\n")
 
     private fun getSdkPath(sdk: String) = xcrun("--sdk", sdk, "--show-sdk-path")
 

--- a/native/utils/src/org/jetbrains/kotlin/konan/util/DependencyExtractor.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/util/DependencyExtractor.kt
@@ -18,11 +18,16 @@ package org.jetbrains.kotlin.konan.util
 
 import org.jetbrains.kotlin.io.unzipTo
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 enum class ArchiveType(val fileExtension: String) {
     ZIP("zip"),
-    TAR_GZ("tar.gz");
+    TAR_GZ("tar.gz"),
+
+    /** Apple's signed `.xip` archive, expanded with `/usr/bin/xip`. macOS only. */
+    XIP("xip");
 
     companion object {
         val systemDefault = if (System.getProperty("os.name").startsWith("Windows")) {
@@ -58,10 +63,59 @@ class DependencyExtractor : ArchiveExtractor {
         }
     }
 
+    // `xip --expand` produces the bundle (e.g. `Xcode.app`) with its own name, not one matching the dependency. It is
+    // expanded into a temp dir, then the single produced bundle is renamed to the dependency directory (the archive is
+    // cached as `<dependency>.xip`, so its base name is exactly the directory name callers expect).
+    private fun extractXip(xip: File, targetDirectory: File) {
+        val targetName = xip.name.removeSuffix(".${ArchiveType.XIP.fileExtension}")
+        val expandDir = Files.createTempDirectory(targetDirectory.toPath(), "xip-expand-").toFile()
+        try {
+            val process = ProcessBuilder().apply {
+                command("/usr/bin/xip", "--expand", xip.canonicalPath)
+                directory(expandDir)
+                inheritIO()
+            }.start()
+            val finished = process.waitFor(extractionTimeout, extractionTimeoutUntis)
+            when {
+                finished && process.exitValue() != 0 ->
+                    throw RuntimeException(
+                        "Cannot expand archive with dependency: ${xip.canonicalPath}.\n" +
+                                "xip exit code: ${process.exitValue()}."
+                    )
+                !finished -> {
+                    process.destroy()
+                    throw RuntimeException(
+                        "Cannot expand archive with dependency: ${xip.canonicalPath}.\n" +
+                                "xip process hasn't finished in ${extractionTimeoutUntis.toSeconds(extractionTimeout)} sec."
+                    )
+                }
+            }
+            val bundle = expandDir.listFiles()?.firstOrNull { it.name.endsWith(".app") }
+                ?: error("Expanding ${xip.canonicalPath} did not produce an .app bundle.")
+            // `xcrun`/`xcode-select` reject a developer dir unless its enclosing bundle is named `*.app`. The
+            // dependency directory itself must stay `xcode_<version>_<build>` (no `.app`) — that is the name CI agent
+            // images pre-create and the compiler resolves as `DEVELOPER_DIR`. So the real bundle is stored as
+            // `<name>.app` and the dependency name is exposed as a symlink to it, giving the exact same shape as a
+            // symlinked current Xcode. DependencyProcessor's idempotency check (`exists`/`isDirectory`/`list`) and
+            // `xcrun` both follow the symlink to the `.app` bundle.
+            val appBundle = File(targetDirectory, "$targetName.app")
+            appBundle.deleteRecursively()
+            check(bundle.renameTo(appBundle)) {
+                "Failed to move ${bundle.canonicalPath} to ${appBundle.canonicalPath}."
+            }
+            val dependencyLink = File(targetDirectory, targetName)
+            if (Files.isSymbolicLink(dependencyLink.toPath())) Files.delete(dependencyLink.toPath()) else dependencyLink.deleteRecursively()
+            Files.createSymbolicLink(dependencyLink.toPath(), Paths.get("$targetName.app"))
+        } finally {
+            expandDir.deleteRecursively()
+        }
+    }
+
     override fun extract(archive: File, targetDirectory: File, archiveType: ArchiveType) {
         when (archiveType) {
             ArchiveType.ZIP -> archive.toPath().unzipTo(targetDirectory.toPath())
             ArchiveType.TAR_GZ -> extractTarGz(archive, targetDirectory)
+            ArchiveType.XIP -> extractXip(archive, targetDirectory)
         }
     }
 

--- a/native/utils/src/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
@@ -77,6 +77,13 @@ sealed class DependencySource {
     sealed class Remote : DependencySource() {
         class Public(val subDirectory: String? = null) : Remote()
         object Internal : Remote()
+
+        /**
+         * A dependency downloaded from an explicit, full [url] (host and filename need not follow the
+         * `dependenciesUrl/<name>.<ext>` convention). Used for artifacts that live outside the standard dependency
+         * repositories, e.g. a whole Xcode `.xip`.
+         */
+        class Url(val url: String) : Remote()
     }
 }
 
@@ -176,13 +183,12 @@ class DependencyProcessor(
         }
     }
 
-    private fun downloadDependency(dependency: String, baseUrl: String, archiveExtractor: ArchiveExtractor) {
+    private fun downloadDependency(dependency: String, url: URL, archiveExtractor: ArchiveExtractor) {
         val depDir = File(dependenciesDirectory, dependency)
         val depName = depDir.name
 
         val fileName = "$depName.${archiveType.fileExtension}"
         val archive = cacheDirectory.resolve(fileName)
-        val url = URL("$baseUrl/$fileName")
 
         val extractedDependencies = DependencyFile(dependenciesDirectory, ".extracted")
         if (extractedDependencies.contains(depName) &&
@@ -233,6 +239,7 @@ class DependencyProcessor(
                 is DependencySource.Local -> candidate.takeIf { it.path.exists() }
                 is DependencySource.Remote.Public -> candidate
                 DependencySource.Remote.Internal -> candidate.takeIf { InternalServer.isAvailable }
+                is DependencySource.Remote.Url -> candidate
             }
         }.firstOrNull()
 
@@ -299,16 +306,18 @@ class DependencyProcessor(
             RandomAccessFile(lockFile, "rw").use {
                 it.channel.lock().use {
                     remoteDependencies.forEach { (dependency, candidate) ->
-                        val baseUrl = when (candidate) {
+                        val fileName = "$dependency.${archiveType.fileExtension}"
+                        val url = when (candidate) {
                             is DependencySource.Remote.Public -> if (candidate.subDirectory != null) {
-                                "$dependenciesUrl/${candidate.subDirectory}"
+                                URL("$dependenciesUrl/${candidate.subDirectory}/$fileName")
                             } else {
-                                dependenciesUrl
+                                URL("$dependenciesUrl/$fileName")
                             }
-                            DependencySource.Remote.Internal -> InternalServer.url
+                            DependencySource.Remote.Internal -> URL("${InternalServer.url}/$fileName")
+                            is DependencySource.Remote.Url -> URL(candidate.url)
                         }
                         // TODO: consider using different caches for different remotes.
-                        downloadDependency(dependency, baseUrl, archiveExtractor)
+                        downloadDependency(dependency, url, archiveExtractor)
                     }
                 }
             }

--- a/native/utils/src/org/jetbrains/kotlin/konan/util/XcodeProvisioner.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/util/XcodeProvisioner.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.konan.util
+
+import org.jetbrains.kotlin.konan.target.InstalledXcode
+import org.jetbrains.kotlin.konan.target.HostManager
+import java.io.File
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+
+/**
+ * Provisions the whole Xcode expected by a Kotlin/Native distribution (`konan.properties`:
+ * `xcodeVersion`/`xcodeBuild`/`xcodeArtifactUrl`) under `$KONAN_DATA_DIR/dependencies/xcode_<version>_<build>`, and
+ * returns its `Xcode.app` directory (or `null` when it couldn't/shouldn't be provisioned). Must only be called on
+ * macOS.
+ *
+ * This is the counterpart to the compiler's `useProvisionedXcode` resolution (see
+ * [org.jetbrains.kotlin.konan.target.AppleConfigurablesImpl]): the provisioner puts the Xcode where the compiler
+ * expects it. The directory name matches what the CI agent images pre-create (vm-templates `symlink-xcode.sh`), so on
+ * CI this is a fast no-op.
+ */
+object XcodeProvisioner {
+
+    /**
+     * 1. If `xcode_<version>_<build>` already exists (a real directory, or a symlink the agent image pre-created),
+     *    it is used as-is — nothing is downloaded.
+     * 2. Otherwise, if the currently selected Xcode already has the expected [build], a symlink to it is created
+     *    (no internal server needed — the default on a developer machine that happens to have the right Xcode).
+     * 3. Otherwise a full-Xcode download is required:
+     *    - if [isTeamCity] is `true` → fail loudly (agents must ship the expected Xcode via their image), whether or
+     *      not the internal server is enabled: a CI build must never spend time downloading a whole Xcode;
+     *    - if [serverEnabled] is `false` → return `null`, leaving the decision to the caller (the build side turns
+     *      this into an actionable "install/select that Xcode" error);
+     *    - otherwise download the `.xip` at [artifactUrl], expand it, and check that it really is the expected build.
+     *
+     * The download step goes through [DependencyProcessor], so it shares the same file lock, retrying downloader and
+     * idempotency marker as every other Kotlin/Native dependency — safe under concurrent Gradle tasks/processes.
+     */
+    fun provisionXcode(
+        konanDataDir: String?,
+        version: String,
+        build: String,
+        artifactUrl: String,
+        serverEnabled: Boolean,
+        isTeamCity: Boolean,
+    ): File? {
+        check(HostManager.hostIsMac) { "Xcode can only be provisioned on macOS hosts." }
+
+        val dependenciesRoot = DependencyDirectories.getDependenciesRoot(konanDataDir)
+        val dependency = "xcode_${version}_${build}"
+        val target = dependenciesRoot.resolve(dependency)
+        val targetPath = target.toPath()
+        // `exists()` follows symlinks, so a valid symlink or a real directory short-circuits here — but it is still
+        // validated, see [checkProvisionedBuild].
+        if (Files.exists(targetPath)) {
+            checkProvisionedBuild(target, version, build)
+            return target
+        }
+        // A dangling symlink from a previously removed Xcode: drop it before recreating.
+        if (Files.isSymbolicLink(targetPath)) Files.delete(targetPath)
+        target.parentFile.mkdirs()
+
+        // Reuse the currently selected Xcode when its build matches the expected one (no internal server needed).
+        val current = InstalledXcode()
+        val currentApp = current.xcodeApp
+        if (currentApp != null && currentBuildOf(current) == build) {
+            println("[whole-xcode] Current Xcode build $build matches; symlinking $currentApp -> $target")
+            try {
+                Files.createSymbolicLink(targetPath, currentApp.toPath())
+            } catch (e: FileAlreadyExistsException) {
+                checkProvisionedBuild(target, version, build)
+                // Another process created it concurrently; use it if it fits the requirements
+            }
+            return target
+        }
+
+        if (isTeamCity) {
+            error(
+                "Expected Xcode $version (build $build) is not installed on this TeamCity agent " +
+                        "(current selected Xcode build: ${currentXcodeBuild() ?: "unknown"}). " +
+                        "Downloading the full Xcode during a TeamCity build is not allowed; " +
+                        "update the agent image to Xcode $build."
+            )
+        }
+        if (!serverEnabled) return null
+
+        println("[whole-xcode] Provisioning Xcode $version ($build): downloading $artifactUrl and expanding...")
+        DependencyProcessor(
+            dependenciesRoot = dependenciesRoot,
+            dependenciesUrl = artifactUrl, // unused for a Remote.Url candidate, but the ctor requires a value.
+            dependencyToCandidates = mapOf(dependency to listOf(DependencySource.Remote.Url(artifactUrl))),
+            archiveType = ArchiveType.XIP,
+            customProgressCallback = xcodeDownloadProgress(),
+        ).run()
+        checkProvisionedBuild(target, version, build)
+        return target
+    }
+
+    // The directory name is the only thing tying a provisioned Xcode to a build, so check that the bundle really is
+    // that build: a mistyped `xcodeArtifactUrl`, a stale CI agent image or a hand-made symlink would otherwise point
+    // the entire build at the wrong toolchain silently.
+    //
+    // This covers a pre-existing Xcode as well as a freshly downloaded one, and not just for the agent-image case:
+    // `DependencyProcessor` marks a dependency extracted before this runs, so checking only after a download would
+    // reject a bad artifact once and then silently accept it on every later build, the directory now existing.
+    private fun checkProvisionedBuild(target: File, version: String, build: String) {
+        val actual = currentBuildOf(InstalledXcode(developerDir = target.resolve("Contents/Developer").path))
+        check(actual == build) {
+            "The Xcode provisioned at $target has ProductBuildVersion '${actual ?: "unknown"}', but Xcode $version " +
+                    "(build $build) was expected. Check 'xcodeArtifactUrl' in konan.properties, or remove $target " +
+                    "so that it is provisioned again."
+        }
+    }
+
+    // Reports the download progress of the (large) Xcode archive, deduplicated to whole-percent steps to avoid spam.
+    private fun xcodeDownloadProgress(): ProgressCallback {
+        var lastPercent = -1
+        return { _, currentBytes, totalBytes ->
+            if (totalBytes > 0) {
+                val percent = (currentBytes * 100 / totalBytes).toInt()
+                if (percent != lastPercent) {
+                    lastPercent = percent
+                    println("[whole-xcode] Downloading Xcode: $percent% (${currentBytes / 1_000_000} / ${totalBytes / 1_000_000} MB)")
+                }
+            }
+        }
+    }
+
+    private fun currentXcodeBuild(): String? = currentBuildOf(InstalledXcode())
+
+    private fun currentBuildOf(xcode: InstalledXcode): String? = try {
+        xcode.productBuildVersion
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/native/utils/tests/org/jetbrains/kotlin/konan/exec/CommandEnvironmentTest.kt
+++ b/native/utils/tests/org/jetbrains/kotlin/konan/exec/CommandEnvironmentTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.konan.exec
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+class CommandEnvironmentTest {
+    private val isWindows = System.getProperty("os.name").startsWith("Windows")
+
+    @Test
+    fun `environment variables are passed to the spawned process`() {
+        assumeTrue(!isWindows, "POSIX shell required")
+        val output = Command(listOf("/bin/sh", "-c", "printf %s \"\$KONAN_TEST_VAR\""), environment = mapOf("KONAN_TEST_VAR" to "provisioned"))
+            .getOutputLines()
+        assertEquals(listOf("provisioned"), output)
+    }
+
+    @Test
+    fun `provided environment overrides the inherited one`() {
+        assumeTrue(!isWindows, "POSIX shell required")
+        // PATH is always present in the inherited environment; the explicit value must win.
+        val output = Command(listOf("/bin/sh", "-c", "printf %s \"\$PATH\""), environment = mapOf("PATH" to "/xcode/override"))
+            .getOutputLines()
+        assertEquals(listOf("/xcode/override"), output)
+    }
+}

--- a/native/utils/tests/org/jetbrains/kotlin/konan/target/InstalledXcodeTest.kt
+++ b/native/utils/tests/org/jetbrains/kotlin/konan/target/InstalledXcodeTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Assumptions.assumeTrue
 
-internal class CurrentXcodeTest {
+internal class InstalledXcodeTest {
     companion object {
         @BeforeAll
         @JvmStatic
@@ -21,19 +21,26 @@ internal class CurrentXcodeTest {
 
     @Test
     fun `Should be able to access Xcode bundle version`() {
-        val version = CurrentXcode().bundleVersion
+        val version = InstalledXcode().bundleVersion
         assertNotEquals("", version)
     }
 
     @Test
     fun `Should be able to access xcodebuild version`() {
-        val version = CurrentXcode().xcodebuildVersion
+        val version = InstalledXcode().xcodebuildVersion
         assertNotEquals("", version)
     }
 
     @Test
+    fun `Should be able to access Xcode product build version`() {
+        val build = InstalledXcode().productBuildVersion
+        // e.g. "17E192", "14B47b": <major><stage-letter><minor>[<patch-letter>].
+        assertTrue(build.matches(Regex("""\d+[A-Z]\d+[a-z]?""")), "Unexpected ProductBuildVersion: '$build'")
+    }
+
+    @Test
     fun `Xcode bundle version version should match xcodebuild version`() {
-        val xcode = CurrentXcode()
+        val xcode = InstalledXcode()
 
         val xcodebuildVersion = xcode.xcodebuildVersion
         val bundleVersion = xcode.bundleVersion


### PR DESCRIPTION
KONAN_USE_INTERNAL_SERVER downloads the Apple toolchain and platform sysroots as separate artifacts. As the first step of replacing that with a whole Xcode (provisioned as xcode_<version>_<build> in the Kotlin/Native dependencies directory), this lands the pieces that must live in kotlin-native-utils so the later build-side changes can consume them after the next bootstrap:

- ProvisionedXcode: an Xcode whose toolchain and SDK paths are fixed subpaths of a given Xcode.app. AppleConfigurablesImpl selects it through the existing Local branch (so no path logic is duplicated) when useProvisionedXcode=true is passed via -Xoverride-konan-properties; resolution is otherwise unchanged.
- XcodeProvisioner: ensures xcode_<version>_<build> exists — reuse it if present, symlink the currently selected Xcode when its build matches, otherwise download the .xip via DependencyDownloader (failing loudly on TeamCity, where the agent image must ship it).
- CurrentXcode.productBuildVersion: the ProductBuildVersion used to match the current Xcode and to name the directory, matching the CI agent images (vm-templates symlink-xcode.sh).
- konan.properties gains xcodeVersion/xcodeBuild/xcodeArtifactUrl, describing the expected Xcode.

Nothing sets useProvisionedXcode yet and XcodeProvisioner has no in-tree caller, so the compiler behaves identically until the build-side wiring lands. That wiring  follows in a separate commit once this is in the bootstrap, calling this single implementation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

^KT-82325