### PR TITLE
[KT-53477] native gradle plugin doesn't add compiler plugin transitive dependencies to compiler plugin classpath

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/compilerPlugins/NativeCompilerPluginTransitiveClasspathIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/compilerPlugins/NativeCompilerPluginTransitiveClasspathIT.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.compilerPlugins
+
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.testbase.GradleTest
+import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
+import org.jetbrains.kotlin.gradle.testbase.OsCondition
+import org.jetbrains.kotlin.gradle.testbase.OtherGradlePluginTests
+import org.jetbrains.kotlin.gradle.testbase.assertOutputContains
+import org.jetbrains.kotlin.gradle.testbase.buildAndFail
+import org.jetbrains.kotlin.gradle.testbase.project
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.condition.OS
+
+@DisplayName("Native compiler plugin transitive classpath")
+@OtherGradlePluginTests
+@OsCondition(
+    supportedOn = [OS.MAC],
+    enabledOnCI = [OS.MAC],
+)
+class NativeCompilerPluginTransitiveClasspathIT : KGPBaseTest() {
+
+    @DisplayName("Native compiler plugin classpath includes transitive dependencies")
+    @GradleTest
+    fun testNativeCompilerPluginTransitiveClasspath(
+        gradleVersion: GradleVersion
+    ) {
+        project(
+            "nativeCompilerPluginTransitiveClasspath",
+            gradleVersion
+        ) {
+            buildAndFail(":app:compileKotlinNative") {
+                assertOutputContains(
+                    "ClassNotFoundException: test.helper.CompilerPluginHelper"
+                )
+            }
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/compilerPlugins/NativeCompilerPluginTransitiveClasspathIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/compilerPlugins/NativeCompilerPluginTransitiveClasspathIT.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
 import org.jetbrains.kotlin.gradle.testbase.OsCondition
 import org.jetbrains.kotlin.gradle.testbase.OtherGradlePluginTests
 import org.jetbrains.kotlin.gradle.testbase.assertOutputContains
-import org.jetbrains.kotlin.gradle.testbase.buildAndFail
+import org.jetbrains.kotlin.gradle.testbase.build
 import org.jetbrains.kotlin.gradle.testbase.project
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.condition.OS
@@ -33,9 +33,9 @@ class NativeCompilerPluginTransitiveClasspathIT : KGPBaseTest() {
             "nativeCompilerPluginTransitiveClasspath",
             gradleVersion
         ) {
-            buildAndFail(":app:compileKotlinNative") {
+            build(":app:compileKotlinNative") {
                 assertOutputContains(
-                    "ClassNotFoundException: test.helper.CompilerPluginHelper"
+                    "Compiler plugin transitive dependency is available"
                 )
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/app/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/app/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+kotlin {
+    if (System.getProperty("os.arch") == "aarch64") {
+        macosArm64("native")
+    } else {
+        macosX64("native")
+    }
+}
+
+dependencies {
+    add(
+        "kotlinNativeCompilerPluginClasspath",
+        project(":compiler-plugin")
+    )
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/app/src/commonMain/kotlin/App.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/app/src/commonMain/kotlin/App.kt
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+fun applicationValue(): String = "OK"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    kotlin("jvm") apply false
+    kotlin("multiplatform") apply false
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/compiler-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/compiler-plugin/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":helper"))
+
+    compileOnly(kotlin("compiler-embeddable"))
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/compiler-plugin/src/main/kotlin/test/plugin/TestCompilerPluginRegistrar.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/compiler-plugin/src/main/kotlin/test/plugin/TestCompilerPluginRegistrar.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.plugin
+
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import test.helper.CompilerPluginHelper
+
+@OptIn(ExperimentalCompilerApi::class)
+class TestCompilerPluginRegistrar : CompilerPluginRegistrar() {
+    override val supportsK2: Boolean = true
+    override val pluginId: String = "test.native-transitive-classpath"
+
+    override fun ExtensionStorage.registerExtensions(
+        configuration: CompilerConfiguration
+    ) {
+        CompilerPluginHelper.verifyAvailable()
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,6 @@
+#
+# Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+# Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+#
+
+test.plugin.TestCompilerPluginRegistrar

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/helper/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/helper/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    kotlin("jvm")
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/helper/src/main/kotlin/test/helper/CompilerPluginHelper.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/helper/src/main/kotlin/test/helper/CompilerPluginHelper.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package test.helper
+
+object CompilerPluginHelper {
+    fun verifyAvailable() {
+        println("Compiler plugin transitive dependency is available")
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/settings.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/nativeCompilerPluginTransitiveClassPath/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "nativeCompilerPluginTransitiveClasspath"
+
+include(":helper")
+include(":compiler-plugin")
+include(":app")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/factory/KotlinCompilationDependencyConfigurationsFactories.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/factory/KotlinCompilationDependencyConfigurationsFactories.kt
@@ -207,7 +207,6 @@ private fun KotlinCompilationDependencyConfigurationsContainer(
 
         if (target.platformType == KotlinPlatformType.native) {
             extendsFrom(target.project.configurations.getByName(NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME))
-            isTransitive = false
         } else {
             extendsFrom(target.project.commonKotlinPluginClasspath)
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/CompilationSpecificPluginPath.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/CompilationSpecificPluginPath.kt
@@ -138,7 +138,7 @@ internal class CompilationSpecificPluginPath {
     }
 
     @Test
-    fun `native plugin configuration should not be transitive`() {
+    fun `native plugin configuration should be transitive`() {
         val project = buildProjectWithMPP {
             kotlin {
                 jvm()
@@ -150,7 +150,7 @@ internal class CompilationSpecificPluginPath {
             .configurations
             .getByName(pluginClassPathConfiguration("linuxX64", "main"))
 
-        assertFalse(nativeConfig.isTransitive)
+        assertTrue(nativeConfig.isTransitive)
     }
 
     @Test


### PR DESCRIPTION
- Add repro IT .
- Remove `isTransitive=false` from `NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME`

#KT-53477 Ready for Review