### PR TITLE
Add DeserializedCallableMemberDescriptor.companionExtensionClass

### DIFF
--- a/core/descriptors/src/org/jetbrains/kotlin/descriptors/ParameterDescriptor.java
+++ b/core/descriptors/src/org/jetbrains/kotlin/descriptors/ParameterDescriptor.java
@@ -17,7 +17,6 @@
 package org.jetbrains.kotlin.descriptors;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.kotlin.types.KotlinType;
 
 public interface ParameterDescriptor extends ValueDescriptor {
     @NotNull

--- a/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt
+++ b/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/MemberDeserializer.kt
@@ -48,6 +48,7 @@ class MemberDeserializer(private val c: DeserializationContext) {
             c.nameResolver,
             c.typeTable,
             c.versionRequirementTable,
+            null,
             c.containerSource
         )
 
@@ -71,6 +72,11 @@ class MemberDeserializer(private val c: DeserializationContext) {
                 proto.contextReceiverTypes(c.typeTable), proto.contextParameterList, proto, AnnotatedCallableKind.PROPERTY_GETTER,
             ),
         )
+
+        property.companionExtensionClass = proto.companionExtensionReceiverType(c.typeTable)
+            ?.let(local.typeDeserializer::type)
+            ?.constructor
+            ?.declarationDescriptor as? ClassDescriptor
 
         // Per documentation on Property.getter_flags in metadata.proto, if an accessor flags field is absent, its value should be computed
         // by taking hasAnnotations/visibility/modality from property flags, and using false for the rest
@@ -210,7 +216,7 @@ class MemberDeserializer(private val c: DeserializationContext) {
                 c.versionRequirementTable
         val function = DeserializedSimpleFunctionDescriptor(
             c.containingDeclaration, /* original = */ null, annotations, c.nameResolver.getName(proto.name),
-            ProtoEnumFlags.memberKind(Flags.MEMBER_KIND.get(flags)), proto, c.nameResolver, c.typeTable, versionRequirementTable,
+            ProtoEnumFlags.memberKind(Flags.MEMBER_KIND.get(flags)), proto, c.nameResolver, c.typeTable, versionRequirementTable, null,
             c.containerSource
         )
 
@@ -240,6 +246,11 @@ class MemberDeserializer(private val c: DeserializationContext) {
         function.isSuspend = Flags.IS_SUSPEND.get(flags)
         function.isExpect = Flags.IS_EXPECT_FUNCTION.get(flags)
         function.setHasStableParameterNames(!Flags.IS_FUNCTION_WITH_NON_STABLE_PARAMETER_NAMES.get(flags))
+
+        function.companionExtensionClass = proto.companionExtensionReceiverType(c.typeTable)
+            ?.let(local.typeDeserializer::type)
+            ?.constructor
+            ?.declarationDescriptor as? ClassDescriptor
 
         val mapValueForContract =
             c.components.contractDeserializer.deserializeContractFromFunction(proto, function, c.typeTable, local.typeDeserializer)

--- a/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberDescriptor.kt
+++ b/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberDescriptor.kt
@@ -35,7 +35,9 @@ interface DeserializedMemberDescriptor : DeserializedDescriptor, MemberDescripto
 }
 
 @K1Deprecation
-interface DeserializedCallableMemberDescriptor : DeserializedMemberDescriptor, CallableMemberDescriptor
+interface DeserializedCallableMemberDescriptor : DeserializedMemberDescriptor, CallableMemberDescriptor {
+    val companionExtensionClass: ClassDescriptor?
+}
 
 @K1Deprecation
 class DeserializedSimpleFunctionDescriptor(
@@ -48,6 +50,7 @@ class DeserializedSimpleFunctionDescriptor(
     override val nameResolver: NameResolver,
     override val typeTable: TypeTable,
     override val versionRequirementTable: VersionRequirementTable,
+    override var companionExtensionClass: ClassDescriptor?,
     override val containerSource: DeserializedContainerSource?,
     source: SourceElement? = null
 ) : DeserializedCallableMemberDescriptor,
@@ -66,7 +69,7 @@ class DeserializedSimpleFunctionDescriptor(
     ): FunctionDescriptorImpl {
         return DeserializedSimpleFunctionDescriptor(
             newOwner, original as SimpleFunctionDescriptor?, annotations, newName ?: name, kind,
-            proto, nameResolver, typeTable, versionRequirementTable, containerSource, source
+            proto, nameResolver, typeTable, versionRequirementTable, companionExtensionClass, containerSource, source
         ).also {
             it.setHasStableParameterNames(hasStableParameterNames())
         }
@@ -92,6 +95,7 @@ class DeserializedPropertyDescriptor(
         override val nameResolver: NameResolver,
         override val typeTable: TypeTable,
         override val versionRequirementTable: VersionRequirementTable,
+        override var companionExtensionClass: ClassDescriptor?,
         override val containerSource: DeserializedContainerSource?
 ) : DeserializedCallableMemberDescriptor, PropertyDescriptorImpl(
     containingDeclaration, original, annotations, modality, visibility, isVar, name, kind, SourceElement.NO_SOURCE,
@@ -108,7 +112,7 @@ class DeserializedPropertyDescriptor(
     ): PropertyDescriptorImpl {
         return DeserializedPropertyDescriptor(
             newOwner, original, annotations, newModality, newVisibility, isVar, newName, kind, isLateInit, isConst, isExternal,
-            isDelegated, isExpect, proto, nameResolver, typeTable, versionRequirementTable, containerSource
+            isDelegated, isExpect, proto, nameResolver, typeTable, versionRequirementTable, companionExtensionClass, containerSource
         )
     }
 
@@ -154,6 +158,8 @@ class DeserializedClassConstructorDescriptor(
     override fun isTailrec(): Boolean = false
 
     override fun isSuspend(): Boolean = false
+
+    override val companionExtensionClass: ClassDescriptor? get() = null
 }
 
 @K1Deprecation


### PR DESCRIPTION
To be used by reflection for `KCallable.companionExtensionClass`.

^KT-85904