### PR TITLE
[Build] Use local bootstrap in the `kotlin-native/performance` build

### DIFF
--- a/kotlin-native/performance/README.md
+++ b/kotlin-native/performance/README.md
@@ -1,12 +1,19 @@
 # Micro Benchmarks for Kotlin/Native
 
-To run the benchmarks you need a built Kotlin/Native distribution with the platform libraries:
-* either specify the full path to the existing distribution with `-Pkotlin.native.home=<path>`
-* or run `./gradlew -Pkotlin.native.enabled=true :kotlin-native:dist :kotlin-native:distPlatformLibs`
-  in the root of the `git` repository (that is in the `kotlin` folder not in the current `kotlin/kotlin-native/performance`)
-  to build the distribution from sources
+## Prerequisites
 
-To run all the benchmarks just run `./gradlew :konanRun` from this folder. The output will be placed in `build/nativeReport.json`.
+You need a locally built Kotlin compiler distribution.
+
+In the root directory of kotlin.git, execute:
+```bash
+./gradlew -Pkotlin.native.enabled=true publish
+```
+
+Now you may sync this project in your IDEA.
+
+## Running benchmarks
+
+To run all the benchmarks, just run `./gradlew :konanRun` from this folder. The output will be placed in `build/nativeReport.json`.
 
 **NOTE**: consider running with `-PdryRun` beforehand to build everything before running the benchmarks, this will
 make the benchmarking results a bit more stable

--- a/kotlin-native/performance/gradle.properties
+++ b/kotlin-native/performance/gradle.properties
@@ -9,6 +9,9 @@ nativeWarmup = 10
 attempts = 20
 nativeJson = nativeReport.json
 
+bootstrap.local=true
+bootstrap.local.path=build/repo
+
 kotlin.mpp.enableCInteropCommonization=true
 # klib cross-compilation is not required and produces warnings on Linux
 kotlin.native.enableKlibsCrossCompilation=false


### PR DESCRIPTION
KTI-3452

The issue was like that:
- `kotlin-native/performance` compiles with local snapshot of Kotlin Native (2.5.255-SNAPSHOT)
- at the same time, it uses KGP with bootstrap version (2.4.20-dev-123)
- KGP brings `kotlin-util-klib` in version 2.4.20-dev-123, where the code for reading klibs lives (used by `kotlinx-benchmark-plugin`)
- it tries to read klib serialized with `abi_version=2.5.0` with a deserializer capable of reading `abi_version=2.4.0`
- the bytes makes no sense to the deserializer

This issue would likely come back for branching 2.5.20 -> 2.6.0 and every future one that needs bumping of Language Version.

Here we use local bootstrap so both Kotlin Native and KGP are in version 2.5.255-SNAPSHOT freshly built from the sources.