### PR TITLE
[Gradle] Make sure that perf metric for lowerings is reported correctly

### DIFF
--- a/compiler/build-tools/kotlin-build-statistics/src/org/jetbrains/kotlin/build/report/metrics/CustomBuildTimeMetric.kt
+++ b/compiler/build-tools/kotlin-build-statistics/src/org/jetbrains/kotlin/build/report/metrics/CustomBuildTimeMetric.kt
@@ -12,16 +12,20 @@ class CustomBuildTimeMetric private constructor(name: String, parent: BuildTimeM
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is CustomBuildTimeMetric) return false
-        return this.name == other.name
+        // The same lowering may run both on the first (pre-serialization) and on the second compilation stage,
+        // producing dynamic phases with equal names but different parent metrics (e.g. IR_PRE_LOWERING vs IR_LOWERING).
+        // Distinguish such metrics by the parent as well, otherwise their measurements get merged and the
+        // performance report becomes incorrect (KT-87438).
+        return this.name == other.name && this.parent == other.parent
     }
 
-    override fun hashCode(): Int = name.hashCode()
+    override fun hashCode(): Int = 31 * name.hashCode() + (parent?.hashCode() ?: 0)
 
     companion object {
         fun createIfDoesNotExistAndReturn(name: String, parent: BuildTimeMetric? = null): BuildTimeMetric {
             val newCustomBuildTimeMetric = CustomBuildTimeMetric(name, parent)
             allCustomBuildTimeMetrics.addIfAbsent(newCustomBuildTimeMetric)
-            return getAllCustomBuildTimeMetrics().find { it.name == name }
+            return getAllCustomBuildTimeMetrics().find { it == newCustomBuildTimeMetric }
                 ?: error("Cannot find metric $name") //I am not sure how it could be
         }
     }

--- a/compiler/build-tools/kotlin-build-statistics/src/org/jetbrains/kotlin/build/report/statistics/json/BuildExecutionDataGson.kt
+++ b/compiler/build-tools/kotlin-build-statistics/src/org/jetbrains/kotlin/build/report/statistics/json/BuildExecutionDataGson.kt
@@ -22,6 +22,14 @@ import org.jetbrains.kotlin.build.report.metrics.getAllMetrics
 import java.io.File
 import java.lang.reflect.Type
 
+private fun BuildPerformanceMetric.matches(metricName: String, parentMetricName: String?): Boolean {
+    return if (this is CustomBuildTimeMetric) {
+        this.name == metricName && this.parent?.name == parentMetricName
+    } else {
+        this.name == metricName
+    }
+}
+
 val buildExecutionDataGson = GsonBuilder()
     .enableComplexMapKeySerialization()
     .registerTypeAdapter(File::class.java, object : JsonSerializer<File> {
@@ -42,15 +50,16 @@ val buildExecutionDataGson = GsonBuilder()
             context: JsonDeserializationContext?,
         ): BuildPerformanceMetric? {
             val metricName = json?.asJsonObject["name"]?.let { context?.deserialize<String>(it, String::class.java) } ?: return null
-            val metric = getAllMetrics().firstOrNull { it.name == metricName }
+            val parentMetricName =
+                json.asJsonObject["parent"]?.asJsonObject["name"]?.let { context?.deserialize<String>(it, String::class.java) }
+
+            val metric = getAllMetrics().firstOrNull { it.matches(metricName, parentMetricName) }
             if (metric != null) return metric
 
             if (metricName.startsWith(KlibSizeMetric.ROOT_METRIC_NAME)) {
                 return KlibSizeMetric.createIfDoesNotExistAndReturn(metricName)
             }
 
-            val parentMetricName =
-                json.asJsonObject["parent"]?.asJsonObject["name"]?.let { context?.deserialize<String>(it, String::class.java) }
             val parentMetric = allBuildTimeMetrics.firstOrNull { it.name == parentMetricName }
 
             return CustomBuildTimeMetric.createIfDoesNotExistAndReturn(name = metricName, parentMetric)
@@ -63,11 +72,11 @@ val buildExecutionDataGson = GsonBuilder()
             context: JsonDeserializationContext?,
         ): BuildTimeMetric? {
             val metricName = json?.asJsonObject["name"]?.let { context?.deserialize<String>(it, String::class.java) } ?: return null
-            val metric = allBuildTimeMetrics.firstOrNull { it.name == metricName }
-            if (metric != null) return metric
-
             val parentMetricName =
                 json.asJsonObject["parent"]?.asJsonObject["name"]?.let { context?.deserialize<String>(it, String::class.java) }
+            val metric = allBuildTimeMetrics.firstOrNull { it.matches(metricName, parentMetricName) }
+            if (metric != null) return metric
+
             val parentMetric = allBuildTimeMetrics.firstOrNull { it.name == parentMetricName }
 
             return CustomBuildTimeMetric.createIfDoesNotExistAndReturn(name = metricName, parentMetric)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
@@ -323,11 +323,11 @@ class BuildReportsIT : KGPBaseTest() {
     }
 
     val nativeBuildExpectedMetrics = arrayOf(
-        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("InlineFunctionSerializationPreProcessing"),
-        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrBeforeLowering"),
-        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrAfterLowering"),
-        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("llvm-default.AlwaysInlinerPass"),
-        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("InlineFunctionSerializationPreProcessing"),
+        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("InlineFunctionSerializationPreProcessing", IR_PRE_LOWERING),
+        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrBeforeLowering", IR_LOWERING),
+        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrAfterLowering", IR_LOWERING),
+        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("llvm-default.AlwaysInlinerPass", BACKEND),
+        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("InlineFunctionSerializationPreProcessing", IR_PRE_LOWERING),
         RUN_COMPILATION_IN_WORKER,
         NATIVE_IN_PROCESS,
         IR_PRE_LOWERING,
@@ -1134,7 +1134,7 @@ class BuildReportsIT : KGPBaseTest() {
                     taskName = null,
                     NATIVE_IN_PROCESS,
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("UpgradeCallableReferences", IR_PRE_LOWERING),
-                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("AssertionWrapperLowering", IR_PRE_LOWERING),
+                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("NativeAssertionWrapperLowering", IR_PRE_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("AvoidLocalFOsInInlineFunctionsLowering", IR_PRE_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("LateinitLowering", IR_PRE_LOWERING)
                 ) { buildExecutionData ->


### PR DESCRIPTION
In the compiler we can have the same lowering to be executed twice. Once on the first stage (IR_PRE_LOWERING) and once on the second (IR_LOWERING). It is important to distinguish them, otherwise we will have an incorrect report.

Compilers itself report these metrics separately under different parents, but inside Gradle they get mixed up because `CustomBuildTimeMetric` did not account for parent metric.

#KT-87438 Fixed