### PR TITLE
[Native] ^KT-87702: make LLVM value/type to string API consistent

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
@@ -81,7 +81,7 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
                 }
                 LLVMIsAGlobalAlias(value) != null -> cleanCalledFunction(LLVMAliasGetAliasee(value)!!)
                 else -> {
-                    TODO("not implemented call argument ${llvm2string(value)} called in ${llvm2string(this)}")
+                    TODO("not implemented call argument ${value.toValueString()} called in ${this.toValueString()}")
                 }
             }
         }
@@ -112,9 +112,9 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
                 (invoke instructions are intertwined with basic blocks, so getting the next instruction requires more code).
                 The function doesn't throw, so nobody should generate "invokes" to it anyway.
                 */
-                check(LLVMIsACallInst(call) != null) { "Expected a call instruction, not invoke: ${llvm2string(call)}" }
+                check(LLVMIsACallInst(call) != null) { "Expected a call instruction, not invoke: ${call.toValueString()}" }
                 val nextInstruction = LLVMGetNextInstruction(call)
-                check(nextInstruction != null) { "Expected a next instruction after ${llvm2string(call)}" }
+                check(nextInstruction != null) { "Expected a next instruction after ${call.toValueString()}" }
                 nextInstruction
             } else {
                 /*
@@ -164,7 +164,7 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
                     calledPtrLlvm = when (val typeKind = LLVMGetTypeKind(calleeInfo.calledPtr.type)) {
                         LLVMTypeKind.LLVMPointerTypeKind -> calleeInfo.calledPtr
                         LLVMTypeKind.LLVMIntegerTypeKind -> LLVMBuildIntToPtr(builder, calleeInfo.calledPtr, llvm.pointerType, "")!!
-                        else -> TODO("Unsupported typeKind=${typeKind} of calledPtr=${llvm2string(calleeInfo.calledPtr)}")
+                        else -> TODO("Unsupported typeKind=${typeKind} of calledPtr=${calleeInfo.calledPtr.toValueString()}")
                     }
                 }
             }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
@@ -268,7 +268,7 @@ internal object VirtualTablesLookup {
         else
             loadTypeInfo(receiver)
 
-        assert(typeInfoPtr.type == llvm.pointerType) { llvmtype2string(typeInfoPtr.type) }
+        assert(typeInfoPtr.type == llvm.pointerType) { typeInfoPtr.type.toTypeString() }
 
         val owner = irFunction.parentAsClass
         val canCallViaVtable = !owner.isInterface

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -368,8 +368,8 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
         val found = LLVMGetNamedFunction(module, llvmFunctionProto.name)
         if (found != null) {
             require(getGlobalFunctionType(found) == llvmFunctionProto.signature.llvmFunctionType) {
-                "Inconsistent function type of ${llvmFunctionProto.name}. Expected: ${LLVMPrintTypeToString(llvmFunctionProto.signature.llvmFunctionType)!!.toKString()}, " +
-                        "found: ${LLVMPrintTypeToString(getGlobalFunctionType(found))!!.toKString()}"
+                "Inconsistent function type of ${llvmFunctionProto.name}. Expected: ${llvmFunctionProto.signature.llvmFunctionType.toTypeString()}, " +
+                        "found: ${getGlobalFunctionType(found).toTypeString()}"
             }
             require(LLVMGetLinkage(found) == llvmFunctionProto.linkage)
             return LlvmCallable(found, llvmFunctionProto.signature)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -504,7 +504,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
 
     private fun FunctionGenerationContext.emitAreEqualByValue(args: List<LLVMValueRef>): LLVMValueRef {
         val [first, second] = args
-        assert (first.type == second.type) { "Types are different: '${llvmtype2string(first.type)}' and '${llvmtype2string(second.type)}'" }
+        assert (first.type == second.type) { "Types are different: '${first.type.toTypeString()}' and '${second.type.toTypeString()}'" }
 
         return when (val typeKind = LLVMGetTypeKind(first.type)) {
             LLVMTypeKind.LLVMFloatTypeKind, LLVMTypeKind.LLVMDoubleTypeKind,
@@ -521,10 +521,10 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
     private fun FunctionGenerationContext.emitIeee754Equals(args: List<LLVMValueRef>): LLVMValueRef {
         val [first, second] = args
         assert (first.type == second.type)
-                { "Types are different: '${llvmtype2string(first.type)}' and '${llvmtype2string(second.type)}'" }
+                { "Types are different: '${first.type.toTypeString()}' and '${second.type.toTypeString()}'" }
         val type = LLVMGetTypeKind(first.type)
         assert (type == LLVMTypeKind.LLVMFloatTypeKind || type == LLVMTypeKind.LLVMDoubleTypeKind)
-                { "Should be of floating point kind, not: '${llvmtype2string(first.type)}'"}
+                { "Should be of floating point kind, not: '${first.type.toTypeString()}'"}
         return fcmpEq(first, second)
     }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1464,7 +1464,7 @@ internal class CodeGeneratorVisitor(
             onCheck: (argument: LLVMValueRef, checkResult: LLVMValueRef) -> LLVMValueRef,
     ) : LLVMValueRef {
         val srcArg = evaluateExpression(value.argument, resultSlot)
-        require(srcArg.type == llvm.pointerType) { "Expected ObjHeader but was ${llvmtype2string(srcArg.type)} for ${value.argument.dump()}" }
+        require(srcArg.type == llvm.pointerType) { "Expected ObjHeader but was ${srcArg.type.toTypeString()} for ${value.argument.dump()}" }
         val srcType = value.argument.type
         val isSuperClassCast = srcType.isSuperClassCastTo(dstClass)
 
@@ -1705,7 +1705,7 @@ internal class CodeGeneratorVisitor(
         if (thisPtr != null) {
             require(!field.isStatic) { "Unexpected receiver for a static field: ${value.render()}" }
             require(thisPtr.type == llvm.pointerType) {
-                LLVMPrintTypeToString(thisPtr.type)?.toKString().toString()
+                thisPtr.type.toTypeString()
             }
             address = fieldPtrOfClass(thisPtr, field)
             alignment = generationState.llvmDeclarations.forField(field).alignment

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -124,12 +124,12 @@ private fun ContextUtils.createClassBody(name: String, fields: List<ClassLayoutB
     context.logMultiple {
         +"$name has following fields:"
         for (i in fieldTypes.indices) {
-            +"  $i: ${llvmtype2string(fieldTypes[i])} at offset ${LLVMOffsetOfElement(runtime.targetData, classType, i)}"
+            +"  $i: ${fieldTypes[i].toTypeString()} at offset ${LLVMOffsetOfElement(runtime.targetData, classType, i)}"
         }
         +"  Overall llvm alignment is ${LLVMABIAlignmentOfType(runtime.targetData, classType)}"
         +"  Overall required alignment is ${alignment}"
         +"  Overall size is ${LLVMABISizeOfType(runtime.targetData, classType)}"
-        +"  Resulting type is ${llvmtype2string(classType)}"
+        +"  Resulting type is ${classType.toTypeString()}"
     }
 
     return ClassBodyAndAlignmentInfo(classType, alignment, indices)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
@@ -46,7 +46,7 @@ internal class ConstArray(elementType: LLVMTypeRef?, val elements: List<ConstVal
     init {
         elements.forEach {
             assert(it.llvmType == elementType) {
-                "Expected element type: ${llvmtype2string(elementType)}, actual: ${llvmtype2string(it.llvmType)}"
+                "Expected element type: ${elementType.toTypeString()}, actual: ${it.llvmType.toTypeString()}"
             }
         }
     }
@@ -64,8 +64,8 @@ internal open class Struct(val type: LLVMTypeRef?, val elements: List<ConstValue
         } else {
             element.llvm.also {
                 assert(it.type == expectedType) {
-                    "Unexpected type at $index: expected ${LLVMPrintTypeToString(expectedType)!!.toKString()}, " +
-                            "got ${LLVMPrintTypeToString(it.type)!!.toKString()} in ${LLVMPrintTypeToString(type)!!.toKString()}"
+                    "Unexpected type at $index: expected ${expectedType.toTypeString()}, " +
+                            "got ${it.type.toTypeString()} in ${type.toTypeString()}"
                 }
             }
         }
@@ -74,7 +74,7 @@ internal open class Struct(val type: LLVMTypeRef?, val elements: List<ConstValue
     init {
         assert(elements.size == LLVMCountStructElementTypes(type)) {
             "Should have ${LLVMCountStructElementTypes(type)} elements, have ${elements.size} " +
-                    "for type ${LLVMPrintTypeToString(type)!!.toKString()}"
+                    "for type ${type.toTypeString()}"
         }
     }
 }
@@ -248,14 +248,14 @@ internal fun functionType(returnType: LLVMTypeRef, isVarArg: Boolean = false, pa
         functionType(returnType, isVarArg, *paramTypes.toTypedArray())
 
 
-fun llvm2string(value: LLVMValueRef?): String {
-  if (value == null) return "<null>"
-  return LLVMPrintValueToString(value)!!.toKString()
+fun LLVMValueRef?.toValueString(): String {
+    if (this == null) return "<null>"
+    return LLVMPrintValueToString(this)!!.toKString()
 }
 
-fun llvmtype2string(type: LLVMTypeRef?): String {
-    if (type == null) return "<null type>"
-    return LLVMPrintTypeToString(type)!!.toKString()
+fun LLVMTypeRef?.toTypeString(): String {
+    if (this == null) return "<null type>"
+    return LLVMPrintTypeToString(this)!!.toKString()
 }
 
 fun getStructElements(type: LLVMTypeRef): List<LLVMTypeRef> {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.objcinterop.*
 import org.jetbrains.kotlin.ir.util.*
-import org.jetbrains.kotlin.name.NativeRuntimeNames
 
 internal class RTTIGenerator(
         override val generationState: NativeGenerationState,
@@ -381,11 +380,11 @@ internal class RTTIGenerator(
 
     private fun mapRuntimeType(type: LLVMTypeRef, isObjectType: Boolean): Int {
         if (isObjectType) {
-            require(type == llvm.pointerType) { "Expected object type, got ${llvmtype2string(type)}" }
+            require(type == llvm.pointerType) { "Expected object type, got ${type.toTypeString()}" }
             return RT_OBJECT
         }
 
-        return primitiveRuntimeTypeMap[type] ?: throw Error("Unmapped type: ${llvmtype2string(type)}")
+        return primitiveRuntimeTypeMap[type] ?: throw Error("Unmapped type: ${type.toTypeString()}")
     }
 
     private val debugRuntimeOrNull: LLVMModuleRef? by lazy {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/linkObjC.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/linkObjC.kt
@@ -170,7 +170,7 @@ private fun PatchBuilder.buildAndApply(llvmModule: LLVMModuleRef, state: NativeG
 
 private fun getStringValue(initializer: LLVMValueRef): String? = when (LLVMGetValueKind(initializer)) {
     LLVMValueKind.LLVMConstantDataArrayValueKind -> memScoped {
-        require(LLVMIsConstantString(initializer) != 0) { "not a constant string: ${llvm2string(initializer)}" }
+        require(LLVMIsConstantString(initializer) != 0) { "not a constant string: ${initializer.toValueString()}" }
 
         val lengthVar = alloc<size_tVar>()
         val bytePtr = LLVMGetAsString(initializer, lengthVar.ptr)!!
@@ -178,7 +178,7 @@ private fun getStringValue(initializer: LLVMValueRef): String? = when (LLVMGetVa
 
         val lastByte = bytePtr[length - 1]
         require(lastByte == 0.toByte()) {
-            "${llvm2string(initializer)}:\n  expected zero terminator, found $lastByte"
+            "${initializer.toValueString()}:\n  expected zero terminator, found $lastByte"
         }
 
         bytePtr.toKString()
@@ -186,7 +186,7 @@ private fun getStringValue(initializer: LLVMValueRef): String? = when (LLVMGetVa
 
     LLVMValueKind.LLVMConstantAggregateZeroValueKind -> ""
 
-    else -> error("Unexpected literal initializer: ${llvm2string(initializer)}")
+    else -> error("Unexpected literal initializer: ${initializer.toValueString()}")
 }
 
 private fun <T, K> List<T>.associateNonRepeatingBy(keySelector: (T) -> K): Map<K, T> =
@@ -212,7 +212,7 @@ private fun patchLiteral(
         generateSequence(LLVMGetFirstUse(global), { LLVMGetNextUse(it) }).forEach { use ->
             val firstCharPtr = LLVMGetUser(use)!!.also {
                 require(it.isFirstCharPtr(llvm, global)) {
-                    "Unexpected literal usage: ${llvm2string(it)}"
+                    "Unexpected literal usage: ${it.toValueString()}"
                 }
             }
             LLVMReplaceAllUsesWith(firstCharPtr, newFirstCharPtr)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/WritableTypeInfo.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/WritableTypeInfo.kt
@@ -5,9 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan.llvm.objcexport
 
-import kotlinx.cinterop.toKString
 import llvm.LLVMLinkage
-import llvm.LLVMPrintTypeToString
 import org.jetbrains.kotlin.backend.konan.llvm.CodeGenerator
 import org.jetbrains.kotlin.backend.konan.llvm.ConstPointer
 import org.jetbrains.kotlin.backend.konan.llvm.ConstValue
@@ -17,6 +15,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.Struct
 import org.jetbrains.kotlin.backend.konan.llvm.isExported
 import org.jetbrains.kotlin.backend.konan.llvm.llvmType
 import org.jetbrains.kotlin.backend.konan.llvm.replaceExternalWeakOrCommonGlobal
+import org.jetbrains.kotlin.backend.konan.llvm.toTypeString
 import org.jetbrains.kotlin.backend.konan.llvm.writableTypeInfoSymbolName
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.util.isInterface
@@ -137,8 +136,8 @@ private fun CodeGenerator.buildWritableTypeInfoValue(
     if (convertToRetained != null) {
         val expectedType = llvm.pointerType
         assert(convertToRetained.llvmType == expectedType) {
-            "Expected: ${LLVMPrintTypeToString(expectedType)!!.toKString()} " +
-                    "found: ${LLVMPrintTypeToString(convertToRetained.llvmType)!!.toKString()}"
+            "Expected: ${expectedType.toTypeString()} " +
+                    "found: ${convertToRetained.llvmType.toTypeString()}"
         }
     }
 


### PR DESCRIPTION
Small cleanup to make conversion of LLVM Types/Values to Strings more consistent and idiomatic to Kotlin.

It basically converts the old `llvm2string` and `llvmtype2string` functions to their extension version, and replace the raw usages of `LLVMPrintValueToString` and `LLVMPrintTypeToString` to their new wrappers (so we have a single 'failure' point).