### PR TITLE
[Gradle] Fix SwiftExportDslIT & SwiftExportXCIT for Gradle 9.6 compatibility

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportDslIT.kt
@@ -48,8 +48,8 @@ class SwiftExportDslIT : KGPBaseTest() {
                     applyMultiplatform {
                         iosArm64()
                         with(swiftExport) {
-                            export(dependencies.project(":subproject"))
-                            export(dependencies.project(":not-good-looking-project-name"))
+                            export(dependencies.project(mapOf("path" to ":subproject")))
+                            export(dependencies.project(mapOf("path" to ":not-good-looking-project-name")))
                         }
 
                         sourceSets.commonMain {
@@ -140,7 +140,7 @@ class SwiftExportDslIT : KGPBaseTest() {
                         iosArm64()
                         with(swiftExport) {
                             moduleName.set("CustomShared")
-                            export(dependencies.project(":subproject")) {
+                            export(dependencies.project(mapOf("path" to ":subproject"))) {
                                 moduleName.set("CustomSubproject")
                             }
                         }
@@ -218,7 +218,7 @@ class SwiftExportDslIT : KGPBaseTest() {
                         iosArm64()
                         with(swiftExport) {
                             flattenPackage.set("com.github.jetbrains.swiftexport")
-                            export(dependencies.project(":subproject")) {
+                            export(dependencies.project(mapOf("path" to ":subproject"))) {
                                 flattenPackage.set("com.subproject.library")
                             }
                         }
@@ -336,8 +336,8 @@ class SwiftExportDslIT : KGPBaseTest() {
                     applyMultiplatform {
                         iosArm64()
                         with(swiftExport) {
-                            export(dependencies.project(":subproject"))
-                            export(dependencies.project(":not-good-looking-project-name"))
+                            export(dependencies.project(mapOf("path" to ":subproject")))
+                            export(dependencies.project(mapOf("path" to ":not-good-looking-project-name")))
                         }
                     }
                 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportXCIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/SwiftExportXCIT.kt
@@ -47,7 +47,7 @@ class SwiftExportXCIT : KGPBaseTest() {
                                 moduleName.set("Shared")
                                 flattenPackage.set("com.github.jetbrains.example")
 
-                                export(dependencies.project(":subproject")) {
+                                export(dependencies.project(mapOf("path" to ":subproject"))) {
                                     moduleName.set("Subproject")
                                     flattenPackage.set("com.github.jetbrains.library")
                                 }


### PR DESCRIPTION
In addition to https://github.com/JetBrains/kotlin/pull/6143

^KT-86040