### PR TITLE
[JVM] Inline cast bound receivers in property reference delegation

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
@@ -60,7 +60,8 @@ internal class PropertyReferenceDelegationLowering(val context: JvmBackendContex
 
 private class PropertyReferenceDelegationTransformer(val context: JvmBackendContext) : IrElementTransformerVoid() {
 
-    // Some receivers don't need to be stored in fields and can be reevaluated every time an accessor is called:
+    // A stable bound receiver doesn't need to be stored in a field and can be reevaluated every time an accessor is called.
+    // Every expression shape accepted here must be copyable by `IrExpression.remapReceiver`:
     private fun IrExpression?.canInline(visibleScopes: Set<IrDeclarationParent>): Boolean = when (this) {
         null -> true
         is IrGetValue -> {
@@ -79,6 +80,12 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
             val callee = symbol.owner
             callee.isFinalDefaultValGetter && callee.fileParentOrNull.let { it != null && it in visibleScopes }
                     && arguments.all { it.canInline(visibleScopes) }
+        }
+        is IrTypeOperatorCall -> {
+            // Implicit casts (e.g. coming from smart casts) cannot fail and have no side effects. Unsafe casts of stable
+            // arguments are deterministic, and the initializer block generated below evaluates them once at the position of
+            // the original delegate construction, so reevaluations in accessors cannot fail if initialization succeeded:
+            (operator == IrTypeOperator.IMPLICIT_CAST || operator == IrTypeOperator.CAST) && argument.canInline(visibleScopes)
         }
         else -> {
             // Constants and singleton object accesses are always stable:

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IrUtils.kt
@@ -673,6 +673,8 @@ fun IrExpression.remapReceiver(oldReceiver: IrValueParameter?, newReceiver: IrVa
                     } else argument
             }
         }
+    is IrTypeOperatorCall ->
+        IrTypeOperatorCallImpl(startOffset, endOffset, type, operator, typeOperand, argument.remapReceiver(oldReceiver, newReceiver))
     else -> shallowCopy()
 }
 

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToCastReceiver.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToCastReceiver.kt
@@ -1,0 +1,19 @@
+// WITH_STDLIB
+// CHECK_BYTECODE_LISTING
+
+class A {
+    var x = "start"
+}
+
+val a: Any = A()
+
+class B {
+    var y by (a as A)::x
+}
+
+fun box(): String {
+    val b = B()
+    if (b.y != "start") return "FAIL 1: ${b.y}"
+    b.y = "K"
+    return "O" + (a as A).x
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToCastReceiver.txt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToCastReceiver.txt
@@ -1,0 +1,26 @@
+@kotlin.Metadata
+public final class A {
+    // source: 'delegateToCastReceiver.kt'
+    private @org.jetbrains.annotations.NotNull field x: java.lang.String
+    public method <init>(): void
+    public final @org.jetbrains.annotations.NotNull method getX(): java.lang.String
+    public final method setX(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+}
+
+@kotlin.Metadata
+public final class B {
+    // source: 'delegateToCastReceiver.kt'
+    public method <init>(): void
+    private static method getY$delegate(p0: B): java.lang.Object
+    public final @org.jetbrains.annotations.NotNull method getY(): java.lang.String
+    public final method setY(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+}
+
+@kotlin.Metadata
+public final class DelegateToCastReceiverKt {
+    // source: 'delegateToCastReceiver.kt'
+    private final static @org.jetbrains.annotations.NotNull field a: java.lang.Object
+    static method <clinit>(): void
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    public final static @org.jetbrains.annotations.NotNull method getA(): java.lang.Object
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToFailingCastReceiver.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToFailingCastReceiver.kt
@@ -1,0 +1,20 @@
+// WITH_STDLIB
+
+class A {
+    val x = "unreachable"
+}
+
+val bad: Any = "not an A"
+
+class C {
+    val y by (bad as A)::x
+}
+
+fun box(): String {
+    val c = try {
+        C()
+    } catch (e: ClassCastException) {
+        return "OK"
+    }
+    return "FAIL: no CCE when constructing C, y = ${c.y}"
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToSmartCastReceiver.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToSmartCastReceiver.kt
@@ -1,0 +1,19 @@
+// WITH_STDLIB
+// CHECK_BYTECODE_LISTING
+
+class A {
+    var x = "start"
+}
+
+fun test(a: Any): String {
+    if (a !is A) return "FAIL 0: $a"
+    class B {
+        var y by a::x
+    }
+    val b = B()
+    if (b.y != "start") return "FAIL 1: ${b.y}"
+    b.y = "K"
+    return "O" + a.x
+}
+
+fun box(): String = test(A())

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToSmartCastReceiver.txt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToSmartCastReceiver.txt
@@ -1,0 +1,28 @@
+@kotlin.Metadata
+public final class A {
+    // source: 'delegateToSmartCastReceiver.kt'
+    private @org.jetbrains.annotations.NotNull field x: java.lang.String
+    public method <init>(): void
+    public final @org.jetbrains.annotations.NotNull method getX(): java.lang.String
+    public final method setX(@org.jetbrains.annotations.NotNull p0: java.lang.String): void
+}
+
+@kotlin.Metadata
+public final class DelegateToSmartCastReceiverKt$test$B {
+    // source: 'delegateToSmartCastReceiver.kt'
+    enclosing method DelegateToSmartCastReceiverKt.test(Ljava/lang/Object;)Ljava/lang/String;
+    synthetic final field $a: java.lang.Object
+    inner (local) class DelegateToSmartCastReceiverKt$test$B B
+    public method <init>(p0: java.lang.Object): void
+    private static method getY$delegate(p0: DelegateToSmartCastReceiverKt$test$B): java.lang.Object
+    public final method getY(): java.lang.String
+    public final method setY(p0: java.lang.String): void
+}
+
+@kotlin.Metadata
+public final class DelegateToSmartCastReceiverKt {
+    // source: 'delegateToSmartCastReceiver.kt'
+    inner (local) class DelegateToSmartCastReceiverKt$test$B B
+    public final static @org.jetbrains.annotations.NotNull method box(): java.lang.String
+    public final static @org.jetbrains.annotations.NotNull method test(@org.jetbrains.annotations.NotNull p0: java.lang.Object): java.lang.String
+}

--- a/compiler/testData/codegen/boxJvm/reflection/properties/getDelegate/method/delegateToAnother.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/properties/getDelegate/method/delegateToAnother.kt
@@ -19,6 +19,13 @@ var x = 1
 var y by ::x
 var z by C(1)::x
 
+val anyC: Any = C(1)
+var castY by (anyC as C)::x
+
+class E {
+    var y by (anyC as C)::x
+}
+
 var _x = -99
 var Int.x
     get() = this + _x
@@ -45,12 +52,24 @@ fun <T> KMutableProperty1<T, Int>.test(receiver: T, receiver2: T) =
 fun <R1, R2> KMutableProperty2<R1, R2, Int>.test(receiver1: R1, receiver2: R2) =
     test({ getDelegate(receiver1, receiver2) as KMutableProperty1<R2, Int> }, { get(receiver2) }, { set(receiver2, it) })
 
+fun testSmartCast(a: Any) {
+    require(a is C) { "$a is not C" }
+    class Local {
+        var y by a::x
+    }
+    Local()::y.test()
+}
+
 fun box(): String {
     C::y.test(C(100), C(1))
     C::z.test(C(1))
     D::y.test(D(C(1)))
     ::y.test()
     ::z.test()
+    ::castY.test()
+    E()::y.test()
+    E::y.test(E())
+    testSmartCast(C(1))
     Int::y.test({ getExtensionDelegate() as KMutableProperty1<Int, Int> }, { get(100) }, { set(100, it) })
 
     val w = D::class.members.single { it.name == "w" } as KMutableProperty2<D, C, Int>


### PR DESCRIPTION
A stable bound receiver in `val x by receiver::y` is reevaluated in accessors instead of being stored in a `x$receiver` field, but a receiver wrapped in a smart cast or `as` was never treated as stable.

Accept IMPLICIT_CAST and CAST of inlinable arguments in `canInline`: both are side-effect-free, and an unsafe cast is still evaluated once at the delegate construction site, so later reevaluations cannot fail.

Teach `remapReceiver` to copy `IrTypeOperatorCall` accordingly.

Found while working on OSIP-831; unblocks generalizing this lowering to references with bound context values.

^KT-87952: Fixed