### PR TITLE
[BTA] Tests: make tests isolated by not sharing KotlinToolchains

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestArgumentProviders.kt
@@ -89,20 +89,25 @@ class BtaV2StrategyAndPlatformAgnosticCompilationTestArgumentProvider : Argument
 }
 
 class DefaultStrategyAgnosticCompilationTestArgumentProvider : ArgumentsProvider {
-    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> {
-        return namedStrategyArguments().map { Arguments.of(it) }.stream()
-    }
+    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<Arguments> =
+        namedStrategyProviders().map { Arguments.of(named(it.name, it.payload())) }.stream()
 
     companion object {
-        fun namedStrategyArguments(): List<Named<Pair<KotlinToolchains, ExecutionPolicy>>> {
-            return BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments().flatMap { namedArgument ->
+        fun namedStrategyProviders(): List<Named<() -> Pair<KotlinToolchains, ExecutionPolicy>>> {
+            return BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders().flatMap { namedArgument ->
                 listOfNotNull(
                     named(
-                        "${namedArgument.name}[in-process]", namedArgument.payload to namedArgument.payload.createInProcessExecutionPolicy()
-                    ),
+                        "${namedArgument.name}[in-process]"
+                    ) {
+                        namedArgument.payload().let { it to it.createInProcessExecutionPolicy() }
+                    },
                     // We do not test the daemon when running in Smoke test mode
                     if (testFederationMode != TestFederationMode.Smoke) {
-                        named("${namedArgument.name}[daemon]", namedArgument.payload to namedArgument.payload.daemonExecutionPolicy())
+                        named(
+                            "${namedArgument.name}[daemon]"
+                        ) {
+                            namedArgument.payload().let { it to it.daemonExecutionPolicy() }
+                        }
                     } else null
                 )
             }
@@ -111,39 +116,47 @@ class DefaultStrategyAgnosticCompilationTestArgumentProvider : ArgumentsProvider
 }
 
 class DefaultStrategyAndPlatformAgnosticProjectTestArgumentProvider : ArgumentsProvider {
-    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> {
-        return namedStrategyArguments().map { Arguments.of(it) }.stream()
-    }
+    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<Arguments> =
+        namedProjectProviders().map { Arguments.of(named(it.name, it.payload())) }.stream()
 
     companion object {
-        fun namedStrategyArguments(): List<Named<ProjectCreator>> {
-            return DefaultStrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
+        fun namedProjectProviders(): List<Named<() -> ProjectCreator>> {
+            return DefaultStrategyAgnosticCompilationTestArgumentProvider.namedStrategyProviders()
                 .flatMap { executionStrategyConfiguration ->
+                    val temporaryKotlinToolchains = executionStrategyConfiguration.payload().first
                     listOfNotNull(
                         named(
                             "${executionStrategyConfiguration.name}[JVM]"
-                        ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                            baseTest.jvmProject(executionStrategyConfiguration.payload, testAction)
+                        ) {
+                            { baseTest: BaseCompilationTest, testAction: ProjectAction ->
+                                baseTest.jvmProject(executionStrategyConfiguration.payload(), testAction)
+                            }
                         },
-                        if (executionStrategyConfiguration.payload.first.supportsJs()) {
+                        if (temporaryKotlinToolchains.supportsJs()) {
                             named(
                                 "${executionStrategyConfiguration.name}[JS]"
-                            ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                                baseTest.jsProject(executionStrategyConfiguration.payload, testAction)
+                            ) {
+                                { baseTest: BaseCompilationTest, testAction: ProjectAction ->
+                                    baseTest.jsProject(executionStrategyConfiguration.payload(), testAction)
+                                }
                             }
                         } else null,
-                        if (executionStrategyConfiguration.payload.first.supportsWasm()) {
+                        if (temporaryKotlinToolchains.supportsWasm()) {
                             named(
                                 "${executionStrategyConfiguration.name}[Wasm]"
-                            ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                                baseTest.wasmProject(executionStrategyConfiguration.payload, testAction)
+                            ) {
+                                { baseTest: BaseCompilationTest, testAction: ProjectAction ->
+                                    baseTest.wasmProject(executionStrategyConfiguration.payload(), testAction)
+                                }
                             }
                         } else null,
-                        if (executionStrategyConfiguration.payload.first.supportsMetadata()) {
+                        if (temporaryKotlinToolchains.supportsMetadata()) {
                             named(
                                 "${executionStrategyConfiguration.name}[Metadata]"
-                            ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                                baseTest.metadataProject(executionStrategyConfiguration.payload, testAction)
+                            ) {
+                                { baseTest: BaseCompilationTest, testAction: ProjectAction ->
+                                    baseTest.metadataProject(executionStrategyConfiguration.payload(), testAction)
+                                }
                             }
                         } else null,
                     )
@@ -153,31 +166,38 @@ class DefaultStrategyAndPlatformAgnosticProjectTestArgumentProvider : ArgumentsP
 }
 
 class DefaultStrategyAndPlatformAgnosticScenarioTestArgumentProvider : ArgumentsProvider {
-    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> {
-        return namedStrategyArguments().map { Arguments.of(it) }.stream()
-    }
+    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> =
+        namedScenarioProviders().map { Arguments.of(named(it.name, it.payload())) }.stream()
 
     companion object {
-        fun namedStrategyArguments(): List<Named<ScenarioCreator>> {
-            return DefaultStrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
+        fun namedScenarioProviders(): List<Named<() -> ScenarioCreator>> {
+            return DefaultStrategyAgnosticCompilationTestArgumentProvider.namedStrategyProviders()
                 .flatMap { executionStrategyConfiguration ->
+                    val temporaryKotlinToolchains = executionStrategyConfiguration.payload().first
+
                     listOfNotNull(
                         named(
                             "${executionStrategyConfiguration.name}[JVM]"
-                        ) { baseTest: BaseCompilationTest, testAction: ScenarioAction ->
-                            baseTest.jvmScenario(executionStrategyConfiguration.payload, testAction)
-                        }, if (executionStrategyConfiguration.payload.first.supportsJs()) {
+                        ) {
+                            { baseTest: BaseCompilationTest, testAction: ScenarioAction ->
+                                baseTest.jvmScenario(executionStrategyConfiguration.payload(), testAction)
+                            }
+                        }, if (temporaryKotlinToolchains.supportsJs()) {
                             named(
                                 "${executionStrategyConfiguration.name}[JS]"
-                            ) { baseTest: BaseCompilationTest, testAction: ScenarioAction ->
-                                baseTest.jsScenario(executionStrategyConfiguration.payload, testAction)
+                            ) {
+                                { baseTest: BaseCompilationTest, testAction: ScenarioAction ->
+                                    baseTest.jsScenario(executionStrategyConfiguration.payload(), testAction)
+                                }
                             }
                         } else null,
-                        if (executionStrategyConfiguration.payload.first.supportsWasm()) {
+                        if (temporaryKotlinToolchains.supportsWasm()) {
                             named(
                                 "${executionStrategyConfiguration.name}[Wasm]"
-                            ) { baseTest: BaseCompilationTest, testAction: ScenarioAction ->
-                                baseTest.wasmScenario(executionStrategyConfiguration.payload, testAction)
+                            ) {
+                                { baseTest: BaseCompilationTest, testAction: ScenarioAction ->
+                                    baseTest.wasmScenario(executionStrategyConfiguration.payload(), testAction)
+                                }
                             }
                         } else null
                     )
@@ -186,36 +206,38 @@ class DefaultStrategyAndPlatformAgnosticScenarioTestArgumentProvider : Arguments
     }
 }
 
-
 class BtaVersionsCompilationTestArgumentProvider : ArgumentsProvider {
-    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> {
-        return namedStrategyArguments().map { Arguments.of(it) }.stream()
-    }
+    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<Arguments> =
+        namedToolchainProviders().map { Arguments.of(named(it.name, it.payload())) }.stream()
 
     companion object {
-        fun namedStrategyArguments(): List<Named<KotlinToolchains>> {
+        fun namedToolchainProviders(): List<Named<() -> KotlinToolchains>> {
             return buildList {
-                val kotlinToolchains = KotlinToolchains.loadImplementation(btaClassloader)
+                val kotlinToolchainsProvider = { KotlinToolchains.loadImplementation(btaClassloader) }
+                val temporaryKotlinToolchains = kotlinToolchainsProvider()
+                val version = temporaryKotlinToolchains.getCompilerVersion()
 
                 @Suppress("DEPRECATION_ERROR") val kotlinToolchainV1Adapter =
-                    if (KotlinToolingVersion(kotlinToolchains.getCompilerVersion()) < KotlinToolingVersion(2, 4, 0, null)) {
-                        val asKotlinToolchainsMethod =
-                            btaClassloader.loadClass("org.jetbrains.kotlin.buildtools.internal.compat.KotlinToolchainsV1AdapterKt")
-                                .getDeclaredMethod("asKotlinToolchains", CompilationService::class.java)
-                        asKotlinToolchainsMethod.invoke(
-                            null, CompilationService.loadImplementation(
-                                btaClassloader
-                            )
-                        ) as KotlinToolchains
+                    if (KotlinToolingVersion(version) < KotlinToolingVersion(2, 4, 0, null)) {
+                        {
+                            val asKotlinToolchainsMethod =
+                                btaClassloader.loadClass("org.jetbrains.kotlin.buildtools.internal.compat.KotlinToolchainsV1AdapterKt")
+                                    .getDeclaredMethod("asKotlinToolchains", CompilationService::class.java)
+                            asKotlinToolchainsMethod.invoke(
+                                null, CompilationService.loadImplementation(
+                                    btaClassloader
+                                )
+                            ) as KotlinToolchains
+                        }
                     } else null
                 if (kotlinToolchainV1Adapter != null) {
                     add(
-                        named("[v1][${kotlinToolchainV1Adapter.getCompilerVersion()}]", kotlinToolchainV1Adapter)
+                        named("[v1][$version]", kotlinToolchainV1Adapter)
                     )
                 }
-                if (kotlinToolchainV1Adapter == null || kotlinToolchainV1Adapter::class != kotlinToolchains::class) {
+                if (kotlinToolchainV1Adapter == null || kotlinToolchainV1Adapter()::class != temporaryKotlinToolchains::class) {
                     add(
-                        named("[v2][${kotlinToolchains.getCompilerVersion()}]", kotlinToolchains)
+                        named("[v2][$version]", kotlinToolchainsProvider)
                     )
                 }
             }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/common/CommonArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/common/CommonArgumentProviders.kt
@@ -88,7 +88,7 @@ private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<C
 }
 
 private fun namedArgumentConfiguration(argumentPredicate: (CommonArgumentTestDescriptor<*>) -> Boolean = { true }): List<Named<CommonArgumentConfiguration<*>>> {
-    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
     val compilerArguments = commonCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
@@ -96,7 +96,7 @@ private fun namedArgumentConfiguration(argumentPredicate: (CommonArgumentTestDes
             if (namedArgumentDescriptor.payload.skipBtaV1 && namedKotlinToolchains.name.contains("[v1]")) return@mapNotNull null
             named(
                 namedKotlinToolchains.name + namedArgumentDescriptor.name,
-                CommonArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+                CommonArgumentConfiguration(namedKotlinToolchains.payload(), namedArgumentDescriptor.payload)
             )
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonjswasm/CommonJsAndWasmArgumentProviders.kt
@@ -85,7 +85,7 @@ private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<C
 private fun namedArgumentConfiguration(
     argumentPredicate: (CommonJsAndWasmArgumentTestDescriptor<*>) -> Boolean = { true },
 ): List<Named<CommonJsAndWasmArgumentConfiguration<*>>> {
-    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
     val compilerArguments = commonJsAndWasmCompilerArguments.filter { argumentPredicate(it) }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
@@ -93,7 +93,7 @@ private fun namedArgumentConfiguration(
             descriptor.operationKinds.mapNotNull { operationKind ->
                 named(
                     namedKotlinToolchains.name + "[${operationKind.displayName}][${descriptor.argumentName}]",
-                    CommonJsAndWasmArgumentConfiguration(namedKotlinToolchains.payload, descriptor, operationKind)
+                    CommonJsAndWasmArgumentConfiguration(namedKotlinToolchains.payload(), descriptor, operationKind)
                 )
             }
         }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/commonklib/CommonKlibArgumentProviders.kt
@@ -79,7 +79,7 @@ private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<C
 private fun namedArgumentConfiguration(
     argumentPredicate: (CommonKlibArgumentTestDescriptor<*>) -> Boolean = { true },
 ): List<Named<CommonKlibArgumentConfiguration<*>>> {
-    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
     val compilerArguments = commonKlibCompilerArguments.filter { argumentPredicate(it) }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
@@ -87,7 +87,7 @@ private fun namedArgumentConfiguration(
             descriptor.operationKinds.mapNotNull { operationKind ->
                 named(
                     namedKotlinToolchains.name + "[${operationKind.displayName}][${descriptor.argumentName}]",
-                    CommonKlibArgumentConfiguration(namedKotlinToolchains.payload, descriptor, operationKind)
+                    CommonKlibArgumentConfiguration(namedKotlinToolchains.payload(), descriptor, operationKind)
                 )
             }
         }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentProviders.kt
@@ -61,14 +61,14 @@ private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<J
 private fun namedArgumentConfiguration(
     argumentPredicate: (JsArgumentTestDescriptor<*>) -> Boolean = { true },
 ): List<Named<JsArgumentConfiguration<*>>> {
-    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
     val compilerArguments = jsCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
         compilerArguments.map { namedArgumentDescriptor ->
             named(
                 namedKotlinToolchains.name + namedArgumentDescriptor.name,
-                JsArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+                JsArgumentConfiguration(namedKotlinToolchains.payload(), namedArgumentDescriptor.payload)
             )
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/jvm/JvmArgumentProviders.kt
@@ -96,7 +96,7 @@ private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<J
 }
 
 private fun namedArgumentConfiguration(argumentPredicate: (JvmArgumentTestDescriptor<*>) -> Boolean = { true }): List<Named<JvmArgumentConfiguration<*>>> {
-    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
     val compilerArguments = jvmCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
@@ -105,7 +105,7 @@ private fun namedArgumentConfiguration(argumentPredicate: (JvmArgumentTestDescri
 
             named(
                 namedKotlinToolchains.name + namedArgumentDescriptor.name,
-                JvmArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+                JvmArgumentConfiguration(namedKotlinToolchains.payload(), namedArgumentDescriptor.payload)
             )
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/metadata/MetadataArgumentProviders.kt
@@ -76,14 +76,14 @@ private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<M
 private fun namedArgumentConfiguration(
     argumentPredicate: (MetadataArgumentTestDescriptor<*>) -> Boolean = { true },
 ): List<Named<MetadataArgumentConfiguration<*>>> {
-    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
     val compilerArguments = metadataCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
         compilerArguments.map { namedArgumentDescriptor ->
             named(
                 namedKotlinToolchains.name + namedArgumentDescriptor.name,
-                MetadataArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+                MetadataArgumentConfiguration(namedKotlinToolchains.payload(), namedArgumentDescriptor.payload)
             )
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/wasm/WasmArgumentProviders.kt
@@ -66,7 +66,7 @@ private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<W
 private fun namedArgumentConfiguration(
     argumentPredicate: (WasmArgumentTestDescriptor<*>) -> Boolean = { true },
 ): List<Named<WasmArgumentConfiguration<*>>> {
-    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
+    val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
     val compilerArguments = wasmCompilerArguments.filter { argumentPredicate(it) }.map {
         named("[${it.operationKind.displayName}][${it.argumentName}]", it)
     }
@@ -75,7 +75,7 @@ private fun namedArgumentConfiguration(
         compilerArguments.map { namedArgumentDescriptor ->
             named(
                 namedKotlinToolchains.name + namedArgumentDescriptor.name,
-                WasmArgumentConfiguration(namedKotlinToolchains.payload, namedArgumentDescriptor.payload)
+                WasmArgumentConfiguration(namedKotlinToolchains.payload(), namedArgumentDescriptor.payload)
             )
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCrossModuleIncrementalChanges/kotlin/ClasspathSnapshottingWithDebugInfoTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCrossModuleIncrementalChanges/kotlin/ClasspathSnapshottingWithDebugInfoTest.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.buildtools.tests.compilation
 
 import org.jetbrains.kotlin.buildtools.api.jvm.ClassSnapshotGranularity
 import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.DefaultStrategyAgnosticCompilationTestArgumentProvider.Companion.namedStrategyArguments
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.DefaultStrategyAgnosticCompilationTestArgumentProvider.Companion.namedStrategyProviders
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.SnapshotConfig
 import org.jetbrains.kotlin.buildtools.tests.compilation.scenario.ScenarioModule
 import org.jetbrains.kotlin.buildtools.tests.compilation.scenario.jvmScenario
@@ -34,25 +34,25 @@ private annotation class StrategyAgnosticSnapshotterTest
 
 private class StrategyAgnosticSnapshotterTestArgumentProvider : ArgumentsProvider {
     override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> {
-        return namedStrategyArguments().flatMap { namedStrategyArg ->
+        return namedStrategyProviders().flatMap { namedStrategyArg ->
             sequenceOf(
                 Arguments.of(
-                    namedStrategyArg,
+                    named(namedStrategyArg.name, namedStrategyArg.payload()),
                     ClassSnapshotGranularity.CLASS_LEVEL,
                     named("ignore inlined classes", false)
                 ),
                 Arguments.of(
-                    namedStrategyArg,
+                    named(namedStrategyArg.name, namedStrategyArg.payload()),
                     ClassSnapshotGranularity.CLASS_LEVEL,
                     named("use inlined classes", true)
                 ),
                 Arguments.of(
-                    namedStrategyArg,
+                    named(namedStrategyArg.name, namedStrategyArg.payload()),
                     ClassSnapshotGranularity.CLASS_MEMBER_LEVEL,
                     named("ignore inlined classes", false)
                 ),
                 Arguments.of(
-                    namedStrategyArg,
+                    named(namedStrategyArg.name, namedStrategyArg.payload()),
                     ClassSnapshotGranularity.CLASS_MEMBER_LEVEL,
                     named("use inlined classes", true)
                 ),


### PR DESCRIPTION
Previously parameterized tests were sharing the same instance of KotlinToolchains between invocations, making it impossible to test e.g. classloader caching once it's added.