### PR TITLE
[Build] clean doesn't need to depend on other projects clean

### DIFF
--- a/kotlin-native/build.gradle
+++ b/kotlin-native/build.gradle
@@ -721,7 +721,6 @@ KotlinBuildPublishingPluginKt.configureDefaultPublishing(
 )
 
 tasks.named("clean", Delete) {
-    dependsOn subprojects.collect { "$it:clean" }
     it.delete(nativeDistribution.map { it.root })
     it.delete(layout.buildDirectory)
     it.delete(bundle.outputs.files)


### PR DESCRIPTION
I broke it in 53c3e682ddec86f91c6fb767360d6f90e196c2f3
Originally :`kotlin-native:clean` depended in all tasks named `clean` of it's subprojects.
I made it to depend on the task paths directly, but there are projects without `clean`task (folders that don't really contain any real project)
Running `./gradlew clean` will always go through all clean tasks.