### PR TITLE
[Native] ^KT-87702: split LlvmCallable into sealed classes

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -10,12 +10,6 @@ import org.jetbrains.kotlin.backend.konan.llvm.*
 import org.jetbrains.kotlin.backend.konan.llvm.objc.OBJC_RETAIN_AUTORELEASED_RETURN_VALUE
 import org.jetbrains.kotlin.backend.konan.serialization.CacheDeserializationStrategy
 import org.jetbrains.kotlin.library.uniqueName
-
-private fun LLVMValueRef.isLLVMBuiltin(): Boolean {
-    val name = this.name ?: return false
-    return name.startsWith("llvm.")
-}
-
 
 private class CallsChecker(generationState: NativeGenerationState, goodFunctions: List<String>) {
     private val llvm = generationState.llvm
@@ -66,9 +60,9 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
         fun cleanCalledFunction(value: LLVMValueRef): ExternalCallInfo? {
             return when {
                 LLVMIsAFunction(value) != null -> {
-                    val valueOrSpecial = value.takeIf { !it.isLLVMBuiltin() }
+                    val valueOrSpecial = value.takeIf { !it.isLLVMBuiltin }
                             ?: LLVMConstIntToPtr(llvm.int64(CALLED_LLVM_BUILTIN), llvm.pointerType)!!
-                    ExternalCallInfo(value.name!!, valueOrSpecial).takeIf { value.isExternalFunction() }
+                    ExternalCallInfo(value.valueName!!, valueOrSpecial).takeIf { value.isExternalFunction() }
                 }
                 LLVMIsACastInst(value) != null -> cleanCalledFunction(LLVMGetOperand(value, 0)!!)
                 isIndirectCallArgument(value) -> ExternalCallInfo(null, value) // this is a callback call
@@ -176,9 +170,9 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
     }
 
     fun processFunction(function: LLVMValueRef) {
-        if (function.name == checkerFunction.name) return
+        if (function.valueName == checkerFunction.name) return
         getBasicBlocks(function).forEach {
-            processBasicBlock(function.name!!, it)
+            processBasicBlock(function.valueName!!, it)
         }
     }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -94,7 +94,7 @@ internal class NativeGenerationState(
     val cStubsManager = CStubsManager(config.target, this)
     lateinit var llvmDeclarations: LlvmDeclarations
 
-    val virtualFunctionTrampolines = mutableMapOf<IrSimpleFunction, LlvmCallable>()
+    val virtualFunctionTrampolines = mutableMapOf<IrSimpleFunction, LlvmFunction>()
 
     val bindClassToObjCNameClassAdapters = mutableMapOf<String, ConstPointer>()
     val bindClassToObjCNameInterfaceAdapters = mutableMapOf<String, ConstPointer>()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterCodegen.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterCodegen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -23,8 +23,8 @@ import org.jetbrains.kotlin.resolve.DescriptorUtils
  * Second phase of C Export: build bitcode bridges from C wrappers to Kotlin functions.
  */
 internal class CAdapterCodegen(
-    private val codegen: CodeGenerator,
-    override val generationState: NativeGenerationState,
+        private val codegen: CodeGenerator,
+        override val generationState: NativeGenerationState,
 ) : ContextUtils {
 
     fun buildAllAdaptersRecursively(elements: CAdapterExportedElements) {
@@ -55,7 +55,7 @@ internal class CAdapterCodegen(
                     } else {
                         // KT-45468: Alias insertion may not be handled by LLVM properly, in case callee is in the cache.
                         // Hence, insert not an alias but a wrapper, hoping it will be optimized out later.
-                        codegen.llvmFunction(irFunction)
+                        codegen.getLlvmFunctionFrom(irFunction)
                     }
 
                     val args = signature.parameterTypes.indices.map { param(it) }
@@ -86,12 +86,12 @@ internal class CAdapterCodegen(
                     )
                     generateFunction(codegen, functionProto) {
                         val value = call(
-                            codegen.llvmFunction(context.getObjectClassInstanceFunction(irClass)),
-                            emptyList(),
-                            Lifetime.GLOBAL,
-                            ExceptionHandler.Caller,
-                            false,
-                            returnSlot
+                                codegen.getLlvmFunctionFrom(context.getObjectClassInstanceFunction(irClass)),
+                                emptyList(),
+                                Lifetime.GLOBAL,
+                                ExceptionHandler.Caller,
+                                false,
+                                returnSlot
                         )
                         ret(value)
                     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.backend.konan.driver.utilities.getDefaultLlvmModuleA
 import org.jetbrains.kotlin.backend.konan.llvm.LlvmFunctionAttribute
 import org.jetbrains.kotlin.backend.konan.llvm.addLlvmFunctionEnumAttribute
 import org.jetbrains.kotlin.backend.konan.llvm.getFunctions
-import org.jetbrains.kotlin.backend.konan.llvm.name
+import org.jetbrains.kotlin.backend.konan.llvm.valueName
 import org.jetbrains.kotlin.backend.konan.llvm.verifyModule
 import org.jetbrains.kotlin.backend.konan.optimizations.RemoveRedundantSafepointsPass
 import org.jetbrains.kotlin.config.nativeBinaryOptions.SanitizerKind
@@ -120,7 +120,7 @@ internal val StackProtectorPhaseInCompiler = createSimpleNamedCompilerPhase<Opti
             }
             attribute?.let { sspAttribute ->
                 getFunctions(module)
-                        .filter { LLVMIsDeclaration(it) == 0 && it.name != "__clang_call_terminate" }
+                        .filter { LLVMIsDeclaration(it) == 0 && it.valueName != "__clang_call_terminate" }
                         .forEach { addLlvmFunctionEnumAttribute(it, sspAttribute) }
             }
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -28,18 +28,22 @@ import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
 
 internal class CodeGenerator(override val generationState: NativeGenerationState) : ContextUtils {
-    fun addFunction(proto: LlvmFunctionProto): LlvmCallable =
+
+    /**
+     * Creates an LLVM function declaration within the current context and the associated LLVM module.
+     */
+    fun addFunctionDefinition(proto: LlvmFunctionProto): LlvmFunction.Definition =
             proto.createLlvmFunction(context, llvm.module)
 
-    fun llvmFunction(function: IrSimpleFunction): LlvmCallable =
-            llvmFunctionOrNull(function)
-                    ?: error("no function ${function.name} in ${function.file.packageFqName}")
+    fun getLlvmFunctionFrom(function: IrSimpleFunction): LlvmFunction =
+            getLlvmFunctionOrNullFrom(function) ?: error("No function ${function.name} in ${function.file.packageFqName}")
 
-    fun llvmFunctionOrNull(function: IrSimpleFunction): LlvmCallable? =
+    fun getLlvmFunctionOrNullFrom(function: IrSimpleFunction): LlvmFunction? =
             function.llvmFunctionOrNull
 
     val llvmDeclarations = generationState.llvmDeclarations
     val intPtrType = LLVMIntPtrTypeInContext(llvm.llvmContext, llvmTargetData)!!
+
     internal val immOneIntPtrType = LLVMConstInt(intPtrType, 1, 1)!!
     internal val immThreeIntPtrType = LLVMConstInt(intPtrType, 3, 1)!!
     // Keep in sync with OBJECT_TAG_MASK in C++.
@@ -97,13 +101,6 @@ internal enum class ThreadState {
     Native, Runnable
 }
 
-val LLVMValueRef.name:String?
-    get() = LLVMGetValueName(this)?.toKString()
-
-val LLVMValueRef.isConst:Boolean
-    get() = (LLVMIsConstant(this) == 1)
-
-
 internal inline fun generateFunction(
         codegen: CodeGenerator,
         function: IrSimpleFunction,
@@ -111,7 +108,7 @@ internal inline fun generateFunction(
         endLocation: LocationInfo?,
         code: FunctionGenerationContext.() -> Unit
 ) {
-    val llvmFunction = codegen.llvmFunction(function)
+    val llvmFunction = codegen.getLlvmFunctionFrom(function) as LlvmFunction.Definition
 
     val isCToKotlinBridge = function.origin == CBridgeOrigin.C_TO_KOTLIN_BRIDGE
             // TODO: Alternative approach: lowering that changes origin of such functions to C_TO_KOTLIN_BRIDGE?
@@ -152,8 +149,8 @@ internal inline fun generateFunction(
         switchToRunnable: Boolean = false,
         needSafePoint: Boolean = true,
         code: FunctionGenerationContext.() -> Unit
-) : LlvmCallable {
-    val function = codegen.addFunction(functionProto)
+): LlvmFunction.Definition {
+    val function = codegen.addFunctionDefinition(functionProto)
     val functionGenerationContext = DefaultFunctionGenerationContext(
             function,
             codegen,
@@ -175,8 +172,8 @@ internal inline fun generateFunctionNoRuntime(
         codegen: CodeGenerator,
         functionProto: LlvmFunctionProto,
         code: FunctionGenerationContext.() -> Unit,
-) : LlvmCallable {
-    val function = codegen.addFunction(functionProto)
+): LlvmCallable {
+    val function = codegen.addFunctionDefinition(functionProto)
     val functionGenerationContext = DefaultFunctionGenerationContext(function, codegen, null, null,
             switchToRunnable = false, needSafePoint = true)
     try {
@@ -292,7 +289,8 @@ internal object VirtualTablesLookup {
                 load(llvm.pointerType, slot)
             }
         }
-        return LlvmCallable(llvmMethod, llvmFunctionSignature)
+
+        return LlvmFunctionPointer(llvmMethod, llvmFunctionSignature)
     }
 }
 
@@ -311,7 +309,7 @@ internal val IrSimpleFunction.needsVirtualTrampoline: Boolean
  * so virtual call sites emit a plain `call @<name>` and stay decoupled from concrete vtable layouts:
  * a change to a class's vtable/itable does not invalidate cached callers in other files.
  */
-internal fun CodeGenerator.getVirtualFunctionTrampoline(irFunction: IrSimpleFunction): LlvmCallable {
+internal fun CodeGenerator.getVirtualFunctionTrampoline(irFunction: IrSimpleFunction): LlvmFunction {
     /*
      * Resolve owner of the call with special handling of Any methods:
      * if toString/eq/hc is invoked on an interface instance, we resolve
@@ -551,12 +549,12 @@ internal class StackLocalsManagerImpl(
 }
 
 internal abstract class FunctionGenerationContextBuilder<T : FunctionGenerationContext>(
-        val function: LlvmCallable,
+        val function: LlvmFunction.Definition,
         val codegen: CodeGenerator
 ) {
     constructor(functionProto: LlvmFunctionProto, codegen: CodeGenerator) :
             this(
-                    codegen.addFunction(functionProto),
+                    codegen.addFunctionDefinition(functionProto),
                     codegen
             )
 
@@ -571,7 +569,7 @@ internal abstract class FunctionGenerationContextBuilder<T : FunctionGenerationC
 }
 
 internal abstract class FunctionGenerationContext(
-        val function: LlvmCallable,
+        val function: LlvmFunction.Definition,
         val codegen: CodeGenerator,
         private val startLocation: LocationInfo?,
         protected val endLocation: LocationInfo?,
@@ -792,11 +790,13 @@ internal abstract class FunctionGenerationContext(
                             llvm.int32(size),
                             llvm.int1(isVolatile)))
 
-    fun call(llvmCallable: LlvmCallable, args: List<LLVMValueRef>,
-             resultLifetime: Lifetime = Lifetime.IRRELEVANT,
-             exceptionHandler: ExceptionHandler = ExceptionHandler.None,
-             verbatim: Boolean = false,
-             resultSlot: LLVMValueRef? = null,
+    fun call(
+            llvmCallable: LlvmCallable,
+            args: List<LLVMValueRef>,
+            resultLifetime: Lifetime = Lifetime.IRRELEVANT,
+            exceptionHandler: ExceptionHandler = ExceptionHandler.None,
+            verbatim: Boolean = false,
+            resultSlot: LLVMValueRef? = null,
     ): LLVMValueRef {
         val callArgs = if (verbatim || !llvmCallable.returnsObjectType) {
             args
@@ -827,41 +827,42 @@ internal abstract class FunctionGenerationContext(
         return callRaw(llvmCallable, callArgs, exceptionHandler)
     }
 
-    private fun callRaw(llvmCallable: LlvmCallable, args: List<LLVMValueRef>,
-                        exceptionHandler: ExceptionHandler): LLVMValueRef {
-        if (llvmCallable.isNoUnwind) {
+    private fun callRaw(
+            llvmCallable: LlvmCallable,
+            args: List<LLVMValueRef>,
+            exceptionHandler: ExceptionHandler
+    ): LLVMValueRef {
+        if (llvmCallable is LlvmFunction && llvmCallable.isNoUnwind) {
             return llvmCallable.buildCall(builder, args)
-        } else {
-            val unwind = when (exceptionHandler) {
-                ExceptionHandler.Caller -> {
-                    if (cleanupLandingpad == null) {
-                        return llvmCallable.buildCall(builder, args)
-                    } else {
-                        cleanupLangdingpadIsUsed = true
-                        cleanupLandingpad
-                    }
-                }
-                is ExceptionHandler.Local -> exceptionHandler.unwind
+        }
 
-                ExceptionHandler.None -> {
-                    // When calling a function that is not marked as nounwind (can throw an exception),
-                    // it is required to specify an unwind label to handle exceptions properly.
-                    // Runtime C++ function can be marked as non-throwing using `RUNTIME_NOTHROW`.
-                    val functionName = llvmCallable.name
-                    val message =
-                            "no exception handler specified when calling function $functionName without nounwind attr"
-                    throw IllegalArgumentException(message)
+        val unwind = when (exceptionHandler) {
+            ExceptionHandler.Caller -> {
+                if (cleanupLandingpad == null) {
+                    return llvmCallable.buildCall(builder, args)
+                } else {
+                    cleanupLangdingpadIsUsed = true
+                    cleanupLandingpad
                 }
             }
+            is ExceptionHandler.Local -> exceptionHandler.unwind
 
-            val position = position()
-            val endLocation = position?.end
-            val success = basicBlock("call_success", endLocation)
-            val result = llvmCallable.buildInvoke(builder, args, success, unwind)
-            positionAtEnd(success)
-
-            return result
+            ExceptionHandler.None -> {
+                // When calling a function that is not marked as nounwind (can throw an exception),
+                // it is required to specify an unwind label to handle exceptions properly.
+                // Runtime C++ function can be marked as non-throwing using `RUNTIME_NOTHROW`.
+                val functionName = llvmCallable.name
+                throw IllegalArgumentException("No exception handler specified when calling function $functionName without nounwind attr")
+            }
         }
+
+        val position = position()
+        val endLocation = position?.end
+        val success = basicBlock("call_success", endLocation)
+        val result = llvmCallable.buildInvoke(builder, args, success, unwind)
+        positionAtEnd(success)
+
+        return result
     }
 
     //-------------------------------------------------------------------------//
@@ -1333,7 +1334,7 @@ internal abstract class FunctionGenerationContext(
 
     internal fun prologue() {
         if (function.returnsObjectType) {
-            returnSlot = function.param( function.numParams - 1)
+            returnSlot = function.param(function.numParams - 1)
         }
 
         positionAtEnd(localsInitBb)
@@ -1560,7 +1561,7 @@ internal abstract class FunctionGenerationContext(
 
     fun positionBefore(instruction: LLVMValueRef) = currentPositionHolder.positionBefore(instruction)
 
-    inline private fun <R> preservingPosition(code: () -> R): R {
+    private inline fun <R> preservingPosition(code: () -> R): R {
         val oldPositionHolder = currentPositionHolder
         val newPositionHolder = PositionHolder()
         currentPositionHolder = newPositionHolder
@@ -1597,7 +1598,7 @@ internal abstract class FunctionGenerationContext(
 }
 
 internal class DefaultFunctionGenerationContext(
-        function: LlvmCallable,
+        function: LlvmFunction.Definition,
         codegen: CodeGenerator,
         startLocation: LocationInfo?,
         endLocation: LocationInfo?,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -182,11 +182,10 @@ internal interface ContextUtils : RuntimeAware {
      * LLVM function generated from the Kotlin function.
      * It may be declared as external function prototype.
      */
-    val IrSimpleFunction.llvmFunction: LlvmCallable
-        get() = llvmFunctionOrNull
-                ?: error("$name in ${file.name}/${parent.fqNameForIrSerialization}")
+    val IrSimpleFunction.llvmFunction: LlvmFunction
+        get() = llvmFunctionOrNull ?: error("$name in ${file.name}/${parent.fqNameForIrSerialization}")
 
-    val IrSimpleFunction.llvmFunctionOrNull: LlvmCallable?
+    val IrSimpleFunction.llvmFunctionOrNull: LlvmFunction?
         get() {
             assert(this.isReal) {
                 this.computeFullName()
@@ -343,7 +342,7 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
 
         attributesCopier.addFunctionAttributes(function)
 
-        return LlvmCallable(functionType, returnsObjectType, function, attributesCopier)
+        return LlvmFunction.Prototype(functionType, returnsObjectType, function, attributesCopier)
     }
 
     private fun importMemset(): LlvmCallable {
@@ -354,16 +353,16 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
                 functionType)
     }
 
-    private fun llvmIntrinsic(name: String, type: LLVMTypeRef, vararg attributes: String): LlvmCallable {
+    private fun llvmIntrinsic(name: String, type: LLVMTypeRef, vararg attributes: String): LlvmFunction.Prototype {
         val result = LLVMAddFunction(module, name, type)!!
         attributes.forEach {
             val kindId = getLlvmAttributeKindId(it)
             addLlvmFunctionEnumAttribute(result, kindId)
         }
-        return LlvmCallable(type, false, result, LlvmFunctionAttributeProvider.copyFromExternal(result))
+        return LlvmFunction.Prototype(type, false, result, LlvmFunctionAttributeProvider.copyFromExternal(result))
     }
 
-    internal fun externalFunction(llvmFunctionProto: LlvmFunctionProto): LlvmCallable {
+    internal fun externalFunction(llvmFunctionProto: LlvmFunctionProto): LlvmFunction {
         if (llvmFunctionProto.origin != null) {
             this.dependenciesTracker.add(llvmFunctionProto.origin, onlyBitcode = llvmFunctionProto.independent)
         }
@@ -374,7 +373,7 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
                         "found: ${getGlobalFunctionType(found).toTypeString()}"
             }
             require(LLVMGetLinkage(found) == llvmFunctionProto.linkage)
-            return LlvmCallable(found, llvmFunctionProto.signature)
+            return LlvmFunction.Prototype(found, llvmFunctionProto.signature)
         } else {
             return llvmFunctionProto.createLlvmFunction(context, module)
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -328,7 +328,7 @@ internal open class BasicLlvmHelpers(bitcodeContext: BitcodePostProcessingContex
 internal class CodegenLlvmHelpers(private val generationState: NativeGenerationState, module: LLVMModuleRef) : BasicLlvmHelpers(generationState, module), RuntimeAware {
     private val context = generationState.context
 
-    private fun importFunction(name: String, otherModule: LLVMModuleRef, returnsObjectType: Boolean): LlvmCallable {
+    private fun importFunction(name: String, otherModule: LLVMModuleRef, returnsObjectType: Boolean): LlvmFunction {
         if (LLVMGetNamedFunction(module, name) != null) {
             throw IllegalArgumentException("function $name already exists")
         }
@@ -342,7 +342,7 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
 
         attributesCopier.addFunctionAttributes(function)
 
-        return LlvmFunction.Prototype(functionType, returnsObjectType, function, attributesCopier)
+        return LlvmFunction.Declaration(functionType, returnsObjectType, function, attributesCopier)
     }
 
     private fun importMemset(): LlvmCallable {
@@ -353,13 +353,13 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
                 functionType)
     }
 
-    private fun llvmIntrinsic(name: String, type: LLVMTypeRef, vararg attributes: String): LlvmFunction.Prototype {
+    private fun llvmIntrinsic(name: String, type: LLVMTypeRef, vararg attributes: String): LlvmFunction.Declaration {
         val result = LLVMAddFunction(module, name, type)!!
         attributes.forEach {
             val kindId = getLlvmAttributeKindId(it)
             addLlvmFunctionEnumAttribute(result, kindId)
         }
-        return LlvmFunction.Prototype(type, false, result, LlvmFunctionAttributeProvider.copyFromExternal(result))
+        return LlvmFunction.Declaration(type, false, result, LlvmFunctionAttributeProvider.copyFromExternal(result))
     }
 
     internal fun externalFunction(llvmFunctionProto: LlvmFunctionProto): LlvmFunction {
@@ -373,7 +373,7 @@ internal class CodegenLlvmHelpers(private val generationState: NativeGenerationS
                         "found: ${getGlobalFunctionType(found).toTypeString()}"
             }
             require(LLVMGetLinkage(found) == llvmFunctionProto.linkage)
-            return LlvmFunction.Prototype(found, llvmFunctionProto.signature)
+            return LlvmFunction.Declaration(found, llvmFunctionProto.signature)
         } else {
             return llvmFunctionProto.createLlvmFunction(context, module)
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/DebugUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/DebugUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -320,7 +320,7 @@ internal fun String?.toFileAndFolder(config: NativeSecondStageCompilationConfig)
 
 internal fun alignTo(value: Long, align: Long): Long = (value + align - 1) / align * align
 
-internal fun setupBridgeDebugInfo(generationState: NativeGenerationState, function: LlvmCallable): LocationInfo? {
+internal fun setupBridgeDebugInfo(generationState: NativeGenerationState, function: LlvmFunction.Definition): LocationInfo? {
     if (!generationState.shouldContainLocationDebugInfo()) {
         return null
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
 package org.jetbrains.kotlin.backend.konan.llvm
 
 import llvm.*
@@ -643,7 +648,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
 
     private fun FunctionGenerationContext.emitThrowIfZero(divider: LLVMValueRef) {
         ifThen(icmpEq(divider, Zero(divider.type).llvm)) {
-            val throwArithExc = codegen.llvmFunction(context.symbols.throwArithmeticException.owner)
+            val throwArithExc = codegen.getLlvmFunctionFrom(context.symbols.throwArithmeticException.owner)
             call(throwArithExc, emptyList(), Lifetime.GLOBAL, environment.exceptionHandler)
             unreachable()
         }
@@ -651,7 +656,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
 
     private fun FunctionGenerationContext.emitThrowIfOOB(index: LLVMValueRef, size: LLVMValueRef) {
         ifThen(icmpUGe(index, size)) {
-            val throwIndexOutOfBoundsException = codegen.llvmFunction(context.symbols.throwIndexOutOfBoundsException.owner)
+            val throwIndexOutOfBoundsException = codegen.getLlvmFunctionFrom(context.symbols.throwIndexOutOfBoundsException.owner)
             call(throwIndexOutOfBoundsException, emptyList(), Lifetime.GLOBAL, environment.exceptionHandler)
             unreachable()
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -603,12 +603,12 @@ internal class CodeGeneratorVisitor(
     private inner class FunctionScope private constructor(
             val functionGenerationContext: FunctionGenerationContext,
             val declaration: IrSimpleFunction?,
-            val llvmFunction: LlvmCallable) : InnerScopeImpl() {
+            val llvmFunction: LlvmFunction) : InnerScopeImpl() {
 
         constructor(declaration: IrSimpleFunction, functionGenerationContext: FunctionGenerationContext) :
-                this(functionGenerationContext, declaration, codegen.llvmFunction(declaration))
+                this(functionGenerationContext, declaration, codegen.getLlvmFunctionFrom(declaration))
 
-        constructor(llvmFunction: LlvmCallable, functionGenerationContext: FunctionGenerationContext) :
+        constructor(llvmFunction: LlvmFunction, functionGenerationContext: FunctionGenerationContext) :
                 this(functionGenerationContext, null, llvmFunction)
 
         override fun genReturn(target: IrSymbolOwner, value: LLVMValueRef?) {
@@ -713,11 +713,11 @@ internal class CodeGeneratorVisitor(
             }
             StaticInitializersOrigins.EAGER_STATIC_GLOBAL_INITIALIZER -> {
                 require(scopeState.globalEagerInitFunction == null) { "There can only be at most one global eager file initializer" }
-                scopeState.globalEagerInitFunction = codegen.llvmFunction(declaration)
+                scopeState.globalEagerInitFunction = codegen.getLlvmFunctionFrom(declaration)
             }
             StaticInitializersOrigins.EAGER_STATIC_THREAD_LOCAL_INITIALIZER -> {
                 require(scopeState.threadLocalEagerInitFunction == null) { "There can only be at most one thread local eager file initializer" }
-                scopeState.threadLocalEagerInitFunction = codegen.llvmFunction(declaration)
+                scopeState.threadLocalEagerInitFunction = codegen.getLlvmFunctionFrom(declaration)
             }
             else -> return
         }
@@ -760,7 +760,7 @@ internal class CodeGeneratorVisitor(
 
 
         if (declaration.retainAnnotation(context.config.target)) {
-            llvm.usedFunctions.add(codegen.llvmFunction(declaration))
+            llvm.usedFunctions.add(codegen.getLlvmFunctionFrom(declaration))
         }
 
         if (context.shouldVerifyBitCode())
@@ -2193,7 +2193,7 @@ internal class CodeGeneratorVisitor(
             ) else null
 
     @Suppress("UNCHECKED_CAST")
-    private fun IrSimpleFunction.scope(startLine:Int): DIScopeOpaqueRef? {
+    private fun IrSimpleFunction.scope(startLine: Int): DIScopeOpaqueRef? {
         if (!context.shouldContainLocationDebugInfo())
             return null
 
@@ -2201,8 +2201,8 @@ internal class CodeGeneratorVisitor(
             isReifiedInline -> null
             // TODO: May be tie up inline lambdas to their outer function?
             codegen.isExternal(this) && !KonanBinaryInterface.isExported(this) -> null
-            isSuspend -> this.getOrCreateFunctionWithContinuationStub(context).let { codegen.llvmFunctionOrNull(it) }
-            else -> codegen.llvmFunctionOrNull(this)
+            isSuspend -> this.getOrCreateFunctionWithContinuationStub(context).let { codegen.getLlvmFunctionOrNullFrom(it) }
+            else -> codegen.getLlvmFunctionOrNullFrom(this)
         }
         return with(debugInfo) {
             val f = this@scope
@@ -2214,7 +2214,7 @@ internal class CodeGeneratorVisitor(
                             && f.hasAnnotation(KonanFqNames.transparentForDebugger)
 
                     diFunctionScope(fileEntry(), functionLlvmValue.name!!, startLine, nodebug, isTransparentStepping).also {
-                        if (!this@scope.isInline)
+                        if (!this@scope.isInline && functionLlvmValue is LlvmFunction.Definition)
                             functionLlvmValue.addDebugInfoSubprogram(it)
                     }
                 } as DIScopeOpaqueRef
@@ -2523,7 +2523,7 @@ internal class CodeGeneratorVisitor(
     //-------------------------------------------------------------------------//
 
     fun callDirect(function: IrSimpleFunction, args: List<LLVMValueRef>, resultLifetime: Lifetime, resultSlot: LLVMValueRef?): LLVMValueRef {
-        val functionDeclarations = codegen.llvmFunction(function.target)
+        val functionDeclarations = codegen.getLlvmFunctionFrom(function.target)
         return call(function, functionDeclarations, args, resultLifetime, resultSlot)
     }
 
@@ -2778,7 +2778,7 @@ internal class CodeGeneratorVisitor(
                         files.map { ctorProto(fileCtorName(library.uniqueName, it)) }
                     }
                 }.map {
-                    codegen.addFunction(it)
+                    codegen.addFunctionDefinition(it)
                 }
             }
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmCallable.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmCallable.kt
@@ -72,7 +72,7 @@ sealed class LlvmFunction(
     /**
      * Function prototypes (or [declaration in LLVM terms](https://llvm.org/docs/LangRef.html#functions)) do not belong to a specific module.
      */
-    class Prototype(
+    class Declaration(
             functionType: LLVMTypeRef,
             returnsObjectType: Boolean,
             llvmValue: LLVMValueRef,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmCallable.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmCallable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -8,33 +8,17 @@ package org.jetbrains.kotlin.backend.konan.llvm
 import kotlinx.cinterop.toCValues
 import llvm.*
 
-/**
- *  Wrapper around LLVM value of functional type.
- *
- *  @todo This class mixes "something that can be called" and function abstractions.
- *        Some of it's methods make sense only for functions. Probably, LlvmFunction sub-class should be extracted.
- */
-class LlvmCallable(val functionType: LLVMTypeRef, val returnsObjectType: Boolean, private val llvmValue: LLVMValueRef, private val attributeProvider: LlvmFunctionAttributeProvider) {
-    internal constructor(
-            llvmValue: LLVMValueRef,
-            signature: LlvmFunctionSignature,
-    ) : this(signature.llvmFunctionType, signature.returnsObjectType, llvmValue, signature)
+sealed class LlvmCallable(
+        val functionType: LLVMTypeRef,
+        val returnsObjectType: Boolean,
+        protected val llvmValue: LLVMValueRef,
+        protected val attributeProvider: LlvmFunctionAttributeProvider,
+) {
 
-    val returnType: LLVMTypeRef by lazy {
-        LLVMGetReturnType(functionType)!!
-    }
-
-    val name by lazy {
-        llvmValue.name
-    }
-
-    val numParams by lazy {
-        LLVMCountParamTypes(functionType)
-    }
-
-    val isConstant by lazy {
-        LLVMIsConstant(llvmValue) == 1
-    }
+    val name: String? by lazy { llvmValue.valueName }
+    val returnType: LLVMTypeRef by lazy { LLVMGetReturnType(functionType)!! }
+    val numParams: Int by lazy { LLVMCountParamTypes(functionType) }
+    val isConstant by lazy { llvmValue.isConst }
 
     fun buildCall(builder: LLVMBuilderRef, args: List<LLVMValueRef>, name: String = "") =
             LLVMBuildCall2(builder, functionType, llvmValue, args.toCValues(), args.size, name)!!.also {
@@ -46,51 +30,99 @@ class LlvmCallable(val functionType: LLVMTypeRef, val returnsObjectType: Boolean
                 attributeProvider.addCallSiteAttributes(it)
             }
 
-    fun buildLandingpad(builder: LLVMBuilderRef, landingpadType: LLVMTypeRef, numClauses: Int, name: String = "") =
-            LLVMBuildLandingPad(builder, landingpadType, llvmValue, numClauses, name)!!
+    internal fun toConstPointer() = constPointer(llvmValue)
 
-    fun addBasicBlock(context: LLVMContextRef, name: String = "") =
-            LLVMAppendBasicBlockInContext(context, llvmValue, name)!!
+    internal fun asCallback() = llvmValue
+}
 
-    fun blockAddress(label: LLVMBasicBlockRef) = LLVMBlockAddress(llvmValue, label)!!
+class LlvmFunctionPointer(
+        functionType: LLVMTypeRef,
+        returnsObjectType: Boolean,
+        llvmValue: LLVMValueRef,
+        attributeProvider: LlvmFunctionAttributeProvider,
+) : LlvmCallable(functionType, returnsObjectType, llvmValue, attributeProvider) {
+    internal constructor(llvmValue: LLVMValueRef, signature: LlvmFunctionSignature) :
+            this(signature.llvmFunctionType, signature.returnsObjectType, llvmValue, signature)
+}
 
-    fun addDebugInfoSubprogram(subprogram: DISubprogramRef) {
-        DIFunctionAddSubprogram(llvmValue, subprogram)
+sealed class LlvmFunction(
+        functionType: LLVMTypeRef,
+        returnsObjectType: Boolean,
+        llvmValue: LLVMValueRef,
+        attributeProvider: LlvmFunctionAttributeProvider,
+) : LlvmCallable(functionType, returnsObjectType, llvmValue, attributeProvider) {
+
+    val isNoUnwind by lazy {
+        requireNotNull(LLVMIsAFunction(llvmValue)) {
+            "The LLVM value '${llvmValue.valueName}' is not a function. Supposed to be a function named '$name'."
+        }
+        isFunctionNoUnwind(llvmValue)
     }
 
-    fun createBridgeFunctionDebugInfo(
-            builder: DIBuilderRef,
-            scope: DIScopeOpaqueRef,
-            file: DIFileRef,
-            lineNo: Int,
-            type: DISubroutineTypeRef,
-            isLocal: Int,
-            isDefinition: Int,
-            scopeLine: Int,
-            isTransparentStepping: Boolean,
-    ) = DICreateBridgeFunction(
-            builder = builder,
-            scope = scope,
-            function = llvmValue,
-            file = file,
-            lineNo = lineNo,
-            type = type,
-            isLocal = isLocal,
-            isDefinition = isDefinition,
-            scopeLine = scopeLine,
-            isTransparentStepping = if (isTransparentStepping) 1 else 0,
-    )!!
-
-    fun param(i: Int) : LLVMValueRef {
-        require(i in 0 until numParams)
+    fun param(i: Int): LLVMValueRef {
+        require(i in 0 until numParams) {
+            "Requested index $i but function '$name' got only $numParams params."
+        }
         return LLVMGetParam(llvmValue, i)!!
     }
 
-    val isNoUnwind by lazy {
-        LLVMIsAFunction(llvmValue) != null && isFunctionNoUnwind(llvmValue)
+    fun buildLandingpad(builder: LLVMBuilderRef, landingpadType: LLVMTypeRef, numClauses: Int, name: String = "") =
+            LLVMBuildLandingPad(builder, landingpadType, llvmValue, numClauses, name)!!
+
+    /**
+     * Function prototypes (or [declaration in LLVM terms](https://llvm.org/docs/LangRef.html#functions)) do not belong to a specific module.
+     */
+    class Prototype(
+            functionType: LLVMTypeRef,
+            returnsObjectType: Boolean,
+            llvmValue: LLVMValueRef,
+            attributeProvider: LlvmFunctionAttributeProvider,
+    ) : LlvmFunction(functionType, returnsObjectType, llvmValue, attributeProvider) {
+        internal constructor(llvmValue: LLVMValueRef, signature: LlvmFunctionSignature) :
+                this(signature.llvmFunctionType, signature.returnsObjectType, llvmValue, signature)
     }
 
-    // these functions are potentially unsafe, as they need to use same attribute provider when converted to callable
-    internal fun toConstPointer() = constPointer(llvmValue)
-    internal fun asCallback() = llvmValue
+    class Definition(
+            functionType: LLVMTypeRef,
+            returnsObjectType: Boolean,
+            llvmValue: LLVMValueRef,
+            attributeProvider: LlvmFunctionAttributeProvider,
+    ) : LlvmFunction(functionType, returnsObjectType, llvmValue, attributeProvider) {
+
+        internal constructor(llvmValue: LLVMValueRef, signature: LlvmFunctionSignature) :
+                this(signature.llvmFunctionType, signature.returnsObjectType, llvmValue, signature)
+
+        fun addBasicBlock(context: LLVMContextRef, name: String = "") =
+                LLVMAppendBasicBlockInContext(context, llvmValue, name)!!
+
+        fun blockAddress(label: LLVMBasicBlockRef) =
+                LLVMBlockAddress(llvmValue, label)!!
+
+        fun addDebugInfoSubprogram(subprogram: DISubprogramRef) {
+            DIFunctionAddSubprogram(llvmValue, subprogram)
+        }
+
+        fun createBridgeFunctionDebugInfo(
+                builder: DIBuilderRef,
+                scope: DIScopeOpaqueRef,
+                file: DIFileRef,
+                lineNo: Int,
+                type: DISubroutineTypeRef,
+                isLocal: Int,
+                isDefinition: Int,
+                scopeLine: Int,
+                isTransparentStepping: Boolean,
+        ) = DICreateBridgeFunction(
+                builder = builder,
+                scope = scope,
+                function = llvmValue,
+                file = file,
+                lineNo = lineNo,
+                type = type,
+                isLocal = isLocal,
+                isDefinition = isDefinition,
+                scopeLine = scopeLine,
+                isTransparentStepping = if (isTransparentStepping) 1 else 0,
+        )!!
+    }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -40,12 +40,8 @@ enum class UniqueKind(val llvmName: String) {
 }
 
 internal class LlvmDeclarations(private val unique: Map<UniqueKind, UniqueLlvmDeclarations>) {
-    fun forFunction(function: IrSimpleFunction): LlvmCallable =
-            forFunctionOrNull(function) ?: with(function) {
-                error("$name in $file/${parent.fqNameForIrSerialization}")
-            }
 
-    fun forFunctionOrNull(function: IrSimpleFunction): LlvmCallable? =
+    fun forFunctionOrNull(function: IrSimpleFunction) =
             (function.metadata as? KonanMetadata.Function)?.llvm
 
     fun forClass(irClass: IrClass) =
@@ -475,7 +471,7 @@ internal sealed class KonanMetadata(override val name: Name?, val konanLibrary: 
 
     class Class(irClass: IrClass, val llvm: ClassLlvmDeclarations, val layoutBuilder: ClassLayoutBuilder) : Declaration<IrClass>(irClass)
 
-    class Function(irFunction: IrSimpleFunction, val llvm: LlvmCallable) : Declaration<IrSimpleFunction>(irFunction)
+    class Function(irFunction: IrSimpleFunction, val llvm: LlvmFunction) : Declaration<IrSimpleFunction>(irFunction)
 
     class InstanceField(irField: IrField, val llvm: FieldLlvmDeclarations) : Declaration<IrField>(irField)
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmFunctionPrototype.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmFunctionPrototype.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -179,16 +179,15 @@ sealed class FunctionOrigin {
     class OwnedBy(val declaration: IrDeclaration, val weak: Boolean = false) : FunctionOrigin()
 }
 
-
 /**
  * Prototype of a LLVM function that is not tied to a specific LLVM module.
  */
 internal class LlvmFunctionProto(
-      val name: String,
-      val signature: LlvmFunctionSignature,
-      val origin: FunctionOrigin?,
-      val linkage: LLVMLinkage,
-      val independent: Boolean = false,
+        val name: String,
+        val signature: LlvmFunctionSignature,
+        val origin: FunctionOrigin?,
+        val linkage: LLVMLinkage,
+        val independent: Boolean = false,
 ) {
     constructor(irFunction: IrSimpleFunction, symbolName: String, contextUtils: ContextUtils, linkage: LLVMLinkage) : this(
             name = symbolName,
@@ -198,20 +197,21 @@ internal class LlvmFunctionProto(
             independent = irFunction.hasAnnotation(RuntimeNames.independent)
     )
 
-    fun createLlvmFunction(context: NativeBackendContext, llvmModule: LLVMModuleRef): LlvmCallable {
+    /**
+     * Given the current [context], it creates a new function definition within the [llvmModule] module.
+     */
+    fun createLlvmFunction(context: NativeBackendContext, llvmModule: LLVMModuleRef): LlvmFunction.Definition {
         val function = LLVMAddFunction(llvmModule, name, signature.llvmFunctionType)!!
         addDefaultLlvmFunctionAttributes(context, function)
         addTargetCpuAndFeaturesAttributes(context, function)
         signature.addFunctionAttributes(function)
         LLVMSetLinkage(function, linkage)
-        return LlvmCallable(function, signature)
+        return LlvmFunction.Definition(function, signature)
     }
 }
 
 internal fun LlvmFunctionSignature.toProto(name: String, origin: FunctionOrigin?, linkage: LLVMLinkage, independent: Boolean = false) =
         LlvmFunctionProto(name, this, origin, linkage, independent)
-
-
 
 private fun mustNotInline(context: NativeBackendContext, irFunction: IrSimpleFunction): Boolean {
     if (context.shouldContainLocationDebugInfo()) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -257,6 +257,18 @@ fun LLVMTypeRef?.toTypeString(): String {
     if (this == null) return "<null type>"
     return LLVMPrintTypeToString(this)!!.toKString()
 }
+
+val LLVMValueRef.valueName: String?
+    get() = LLVMGetValueName(this)?.toKString()
+
+val LLVMValueRef.isConst: Boolean
+    get() = (LLVMIsConstant(this) == 1)
+
+val LLVMValueRef.isLLVMBuiltin: Boolean
+    get() {
+        val name = valueName ?: return false
+        return name.startsWith("llvm.")
+    }
 
 fun getStructElements(type: LLVMTypeRef): List<LLVMTypeRef> {
     val count = LLVMCountStructElementTypes(type)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/Runtime.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/Runtime.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -22,7 +22,7 @@ internal class Runtime(
 ) {
     val llvmModule: LLVMModuleRef = parseBitcodeFile(phaseContext, phaseContext.diagnosticReporter, llvmContext, bitcodeFile)
     val calculatedLLVMTypes: MutableMap<IrType, LLVMTypeRef> = HashMap()
-    val addedLLVMExternalFunctions: MutableMap<IrFunction, LlvmCallable> = HashMap()
+    val addedLLVMExternalFunctions: MutableMap<IrFunction, LlvmFunction> = HashMap()
 
     private fun getStructTypeOrNull(name: String, isClass: Boolean = false) =
             LLVMGetTypeByName(llvmModule, "${if (isClass) "class" else "struct"}.$name")

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/BindReverseBridgeToMethodCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/BindReverseBridgeToMethodCodeGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -36,9 +36,9 @@ internal fun CodeGenerator.collectReverseBridgeAdapters(file: IrFile): Map<IrCla
 }
 
 private fun CodeGenerator.resolveReverseBridgeAdapter(
-    irClass: IrClass,
-    layoutBuilder: ClassLayoutBuilder,
-    bridge: BindReverseBridgeToMethod,
+        irClass: IrClass,
+        layoutBuilder: ClassLayoutBuilder,
+        bridge: BindReverseBridgeToMethod,
 ): KotlinToObjCMethodAdapter? {
     val targetFunction = irClass.simpleFunctions()
             .firstOrNull { it.name.asString() == bridge.targetMethod }
@@ -59,9 +59,9 @@ private fun CodeGenerator.resolveReverseBridgeAdapter(
     }
 
     return KotlinToObjCMethodAdapter(
-        selector = bridge.targetMethod,
-        itablePlace = itablePlace,
-        vtableIndex = vtableIndex,
-        kotlinImpl = llvmFunction(bridge.bridgeFunction).toConstPointer(),
+            selector = bridge.targetMethod,
+            itablePlace = itablePlace,
+            vtableIndex = vtableIndex,
+            kotlinImpl = getLlvmFunctionFrom(bridge.bridgeFunction).toConstPointer(),
     )
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/ObjCCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/ObjCCodeGenerator.kt
@@ -76,7 +76,7 @@ internal open class ObjCCodeGenerator(val codegen: CodeGenerator) {
 
     // TODO: this doesn't support stret.
     fun msgSender(functionType: LlvmFunctionSignature): LlvmCallable =
-            LlvmFunction.Prototype(objcMsgSend.llvm, functionType)
+            LlvmFunction.Declaration(objcMsgSend.llvm, functionType)
 }
 
 internal const val OBJC_RETAIN_AUTORELEASED_RETURN_VALUE = "llvm.objc.retainAutoreleasedReturnValue"

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/ObjCCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/ObjCCodeGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -76,7 +76,7 @@ internal open class ObjCCodeGenerator(val codegen: CodeGenerator) {
 
     // TODO: this doesn't support stret.
     fun msgSender(functionType: LlvmFunctionSignature): LlvmCallable =
-            LlvmCallable(objcMsgSend.llvm, functionType)
+            LlvmFunction.Prototype(objcMsgSend.llvm, functionType)
 }
 
 internal const val OBJC_RETAIN_AUTORELEASED_RETURN_VALUE = "llvm.objc.retainAutoreleasedReturnValue"

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/BlockPointerSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/BlockPointerSupport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -131,7 +131,7 @@ private fun FunctionGenerationContext.loadBlockInvoke(
     val invokePtr = structGep(codegen.runtime.blockLiteralType, blockPtr, 3)
     val signature = bridge.blockType.toBlockInvokeLlvmType(llvm)
     val functionPointer = load(llvm.pointerType, invokePtr)
-    return LlvmCallable(functionPointer, signature)
+    return LlvmFunctionPointer(functionPointer, signature)
 }
 
 private fun FunctionGenerationContext.allocInstanceWithAssociatedObject(

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -120,6 +120,7 @@ internal class ObjCExportFunctionGenerationContextBuilder(
     init {
         forceCleanupLandingpad = true
     }
+
     override fun build(): ObjCExportFunctionGenerationContext {
         return ObjCExportFunctionGenerationContext(this)
     }
@@ -171,7 +172,7 @@ internal fun ObjCExportFunctionGenerationContext.callAndMaybeRetainAutoreleased(
             functionAttributes = listOf(LlvmFunctionAttribute.NoInline)
     )
 
-    val outlined = objCExportCodegen.functionGenerator(outlinedType.toProto( this.function.name.orEmpty() + "_outlined", null, LLVMLinkage.LLVMPrivateLinkage)) {
+    val outlined = objCExportCodegen.functionGenerator(outlinedType.toProto(this.function.name.orEmpty() + "_outlined", null, LLVMLinkage.LLVMPrivateLinkage)) {
         setupBridgeDebugInfo()
         // Don't generate redundant cleanup landingpad (the generation would fail due to forbidRuntime below):
         forceCleanupLandingpad = false
@@ -179,7 +180,10 @@ internal fun ObjCExportFunctionGenerationContext.callAndMaybeRetainAutoreleased(
         forbidRuntime = true // Don't emit safe points, frame management etc.
 
         val actualArgs = signature.parameterTypes.indices.map { param(it) }
-        val actualCallable = if (functionIsPassedAsLastParameter) LlvmCallable(param(signature.parameterTypes.size), signature) else function
+        val actualCallable = if (functionIsPassedAsLastParameter)
+            LlvmFunctionPointer(param(signature.parameterTypes.size), signature)
+        else
+            function
 
         // Use LLVMBuildCall instead of call, because the latter enforces using exception handler, which is exactly what we have to avoid.
         val result = actualCallable.buildCall(builder, actualArgs).let { callResult ->
@@ -341,9 +345,9 @@ internal class ObjCExportCodeGenerator(
     }
 
     private fun ObjCExportFunctionGenerationContext.objCBlockPointerToKotlin(
-        value: LLVMValueRef,
-        typeBridge: BlockPointerBridge,
-        resultLifetime: Lifetime
+            value: LLVMValueRef,
+            typeBridge: BlockPointerBridge,
+            resultLifetime: Lifetime
     ) = callFromBridge(
             blockToKotlinFunctionConverter(typeBridge),
             listOf(value),
@@ -430,7 +434,7 @@ internal class ObjCExportCodeGenerator(
     internal fun generate(spec: ObjCExportCodeSpec?) {
         generateTypeAdapters(spec)
 
-        NSNumberKind.values().mapNotNull { it.mappedKotlinClassId }.forEach {
+        NSNumberKind.entries.mapNotNull { it.mappedKotlinClassId }.forEach {
             dataGenerator.exportClass(namer.numberBoxName(it).binaryName)
         }
         dataGenerator.exportClass(namer.mutableSetName.binaryName)
@@ -814,7 +818,7 @@ private fun ObjCExportCodeGenerator.generateObjCImp(
                 debugInfo = false,
                 suffix = baseMethod.computeSymbolName(),
         ) {
-            callFromBridge(codegen.llvmFunction(symbols.throwIllegalStateException.owner), emptyList())
+            callFromBridge(codegen.getLlvmFunctionFrom(symbols.throwIllegalStateException.owner), emptyList())
         }
     } else generateObjCImp(
             methodBridge,
@@ -830,7 +834,7 @@ private fun ObjCExportCodeGenerator.generateObjCImp(
         val llvmCallable = if (isVirtual) {
             codegen.getVirtualFunctionTrampoline(target as IrSimpleFunction)
         } else {
-            codegen.llvmFunction(target as? IrSimpleFunction ?: context.getLoweredConstructorFunction(target as IrConstructor))
+            codegen.getLlvmFunctionFrom(target as? IrSimpleFunction ?: context.getLoweredConstructorFunction(target as IrConstructor))
         }
         call(llvmCallable, args, resultLifetime, exceptionHandler)
     }
@@ -963,7 +967,7 @@ private fun ObjCExportCodeGenerator.generateObjCImp(
             MethodBridge.ReturnValue.Instance.FactoryResult -> return autoreleaseAndRet(kotlinReferenceToRetainedObjC(targetResult!!)) // provided by [callKotlin]
             MethodBridge.ReturnValue.Suspend -> {
                 val coroutineSuspended = callFromBridge(
-                        codegen.llvmFunction(context.symbols.objCExportGetCoroutineSuspended.owner),
+                        codegen.getLlvmFunctionFrom(context.symbols.objCExportGetCoroutineSuspended.owner),
                         emptyList(),
                         Lifetime.STACK
                 )
@@ -1647,10 +1651,10 @@ private fun ObjCExportCodeGenerator.nonOverridableAdapter(
         selector: String,
         hasSelectorAmbiguity: Boolean
 ): KotlinToObjCMethodAdapter = codegen.KotlinToObjCMethodAdapter(
-    selector,
-    vtableIndex = if (hasSelectorAmbiguity) -2 else -1, // Describes the reason.
-    kotlinImpl = llvm.nullPointer,
-    itablePlace = ClassLayoutBuilder.InterfaceTablePlace.INVALID
+        selector,
+        vtableIndex = if (hasSelectorAmbiguity) -2 else -1, // Describes the reason.
+        kotlinImpl = llvm.nullPointer,
+        itablePlace = ClassLayoutBuilder.InterfaceTablePlace.INVALID
 )
 
 private val ObjCTypeForKotlinType.kotlinMethods: List<ObjCMethodForKotlinMethod>


### PR DESCRIPTION
Resolve long-standing TODO by splitting `LlvmCallable` into a sealed class hierarchy:
* `LlvmFunctionPointer`: Represents function pointers.
* `LlvmFunction`: Represents functions that are either prototypes/declarations or definitions.

This distinction is required for native hot-reload support, where the bootstrap object references functions outside its LLVM module.

These changes provide clearer responsibilities and intent across the hierarchy and `LlvmCallable` usages.