### PR TITLE
[K/N] Wire whole-Xcode provisioning into the build

### DIFF
--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/PlatformManagerProvider.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/PlatformManagerProvider.kt
@@ -51,7 +51,19 @@ open class PlatformManagerProvider @Inject constructor(
         }.getOrDefault(false)
         if (isNativeProtoDistribution) {
             // For proto distribution, we must patch the llvm distribution.
-            project.llvmDistributionSource.asProperties
+            val llvmOverride = project.llvmDistributionSource.asProperties
+            // With whole-Xcode provisioning on, put build-tools' own PlatformManager into ProvisionedXcode mode so the
+            // runtime clang/linker resolve the toolchain and sysroot from the provisioned Xcode via
+            // AppleConfigurablesImpl.absoluteTargetSysRoot.
+            //
+            // Only the distribution being built understands the flag: it is the one whose konan.properties carries
+            // xcodeVersion/xcodeBuild. A released distribution — notably the native bootstrap that libclangInterop's
+            // genInteropStubs runs against — has no such keys and would fail resolving them.
+            if (project.isWholeXcodeProvisioningEnabled()) {
+                llvmOverride + ("useProvisionedXcode" to "true")
+            } else {
+                llvmOverride
+            }
         } else {
             // For any other distribution, we shouldn't change anything.
             emptyMap()

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/PlatformManagerProvider.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/PlatformManagerProvider.kt
@@ -51,7 +51,12 @@ open class PlatformManagerProvider @Inject constructor(
         }.getOrDefault(false)
         if (isNativeProtoDistribution) {
             // For proto distribution, we must patch the llvm distribution.
-            project.llvmDistributionSource.asProperties
+            val llvmOverride = project.llvmDistributionSource.asProperties
+            if (project.isWholeXcodeProvisioningEnabled()) {
+                llvmOverride + ("useProvisionedXcode" to "true")
+            } else {
+                llvmOverride
+            }
         } else {
             // For any other distribution, we shouldn't change anything.
             emptyMap()

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/ProvisionedXcodeSdk.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/ProvisionedXcodeSdk.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.jetbrains.kotlin.konan.properties.KonanPropertiesLoader
+import org.jetbrains.kotlin.konan.target.AppleConfigurables
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.target.PlatformManager
+import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import org.jetbrains.kotlin.konan.util.XcodeProvisioner
+
+/**
+ * Whether the whole-Xcode provisioning is opted in for this build (Gradle property
+ * `kotlin.native.internalServer.wholeXcode`). Only meaningful on macOS hosts.
+ *
+ * The helpers here compute the provisioning spec and trigger provisioning. The runtime clang/linker pick up the
+ * provisioned sysroot automatically via PlatformManager's `konanPropertiesOverride` (which flips
+ * `useProvisionedXcode`); the compiler-side counterpart is `useProvisionedXcode`/`ProvisionedXcode` in
+ * `AppleConfigurablesImpl`.
+ */
+fun Project.isWholeXcodeProvisioningEnabled(): Boolean =
+        HostManager.hostIsMac &&
+                providers.gradleProperty("kotlin.native.internalServer.wholeXcode").map { it.toBoolean() }.getOrElse(false)
+
+/**
+ * Configuration-time snapshot of everything [XcodeProvisioner.provisionXcode] needs. All fields are plain
+ * serializable values so a task can capture it and provision in a `doFirst` (configuration-cache safe).
+ */
+class XcodeProvisioningSpec(
+        val konanDataDir: String?,
+        val version: String,
+        val build: String,
+        val artifactUrl: String,
+        val serverEnabled: Boolean,
+        val isTeamCity: Boolean,
+)
+
+/**
+ * The provisioning spec for [target] when whole-Xcode provisioning is enabled for an Apple target, else `null`.
+ * Computed at configuration time.
+ */
+fun Project.xcodeProvisioningSpec(platformManager: PlatformManager, target: KonanTarget): XcodeProvisioningSpec? {
+    if (!isWholeXcodeProvisioningEnabled()) return null
+    if (!target.family.isAppleFamily) return null
+    val configurables = platformManager.platform(target).configurables as? AppleConfigurables ?: return null
+    val properties = (configurables as KonanPropertiesLoader).properties
+    val version = properties.getProperty("xcodeVersion") ?: return null
+    val build = properties.getProperty("xcodeBuild") ?: return null
+    val artifactUrl = properties.getProperty("xcodeArtifactUrl") ?: return null
+    val konanDataDir = providers.gradleProperty("konan.data.dir").orNull
+    val forceServer = providers.gradleProperty("kotlin.native.useInternalServer").map { it.toBoolean() }.getOrElse(false)
+    val serverEnabled = DependencyProcessor.isInternalSeverAvailable || forceServer
+    val isTeamCity = providers.environmentVariable("TEAMCITY_VERSION").isPresent
+    return XcodeProvisioningSpec(konanDataDir, version, build, artifactUrl, serverEnabled, isTeamCity)
+}
+
+/**
+ * Adds a `doFirst` that provisions the whole Xcode before this task runs, when [spec] is non-null (i.e. the
+ * feature is on for an Apple target). On CI the symlink already exists so it is a fast no-op.
+ */
+fun Task.provisionXcodeBeforeRun(spec: XcodeProvisioningSpec?) {
+    val provisioningSpec = spec ?: return
+    doFirst {
+        XcodeProvisioner.provisionXcode(
+                konanDataDir = provisioningSpec.konanDataDir,
+                version = provisioningSpec.version,
+                build = provisioningSpec.build,
+                artifactUrl = provisioningSpec.artifactUrl,
+                serverEnabled = provisioningSpec.serverEnabled,
+                isTeamCity = provisioningSpec.isTeamCity,
+        )
+    }
+}

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/ProvisionedXcodeSdk.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/ProvisionedXcodeSdk.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin
+
+import kotlinBuildProperties
+import org.gradle.api.Project
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import org.jetbrains.kotlin.konan.util.XcodeProvisioner
+import java.io.File
+
+fun Project.isWholeXcodeProvisioningEnabled(): Boolean =
+        HostManager.hostIsMac && kotlinBuildProperties.booleanProperty(WHOLE_XCODE_PROPERTY, false).get()
+
+fun Project.isInternalServerEnabled(): Boolean =
+        DependencyProcessor.isInternalSeverAvailable ||
+                kotlinBuildProperties.booleanProperty(USE_INTERNAL_SERVER_PROPERTY, false).get()
+
+private const val WHOLE_XCODE_PROPERTY = "kotlin.native.internalServer.wholeXcode"
+
+private const val USE_INTERNAL_SERVER_PROPERTY = "kotlin.native.useInternalServer"
+
+internal fun isAppleTargetName(targetName: String): Boolean =
+        KonanTarget.predefinedTargets[targetName]?.family?.isAppleFamily == true
+
+class XcodeProvisioningSpec(
+        val konanDataDir: String?,
+        val version: String,
+        val build: String,
+        val artifactUrl: String,
+        val serverEnabled: Boolean,
+        val isTeamCity: Boolean,
+)
+
+fun provisionXcodeOrFail(spec: XcodeProvisioningSpec): File = XcodeProvisioner.provisionXcode(
+        konanDataDir = spec.konanDataDir,
+        version = spec.version,
+        build = spec.build,
+        artifactUrl = spec.artifactUrl,
+        serverEnabled = spec.serverEnabled,
+        isTeamCity = spec.isTeamCity,
+) ?: error(
+        "Whole Xcode ${spec.version} (build ${spec.build}) is not provisioned under the Kotlin/Native dependencies, " +
+                "and the currently selected Xcode has a different build. Install and select Xcode ${spec.version} " +
+                "(build ${spec.build}), or set KONAN_USE_INTERNAL_SERVER=1 to have it downloaded."
+)

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/bitcode/CompileToBitcodePlugin.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/bitcode/CompileToBitcodePlugin.kt
@@ -24,6 +24,8 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.PlatformManagerPlugin
 import org.jetbrains.kotlin.clangArgs
+import org.jetbrains.kotlin.provisionXcodeBeforeRun
+import org.jetbrains.kotlin.xcodeProvisioningSpec
 import org.jetbrains.kotlin.cpp.*
 import org.jetbrains.kotlin.cpp.ClangFrontend
 import org.jetbrains.kotlin.dependencies.NativeDependenciesExtension
@@ -242,6 +244,7 @@ open class CompileToBitcodeExtension @Inject constructor(val project: Project) :
             this.targetName.set(target.name)
             this.compiler.set(module.compiler)
             this.arguments.set(allCompilerArgs)
+            provisionXcodeBeforeRun(project.xcodeProvisioningSpec(platformManager, target))
             // Add the sources, as clang by default adds directory with the source to the include path.
             this.headersDirs.from(this@SourceSet.inputFiles.dir)
             this.headersDirs.from(this@SourceSet.headersDirs)
@@ -617,6 +620,8 @@ open class CompileToBitcodeExtension @Inject constructor(val project: Project) :
                 group = VERIFICATION_BUILD_TASK_GROUP
                 this.target.set(target)
                 this.sanitizer.set(sanitizer)
+                val platformManager = project.extensions.getByType<PlatformManager>()
+                provisionXcodeBeforeRun(project.xcodeProvisioningSpec(platformManager, target))
                 this.outputFile.set(project.layout.buildDirectory.file("bin/test/${target}/$testName.${target.family.exeSuffix}"))
                 this.llvmLinkFirstStageOutputFile.set(project.layout.buildDirectory.file("bitcode/test/$target/$testName-firstStage.bc"))
                 this.llvmLinkOutputFile.set(project.layout.buildDirectory.file("bitcode/test/$target/$testName.bc"))

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/bitcode/CompileToBitcodePlugin.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/bitcode/CompileToBitcodePlugin.kt
@@ -525,6 +525,8 @@ open class CompileToBitcodeExtension @Inject constructor(val project: Project) :
 
         private val project by owner::project
 
+        private val nativeDependencies = project.extensions.getByType<NativeDependenciesExtension>()
+
         // A shared service used to limit parallel execution of test binaries.
         private val runGTestSemaphore = project.gradle.sharedServices.registerIfAbsent("runGTestSemaphore", RunGTestSemaphore::class.java) {
             // Probably can be made configurable if test reporting moves away from simple gtest stdout dumping.
@@ -617,6 +619,7 @@ open class CompileToBitcodeExtension @Inject constructor(val project: Project) :
                 group = VERIFICATION_BUILD_TASK_GROUP
                 this.target.set(target)
                 this.sanitizer.set(sanitizer)
+                dependsOn(nativeDependencies.targetDependency(_target))
                 this.outputFile.set(project.layout.buildDirectory.file("bin/test/${target}/$testName.${target.family.exeSuffix}"))
                 this.llvmLinkFirstStageOutputFile.set(project.layout.buildDirectory.file("bitcode/test/$target/$testName-firstStage.bc"))
                 this.llvmLinkOutputFile.set(project.layout.buildDirectory.file("bitcode/test/$target/$testName.bc"))

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/dependencies/NativeDependenciesDownloader.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/dependencies/NativeDependenciesDownloader.kt
@@ -13,15 +13,18 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.XcodeProvisioningSpec
 import org.jetbrains.kotlin.konan.properties.KonanPropertiesLoader
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.PlatformManager
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import org.jetbrains.kotlin.provisionXcodeOrFail
 
 /**
  * Downloader of native dependencies.
  *
- * Serves as a Gradle task wrapper around [DependencyProcessor].
+ * Serves as a Gradle task wrapper around [DependencyProcessor], plus — for an Apple target with whole-Xcode
+ * provisioning on — around `XcodeProvisioner`: see [xcodeProvisioning].
  */
 @UntrackedTask(because = "Output is large and work avoidance is performed in DependencyProcessor anyway")
 abstract class NativeDependenciesDownloader : DefaultTask() {
@@ -43,10 +46,18 @@ abstract class NativeDependenciesDownloader : DefaultTask() {
     @get:Internal
     abstract val repositoryURL: Property<String>
 
+    /**
+     * The whole Xcode to provision for [target], or absent when there is nothing to provision
+     */
+    @get:Internal
+    abstract val xcodeProvisioning: Property<XcodeProvisioningSpec>
+
     private val platformManager = project.extensions.getByType<PlatformManager>()
 
     @TaskAction
     fun downloadAndExtract() {
+        xcodeProvisioning.orNull?.let { provisionXcodeOrFail(it) }
+
         val loader = platformManager.loader(target.get())
         check(loader is KonanPropertiesLoader)
         val dependencyProcessor =

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/dependencies/NativeDependenciesDownloaderPlugin.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/dependencies/NativeDependenciesDownloaderPlugin.kt
@@ -14,12 +14,18 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.PlatformManagerPlugin
+import org.jetbrains.kotlin.XcodeProvisioningSpec
+import org.jetbrains.kotlin.isInternalServerEnabled
+import org.jetbrains.kotlin.isWholeXcodeProvisioningEnabled
 import org.jetbrains.kotlin.konan.properties.KonanPropertiesLoader
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.PlatformManager
 import org.jetbrains.kotlin.konan.target.TargetDomainObjectContainer
 import org.jetbrains.kotlin.konan.target.TargetWithSanitizer
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
 import org.jetbrains.kotlin.utils.capitalized
+import java.io.File
 import java.nio.file.Paths
 import javax.inject.Inject
 import kotlin.io.path.name
@@ -81,6 +87,33 @@ abstract class NativeDependenciesDownloaderExtension @Inject constructor(private
      */
     abstract val repositoryURL: Property<String>
 
+    private val platformManager = project.extensions.getByType<PlatformManager>()
+
+    private val expectedXcode: XcodeProvisioningSpec? by lazy {
+        if (!project.isWholeXcodeProvisioningEnabled()) return@lazy null
+        val loader = platformManager.loader(HostManager.host)
+        require(loader is KonanPropertiesLoader) {
+            "loader for ${HostManager.host} must implement ${KonanPropertiesLoader::class}"
+        }
+        fun requiredProperty(name: String) = loader.properties.getProperty(name)
+                ?: error("whole-Xcode provisioning is on but '$name' is missing from konan.properties")
+        XcodeProvisioningSpec(
+                konanDataDir = project.providers.gradleProperty("konan.data.dir").orNull,
+                version = requiredProperty("xcodeVersion"),
+                build = requiredProperty("xcodeBuild"),
+                artifactUrl = requiredProperty("xcodeArtifactUrl"),
+                serverEnabled = project.isInternalServerEnabled(),
+                isTeamCity = project.providers.environmentVariable("TEAMCITY_VERSION").isPresent,
+        )
+    }
+
+    internal fun xcodeProvisioningFor(target: KonanTarget): XcodeProvisioningSpec? =
+            expectedXcode?.takeIf { target.family.isAppleFamily }
+
+    val hostXcodeApp: File? by lazy {
+        expectedXcode?.let { dependenciesDirectory.get().asFile.resolve("xcode_${it.version}_${it.build}") }
+    }
+
     abstract class Target @Inject constructor(
             private val owner: NativeDependenciesDownloaderExtension,
             private val _target: TargetWithSanitizer,
@@ -117,6 +150,7 @@ abstract class NativeDependenciesDownloaderExtension @Inject constructor(private
             target.set(this@Target.target)
             dependenciesDirectory.set(owner.dependenciesDirectory)
             repositoryURL.set(owner.repositoryURL)
+            owner.xcodeProvisioningFor(this@Target.target)?.let { xcodeProvisioning.set(it) }
         }
 
         init {
@@ -144,6 +178,16 @@ abstract class NativeDependenciesDownloaderExtension @Inject constructor(private
                                     name = dependencyPath.name
                                     type = "directory"
                                     extension = ""
+                                }
+                            }
+                        }
+                        if (target.family.isAppleFamily) {
+                            owner.hostXcodeApp?.let { xcodeApp ->
+                                artifact(xcodeApp) {
+                                    name = xcodeApp.name
+                                    type = "directory"
+                                    extension = ""
+                                    builtBy(task)
                                 }
                             }
                         }

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanCacheTask.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanCacheTask.kt
@@ -94,6 +94,13 @@ open class KonanCacheTask @Inject constructor(
     @get:Input
     val withOptimizations: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
+    /**
+     * Extra compiler arguments (e.g. `-Xoverride-konan-properties=useProvisionedXcode=true` for whole-Xcode
+     * provisioning). Empty by default, so default builds produce identical argument lists.
+     */
+    @get:Input
+    val extraCompilerArgs: ListProperty<String> = objectFactory.listProperty(String::class.java)
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)
     @Suppress("unused") // used only by Gradle machinery via reflection.
@@ -134,6 +141,7 @@ open class KonanCacheTask @Inject constructor(
             if (makePerFileCache.get()) {
                 add("-Xmake-per-file-cache")
             }
+            addAll(extraCompilerArgs.get())
         }
         val workQueue = workerExecutor.noIsolation()
         workQueue.submit(KonanCacheAction::class.java) {

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanCacheTask.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanCacheTask.kt
@@ -24,6 +24,8 @@ import org.jetbrains.kotlin.gradle.plugin.konan.KonanCliRunnerIsolatedClassLoade
 import org.jetbrains.kotlin.gradle.plugin.konan.prepareAsOutput
 import org.jetbrains.kotlin.gradle.plugin.konan.registerIsolatedClassLoadersServiceIfAbsent
 import org.jetbrains.kotlin.gradle.plugin.konan.runKonanTool
+import org.jetbrains.kotlin.isAppleTargetName
+import org.jetbrains.kotlin.isWholeXcodeProvisioningEnabled
 import org.jetbrains.kotlin.konan.target.PlatformManager
 import org.jetbrains.kotlin.nativeDistribution.NativeDistribution
 import org.jetbrains.kotlin.nativeDistribution.asNativeDistribution
@@ -94,6 +96,12 @@ open class KonanCacheTask @Inject constructor(
     @get:Input
     val withOptimizations: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
+    @get:Input
+    val useProvisionedXcode: Property<Boolean> = objectFactory.property(Boolean::class.java)
+            .convention(project.isWholeXcodeProvisioningEnabled()
+                    .let { wholeXcodeProvisioningEnabled -> target.map { wholeXcodeProvisioningEnabled && isAppleTargetName(it) } }
+            )
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)
     @Suppress("unused") // used only by Gradle machinery via reflection.
@@ -133,6 +141,9 @@ open class KonanCacheTask @Inject constructor(
             add("-Xdebug-prefix-map=${cacheDirectory.get().asFile.absolutePath}=out")
             if (makePerFileCache.get()) {
                 add("-Xmake-per-file-cache")
+            }
+            if (useProvisionedXcode.get()) {
+                add("-Xoverride-konan-properties=useProvisionedXcode=true")
             }
         }
         val workQueue = workerExecutor.noIsolation()

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanInteropTask.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanInteropTask.kt
@@ -22,6 +22,8 @@ import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
 import org.jetbrains.kotlin.PlatformInfo
 import org.jetbrains.kotlin.gradle.plugin.konan.*
+import org.jetbrains.kotlin.isAppleTargetName
+import org.jetbrains.kotlin.isWholeXcodeProvisioningEnabled
 import org.jetbrains.kotlin.konan.target.AbstractToolConfig
 import org.jetbrains.kotlin.nativeDistribution.asNativeDistribution
 import javax.inject.Inject
@@ -111,6 +113,12 @@ open class KonanInteropTask @Inject constructor(
     @get:Input
     val extraOpts: ListProperty<String> = objectFactory.listProperty(String::class.java)
 
+    @get:Input
+    val useProvisionedXcode: Property<Boolean> = objectFactory.property(Boolean::class.java)
+            .convention(project.isWholeXcodeProvisioningEnabled()
+                    .let { wholeXcodeProvisioningEnabled -> target.map { wholeXcodeProvisioningEnabled && isAppleTargetName(it) } }
+            )
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val defFile: RegularFileProperty = objectFactory.fileProperty()
@@ -164,6 +172,10 @@ open class KonanInteropTask @Inject constructor(
             }
 
             addAll(extraOpts.get())
+
+            if (useProvisionedXcode.get()) {
+                add("-Xoverride-konan-properties=useProvisionedXcode=true")
+            }
 
             add("-Xproject-dir")
             add(layout.projectDirectory.asFile.absolutePath)

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeOverridePlugin.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeOverridePlugin.kt
@@ -9,18 +9,37 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.*
+import org.jetbrains.kotlin.isWholeXcodeProvisioningEnabled
 import org.jetbrains.kotlin.konan.target.*
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import org.jetbrains.kotlin.nativeDistribution.nativeProtoDistribution
 
 open class XcodeOverridePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         // Only for macOS hosts.
         if (!HostManager.hostIsMac)
             return
-        // Only if we use regular Xcode installation.
-        if (DependencyProcessor.isInternalSeverAvailable)
+        val wholeXcodeOn = project.isWholeXcodeProvisioningEnabled()
+        // We snapshot the Xcode into Xcode.xcodeOverride (inside a ValueSource, so configuration-cache-safe) so that
+        // nothing resolves the Apple toolchain live via xcrun at configuration time (which would break the
+        // configuration cache — e.g. libclangext's host `clangForJni`). The cases:
+        //  - whole-Xcode on                         -> snapshot the provisioned Xcode (host build tools use it too);
+        //  - whole-Xcode off, no internal server    -> snapshot the system-selected Xcode (the original behavior);
+        //  - whole-Xcode off, internal server       -> nothing to do: the toolchain resolves from the downloaded
+        //                                              dependency paths (the InternalServer branch), with no xcrun.
+        if (!wholeXcodeOn && DependencyProcessor.isInternalSeverAvailable)
             return
-        val xcodeProvider: Provider<Xcode> = project.providers.of(XcodeValueSource::class) {}
+        val xcodeProvider: Provider<Xcode> = project.providers.of(XcodeValueSource::class) {
+            parameters.wholeXcode.set(wholeXcodeOn)
+            if (wholeXcodeOn) {
+                parameters.konanProperties.set(project.nativeProtoDistribution.konanProperties)
+                project.providers.gradleProperty("konan.data.dir").orNull?.let { parameters.konanDataDir.set(it) }
+                parameters.teamCity.set(project.providers.environmentVariable("TEAMCITY_VERSION").isPresent)
+                val forceServer = project.providers.gradleProperty("kotlin.native.useInternalServer")
+                        .map { it.toBoolean() }.getOrElse(false)
+                parameters.serverEnabled.set(DependencyProcessor.isInternalSeverAvailable || forceServer)
+            }
+        }
         Xcode.xcodeOverride = xcodeProvider.get()
     }
 }

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeOverridePlugin.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeOverridePlugin.kt
@@ -9,18 +9,35 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.*
+import org.jetbrains.kotlin.isInternalServerEnabled
+import org.jetbrains.kotlin.isWholeXcodeProvisioningEnabled
 import org.jetbrains.kotlin.konan.target.*
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import org.jetbrains.kotlin.nativeDistribution.nativeProtoDistribution
 
 open class XcodeOverridePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         // Only for macOS hosts.
         if (!HostManager.hostIsMac)
             return
-        // Only if we use regular Xcode installation.
-        if (DependencyProcessor.isInternalSeverAvailable)
+        val wholeXcodeOn = project.isWholeXcodeProvisioningEnabled()
+        // We snapshot the Xcode into Xcode.xcodeOverride so that nothing resolves the Apple toolchain live via xcrun at configuration time.
+        // The cases:
+        //  - whole-Xcode on                         -> snapshot the provisioned Xcode ;
+        //  - whole-Xcode off, no internal server    -> snapshot the system-selected Xcode ;
+        //  - whole-Xcode off, internal server       -> nothing to do: the toolchain resolves from the downloaded
+        //                                              dependency paths (the InternalServer branch), with no xcrun.
+        if (!wholeXcodeOn && DependencyProcessor.isInternalSeverAvailable)
             return
-        val xcodeProvider: Provider<Xcode> = project.providers.of(XcodeValueSource::class) {}
+        val xcodeProvider: Provider<Xcode> = project.providers.of(XcodeValueSource::class) {
+            parameters.wholeXcode.set(wholeXcodeOn)
+            if (wholeXcodeOn) {
+                parameters.konanProperties.set(project.nativeProtoDistribution.konanProperties)
+                project.providers.gradleProperty("konan.data.dir").orNull?.let { parameters.konanDataDir.set(it) }
+                parameters.teamCity.set(project.providers.environmentVariable("TEAMCITY_VERSION").isPresent)
+                parameters.serverEnabled.set(project.isInternalServerEnabled())
+            }
+        }
         Xcode.xcodeOverride = xcodeProvider.get()
     }
 }

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeValueSource.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeValueSource.kt
@@ -5,9 +5,13 @@
 
 package org.jetbrains.kotlin.xcode
 
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.jetbrains.kotlin.konan.target.*
+import org.jetbrains.kotlin.konan.util.XcodeProvisioner
+import java.util.Properties
 
 private data class XcodeSnapshot(
         override val additionalTools: String,
@@ -37,6 +41,68 @@ private data class XcodeSnapshot(
     )
 }
 
-abstract class XcodeValueSource: ValueSource<Xcode, ValueSourceParameters.None> {
-    override fun obtain(): Xcode = XcodeSnapshot(Xcode.defaultCurrent())
+/**
+ * Snapshots an [Xcode] inside a Gradle [ValueSource]. The toolchain/SDK paths are resolved by running `xcrun`;
+ * doing that directly at configuration time breaks the configuration cache, so it is done here (a ValueSource is
+ * the sanctioned way to run external processes at configuration time) and the resulting plain-value snapshot is
+ * stored in the configuration cache.
+ *
+ * When [Parameters.wholeXcode] is set, the whole Xcode expected by the distribution (`konan.properties`
+ * `xcodeVersion`/`xcodeBuild`) is snapshotted instead of the system-selected (ambient) one. Provisioning has to
+ * happen here rather than in a task: the snapshot below freezes the Apple toolchain/SDK paths, so the Xcode must
+ * already exist by the time this runs. A ValueSource is the sanctioned place for that work, and its result goes
+ * into the configuration cache, so a download happens at most once. See [XcodeProvisioner.provisionXcode] for
+ * when a download is actually allowed — never on TeamCity, and only with the internal server enabled.
+ */
+abstract class XcodeValueSource : ValueSource<Xcode, XcodeValueSource.Parameters> {
+    interface Parameters : ValueSourceParameters {
+        /** When `true`, snapshot the whole provisioned Xcode instead of the system-selected one. */
+        val wholeXcode: Property<Boolean>
+
+        /**
+         * The distribution's `konan.properties`, read for `xcodeVersion`/`xcodeBuild`/`xcodeArtifactUrl`.
+         * Required iff [wholeXcode].
+         */
+        val konanProperties: RegularFileProperty
+
+        /** `konan.data.dir` Gradle property, if set (dependencies live under `<konanDataDir>/dependencies`). */
+        val konanDataDir: Property<String>
+
+        /** Whether this is a TeamCity build (agents must ship the expected Xcode via their image). */
+        val teamCity: Property<Boolean>
+
+        /**
+         * Whether the internal server is enabled. Only then may an Xcode that is neither provisioned nor installed
+         * be downloaded; otherwise the build fails with an actionable message.
+         */
+        val serverEnabled: Property<Boolean>
+    }
+
+    override fun obtain(): Xcode {
+        val xcode = if (parameters.wholeXcode.getOrElse(false)) provisionedXcode() else Xcode.defaultCurrent()
+        return XcodeSnapshot(xcode)
+    }
+
+    private fun provisionedXcode(): Xcode {
+        val properties = Properties().apply {
+            parameters.konanProperties.get().asFile.inputStream().use { load(it) }
+        }
+        fun requiredProperty(name: String) = properties.getProperty(name)
+                ?: error("whole-Xcode provisioning is on but '$name' is missing from konan.properties")
+        val version = requiredProperty("xcodeVersion")
+        val build = requiredProperty("xcodeBuild")
+        val xcodeApp = XcodeProvisioner.provisionXcode(
+                konanDataDir = parameters.konanDataDir.orNull,
+                version = version,
+                build = build,
+                artifactUrl = requiredProperty("xcodeArtifactUrl"),
+                serverEnabled = parameters.serverEnabled.getOrElse(false),
+                isTeamCity = parameters.teamCity.getOrElse(false),
+        ) ?: error(
+                "Whole Xcode $version (build $build) is not provisioned under the Kotlin/Native dependencies, and the " +
+                        "currently selected Xcode has a different build. Install and select Xcode $version " +
+                        "(build $build), or set KONAN_USE_INTERNAL_SERVER=1 to have it downloaded."
+        )
+        return Xcode.forDeveloperDir(xcodeApp.resolve("Contents/Developer").path)
+    }
 }

--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeValueSource.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/xcode/XcodeValueSource.kt
@@ -5,9 +5,14 @@
 
 package org.jetbrains.kotlin.xcode
 
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.jetbrains.kotlin.XcodeProvisioningSpec
 import org.jetbrains.kotlin.konan.target.*
+import org.jetbrains.kotlin.provisionXcodeOrFail
+import java.util.Properties
 
 private data class XcodeSnapshot(
         override val additionalTools: String,
@@ -37,6 +42,53 @@ private data class XcodeSnapshot(
     )
 }
 
-abstract class XcodeValueSource: ValueSource<Xcode, ValueSourceParameters.None> {
-    override fun obtain(): Xcode = XcodeSnapshot(Xcode.defaultCurrent())
+abstract class XcodeValueSource : ValueSource<Xcode, XcodeValueSource.Parameters> {
+    interface Parameters : ValueSourceParameters {
+        /** When `true`, snapshot the whole provisioned Xcode instead of the system-selected one. */
+        val wholeXcode: Property<Boolean>
+
+        /**
+         * The distribution's `konan.properties`, read for `xcodeVersion`/`xcodeBuild`/`xcodeArtifactUrl`.
+         * Required iff [wholeXcode].
+         */
+        val konanProperties: RegularFileProperty
+
+        /** `konan.data.dir` Gradle property, if set (dependencies live under `<konanDataDir>/dependencies`). */
+        val konanDataDir: Property<String>
+
+        /** Whether this is a TeamCity build (agents must ship the expected Xcode via their image). */
+        val teamCity: Property<Boolean>
+
+        /**
+         * Whether the internal server is enabled. Only then may an Xcode that is neither provisioned nor installed
+         * be downloaded; otherwise the build fails with an actionable message.
+         */
+        val serverEnabled: Property<Boolean>
+    }
+
+    override fun obtain(): Xcode {
+        val xcode = if (parameters.wholeXcode.getOrElse(false)) provisionedXcode() else Xcode.defaultCurrent()
+        return XcodeSnapshot(xcode)
+    }
+
+    private fun provisionedXcode(): Xcode {
+        val properties = Properties().apply {
+            parameters.konanProperties.get().asFile.inputStream().use { load(it) }
+        }
+
+        fun requiredProperty(name: String) = properties.getProperty(name)
+                ?: error("whole-Xcode provisioning is on but '$name' is missing from konan.properties")
+
+        val xcodeApp = provisionXcodeOrFail(
+                XcodeProvisioningSpec(
+                        konanDataDir = parameters.konanDataDir.orNull,
+                        version = requiredProperty("xcodeVersion"),
+                        build = requiredProperty("xcodeBuild"),
+                        artifactUrl = requiredProperty("xcodeArtifactUrl"),
+                        serverEnabled = parameters.serverEnabled.getOrElse(false),
+                        isTeamCity = parameters.teamCity.getOrElse(false),
+                )
+        )
+        return Xcode.forDeveloperDir(xcodeApp.resolve("Contents/Developer").path)
+    }
 }

--- a/kotlin-native/dependencies/build.gradle.kts
+++ b/kotlin-native/dependencies/build.gradle.kts
@@ -42,11 +42,22 @@ val llvmDevBinaryData = configurations.create("llvmDevBinaryData") {
     isCanBeResolved = false
 }
 
+val hostXcode = configurations.create("hostXcode") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
 artifacts {
     val llvmHome = nativeDependencies.hostPlatform.llvmHome!!
     val llvmDir = file("${nativeDependencies.nativeDependenciesRoot}/$llvmHome")
     add(llvmDevBinaryData.name, llvmDir) {
         type = "directory"
         builtBy(nativeDependencies.targetDependency())
+    }
+    nativeDependenciesDownloader.hostXcodeApp?.let { xcodeApp ->
+        add(hostXcode.name, xcodeApp) {
+            type = "directory"
+            builtBy(nativeDependencies.targetDependency())
+        }
     }
 }

--- a/kotlin-native/platformLibs/build.gradle.kts
+++ b/kotlin-native/platformLibs/build.gradle.kts
@@ -9,10 +9,13 @@ import org.jetbrains.kotlin.gradle.plugin.konan.tasks.KonanCacheTask
 import org.jetbrains.kotlin.gradle.plugin.konan.tasks.KonanInteropTask
 import org.jetbrains.kotlin.konan.target.*
 import org.jetbrains.kotlin.konan.util.*
+import org.jetbrains.kotlin.isWholeXcodeProvisioningEnabled
 import org.jetbrains.kotlin.nativeDistribution.nativeDistribution
 import org.jetbrains.kotlin.nativeDistribution.registerNativeBootstrapDistribution
 import org.jetbrains.kotlin.platformLibs.*
 import org.jetbrains.kotlin.platformManager
+import org.jetbrains.kotlin.provisionXcodeBeforeRun
+import org.jetbrains.kotlin.xcodeProvisioningSpec
 import org.jetbrains.kotlin.utils.capitalized
 import org.jetbrains.kotlin.utils.reproducibilityCompilerFlags
 import org.jetbrains.kotlin.utils.reproducibilityRootsMap
@@ -123,6 +126,12 @@ enabledTargets(platformManager).forEach { target ->
                 val fmodulesCache = project.layout.buildDirectory.dir("clangModulesCache").get().asFile.toRelativeString(project.layout.projectDirectory.asFile)
                 this.extraOpts.addAll("-compiler-option", "-fmodules-cache-path=$fmodulesCache")
             }
+            if (target.family.isAppleFamily && project.isWholeXcodeProvisioningEnabled()) {
+                // Resolve the Apple toolchain/sysroot from the provisioned whole Xcode (see AppleConfigurablesImpl).
+                // cinterop parses this via kotlinx.cli, so the flag and its value are two separate tokens.
+                this.extraOpts.addAll("-Xoverride-konan-properties", "useProvisionedXcode=true")
+                provisionXcodeBeforeRun(project.xcodeProvisioningSpec(platformManager, target))
+            }
 
             usesService(compilePlatformLibsSemaphore)
         }
@@ -167,6 +176,11 @@ enabledTargets(platformManager).forEach { target ->
                     this.withOptimizations.set(withOptimizations)
                     this.cacheDirectory.set(dist.map { it.cachesRoot(targetName, withOptimizations) })
                     this.cacheName.set(artifactName)
+                    if (target.family.isAppleFamily && project.isWholeXcodeProvisioningEnabled()) {
+                        // Resolve the Apple toolchain/sysroot from the provisioned whole Xcode (see AppleConfigurablesImpl).
+                        this.extraCompilerArgs.addAll("-Xoverride-konan-properties=useProvisionedXcode=true")
+                        provisionXcodeBeforeRun(project.xcodeProvisioningSpec(platformManager, target))
+                    }
 
                     usesService(cachePlatformLibsSemaphore)
                 }

--- a/kotlin-native/platformLibs/build.gradle.kts
+++ b/kotlin-native/platformLibs/build.gradle.kts
@@ -59,6 +59,7 @@ if (HostManager.host == KonanTarget.MACOS_ARM64) {
 }
 
 val cacheableTargetNames = platformManager.hostPlatform.cacheableTargets
+val nativeDependenciesExtension = project.extensions.getByType<NativeDependenciesExtension>()
 
 val updateDefFileDependenciesTask = tasks.register("updateDefFileDependencies")
 val updateDefFileTasksPerFamily = if (HostManager.hostIsMac) {
@@ -105,7 +106,6 @@ enabledTargets(platformManager).forEach { target ->
                 this.klibFiles.from(tasks.named(interopTaskName(defFileToLibName(targetName, defName), targetName)))
             }
 
-            val nativeDependenciesExtension = project.extensions.getByType<NativeDependenciesExtension>()
             val reproducibilityCompilerFlags = reproducibilityCompilerFlags(project, nativeDependenciesExtension).flatMap {
                 listOf("-compiler-option", it)
             }.toTypedArray()
@@ -123,6 +123,8 @@ enabledTargets(platformManager).forEach { target ->
                 val fmodulesCache = project.layout.buildDirectory.dir("clangModulesCache").get().asFile.toRelativeString(project.layout.projectDirectory.asFile)
                 this.extraOpts.addAll("-compiler-option", "-fmodules-cache-path=$fmodulesCache")
             }
+
+            dependsOn(nativeDependenciesExtension.targetDependency(target))
 
             usesService(compilePlatformLibsSemaphore)
         }
@@ -167,6 +169,7 @@ enabledTargets(platformManager).forEach { target ->
                     this.withOptimizations.set(withOptimizations)
                     this.cacheDirectory.set(dist.map { it.cachesRoot(targetName, withOptimizations) })
                     this.cacheName.set(artifactName)
+                    dependsOn(nativeDependenciesExtension.targetDependency(target))
 
                     usesService(cachePlatformLibsSemaphore)
                 }

--- a/kotlin-native/runtime/build.gradle.kts
+++ b/kotlin-native/runtime/build.gradle.kts
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.PlatformInfo
 import org.jetbrains.kotlin.bitcode.CompileToBitcodeExtension
 import org.jetbrains.kotlin.cacheFlavor
 import org.jetbrains.kotlin.cpp.CppUsage
+import org.jetbrains.kotlin.dependencies.NativeDependenciesExtension
 import org.jetbrains.kotlin.gradle.plugin.konan.tasks.KonanCacheTask
 import org.jetbrains.kotlin.gradle.plugin.konan.tasks.KonanCompileTask
 import org.jetbrains.kotlin.konan.target.*
@@ -755,6 +756,9 @@ cacheableTargetNames.forEach { targetName ->
             val cacheFlavor = cacheFlavor(targetName, withOptimizations)
             this.cacheDirectory.set(layout.buildDirectory.dir("cache/$targetName/$cacheFlavor"))
             this.cacheName.set(KOTLIN_NATIVE_STDLIB_NAME)
+            dependsOn(
+                    project.extensions.getByType<NativeDependenciesExtension>()
+                            .targetDependency(platformManager.targetByName(targetName)))
         }
     }
 }

--- a/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/nativeTest.kt
+++ b/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/nativeTest.kt
@@ -22,7 +22,10 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinUsages
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import org.jetbrains.kotlin.konan.util.XcodeProvisioner
 import java.io.File
+import java.util.Properties
 import javax.inject.Inject
 
 private enum class TestProperty(shortName: String) {
@@ -422,6 +425,43 @@ fun ProjectTestsExtension.nativeTestTask(
 
         // Pass the current Gradle task name so test can use it in logging.
         environment("GRADLE_TASK_NAME", path)
+
+        // Opt-in whole-Xcode provisioning (kotlin.native.internalServer.wholeXcode). On a macOS host, select the
+        // Xcode expected by this distribution (konan.properties: xcodeVersion/xcodeBuild/xcodeArtifactUrl) under
+        // ~/.konan/dependencies/xcode_<version>_<build> and point the test JVM at it via DEVELOPER_DIR, so
+        // xcrun/xcode-select resolve the toolchain and SDKs from it. The current Xcode is symlinked when its build
+        // matches; a download is only used when the internal server is enabled (env KONAN_USE_INTERNAL_SERVER=1 or
+        // -Pkotlin.native.useInternalServer=true), and never on TeamCity (agent images must ship the Xcode).
+        val useWholeXcode = project.providers.gradleProperty("kotlin.native.internalServer.wholeXcode")
+            .map { it.toBoolean() }.orElse(false).get()
+        if (HostManager.hostIsMac && useWholeXcode) {
+            val testTask = this
+            val konanDataDir = project.providers.gradleProperty("konan.data.dir").orNull
+            val forceInternalServer = project.providers.gradleProperty("kotlin.native.useInternalServer")
+                .map { it.toBoolean() }.orElse(false).get()
+            val serverEnabled = DependencyProcessor.isInternalSeverAvailable || forceInternalServer
+            val isTeamCity = kotlinBuildProperties.isTeamcityBuild.get()
+            val konanPropertiesFile = project.project(":kotlin-native").isolated.projectDirectory
+                .file("konan/konan.properties").asFile
+            doFirst {
+                val konanProperties = Properties().apply {
+                    konanPropertiesFile.inputStream().use { load(it) }
+                }
+                fun requiredProperty(name: String) = konanProperties.getProperty(name)
+                    ?: error("No '$name' property in ${konanPropertiesFile.absolutePath}")
+                val xcodeApp = XcodeProvisioner.provisionXcode(
+                    konanDataDir = konanDataDir,
+                    version = requiredProperty("xcodeVersion"),
+                    build = requiredProperty("xcodeBuild"),
+                    artifactUrl = requiredProperty("xcodeArtifactUrl"),
+                    serverEnabled = serverEnabled,
+                    isTeamCity = isTeamCity,
+                )
+                if (xcodeApp != null) {
+                    testTask.environment("DEVELOPER_DIR", xcodeApp.resolve("Contents/Developer").absolutePath)
+                }
+            }
+        }
 
         useJUnitPlatform {
             // Note: arbitrary JUnit tag expressions can be used in this property.

--- a/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/nativeTest.kt
+++ b/repo/gradle-build-conventions/project-tests-convention/src/main/kotlin/nativeTest.kt
@@ -320,6 +320,18 @@ private abstract class JdkVersionDependentFlagsProvider : CommandLineArgumentPro
 private fun ProviderFactory.testProperty(property: TestProperty) =
     gradleProperty(property.fullName).orElse(gradleProperty(property.shortName))
 
+private fun Project.hostXcodeConfiguration(): Configuration =
+    configurations.findByName(HOST_XCODE_CONFIGURATION) ?: run {
+        val hostXcode = dependencies.project(":kotlin-native:dependencies", "hostXcode")
+        configurations.create(HOST_XCODE_CONFIGURATION) {
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            dependencies.add(hostXcode)
+        }
+    }
+
+private const val HOST_XCODE_CONFIGURATION = "nativeTestHostXcode"
+
 /**
  * @param taskName Name of Gradle task.
  * @param tag Optional JUnit test tag. See https://junit.org/junit5/docs/current/user-guide/#writing-tests-tagging-and-filtering
@@ -425,6 +437,16 @@ fun ProjectTestsExtension.nativeTestTask(
 
         // Pass the current Gradle task name so test can use it in logging.
         environment("GRADLE_TASK_NAME", path)
+
+        if (HostManager.hostIsMac &&
+            kotlinBuildProperties.booleanProperty("kotlin.native.internalServer.wholeXcode", false).get()
+        ) {
+            dependsOn(project.hostXcodeConfiguration())
+            environment(
+                "DEVELOPER_DIR",
+                project.hostXcodeConfiguration().singleFile.resolve("Contents/Developer").absolutePath
+            )
+        }
 
         useJUnitPlatform {
             // Note: arbitrary JUnit tag expressions can be used in this property.


### PR DESCRIPTION
Build-side consumers of the whole-Xcode provisioning that the previous
commit added to kotlin-native-utils. With the opt-in Gradle property
kotlin.native.internalServer.wholeXcode the Apple toolchain and sysroot
are taken from a whole Xcode under
$KONAN_DATA_DIR/dependencies/xcode_<version>_<build> instead of the
stripped target-sysroot-*, target-toolchain-* and xcode-addon-*
artifacts. The property is off by default, so a build that does not pass
it resolves Xcode exactly as it did before.

Provisioning deliberately happens at configuration time, inside
XcodeValueSource. XcodeOverridePlugin freezes the resolved toolchain and
SDK paths into Xcode.xcodeOverride, so the Xcode has to exist by then
and a download cannot be deferred to a task. A ValueSource is the
sanctioned place to run external processes at configuration time, and
its result is kept in the configuration cache, so a download happens at
most once. Nothing is ever downloaded on TeamCity, where the agent image
is expected to carry the Xcode, nor when the internal server is off,
where the build fails instead and names the Xcode to install.

- The runtime clang and linker need no new arguments.
  PlatformManagerProvider adds useProvisionedXcode=true to
  konanPropertiesOverride, putting build-tools' own PlatformManager into
  that mode, so configurables.absoluteTargetSysRoot, which is where
  -isysroot in ClangArgs and -syslibroot in Linker come from, already
  points into the Xcode. It is added for the proto distribution only: a
  released distribution, such as the native bootstrap that
  libclangInterop's genInteropStubs runs against, has no xcodeVersion or
  xcodeBuild and would fail to resolve the flag.
- konanc does need it spelled out, being a separate process with its own
  Distribution and no Xcode.xcodeOverride. platformLibs passes
  -Xoverride-konan-properties useProvisionedXcode=true to cinterop, and
  KonanCacheTask forwards the same through a new extraCompilerArgs
  input, left empty otherwise so default builds keep identical argument
  lists.
- Native test JVMs get DEVELOPER_DIR pointed at the provisioned Xcode,
  because the compiler runs inside the test process and resolves the
  toolchain through xcrun there.
- ProvisionedXcodeSdk holds what the above share: the property itself
  and XcodeProvisioningSpec, a snapshot of plain serializable values
  that a task can capture so provisioning can be triggered from a
  doFirst without reaching for Project at execution time.

This depends on the bootstrap having advanced past the previous commit:
build-tools and gradle-build-conventions are build logic compiled
against the bootstrap kotlin-native-utils, so until it carries
XcodeProvisioner the whole Gradle build cannot be configured.

^KT-82325