### PR TITLE
[Analysis API] Handle missing standalone classpath roots

### DIFF
--- a/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/StandaloneProjectFactory.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/StandaloneProjectFactory.kt
@@ -13,6 +13,7 @@ import com.intellij.core.CorePackageIndex
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.mock.MockProject
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.PackageIndex
 import com.intellij.openapi.util.io.FileUtil
@@ -67,10 +68,13 @@ import org.jetbrains.kotlin.load.kotlin.MetadataFinderFactory
 import org.jetbrains.kotlin.load.kotlin.VirtualFileFinderFactory
 import org.jetbrains.kotlin.utils.topologicalSort
 import org.picocontainer.PicoContainer
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 object StandaloneProjectFactory {
+    private val LOG = Logger.getInstance(StandaloneProjectFactory::class.java)
+
     fun createProjectEnvironment(
         projectDisposable: Disposable,
         applicationEnvironmentMode: KotlinCoreApplicationEnvironmentMode,
@@ -235,6 +239,7 @@ object StandaloneProjectFactory {
             KotlinStandaloneJavaModuleAnnotationsProvider(delegateJavaModuleResolver),
         )
 
+        reportMissingLibraryRoots(modules)
         val libraryRoots = getAllBinaryRoots(modules, environment.environment)
 
         val rootsWithSingleJavaFileRoots = buildList {
@@ -417,7 +422,10 @@ object StandaloneProjectFactory {
         environment: CoreApplicationEnvironment,
     ): List<VirtualFile> {
         return roots.mapNotNull { path ->
-            val pathString = FileUtil.toSystemIndependentName(path.toAbsolutePath().toString())
+            val absolutePath = path.toAbsolutePath()
+            val pathString = FileUtil.toSystemIndependentName(absolutePath.toString())
+            if (path.isMissingLocalLibraryRoot()) return@mapNotNull null
+
             when {
                 pathString.endsWith(JAR_PROTOCOL) || pathString.endsWith(KLIB_FILE_EXTENSION) -> {
                     environment.jarFileSystem.findFileByPath(pathString + JAR_SEPARATOR)
@@ -447,6 +455,29 @@ object StandaloneProjectFactory {
         val binaryRootsAsVirtualFiles = getVirtualFilesForLibraryRoots(binaryRoots, environment) + binaryVirtualFiles
         return binaryRootsAsVirtualFiles.map { root ->
             JavaRoot(root, JavaRoot.RootType.BINARY)
+        }
+    }
+
+    private fun Path.isMissingLocalLibraryRoot(): Boolean {
+        val absolutePath = toAbsolutePath()
+        val pathString = FileUtil.toSystemIndependentName(absolutePath.toString())
+        return !pathString.contains(JAR_SEPARATOR) && !Files.exists(absolutePath)
+    }
+
+    private fun reportMissingLibraryRoots(modules: List<KaModule>) {
+        val reportedMissingRoots = mutableSetOf<Path>()
+        for (module in withAllTransitiveDependencies(modules)) {
+            val libraryModule = when (module) {
+                is KaLibraryModule -> module
+                is KaLibrarySourceModule -> module.binaryLibrary
+                else -> continue
+            }
+
+            libraryModule.binaryRoots.filter { it.isMissingLocalLibraryRoot() }.forEach { path ->
+                if (reportedMissingRoots.add(path.toAbsolutePath().normalize())) {
+                    LOG.warn("Classpath entry points to a non-existent location: $path")
+                }
+            }
         }
     }
 

--- a/analysis/analysis-api-standalone/analysis-api-standalone-fir/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/StandaloneProjectFactory.kt
+++ b/analysis/analysis-api-standalone/analysis-api-standalone-fir/src/org/jetbrains/kotlin/analysis/api/standalone/base/projectStructure/StandaloneProjectFactory.kt
@@ -13,6 +13,7 @@ import com.intellij.core.CorePackageIndex
 import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.mock.MockProject
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.PackageIndex
 import com.intellij.openapi.util.io.FileUtil
@@ -68,11 +69,14 @@ import org.jetbrains.kotlin.load.kotlin.MetadataFinderFactory
 import org.jetbrains.kotlin.load.kotlin.VirtualFileFinderFactory
 import org.jetbrains.kotlin.utils.topologicalSort
 import org.picocontainer.PicoContainer
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 @KaImplementationDetail
 object StandaloneProjectFactory {
+    private val LOG = Logger.getInstance(StandaloneProjectFactory::class.java)
+
     fun createProjectEnvironment(
         projectDisposable: Disposable,
         applicationEnvironmentMode: KotlinCoreApplicationEnvironmentMode,
@@ -241,6 +245,7 @@ object StandaloneProjectFactory {
             KotlinStandaloneJavaModuleAnnotationsProvider(delegateJavaModuleResolver),
         )
 
+        reportMissingLibraryRoots(modules)
         val libraryRoots = getAllBinaryRoots(modules, environment.environment)
 
         val rootsWithSingleJavaFileRoots = buildList {
@@ -424,7 +429,10 @@ object StandaloneProjectFactory {
         environment: CoreApplicationEnvironment,
     ): List<VirtualFile> {
         return roots.mapNotNull { path ->
-            val pathString = FileUtil.toSystemIndependentName(path.toAbsolutePath().toString())
+            val absolutePath = path.toAbsolutePath()
+            val pathString = FileUtil.toSystemIndependentName(absolutePath.toString())
+            if (path.isMissingLocalLibraryRoot()) return@mapNotNull null
+
             when {
                 pathString.endsWith(JAR_PROTOCOL) || pathString.endsWith(KLIB_FILE_EXTENSION) -> {
                     environment.jarFileSystem.findFileByPath(pathString + JAR_SEPARATOR)
@@ -454,6 +462,29 @@ object StandaloneProjectFactory {
         val binaryRootsAsVirtualFiles = getVirtualFilesForLibraryRoots(binaryRoots, environment) + binaryVirtualFiles
         return binaryRootsAsVirtualFiles.map { root ->
             JavaRoot(root, JavaRoot.RootType.BINARY)
+        }
+    }
+
+    private fun Path.isMissingLocalLibraryRoot(): Boolean {
+        val absolutePath = toAbsolutePath()
+        val pathString = FileUtil.toSystemIndependentName(absolutePath.toString())
+        return !pathString.contains(JAR_SEPARATOR) && !Files.exists(absolutePath)
+    }
+
+    private fun reportMissingLibraryRoots(modules: List<KaModule>) {
+        val reportedMissingRoots = mutableSetOf<Path>()
+        for (module in withAllTransitiveDependencies(modules)) {
+            val libraryModule = when (module) {
+                is KaLibraryModule -> module
+                is KaLibrarySourceModule -> module.binaryLibrary
+                else -> continue
+            }
+
+            libraryModule.binaryRoots.filter { it.isMissingLocalLibraryRoot() }.forEach { path ->
+                if (reportedMissingRoots.add(path.toAbsolutePath().normalize())) {
+                    LOG.warn("Classpath entry points to a non-existent location: $path")
+                }
+            }
         }
     }
 

--- a/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandaloneSessionBuilderTest.kt
+++ b/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandaloneSessionBuilderTest.kt
@@ -59,6 +59,8 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.test.testFramework.runWriteAction
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.assertEquals
@@ -118,6 +120,39 @@ class StandaloneSessionBuilderTest : AbstractStandaloneTest() {
                 )
             }
         }
+        val ktFiles = session.modulesWithFiles.getValue(sourceModule)
+        Assertions.assertEquals(listOf("source0.kt", "source1.kt"), ktFiles.map { it.name })
+    }
+
+    @Test
+    fun testNonExistentLibraryRoot() {
+        lateinit var sourceModule: KaSourceModule
+        lateinit var session: StandaloneAnalysisAPISession
+        val errorOutput = captureSystemError {
+            session = buildStandaloneAnalysisAPISession(disposable) {
+                buildKtModuleProvider {
+                    platform = JvmPlatforms.defaultJvmPlatform
+                    val libraryModule = addModule(
+                        buildKtLibraryModule {
+                            addBinaryRoot(testDataPath("missing-library.jar"))
+                            platform = JvmPlatforms.defaultJvmPlatform
+                            libraryName = "missing-library"
+                        }
+                    )
+                    sourceModule = addModule(
+                        buildKtSourceModule {
+                            addSourceRoot(testDataPath("twoFiles"))
+                            addRegularDependency(libraryModule)
+                            platform = JvmPlatforms.defaultJvmPlatform
+                            moduleName = "source"
+                        }
+                    )
+                }
+            }
+        }
+
+        Assertions.assertTrue(errorOutput.contains("Classpath entry points to a non-existent location:"))
+        Assertions.assertFalse(errorOutput.contains("NoSuchFileException"))
         val ktFiles = session.modulesWithFiles.getValue(sourceModule)
         Assertions.assertEquals(listOf("source0.kt", "source1.kt"), ktFiles.map { it.name })
     }
@@ -813,4 +848,17 @@ class StandaloneSessionBuilderTest : AbstractStandaloneTest() {
         assert(fooReturnType.canonicalText == "java.lang.String")
         assert(fooReturnType.resolve() == null)
     }
+}
+
+private fun captureSystemError(action: () -> Unit): String {
+    val output = ByteArrayOutputStream()
+    val previousError = System.err
+    System.setErr(PrintStream(output))
+    try {
+        action()
+    } finally {
+        System.err.flush()
+        System.setErr(previousError)
+    }
+    return output.toString()
 }

--- a/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandaloneSessionBuilderTest.kt
+++ b/analysis/analysis-api-standalone/tests/org/jetbrains/kotlin/analysis/api/standalone/fir/test/cases/session/builder/StandaloneSessionBuilderTest.kt
@@ -60,6 +60,8 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.test.testFramework.runWriteAction
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.assertEquals
@@ -119,6 +121,39 @@ class StandaloneSessionBuilderTest : AbstractStandaloneTest() {
                 )
             }
         }
+        val ktFiles = session.modulesWithFiles.getValue(sourceModule)
+        Assertions.assertEquals(listOf("source0.kt", "source1.kt"), ktFiles.map { it.name })
+    }
+
+    @Test
+    fun testNonExistentLibraryRoot() {
+        lateinit var sourceModule: KaSourceModule
+        lateinit var session: StandaloneAnalysisAPISession
+        val errorOutput = captureSystemError {
+            session = buildStandaloneAnalysisAPISession(disposable) {
+                buildKtModuleProvider {
+                    platform = JvmPlatforms.defaultJvmPlatform
+                    val libraryModule = addModule(
+                        buildKtLibraryModule {
+                            addBinaryRoot(testDataPath("missing-library.jar"))
+                            platform = JvmPlatforms.defaultJvmPlatform
+                            libraryName = "missing-library"
+                        }
+                    )
+                    sourceModule = addModule(
+                        buildKtSourceModule {
+                            addSourceRoot(testDataPath("twoFiles"))
+                            addRegularDependency(libraryModule)
+                            platform = JvmPlatforms.defaultJvmPlatform
+                            moduleName = "source"
+                        }
+                    )
+                }
+            }
+        }
+
+        Assertions.assertTrue(errorOutput.contains("Classpath entry points to a non-existent location:"))
+        Assertions.assertFalse(errorOutput.contains("NoSuchFileException"))
         val ktFiles = session.modulesWithFiles.getValue(sourceModule)
         Assertions.assertEquals(listOf("source0.kt", "source1.kt"), ktFiles.map { it.name })
     }
@@ -814,4 +849,17 @@ class StandaloneSessionBuilderTest : AbstractStandaloneTest() {
         assert(fooReturnType.canonicalText == "java.lang.String")
         assert(fooReturnType.resolve() == null)
     }
+}
+
+private fun captureSystemError(action: () -> Unit): String {
+    val output = ByteArrayOutputStream()
+    val previousError = System.err
+    System.setErr(PrintStream(output))
+    try {
+        action()
+    } finally {
+        System.err.flush()
+        System.setErr(previousError)
+    }
+    return output.toString()
 }


### PR DESCRIPTION
## Summary
- detect missing local binary roots before accessing the archive file system
- report each missing classpath entry once and omit it from indexes and library scopes
- keep valid source files available for analysis when a dependency root is absent

## Testing
- `./gradlew :analysis:analysis-api-standalone:test --tests 'org.jetbrains.kotlin.analysis.api.standalone.fir.test.cases.session.builder.StandaloneSessionBuilderTest' -q`

Issue: [KT-57715](https://youtrack.jetbrains.com/issue/KT-57715)