### PR TITLE
[Header mode] Fix check for removing initializers for anonymous objects.

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirDeclarationsResolveTransformer.kt
@@ -36,6 +36,8 @@ import org.jetbrains.kotlin.fir.resolve.ResolutionMode.ArrayLiteralPosition
 import org.jetbrains.kotlin.fir.resolve.calls.ConeResolvedLambdaAtom
 import org.jetbrains.kotlin.fir.resolve.calls.candidate.Candidate
 import org.jetbrains.kotlin.fir.resolve.calls.candidate.candidate
+import org.jetbrains.kotlin.fir.types.coneTypeOrNull
+import org.jetbrains.kotlin.fir.types.contains
 import org.jetbrains.kotlin.fir.resolve.dfa.FirControlFlowGraphReferenceImpl
 import org.jetbrains.kotlin.fir.resolve.diagnostics.ConeLocalVariableNoTypeOrInitializer
 import org.jetbrains.kotlin.fir.resolve.inference.FirDelegatedPropertyInferenceSession
@@ -292,7 +294,7 @@ open class FirDeclarationsResolveTransformer(
             if (session.languageVersionSettings.getFlag(AnalysisFlags.headerMode) &&
                 !property.isConst &&
                 property.returnTypeRef !is FirImplicitTypeRef &&
-                property.initializer !is FirAnonymousObjectExpression
+                !property.hasAnonymousReturnType(session)
             ) {
                 property.replaceInitializer(null)
             }
@@ -1690,4 +1692,10 @@ open class FirDeclarationsResolveTransformer(
 
     private val FirFunction.bodyResolved: Boolean
         get() = body?.hasResolvedType == true
+
+    private fun FirProperty.hasAnonymousReturnType(session: FirSession): Boolean {
+        return returnTypeRef.coneTypeOrNull?.contains { coneType ->
+            coneType.toSymbol(session)?.fir is FirAnonymousObject
+        } == true
+    }
 }

--- a/compiler/testData/diagnostics/tests/headerMode/anonymousObjects.fir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/anonymousObjects.fir.txt
@@ -1,3 +1,10 @@
 FILE: anonymousObjects.kt
-    public final fun useAnonObject(): R|kotlin/Unit| {
+    public final val publicRefToChained: R|kotlin/String|
+        public get(): R|kotlin/String|
+    public final val publicRefToNested: R|kotlin/String|
+        public get(): R|kotlin/String|
+    public final fun useAnonObject(): R|kotlin/String| {
     }
+
+
+

--- a/compiler/testData/diagnostics/tests/headerMode/anonymousObjects.kt
+++ b/compiler/testData/diagnostics/tests/headerMode/anonymousObjects.kt
@@ -6,8 +6,23 @@ private fun createPrivateObject() =
             fun foo(): String = "foo"
         }
 
-fun useAnonObject() {
-    createAnonObject().foo()
+private val privatePropertyWithChainedObject =
+        object {
+            fun bar() = "bar"
+        }.also { }
+
+private val privatePropertyWithNestedObject =
+        object {
+            fun baz() = "baz"
+        }
+
+val publicRefToChained = privatePropertyWithChainedObject.bar()
+
+val publicRefToNested = privatePropertyWithNestedObject.baz()
+
+fun useAnonObject(): String {
+    return createPrivateObject().foo() + publicRefToChained + publicRefToNested
 }
 
-/* GENERATED_FIR_TAGS: anonymousObjectExpression, functionDeclaration, stringLiteral */
+
+/* GENERATED_FIR_TAGS: functionDeclaration, propertyDeclaration */

--- a/compiler/testData/diagnostics/tests/headerMode/propertyDeclaration.fir.txt
+++ b/compiler/testData/diagnostics/tests/headerMode/propertyDeclaration.fir.txt
@@ -27,21 +27,7 @@ FILE: propertyDeclaration.kt
         }
     public final const val i: R|kotlin/Int| = Int(123)
         public get(): R|kotlin/Int|
-    public final val j: R|kotlin/Any| = object : R|kotlin/Any| {
-        private constructor(): R|<anonymous>| {
-            super<R|kotlin/Any|>()
-        }
-
-        public final fun foo(): R|kotlin/String| {
-            ^foo String(foo)
-        }
-
-        public final fun bar(): R|kotlin/String| {
-            ^bar String(bar)
-        }
-
-    }
-
+    public final val j: R|kotlin/Any|
         public get(): R|kotlin/Any|
     public final val k: R|(kotlin/String) -> kotlin/String|
         public get(): R|(kotlin/String) -> kotlin/String|


### PR DESCRIPTION
The current check for anonymous objects in initializers is very trivial and fails when anonymous objects are contained within the expression. Changing the check to be more robust.

^KT-82404