### PR TITLE
[cli-base] add missed methods to VarHandleWrapper and VarHandleWrappe…

### DIFF
--- a/compiler/cli/cli-base/src/com/intellij/util/containers/VarHandleWrapper.java
+++ b/compiler/cli/cli-base/src/com/intellij/util/containers/VarHandleWrapper.java
@@ -50,6 +50,9 @@ public abstract class VarHandleWrapper {
         @NotNull VarHandleWrapper createForArrayElement(@NotNull Class<?> arrayClass);
     }
 
+    public abstract Object getVolatile(Object thisObject);
+    public abstract void setVolatile(Object thisObject, Object value);
+
     public abstract boolean compareAndSet(Object thisObject, Object expected, Object actual);
     public abstract boolean compareAndSetInt(Object thisObject, int expected, int actual);
     public abstract boolean compareAndSetLong(Object thisObject, long expected, long actual);

--- a/compiler/cli/cli-base/srcJdk9/com/intellij/concurrency/VarHandleWrapperImpl.java
+++ b/compiler/cli/cli-base/srcJdk9/com/intellij/concurrency/VarHandleWrapperImpl.java
@@ -15,6 +15,7 @@ import java.lang.invoke.VarHandle;
 /**
  * Implementation of {@link VarHandleWrapper} based on {@link VarHandle}, when the latter is available in the classpath
  */
+@SuppressWarnings({"unused", "UnstableApiUsage"})
 @ApiStatus.Internal
 public class VarHandleWrapperImpl extends VarHandleWrapper implements VarHandleWrapper.VarHandleWrapperFactory {
     private final VarHandle myVarHandle;
@@ -43,6 +44,18 @@ public class VarHandleWrapperImpl extends VarHandleWrapper implements VarHandleW
     public @NotNull VarHandleWrapper createForArrayElement(@NotNull Class<?> arrayClass) {
         assert arrayClass.isArray();
         return new VarHandleWrapperImpl(MethodHandles.arrayElementVarHandle(arrayClass), true);
+    }
+
+    //@Override
+    public Object getVolatile(Object thisObject) {
+        assert !isArray;
+        return myVarHandle.getVolatile(thisObject);
+    }
+
+    //@Override
+    public void setVolatile(Object thisObject, Object value) {
+        assert !isArray;
+        myVarHandle.setVolatile(thisObject, value);
     }
 
     @Override


### PR DESCRIPTION
…rImpl

Those classes might substitute real source classes in the IntelliJ platform, so they have to be the same until KT-87672 is fixed

^KT-82657