### PR TITLE
[Header mode] Skip generating bodies of synthetic functions, getters/setters

### DIFF
--- a/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
+++ b/compiler/fir/entrypoint/src/org/jetbrains/kotlin/fir/pipeline/convertToIr.kt
@@ -307,6 +307,7 @@ private class Fir2IrPipeline(
     }
 
     private fun Fir2IrConversionResult.generateSyntheticBodiesOfDataValueMembers() {
+        if (componentsStorage.configuration.languageVersionSettings.getFlag(AnalysisFlags.headerMode)) return
         Fir2IrDataClassGeneratedMemberBodyGenerator(irBuiltIns)
             .generateBodiesForClassesWithSyntheticDataClassMembers(generatedDataValueClassSyntheticFunctions, symbolTable)
     }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/ClassMemberGenerator.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/generators/ClassMemberGenerator.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.fir.backend.generators
 import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.util.PrivateForInline
 import org.jetbrains.kotlin.fir.backend.*
 import org.jetbrains.kotlin.fir.backend.utils.convertWithOffsets
 import org.jetbrains.kotlin.fir.backend.utils.unwrapCallRepresentative
@@ -304,32 +305,61 @@ internal class ClassMemberGenerator(
                     val fieldSymbol = backingField?.symbol
                     val declaration = this
                     if (fieldSymbol != null && !configuration.skipBodies) {
-                        body = factory.createBlockBody(
-                            startOffset, endOffset,
-                            listOf(
-                                if (isSetter) {
-                                    IrSetFieldImpl(startOffset, endOffset, fieldSymbol, builtins.unitType).apply {
-                                        setReceiver(declaration)
-                                        value = IrGetValueImpl(
-                                            startOffset,
-                                            endOffset,
-                                            fieldType,
-                                            parameters.first { it.kind == IrParameterKind.Regular }.symbol
+                        val headerMode = configuration.languageVersionSettings.getFlag(AnalysisFlags.headerMode)
+                        body = if (!headerMode || isEnclosingScopeInline(propertyAccessor, correspondingProperty)) {
+                            factory.createBlockBody(
+                                startOffset, endOffset,
+                                listOf(
+                                    if (isSetter) {
+                                        IrSetFieldImpl(startOffset, endOffset, fieldSymbol, builtins.unitType).apply {
+                                            setReceiver(declaration)
+                                            value = IrGetValueImpl(
+                                                startOffset,
+                                                endOffset,
+                                                fieldType,
+                                                parameters.first { it.kind == IrParameterKind.Regular }.symbol
+                                            )
+                                        }
+                                    } else {
+                                        IrReturnImpl(
+                                            startOffset, endOffset, builtins.nothingType, symbol,
+                                            IrGetFieldImpl(startOffset, endOffset, fieldSymbol, fieldType).setReceiver(declaration)
                                         )
                                     }
-                                } else {
-                                    IrReturnImpl(
-                                        startOffset, endOffset, builtins.nothingType, symbol,
-                                        IrGetFieldImpl(startOffset, endOffset, fieldSymbol, fieldType).setReceiver(declaration)
-                                    )
-                                }
+                                )
                             )
-                        )
+                        } else {
+                            factory.createBlockBody(startOffset, endOffset)
+                        }
                     }
                     declarationStorage.leaveScope(this.symbol)
                 }
             }
         }
+    }
+
+    @OptIn(PrivateForInline::class)
+    private fun IrSimpleFunction.isEnclosingScopeInline(
+        propertyAccessor: FirPropertyAccessor?,
+        correspondingProperty: IrProperty,
+    ): Boolean {
+        if (this.isInline) return true
+        if (propertyAccessor?.isInline == true) return true
+        if (correspondingProperty.getter?.isInline == true || correspondingProperty.setter?.isInline == true) return true
+
+        if (conversionScope.functionStack.any { it.isInline }) return true
+        if (conversionScope.propertyStack.any { pair ->
+                val irProp = pair.first
+                val firProp = pair.second
+                firProp?.isInline == true || irProp.getter?.isInline == true || irProp.setter?.isInline == true
+            }) return true
+
+        for (parent in conversionScope.parentStack) {
+            if (parent is IrFunction && parent.isInline) return true
+            if (parent is IrProperty && (parent.getter?.isInline == true || parent.setter?.isInline == true)) return true
+        }
+
+        return false
     }
 
     @OptIn(UnsafeDuringIrConstructionAPI::class)

--- a/compiler/testData/diagnostics/tests/headerMode/anonymousObjects.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/anonymousObjects.ir.txt
@@ -1,0 +1,3 @@
+FILE fqName:<root> fileName:/anonymousObjects.kt
+  FUN name:useAnonObject visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY

--- a/compiler/testData/diagnostics/tests/headerMode/classDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/classDeclaration.ir.txt
@@ -1,0 +1,148 @@
+FILE fqName:<root> fileName:/classDeclaration.kt
+  CLASS CLASS name:A modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.A
+    CONSTRUCTOR visibility:public returnType:<root>.A [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:funA visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+    FUN name:funB visibility:public modality:FINAL returnType:kotlin.String [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun funB (): kotlin.String declared in <root>.A'
+          CONST String type=kotlin.String value="A.funB body"
+    FUN name:funD visibility:public modality:FINAL returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+    FUN name:funE visibility:public modality:FINAL returnType:kotlin.String [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+        FUN LOCAL_FUNCTION name:funF visibility:local modality:FINAL returnType:kotlin.String
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='local final fun funF (): kotlin.String declared in <root>.A.funE'
+              CONST String type=kotlin.String value="funF body"
+        RETURN type=kotlin.Nothing from='public final fun funE (): kotlin.String declared in <root>.A'
+          CALL 'local final fun funF (): kotlin.String declared in <root>.A.funE' type=kotlin.String origin=null
+    FUN name:isNotNull visibility:public modality:FINAL returnType:kotlin.Boolean
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Any?
+      annotations:
+        OptIn(markerClass = [ExperimentalContracts::class] type=kotlin.Array<out kotlin.reflect.KClass<out kotlin.Annotation>> varargElementType=kotlin.reflect.KClass<out kotlin.Annotation>)
+      BLOCK_BODY
+  CLASS CLASS name:C modality:FINAL visibility:public superTypes:[<root>.B]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.C
+    CLASS CLASS name:D modality:FINAL visibility:public [inner] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.C.D
+      CONSTRUCTOR visibility:public returnType:<root>.C.D [primary]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN name:funA visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C.D
+        BLOCK_BODY
+    CONSTRUCTOR visibility:public returnType:<root>.C [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.B
+    FUN FAKE_OVERRIDE name:funA visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B
+      overridden:
+        public open fun funA (): kotlin.String declared in <root>.B
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.B
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.B
+    FUN name:funB visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.C
+      overridden:
+        public abstract fun funB (): kotlin.String declared in <root>.B
+      BLOCK_BODY
+  CLASS CLASS name:E modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.E
+    CONSTRUCTOR visibility:public returnType:<root>.E [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:funA visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.E
+      BLOCK_BODY
+  CLASS CLASS name:F modality:FINAL visibility:public superTypes:[<root>.E]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.F
+    CONSTRUCTOR visibility:public returnType:<root>.F [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.E
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.E
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.E
+    FUN name:funA visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.F
+      overridden:
+        public final fun funA (): kotlin.String declared in <root>.E
+      BLOCK_BODY
+  CLASS INTERFACE name:B modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.B
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:funA visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B
+      BLOCK_BODY
+    FUN name:funB visibility:public modality:ABSTRACT returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B

--- a/compiler/testData/diagnostics/tests/headerMode/constructorDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/constructorDeclaration.ir.txt
@@ -1,0 +1,79 @@
+FILE fqName:<root> fileName:/constructorDeclaration.kt
+  CLASS CLASS name:A modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.A
+    PROPERTY name:a visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+        correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlin.String declared in <root>.A'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.A declared in <root>.A.<get-a>' type=<root>.A origin=null
+    PROPERTY name:b visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+        correspondingProperty: PROPERTY name:b visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-b> (): kotlin.Int declared in <root>.A'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.A declared in <root>.A.<get-b>' type=<root>.A origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.A
+    CONSTRUCTOR visibility:public returnType:<root>.A [primary]
+      VALUE_PARAMETER kind:Regular name:a index:0 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:b index:1 type:kotlin.Int
+    CONSTRUCTOR visibility:public returnType:<root>.A
+      VALUE_PARAMETER kind:Regular name:e index:0 type:kotlin.String
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS CLASS name:B modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.B
+    PROPERTY name:a visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B
+        correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlin.String declared in <root>.B'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.B declared in <root>.B.<get-a>' type=<root>.B origin=null
+    PROPERTY name:b visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B
+        correspondingProperty: PROPERTY name:b visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-b> (): kotlin.Int declared in <root>.B'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.B declared in <root>.B.<get-b>' type=<root>.B origin=null
+    CONSTRUCTOR visibility:private returnType:<root>.B [primary]
+      VALUE_PARAMETER kind:Regular name:a index:0 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:b index:1 type:kotlin.Int
+    CONSTRUCTOR visibility:public returnType:<root>.B
+    CONSTRUCTOR visibility:public returnType:<root>.B
+      VALUE_PARAMETER kind:Regular name:e index:0 type:kotlin.String
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any

--- a/compiler/testData/diagnostics/tests/headerMode/constructorDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/constructorDeclaration.ir.txt
@@ -7,18 +7,12 @@ FILE fqName:<root> fileName:/constructorDeclaration.kt
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
         correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlin.String declared in <root>.A'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.A declared in <root>.A.<get-a>' type=<root>.A origin=null
     PROPERTY name:b visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:public modality:FINAL returnType:kotlin.Int
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
         correspondingProperty: PROPERTY name:b visibility:public modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-b> (): kotlin.Int declared in <root>.A'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-              receiver: GET_VAR '<this>: <root>.A declared in <root>.A.<get-b>' type=<root>.A origin=null
     CONSTRUCTOR visibility:public returnType:<root>.A
     CONSTRUCTOR visibility:public returnType:<root>.A [primary]
       VALUE_PARAMETER kind:Regular name:a index:0 type:kotlin.String
@@ -46,18 +40,12 @@ FILE fqName:<root> fileName:/constructorDeclaration.kt
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B
         correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlin.String declared in <root>.B'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.B declared in <root>.B.<get-a>' type=<root>.B origin=null
     PROPERTY name:b visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:public modality:FINAL returnType:kotlin.Int
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B
         correspondingProperty: PROPERTY name:b visibility:public modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-b> (): kotlin.Int declared in <root>.B'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-              receiver: GET_VAR '<this>: <root>.B declared in <root>.B.<get-b>' type=<root>.B origin=null
     CONSTRUCTOR visibility:private returnType:<root>.B [primary]
       VALUE_PARAMETER kind:Regular name:a index:0 type:kotlin.String
       VALUE_PARAMETER kind:Regular name:b index:1 type:kotlin.Int

--- a/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.fir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.fir.txt
@@ -5,8 +5,9 @@ FILE: dataClassDeclaration.kt
         public final val name: R|kotlin/String|
             public get(): R|kotlin/String|
 
-        public final val age: R|kotlin/Int|
+        public final var age: R|kotlin/Int|
             public get(): R|kotlin/Int|
+            public set(value: R|kotlin/Int|): R|kotlin/Unit|
 
         public final operator fun component1(): R|kotlin/String|
 

--- a/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.ir.txt
@@ -1,0 +1,130 @@
+FILE fqName:<root> fileName:/dataClassDeclaration.kt
+  CLASS CLASS name:User modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.User
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.User'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.<get-name>' type=<root>.User origin=null
+    PROPERTY name:age visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-age> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+        correspondingProperty: PROPERTY name:age visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-age> (): kotlin.Int declared in <root>.User'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.<get-age>' type=<root>.User origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.User [primary]
+      VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:age index:1 type:kotlin.Int
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.User'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.component1' type=<root>.User origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL returnType:kotlin.Int [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.Int declared in <root>.User'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.component2' type=<root>.User origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.User
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.copy' type=<root>.User origin=null
+      VALUE_PARAMETER kind:Regular name:age index:2 type:kotlin.Int
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.copy' type=<root>.User origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String, age: kotlin.Int): <root>.User declared in <root>.User'
+          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, age: kotlin.Int) declared in <root>.User' type=<root>.User origin=null
+            ARG name: GET_VAR 'name: kotlin.String declared in <root>.User.copy' type=kotlin.String origin=null
+            ARG age: GET_VAR 'age: kotlin.Int declared in <root>.User.copy' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              ARG arg0: GET_VAR '<this>: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.User.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.User
+              GET_VAR 'other: kotlin.Any? declared in <root>.User.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.User [val]
+          TYPE_OP type=<root>.User origin=IMPLICIT_CAST typeOperand=<root>.User
+            GET_VAR 'other: kotlin.Any? declared in <root>.User.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_0: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR '<this>: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR 'val tmp_0: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        VAR name:result type:kotlin.Int [var]
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.hashCode' type=<root>.User origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.User.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.User.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                receiver: GET_VAR '<this>: <root>.User declared in <root>.User.hashCode' type=<root>.User origin=null
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.User'
+          GET_VAR 'var result: kotlin.Int declared in <root>.User.hashCode' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.User'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="User("
+            CONST String type=kotlin.String value="name="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.toString' type=<root>.User origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="age="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.toString' type=<root>.User origin=null
+            CONST String type=kotlin.String value=")"

--- a/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.ir.txt
@@ -7,18 +7,17 @@ FILE fqName:<root> fileName:/dataClassDeclaration.kt
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
         correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.User'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.<get-name>' type=<root>.User origin=null
-    PROPERTY name:age visibility:public modality:FINAL [val]
-      FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]
+    PROPERTY name:age visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-age> visibility:public modality:FINAL returnType:kotlin.Int
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
-        correspondingProperty: PROPERTY name:age visibility:public modality:FINAL [val]
+        correspondingProperty: PROPERTY name:age visibility:public modality:FINAL [var]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-age> (): kotlin.Int declared in <root>.User'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.<get-age>' type=<root>.User origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-age> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY name:age visibility:public modality:FINAL [var]
+        BLOCK_BODY
     CONSTRUCTOR visibility:public returnType:<root>.User [primary]
       VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
       VALUE_PARAMETER kind:Regular name:age index:1 type:kotlin.Int

--- a/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.ir.txt
@@ -22,109 +22,30 @@ FILE fqName:<root> fileName:/dataClassDeclaration.kt
     CONSTRUCTOR visibility:public returnType:<root>.User [primary]
       VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
       VALUE_PARAMETER kind:Regular name:age index:1 type:kotlin.Int
-    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
-      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
-      BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.User'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.component1' type=<root>.User origin=null
-    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL returnType:kotlin.Int [operator]
-      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
-      BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.Int declared in <root>.User'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.component2' type=<root>.User origin=null
-    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.User
-      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
-      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
-        EXPRESSION_BODY
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.copy' type=<root>.User origin=null
-      VALUE_PARAMETER kind:Regular name:age index:2 type:kotlin.Int
-        EXPRESSION_BODY
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-            receiver: GET_VAR '<this>: <root>.User declared in <root>.User.copy' type=<root>.User origin=null
-      BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String, age: kotlin.Int): <root>.User declared in <root>.User'
-          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, age: kotlin.Int) declared in <root>.User' type=<root>.User origin=null
-            ARG name: GET_VAR 'name: kotlin.String declared in <root>.User.copy' type=kotlin.String origin=null
-            ARG age: GET_VAR 'age: kotlin.Int declared in <root>.User.copy' type=kotlin.Int origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
       VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
-      BLOCK_BODY
-        WHEN type=kotlin.Unit origin=null
-          BRANCH
-            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
-              ARG arg0: GET_VAR '<this>: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
-              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.User.equals' type=kotlin.Any? origin=null
-            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
-              CONST Boolean type=kotlin.Boolean value=true
-        WHEN type=kotlin.Unit origin=null
-          BRANCH
-            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.User
-              GET_VAR 'other: kotlin.Any? declared in <root>.User.equals' type=kotlin.Any? origin=null
-            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
-              CONST Boolean type=kotlin.Boolean value=false
-        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.User [val]
-          TYPE_OP type=<root>.User origin=IMPLICIT_CAST typeOperand=<root>.User
-            GET_VAR 'other: kotlin.Any? declared in <root>.User.equals' type=kotlin.Any? origin=null
-        WHEN type=kotlin.Unit origin=null
-          BRANCH
-            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-                  receiver: GET_VAR '<this>: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
-                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-                  receiver: GET_VAR 'val tmp_0: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
-            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
-              CONST Boolean type=kotlin.Boolean value=false
-        WHEN type=kotlin.Unit origin=null
-          BRANCH
-            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-                  receiver: GET_VAR '<this>: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
-                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-                  receiver: GET_VAR 'val tmp_0: <root>.User declared in <root>.User.equals' type=<root>.User origin=null
-            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
-              CONST Boolean type=kotlin.Boolean value=false
-        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.User'
-          CONST Boolean type=kotlin.Boolean value=true
     FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
       overridden:
         public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      BLOCK_BODY
-        VAR name:result type:kotlin.Int [var]
-          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
-            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.hashCode' type=<root>.User origin=null
-        SET_VAR 'var result: kotlin.Int declared in <root>.User.hashCode' type=kotlin.Unit origin=EQ
-          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
-            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
-              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.User.hashCode' type=kotlin.Int origin=null
-              ARG other: CONST Int type=kotlin.Int value=31
-            ARG other: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
-              ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-                receiver: GET_VAR '<this>: <root>.User declared in <root>.User.hashCode' type=<root>.User origin=null
-        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.User'
-          GET_VAR 'var result: kotlin.Int declared in <root>.User.hashCode' type=kotlin.Int origin=null
     FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-      BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.User'
-          STRING_CONCATENATION type=kotlin.String
-            CONST String type=kotlin.String value="User("
-            CONST String type=kotlin.String value="name="
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.toString' type=<root>.User origin=null
-            CONST String type=kotlin.String value=", "
-            CONST String type=kotlin.String value="age="
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
-              receiver: GET_VAR '<this>: <root>.User declared in <root>.User.toString' type=<root>.User origin=null
-            CONST String type=kotlin.String value=")"
+    FUN name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+    FUN name:component2 visibility:public modality:FINAL returnType:kotlin.Int [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+    FUN name:copy visibility:public modality:FINAL returnType:<root>.User
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.User
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+        EXPRESSION_BODY
+          CALL 'public final fun <get-name> (): kotlin.String declared in <root>.User' type=kotlin.String origin=GET_PROPERTY
+            ARG <this>: GET_VAR '<this>: <root>.User declared in <root>.User.copy' type=<root>.User origin=IMPLICIT_ARGUMENT
+      VALUE_PARAMETER kind:Regular name:age index:2 type:kotlin.Int
+        EXPRESSION_BODY
+          CALL 'public final fun <get-age> (): kotlin.Int declared in <root>.User' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: GET_VAR '<this>: <root>.User declared in <root>.User.copy' type=<root>.User origin=IMPLICIT_ARGUMENT

--- a/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.kt
+++ b/compiler/testData/diagnostics/tests/headerMode/dataClassDeclaration.kt
@@ -1,5 +1,5 @@
 // RUN_PIPELINE_TILL: BACKEND
 // FIR_DUMP
-data class User(val name: String, val age: Int)
+data class User(val name: String, var age: Int)
 
 /* GENERATED_FIR_TAGS: classDeclaration, data, primaryConstructor, propertyDeclaration */

--- a/compiler/testData/diagnostics/tests/headerMode/enumClassDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/enumClassDeclaration.ir.txt
@@ -1,0 +1,201 @@
+FILE fqName:<root> fileName:/enumClassDeclaration.kt
+  CLASS ENUM_CLASS name:A modality:FINAL visibility:public superTypes:[kotlin.Enum<<root>.A>]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.A
+    ENUM_ENTRY name:EAST
+      init: EXPRESSION_BODY
+        ENUM_CONSTRUCTOR_CALL 'private constructor <init> () declared in <root>.A'
+    ENUM_ENTRY name:WEST
+      init: EXPRESSION_BODY
+        ENUM_CONSTRUCTOR_CALL 'private constructor <init> () declared in <root>.A'
+    CONSTRUCTOR visibility:private returnType:<root>.A [primary]
+    FUN ENUM_CLASS_SPECIAL_MEMBER name:valueOf visibility:public modality:FINAL returnType:<root>.A [companion]
+      VALUE_PARAMETER kind:Regular name:value index:0 type:kotlin.String
+      SYNTHETIC_BODY kind=ENUM_VALUEOF
+    FUN ENUM_CLASS_SPECIAL_MEMBER name:values visibility:public modality:FINAL returnType:kotlin.Array<<root>.A> [companion]
+      SYNTHETIC_BODY kind=ENUM_VALUES
+    FUN FAKE_OVERRIDE name:compareTo visibility:public modality:FINAL returnType:kotlin.Int [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.A>
+      VALUE_PARAMETER kind:Regular name:other index:1 type:<root>.A
+      overridden:
+        public final fun compareTo (other: E of kotlin.Enum): kotlin.Int declared in kotlin.Enum
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:FINAL returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.A>
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public final fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Enum
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.A>
+      overridden:
+        public final fun hashCode (): kotlin.Int declared in kotlin.Enum
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.A>
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Enum
+    PROPERTY ENUM_CLASS_SPECIAL_MEMBER name:entries visibility:public modality:FINAL [val]
+      FUN ENUM_CLASS_SPECIAL_MEMBER name:<get-entries> visibility:public modality:FINAL returnType:kotlin.enums.EnumEntries<<root>.A> [companion]
+        correspondingProperty: PROPERTY ENUM_CLASS_SPECIAL_MEMBER name:entries visibility:public modality:FINAL [val]
+        SYNTHETIC_BODY kind=ENUM_ENTRIES
+    PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+      annotations:
+        IntrinsicConstEvaluation
+      overridden:
+        public final name: kotlin.String declared in kotlin.Enum
+      FUN FAKE_OVERRIDE name:<get-name> visibility:public modality:FINAL returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.A>
+        correspondingProperty: PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+        overridden:
+          public final fun <get-name> (): kotlin.String declared in kotlin.Enum
+    PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+      overridden:
+        public final ordinal: kotlin.Int declared in kotlin.Enum
+      FUN FAKE_OVERRIDE name:<get-ordinal> visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.A>
+        correspondingProperty: PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+        overridden:
+          public final fun <get-ordinal> (): kotlin.Int declared in kotlin.Enum
+  CLASS ENUM_CLASS name:B modality:ABSTRACT visibility:public superTypes:[kotlin.Enum<<root>.B>]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.B
+    ENUM_ENTRY name:NORTH
+      init: EXPRESSION_BODY
+        ENUM_CONSTRUCTOR_CALL 'private constructor <init> () declared in <root>.B.NORTH'
+      class: CLASS ENUM_ENTRY name:NORTH modality:FINAL visibility:private superTypes:[<root>.B]
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.B.NORTH
+        CONSTRUCTOR visibility:private returnType:<root>.B.NORTH [primary]
+        FUN FAKE_OVERRIDE name:compareTo visibility:public modality:FINAL returnType:kotlin.Int [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          VALUE_PARAMETER kind:Regular name:other index:1 type:<root>.B
+          overridden:
+            public final fun compareTo (other: <root>.B): kotlin.Int declared in <root>.B
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:FINAL returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+          overridden:
+            public final fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.B
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          overridden:
+            public final fun hashCode (): kotlin.Int declared in <root>.B
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          overridden:
+            public open fun toString (): kotlin.String declared in <root>.B
+        FUN name:getString visibility:public modality:OPEN returnType:kotlin.String
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B.NORTH
+          overridden:
+            public abstract fun getString (): kotlin.String declared in <root>.B
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public open fun getString (): kotlin.String declared in <root>.B.NORTH'
+              CONST String type=kotlin.String value="north"
+        PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+          annotations:
+            IntrinsicConstEvaluation
+          overridden:
+            public final name: kotlin.String declared in <root>.B
+          FUN FAKE_OVERRIDE name:<get-name> visibility:public modality:FINAL returnType:kotlin.String [fake_override]
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+            correspondingProperty: PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+            overridden:
+              public final fun <get-name> (): kotlin.String declared in <root>.B
+        PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+          overridden:
+            public final ordinal: kotlin.Int declared in <root>.B
+          FUN FAKE_OVERRIDE name:<get-ordinal> visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+            correspondingProperty: PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+            overridden:
+              public final fun <get-ordinal> (): kotlin.Int declared in <root>.B
+    ENUM_ENTRY name:SOUTH
+      init: EXPRESSION_BODY
+        ENUM_CONSTRUCTOR_CALL 'private constructor <init> () declared in <root>.B.SOUTH'
+      class: CLASS ENUM_ENTRY name:SOUTH modality:FINAL visibility:private superTypes:[<root>.B]
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.B.SOUTH
+        CONSTRUCTOR visibility:private returnType:<root>.B.SOUTH [primary]
+        FUN FAKE_OVERRIDE name:compareTo visibility:public modality:FINAL returnType:kotlin.Int [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          VALUE_PARAMETER kind:Regular name:other index:1 type:<root>.B
+          overridden:
+            public final fun compareTo (other: <root>.B): kotlin.Int declared in <root>.B
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:FINAL returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+          overridden:
+            public final fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.B
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          overridden:
+            public final fun hashCode (): kotlin.Int declared in <root>.B
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+          overridden:
+            public open fun toString (): kotlin.String declared in <root>.B
+        FUN name:getString visibility:public modality:OPEN returnType:kotlin.String
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B.SOUTH
+          overridden:
+            public abstract fun getString (): kotlin.String declared in <root>.B
+          BLOCK_BODY
+        PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+          annotations:
+            IntrinsicConstEvaluation
+          overridden:
+            public final name: kotlin.String declared in <root>.B
+          FUN FAKE_OVERRIDE name:<get-name> visibility:public modality:FINAL returnType:kotlin.String [fake_override]
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+            correspondingProperty: PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+            overridden:
+              public final fun <get-name> (): kotlin.String declared in <root>.B
+        PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+          overridden:
+            public final ordinal: kotlin.Int declared in <root>.B
+          FUN FAKE_OVERRIDE name:<get-ordinal> visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+            correspondingProperty: PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+            overridden:
+              public final fun <get-ordinal> (): kotlin.Int declared in <root>.B
+    CONSTRUCTOR visibility:private returnType:<root>.B [primary]
+    FUN ENUM_CLASS_SPECIAL_MEMBER name:valueOf visibility:public modality:FINAL returnType:<root>.B [companion]
+      VALUE_PARAMETER kind:Regular name:value index:0 type:kotlin.String
+      SYNTHETIC_BODY kind=ENUM_VALUEOF
+    FUN ENUM_CLASS_SPECIAL_MEMBER name:values visibility:public modality:FINAL returnType:kotlin.Array<<root>.B> [companion]
+      SYNTHETIC_BODY kind=ENUM_VALUES
+    FUN FAKE_OVERRIDE name:compareTo visibility:public modality:FINAL returnType:kotlin.Int [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+      VALUE_PARAMETER kind:Regular name:other index:1 type:<root>.B
+      overridden:
+        public final fun compareTo (other: E of kotlin.Enum): kotlin.Int declared in kotlin.Enum
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:FINAL returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public final fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Enum
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+      overridden:
+        public final fun hashCode (): kotlin.Int declared in kotlin.Enum
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Enum
+    FUN name:getString visibility:public modality:ABSTRACT returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.B
+    PROPERTY ENUM_CLASS_SPECIAL_MEMBER name:entries visibility:public modality:FINAL [val]
+      FUN ENUM_CLASS_SPECIAL_MEMBER name:<get-entries> visibility:public modality:FINAL returnType:kotlin.enums.EnumEntries<<root>.B> [companion]
+        correspondingProperty: PROPERTY ENUM_CLASS_SPECIAL_MEMBER name:entries visibility:public modality:FINAL [val]
+        SYNTHETIC_BODY kind=ENUM_ENTRIES
+    PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+      annotations:
+        IntrinsicConstEvaluation
+      overridden:
+        public final name: kotlin.String declared in kotlin.Enum
+      FUN FAKE_OVERRIDE name:<get-name> visibility:public modality:FINAL returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+        correspondingProperty: PROPERTY FAKE_OVERRIDE name:name visibility:public modality:FINAL [fake_override,val]
+        overridden:
+          public final fun <get-name> (): kotlin.String declared in kotlin.Enum
+    PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+      overridden:
+        public final ordinal: kotlin.Int declared in kotlin.Enum
+      FUN FAKE_OVERRIDE name:<get-ordinal> visibility:public modality:FINAL returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Enum<<root>.B>
+        correspondingProperty: PROPERTY FAKE_OVERRIDE name:ordinal visibility:public modality:FINAL [fake_override,val]
+        overridden:
+          public final fun <get-ordinal> (): kotlin.Int declared in kotlin.Enum

--- a/compiler/testData/diagnostics/tests/headerMode/functionDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/functionDeclaration.ir.txt
@@ -1,0 +1,57 @@
+FILE fqName:<root> fileName:/functionDeclaration.kt
+  FUN name:funA visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+  FUN name:funB visibility:public modality:FINAL returnType:kotlin.String [inline]
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun funB (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="funB body"
+  FUN name:funD visibility:public modality:FINAL returnType:kotlin.Int
+    BLOCK_BODY
+  FUN name:funE visibility:public modality:FINAL returnType:kotlin.String [inline]
+    BLOCK_BODY
+      FUN LOCAL_FUNCTION name:funF visibility:local modality:FINAL returnType:kotlin.String
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='local final fun funF (): kotlin.String declared in <root>.funE'
+            CONST String type=kotlin.String value="funF body"
+      RETURN type=kotlin.Nothing from='public final fun funE (): kotlin.String declared in <root>'
+        CALL 'local final fun funF (): kotlin.String declared in <root>.funE' type=kotlin.String origin=null
+  FUN name:funG visibility:public modality:FINAL returnType:kotlin.String [inline]
+    BLOCK_BODY
+      CLASS CLASS name:classA modality:FINAL visibility:local superTypes:[kotlin.Any]
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.funG.classA
+        CONSTRUCTOR visibility:public returnType:<root>.funG.classA [primary]
+          BLOCK_BODY
+            DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+            INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:classA modality:FINAL visibility:local superTypes:[kotlin.Any]' type=kotlin.Unit
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+          overridden:
+            public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun hashCode (): kotlin.Int declared in kotlin.Any
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun toString (): kotlin.String declared in kotlin.Any
+        FUN name:funH visibility:public modality:FINAL returnType:kotlin.String
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.funG.classA
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public final fun funH (): kotlin.String declared in <root>.funG.classA'
+              CONST String type=kotlin.String value="funH body"
+      VAR name:a type:<root>.funG.classA [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.funG.classA' type=<root>.funG.classA origin=null
+      RETURN type=kotlin.Nothing from='public final fun funG (): kotlin.String declared in <root>'
+        CALL 'public final fun funH (): kotlin.String declared in <root>.funG.classA' type=kotlin.String origin=null
+          ARG <this>: GET_VAR 'val a: <root>.funG.classA declared in <root>.funG' type=<root>.funG.classA origin=null
+  FUN name:funI visibility:public modality:FINAL returnType:kotlin.Int
+    BLOCK_BODY
+  FUN name:funJ visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+  FUN name:isNotNull visibility:public modality:FINAL returnType:kotlin.Boolean
+    VALUE_PARAMETER kind:Regular name:value index:0 type:kotlin.Any?
+    annotations:
+      OptIn(markerClass = [ExperimentalContracts::class] type=kotlin.Array<out kotlin.reflect.KClass<out kotlin.Annotation>> varargElementType=kotlin.reflect.KClass<out kotlin.Annotation>)
+    BLOCK_BODY

--- a/compiler/testData/diagnostics/tests/headerMode/objectDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/objectDeclaration.ir.txt
@@ -1,0 +1,43 @@
+FILE fqName:<root> fileName:/objectDeclaration.kt
+  CLASS OBJECT name:A modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.A
+    CONSTRUCTOR visibility:private returnType:<root>.A [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:funA visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+    FUN name:funB visibility:public modality:FINAL returnType:kotlin.String [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun funB (): kotlin.String declared in <root>.A'
+          CONST String type=kotlin.String value="A.funB body"
+    FUN name:funD visibility:public modality:FINAL returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+    FUN name:funE visibility:public modality:FINAL returnType:kotlin.String [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      BLOCK_BODY
+        FUN LOCAL_FUNCTION name:funF visibility:local modality:FINAL returnType:kotlin.String
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='local final fun funF (): kotlin.String declared in <root>.A.funE'
+              CONST String type=kotlin.String value="funF body"
+        RETURN type=kotlin.Nothing from='public final fun funE (): kotlin.String declared in <root>.A'
+          CALL 'local final fun funF (): kotlin.String declared in <root>.A.funE' type=kotlin.String origin=null
+    FUN name:isNotNull visibility:public modality:FINAL returnType:kotlin.Boolean
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.A
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.Any?
+      annotations:
+        OptIn(markerClass = [ExperimentalContracts::class] type=kotlin.Array<out kotlin.reflect.KClass<out kotlin.Annotation>> varargElementType=kotlin.reflect.KClass<out kotlin.Annotation>)
+      BLOCK_BODY

--- a/compiler/testData/diagnostics/tests/headerMode/privateDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/privateDeclaration.ir.txt
@@ -1,0 +1,300 @@
+FILE fqName:<root> fileName:/privateDeclaration.kt
+  CLASS CLASS name:TestClass modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass
+    PROPERTY name:publicProperty visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:publicProperty type:kotlin.String visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-publicProperty> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+        correspondingProperty: PROPERTY name:publicProperty visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-publicProperty> (): kotlin.String declared in <root>.TestClass'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicProperty type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-publicProperty>' type=<root>.TestClass origin=null
+    PROPERTY name:publicBackingField visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:publicBackingField type:kotlin.String visibility:private
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-publicBackingField> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+        correspondingProperty: PROPERTY name:publicBackingField visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-publicBackingField> (): kotlin.String declared in <root>.TestClass'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicBackingField type:kotlin.String visibility:private' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-publicBackingField>' type=<root>.TestClass origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-publicBackingField> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.String
+        correspondingProperty: PROPERTY name:publicBackingField visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicBackingField type:kotlin.String visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<set-publicBackingField>' type=<root>.TestClass origin=null
+            value: GET_VAR '<set-?>: kotlin.String declared in <root>.TestClass.<set-publicBackingField>' type=kotlin.String origin=null
+    PROPERTY name:usedPropertyByInline visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:usedPropertyByInline type:kotlin.String visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-usedPropertyByInline> visibility:private modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+        correspondingProperty: PROPERTY name:usedPropertyByInline visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-usedPropertyByInline> (): kotlin.String declared in <root>.TestClass'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:usedPropertyByInline type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-usedPropertyByInline>' type=<root>.TestClass origin=null
+    PROPERTY name:usedBackingFieldByInline visibility:private modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:usedBackingFieldByInline type:kotlin.Int visibility:private
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-usedBackingFieldByInline> visibility:private modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+        correspondingProperty: PROPERTY name:usedBackingFieldByInline visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-usedBackingFieldByInline> (): kotlin.Int declared in <root>.TestClass'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:usedBackingFieldByInline type:kotlin.Int visibility:private' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-usedBackingFieldByInline>' type=<root>.TestClass origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-usedBackingFieldByInline> visibility:private modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY name:usedBackingFieldByInline visibility:private modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:usedBackingFieldByInline type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<set-usedBackingFieldByInline>' type=<root>.TestClass origin=null
+            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.TestClass.<set-usedBackingFieldByInline>' type=kotlin.Int origin=null
+    PROPERTY name:aliasUser visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:aliasUser type:kotlin.String visibility:private [final]
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-aliasUser> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+        correspondingProperty: PROPERTY name:aliasUser visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-aliasUser> (): kotlin.String declared in <root>.TestClass'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:aliasUser type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-aliasUser>' type=<root>.TestClass origin=null
+    CLASS CLASS name:InlineChain modality:FINAL visibility:private superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.InlineChain
+      CONSTRUCTOR visibility:public returnType:<root>.TestClass.InlineChain [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN name:used visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass.InlineChain
+        BLOCK_BODY
+    CLASS CLASS name:KeptPrivateInner modality:FINAL visibility:private superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.KeptPrivateInner
+      CONSTRUCTOR visibility:public returnType:<root>.TestClass.KeptPrivateInner [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+    CLASS CLASS name:MixedClass modality:FINAL visibility:private superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.MixedClass
+      CONSTRUCTOR visibility:public returnType:<root>.TestClass.MixedClass [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN name:used visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass.MixedClass
+        BLOCK_BODY
+    CLASS CLASS name:NestedMixedOuter modality:FINAL visibility:private superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.NestedMixedOuter
+      CLASS CLASS name:Nested modality:FINAL visibility:public superTypes:[kotlin.Any]
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.NestedMixedOuter.Nested
+        CONSTRUCTOR visibility:public returnType:<root>.TestClass.NestedMixedOuter.Nested [primary]
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+          overridden:
+            public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun hashCode (): kotlin.Int declared in kotlin.Any
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun toString (): kotlin.String declared in kotlin.Any
+        FUN name:used visibility:public modality:FINAL returnType:kotlin.Unit
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass.NestedMixedOuter.Nested
+          BLOCK_BODY
+      CONSTRUCTOR visibility:public returnType:<root>.TestClass.NestedMixedOuter [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+    CLASS CLASS name:PublicInnerClass modality:FINAL visibility:public superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.PublicInnerClass
+      CONSTRUCTOR visibility:public returnType:<root>.TestClass.PublicInnerClass [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+    CLASS OBJECT name:MixedCompanion modality:FINAL visibility:private [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.MixedCompanion
+      CONSTRUCTOR visibility:private returnType:<root>.TestClass.MixedCompanion [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN name:used visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass.MixedCompanion
+        BLOCK_BODY
+    CLASS OBJECT name:PublicCompanion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.PublicCompanion
+      CONSTRUCTOR visibility:private returnType:<root>.TestClass.PublicCompanion [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+    CLASS OBJECT name:UsedByInlineCompanion modality:FINAL visibility:private [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.UsedByInlineCompanion
+      CONSTRUCTOR visibility:private returnType:<root>.TestClass.UsedByInlineCompanion [primary]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN name:companionFun visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass.UsedByInlineCompanion
+        BLOCK_BODY
+    CONSTRUCTOR visibility:public returnType:<root>.TestClass [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:privateInlineChainMiddle visibility:private modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'public final fun used (): kotlin.Unit declared in <root>.TestClass.InlineChain' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TestClass.InlineChain' type=<root>.TestClass.InlineChain origin=null
+    FUN name:privateNonInlineMiddle visibility:private modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+    FUN name:provideInner visibility:public modality:FINAL returnType:<root>.TestClass.KeptPrivateInner
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+    FUN name:publicBrokenChainStart visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'private final fun privateNonInlineMiddle (): kotlin.Unit declared in <root>.TestClass' type=kotlin.Unit origin=null
+          ARG <this>: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.publicBrokenChainStart' type=<root>.TestClass origin=IMPLICIT_ARGUMENT
+    FUN name:publicFunction visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+    FUN name:publicInlineChainStart visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'private final fun privateInlineChainMiddle (): kotlin.Unit declared in <root>.TestClass' type=kotlin.Unit origin=null
+          ARG <this>: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.publicInlineChainStart' type=<root>.TestClass origin=IMPLICIT_ARGUMENT
+    FUN name:useMixed visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'public final fun used (): kotlin.Unit declared in <root>.TestClass.MixedClass' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TestClass.MixedClass' type=<root>.TestClass.MixedClass origin=null
+        CALL 'public final fun used (): kotlin.Unit declared in <root>.TestClass.MixedCompanion' type=kotlin.Unit origin=null
+          ARG <this>: GET_OBJECT 'CLASS OBJECT name:MixedCompanion modality:FINAL visibility:private [companion] superTypes:[kotlin.Any]' type=<root>.TestClass.MixedCompanion
+    FUN name:useNestedMixed visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'public final fun used (): kotlin.Unit declared in <root>.TestClass.NestedMixedOuter.Nested' type=kotlin.Unit origin=null
+          ARG <this>: CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.TestClass.NestedMixedOuter.Nested' type=<root>.TestClass.NestedMixedOuter.Nested origin=null
+    FUN name:usedByInline visibility:private modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+    FUN name:witnessForCompanion visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'public final fun companionFun (): kotlin.Unit declared in <root>.TestClass.UsedByInlineCompanion' type=kotlin.Unit origin=null
+          ARG <this>: GET_OBJECT 'CLASS OBJECT name:UsedByInlineCompanion modality:FINAL visibility:private [companion] superTypes:[kotlin.Any]' type=<root>.TestClass.UsedByInlineCompanion
+    FUN name:witnessForField visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'private final fun <set-usedBackingFieldByInline> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.TestClass' type=kotlin.Unit origin=EQ
+          ARG <this>: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.witnessForField' type=<root>.TestClass origin=IMPLICIT_ARGUMENT
+          ARG <set-?>: CONST Int type=kotlin.Int value=42
+    FUN name:witnessForFunction visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        CALL 'private final fun usedByInline (): kotlin.Unit declared in <root>.TestClass' type=kotlin.Unit origin=null
+          ARG <this>: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.witnessForFunction' type=<root>.TestClass origin=IMPLICIT_ARGUMENT
+    FUN name:witnessForProperty visibility:public modality:FINAL returnType:kotlin.Unit [inline]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
+      BLOCK_BODY
+        VAR name:x type:kotlin.String [val]
+          CALL 'private final fun <get-usedPropertyByInline> (): kotlin.String declared in <root>.TestClass' type=kotlin.String origin=GET_PROPERTY
+            ARG <this>: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.witnessForProperty' type=<root>.TestClass origin=IMPLICIT_ARGUMENT
+  FUN name:topLevelKept visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY

--- a/compiler/testData/diagnostics/tests/headerMode/privateDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/privateDeclaration.ir.txt
@@ -7,61 +7,40 @@ FILE fqName:<root> fileName:/privateDeclaration.kt
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
         correspondingProperty: PROPERTY name:publicProperty visibility:public modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-publicProperty> (): kotlin.String declared in <root>.TestClass'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicProperty type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-publicProperty>' type=<root>.TestClass origin=null
     PROPERTY name:publicBackingField visibility:public modality:FINAL [var]
       FIELD PROPERTY_BACKING_FIELD name:publicBackingField type:kotlin.String visibility:private
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-publicBackingField> visibility:public modality:FINAL returnType:kotlin.String
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
         correspondingProperty: PROPERTY name:publicBackingField visibility:public modality:FINAL [var]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-publicBackingField> (): kotlin.String declared in <root>.TestClass'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicBackingField type:kotlin.String visibility:private' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-publicBackingField>' type=<root>.TestClass origin=null
       FUN DEFAULT_PROPERTY_ACCESSOR name:<set-publicBackingField> visibility:public modality:FINAL returnType:kotlin.Unit
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
         VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.String
         correspondingProperty: PROPERTY name:publicBackingField visibility:public modality:FINAL [var]
         BLOCK_BODY
-          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:publicBackingField type:kotlin.String visibility:private' type=kotlin.Unit origin=null
-            receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<set-publicBackingField>' type=<root>.TestClass origin=null
-            value: GET_VAR '<set-?>: kotlin.String declared in <root>.TestClass.<set-publicBackingField>' type=kotlin.String origin=null
     PROPERTY name:usedPropertyByInline visibility:private modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:usedPropertyByInline type:kotlin.String visibility:private [final]
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-usedPropertyByInline> visibility:private modality:FINAL returnType:kotlin.String
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
         correspondingProperty: PROPERTY name:usedPropertyByInline visibility:private modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='private final fun <get-usedPropertyByInline> (): kotlin.String declared in <root>.TestClass'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:usedPropertyByInline type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-usedPropertyByInline>' type=<root>.TestClass origin=null
     PROPERTY name:usedBackingFieldByInline visibility:private modality:FINAL [var]
       FIELD PROPERTY_BACKING_FIELD name:usedBackingFieldByInline type:kotlin.Int visibility:private
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-usedBackingFieldByInline> visibility:private modality:FINAL returnType:kotlin.Int
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
         correspondingProperty: PROPERTY name:usedBackingFieldByInline visibility:private modality:FINAL [var]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='private final fun <get-usedBackingFieldByInline> (): kotlin.Int declared in <root>.TestClass'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:usedBackingFieldByInline type:kotlin.Int visibility:private' type=kotlin.Int origin=null
-              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-usedBackingFieldByInline>' type=<root>.TestClass origin=null
       FUN DEFAULT_PROPERTY_ACCESSOR name:<set-usedBackingFieldByInline> visibility:private modality:FINAL returnType:kotlin.Unit
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
         VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
         correspondingProperty: PROPERTY name:usedBackingFieldByInline visibility:private modality:FINAL [var]
         BLOCK_BODY
-          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:usedBackingFieldByInline type:kotlin.Int visibility:private' type=kotlin.Unit origin=null
-            receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<set-usedBackingFieldByInline>' type=<root>.TestClass origin=null
-            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.TestClass.<set-usedBackingFieldByInline>' type=kotlin.Int origin=null
     PROPERTY name:aliasUser visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:aliasUser type:kotlin.String visibility:private [final]
       FUN DEFAULT_PROPERTY_ACCESSOR name:<get-aliasUser> visibility:public modality:FINAL returnType:kotlin.String
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestClass
         correspondingProperty: PROPERTY name:aliasUser visibility:public modality:FINAL [val]
         BLOCK_BODY
-          RETURN type=kotlin.Nothing from='public final fun <get-aliasUser> (): kotlin.String declared in <root>.TestClass'
-            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:aliasUser type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
-              receiver: GET_VAR '<this>: <root>.TestClass declared in <root>.TestClass.<get-aliasUser>' type=<root>.TestClass origin=null
     CLASS CLASS name:InlineChain modality:FINAL visibility:private superTypes:[kotlin.Any]
       thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestClass.InlineChain
       CONSTRUCTOR visibility:public returnType:<root>.TestClass.InlineChain [primary]

--- a/compiler/testData/diagnostics/tests/headerMode/propertyDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/propertyDeclaration.ir.txt
@@ -1,0 +1,137 @@
+FILE fqName:<root> fileName:/propertyDeclaration.kt
+  PROPERTY name:a visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
+  PROPERTY name:b visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.String visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:b visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-b> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
+  PROPERTY name:d visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:d type:kotlin.Boolean visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-d> visibility:public modality:FINAL returnType:kotlin.Boolean
+      correspondingProperty: PROPERTY name:d visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-d> (): kotlin.Boolean declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:d type:kotlin.Boolean visibility:private [final,static]' type=kotlin.Boolean origin=null
+  PROPERTY name:e visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:e type:kotlin.String visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-e> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:e visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-e> (): kotlin.String declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:e type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
+  PROPERTY name:f visibility:public modality:FINAL [var]
+    FIELD PROPERTY_BACKING_FIELD name:f type:kotlin.Int visibility:private [static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-f> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:f visibility:public modality:FINAL [var]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-f> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:f type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
+    FUN name:<set-f> visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:value index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:f visibility:public modality:FINAL [var]
+      BLOCK_BODY
+  PROPERTY name:h visibility:public modality:FINAL [delegated,val]
+    FIELD PROPERTY_DELEGATE name:h$delegate type:kotlin.Lazy<kotlin.String> visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun lazy <T> (initializer: kotlin.Function0<T of kotlin.lazy>): kotlin.Lazy<T of kotlin.lazy> declared in kotlin' type=kotlin.Lazy<kotlin.String> origin=null
+          TYPE_ARG T: kotlin.String
+          ARG initializer: FUN_EXPR type=kotlin.Function0<kotlin.String> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.h$delegate'
+                  CONST String type=kotlin.String value="H"
+    FUN DELEGATED_PROPERTY_ACCESSOR name:<get-h> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:h visibility:public modality:FINAL [delegated,val]
+      BLOCK_BODY
+  PROPERTY name:j visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:j type:kotlin.Any visibility:private [final,static]
+      EXPRESSION_BODY
+        BLOCK type=<root>.j.<no name provided> origin=OBJECT_LITERAL
+          CLASS CLASS name:<no name provided> modality:FINAL visibility:local superTypes:[kotlin.Any]
+            thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.j.<no name provided>
+            CONSTRUCTOR visibility:public returnType:<root>.j.<no name provided> [primary]
+              BLOCK_BODY
+                DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+                INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:<no name provided> modality:FINAL visibility:local superTypes:[kotlin.Any]' type=kotlin.Unit
+            FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+              VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+              VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+              overridden:
+                public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+            FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+              VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+              overridden:
+                public open fun hashCode (): kotlin.Int declared in kotlin.Any
+            FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+              VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+              overridden:
+                public open fun toString (): kotlin.String declared in kotlin.Any
+            FUN name:bar visibility:public modality:FINAL returnType:kotlin.String
+              VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.j.<no name provided>
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='public final fun bar (): kotlin.String declared in <root>.j.<no name provided>'
+                  CONST String type=kotlin.String value="bar"
+            FUN name:foo visibility:public modality:FINAL returnType:kotlin.String
+              VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.j.<no name provided>
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='public final fun foo (): kotlin.String declared in <root>.j.<no name provided>'
+                  CONST String type=kotlin.String value="foo"
+          CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.j.<no name provided>' type=<root>.j.<no name provided> origin=OBJECT_LITERAL
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-j> visibility:public modality:FINAL returnType:kotlin.Any
+      correspondingProperty: PROPERTY name:j visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-j> (): kotlin.Any declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:j type:kotlin.Any visibility:private [final,static]' type=kotlin.Any origin=null
+  PROPERTY name:k visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:k type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-k> visibility:public modality:FINAL returnType:kotlin.Function1<kotlin.String, kotlin.String>
+      correspondingProperty: PROPERTY name:k visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-k> (): kotlin.Function1<kotlin.String, kotlin.String> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:k type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]' type=kotlin.Function1<kotlin.String, kotlin.String> origin=null
+  PROPERTY name:l visibility:public modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:l type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-l> visibility:public modality:FINAL returnType:kotlin.Function1<kotlin.String, kotlin.String>
+      correspondingProperty: PROPERTY name:l visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-l> (): kotlin.Function1<kotlin.String, kotlin.String> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:l type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]' type=kotlin.Function1<kotlin.String, kotlin.String> origin=null
+  FUN name:foo visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+  PROPERTY name:c visibility:public modality:FINAL [val]
+    FUN name:<get-c> visibility:public modality:FINAL returnType:kotlin.String
+      correspondingProperty: PROPERTY name:c visibility:public modality:FINAL [val]
+      BLOCK_BODY
+  PROPERTY name:g visibility:public modality:FINAL [val]
+    FUN name:<get-g> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:g visibility:public modality:FINAL [val]
+      BLOCK_BODY
+  PROPERTY name:i visibility:public modality:FINAL [const,val]
+    FIELD PROPERTY_BACKING_FIELD name:i type:kotlin.Int visibility:public [final,static]
+      EXPRESSION_BODY
+        CONST Int type=kotlin.Int value=123
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-i> visibility:public modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:i visibility:public modality:FINAL [const,val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-i> (): kotlin.Int declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:i type:kotlin.Int visibility:public [final,static]' type=kotlin.Int origin=null
+  PROPERTY name:m visibility:public modality:FINAL [val]
+    FUN name:<get-m> visibility:public modality:FINAL returnType:kotlin.String [inline]
+      correspondingProperty: PROPERTY name:m visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-m> (): kotlin.String declared in <root>'
+          CONST String type=kotlin.String value="M"
+  PROPERTY name:n visibility:public modality:FINAL [val]
+    FUN name:<get-n> visibility:public modality:FINAL returnType:kotlin.String [inline]
+      correspondingProperty: PROPERTY name:n visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-n> (): kotlin.String declared in <root>'
+          CONST String type=kotlin.String value="N"

--- a/compiler/testData/diagnostics/tests/headerMode/propertyDeclaration.ir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/propertyDeclaration.ir.txt
@@ -4,36 +4,26 @@ FILE fqName:<root> fileName:/propertyDeclaration.kt
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:public modality:FINAL returnType:kotlin.String
       correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlin.String declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
   PROPERTY name:b visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.String visibility:private [final,static]
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:public modality:FINAL returnType:kotlin.String
       correspondingProperty: PROPERTY name:b visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-b> (): kotlin.String declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
   PROPERTY name:d visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:d type:kotlin.Boolean visibility:private [final,static]
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-d> visibility:public modality:FINAL returnType:kotlin.Boolean
       correspondingProperty: PROPERTY name:d visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-d> (): kotlin.Boolean declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:d type:kotlin.Boolean visibility:private [final,static]' type=kotlin.Boolean origin=null
   PROPERTY name:e visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:e type:kotlin.String visibility:private [final,static]
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-e> visibility:public modality:FINAL returnType:kotlin.String
       correspondingProperty: PROPERTY name:e visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-e> (): kotlin.String declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:e type:kotlin.String visibility:private [final,static]' type=kotlin.String origin=null
   PROPERTY name:f visibility:public modality:FINAL [var]
     FIELD PROPERTY_BACKING_FIELD name:f type:kotlin.Int visibility:private [static]
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-f> visibility:public modality:FINAL returnType:kotlin.Int
       correspondingProperty: PROPERTY name:f visibility:public modality:FINAL [var]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-f> (): kotlin.Int declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:f type:kotlin.Int visibility:private [static]' type=kotlin.Int origin=null
     FUN name:<set-f> visibility:public modality:FINAL returnType:kotlin.Unit
       VALUE_PARAMETER kind:Regular name:value index:0 type:kotlin.Int
       correspondingProperty: PROPERTY name:f visibility:public modality:FINAL [var]
@@ -88,22 +78,16 @@ FILE fqName:<root> fileName:/propertyDeclaration.kt
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-j> visibility:public modality:FINAL returnType:kotlin.Any
       correspondingProperty: PROPERTY name:j visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-j> (): kotlin.Any declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:j type:kotlin.Any visibility:private [final,static]' type=kotlin.Any origin=null
   PROPERTY name:k visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:k type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-k> visibility:public modality:FINAL returnType:kotlin.Function1<kotlin.String, kotlin.String>
       correspondingProperty: PROPERTY name:k visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-k> (): kotlin.Function1<kotlin.String, kotlin.String> declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:k type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]' type=kotlin.Function1<kotlin.String, kotlin.String> origin=null
   PROPERTY name:l visibility:public modality:FINAL [val]
     FIELD PROPERTY_BACKING_FIELD name:l type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-l> visibility:public modality:FINAL returnType:kotlin.Function1<kotlin.String, kotlin.String>
       correspondingProperty: PROPERTY name:l visibility:public modality:FINAL [val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-l> (): kotlin.Function1<kotlin.String, kotlin.String> declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:l type:kotlin.Function1<kotlin.String, kotlin.String> visibility:private [final,static]' type=kotlin.Function1<kotlin.String, kotlin.String> origin=null
   FUN name:foo visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
   PROPERTY name:c visibility:public modality:FINAL [val]
@@ -121,8 +105,6 @@ FILE fqName:<root> fileName:/propertyDeclaration.kt
     FUN DEFAULT_PROPERTY_ACCESSOR name:<get-i> visibility:public modality:FINAL returnType:kotlin.Int
       correspondingProperty: PROPERTY name:i visibility:public modality:FINAL [const,val]
       BLOCK_BODY
-        RETURN type=kotlin.Nothing from='public final fun <get-i> (): kotlin.Int declared in <root>'
-          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:i type:kotlin.Int visibility:public [final,static]' type=kotlin.Int origin=null
   PROPERTY name:m visibility:public modality:FINAL [val]
     FUN name:<get-m> visibility:public modality:FINAL returnType:kotlin.String [inline]
       correspondingProperty: PROPERTY name:m visibility:public modality:FINAL [val]

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/configuration/BaseDiagnosticConfiguration.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/configuration/BaseDiagnosticConfiguration.kt
@@ -15,12 +15,15 @@ import org.jetbrains.kotlin.fir.SessionConfiguration
 import org.jetbrains.kotlin.fir.symbols.FirLazyDeclarationResolver
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.test.*
+import org.jetbrains.kotlin.test.backend.handlers.IrTextDumpHandler
 import org.jetbrains.kotlin.test.backend.ir.IrDiagnosticsHandler
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.builders.configureFirHandlersStep
+import org.jetbrains.kotlin.test.builders.configureIrHandlersStep
 import org.jetbrains.kotlin.test.builders.firHandlersStep
 import org.jetbrains.kotlin.test.builders.irHandlersStep
 import org.jetbrains.kotlin.test.cli.CliDirectives.CHECK_COMPILER_OUTPUT
+import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.DUMP_IR
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.IGNORE_DEXING
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.WITH_STDLIB
 import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.DIAGNOSTICS
@@ -323,7 +326,11 @@ fun TestConfigurationBuilder.configureCommonDiagnosticTestPaths() {
     forTestsMatching("compiler/testData/diagnostics/tests/headerMode/*") {
         defaultDirectives {
             +HEADER_MODE
+            +DUMP_IR
             DISABLE_WITH_PARSER with FirParser.Psi
+        }
+        configureIrHandlersStep {
+            useHandlers(::IrTextDumpHandler)
         }
     }
 }


### PR DESCRIPTION
In header mode, we can avoid generating IR of synthetic functions, getters/setters as long as they're not part of an inline scope.