### PR TITLE
[KGP] Validate custom browser executable

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.DelicateKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBrowserTestDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTestsLocation
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
@@ -44,6 +45,29 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
     override val defaultBuildOptions: BuildOptions
         get() = super.defaultBuildOptions.copy().disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
 
+    @OptIn(DelicateKotlinGradlePluginApi::class)
+    @GradleTest
+    fun `non-existent custom browser executable reports a diagnostic`(gradleVersion: GradleVersion) {
+        project(
+            "empty",
+            gradleVersion = gradleVersion,
+            buildOptions = defaultBuildOptions,
+        ) {
+            val customBrowserExecutable = projectPath.resolve("missing-chrome-executable").toFile()
+            jsProject {
+                chromium {
+                    it.customBrowserExecutable.set(customBrowserExecutable)
+                }
+            }
+
+            buildAndFail(":jsBrowserTest") {
+                assertHasDiagnostic(
+                    KotlinToolingDiagnostics.InvalidCustomBrowserExecutable,
+                    withSubstring = "Custom browser executable for runner 'chromium' does not exist: $customBrowserExecutable",
+                )
+            }
+        }
+    }
 
     @GradleTest
     fun `verify launchArgs configuration with browser api access`(gradleVersion: GradleVersion) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsWithPlaywrightIT.kt
@@ -62,8 +62,8 @@ class JsBrowserTestsWithPlaywrightIT : KGPBaseTest() {
 
             buildAndFail(":jsBrowserTest") {
                 assertHasDiagnostic(
-                    KotlinToolingDiagnostics.InvalidCustomBrowserExecutable,
-                    withSubstring = "Custom browser executable for runner 'chromium' does not exist: $customBrowserExecutable",
+                    KotlinToolingDiagnostics.NonExistentCustomBrowserExecutable,
+                    withSubstring = "Custom browser executable for runner 'chromium' does not exist at path: $customBrowserExecutable",
                 )
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2378,17 +2378,17 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
-    internal object InvalidCustomBrowserExecutable : ToolingDiagnosticFactory(
+    internal object NonExistentCustomBrowserExecutable : ToolingDiagnosticFactory(
         predefinedSeverity = ERROR,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
     ) {
         operator fun invoke(runnerName: String, executable: File) = build {
-            title { "Invalid custom browser executable" }
+            title { "Non-existent custom browser executable" }
                 .description {
-                    "Custom browser executable for runner '$runnerName' does not exist: $executable"
+                    "Custom browser executable for runner '$runnerName' does not exist at path: $executable"
                 }
                 .solution {
-                    "Configure an existing browser executable for runner '$runnerName'"
+                    "Specify a path to an existing browser executable for runner '$runnerName'"
                 }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/KotlinToolingDiagnostics.kt
@@ -2378,6 +2378,21 @@ internal object KotlinToolingDiagnostics {
         }
     }
 
+    internal object InvalidCustomBrowserExecutable : ToolingDiagnosticFactory(
+        predefinedSeverity = ERROR,
+        predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,
+    ) {
+        operator fun invoke(runnerName: String, executable: File) = build {
+            title { "Invalid custom browser executable" }
+                .description {
+                    "Custom browser executable for runner '$runnerName' does not exist: $executable"
+                }
+                .solution {
+                    "Configure an existing browser executable for runner '$runnerName'"
+                }
+        }
+    }
+
     internal object NewJsTestDslNotSupportedForWasmError : ToolingDiagnosticFactory(
         predefinedSeverity = ERROR,
         predefinedGroup = DiagnosticGroup.Kgp.Misconfiguration,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.targets.js.ir
 
-import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginLifecycle
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
@@ -71,19 +71,19 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
             inputs.chromiumRunners.set(
                 browserTestDsl.chromiumRunners.values.map { runner ->
                     KotlinPlaywrightJsTestFramework.createChromiumInputs(objects)
-                        .also { it.populateFrom(runner) }
+                        .also { it.populateFrom(project, runner) }
                 }
             )
             inputs.firefoxRunners.set(
                 browserTestDsl.firefoxRunners.values.map { runner ->
                     KotlinPlaywrightJsTestFramework.createFirefoxInputs(objects)
-                        .also { it.populateFrom(runner) }
+                        .also { it.populateFrom(project, runner) }
                 }
             )
             inputs.webkitRunners.set(
                 browserTestDsl.webkitRunners.values.map { runner ->
                     KotlinPlaywrightJsTestFramework.createWebkitInputs(objects)
-                        .also { it.populateFrom(runner) }
+                        .also { it.populateFrom(project, runner) }
                 }
             )
 
@@ -100,6 +100,7 @@ internal val ConfigureKotlinPlaywrightTestRunner = KotlinTargetSideEffect { targ
 }
 
 private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
+    project: Project,
     runner: KotlinBrowserTestRunnerDsl,
 ) {
     name.convention(runner.name)
@@ -113,8 +114,11 @@ private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
     customBrowserExecutable.convention(
         runner.customBrowserExecutable.map { executable ->
             if (!executable.asFile.exists()) {
-                throw InvalidUserDataException(
-                    "Custom browser executable for runner '${runner.name}' does not exist: ${executable.asFile}"
+                project.reportDiagnostic(
+                    KotlinToolingDiagnostics.InvalidCustomBrowserExecutable(
+                        runnerName = runner.name,
+                        executable = executable.asFile,
+                    )
                 )
             }
             executable

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -115,7 +115,7 @@ private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
         runner.customBrowserExecutable.map { executable ->
             if (!executable.asFile.exists()) {
                 project.reportDiagnostic(
-                    KotlinToolingDiagnostics.InvalidCustomBrowserExecutable(
+                    KotlinToolingDiagnostics.NonExistentCustomBrowserExecutable(
                         runnerName = runner.name,
                         executable = executable.asFile,
                     )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/ConfigureKotlinPlaywrightTestRunner.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.gradle.targets.js.ir
 
+import org.gradle.api.InvalidUserDataException
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginLifecycle
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
@@ -109,5 +110,14 @@ private fun KotlinPlaywrightJsTestFramework.BrowserRunnerInput.populateFrom(
     headless.convention(runner.headless)
     launchArgs.convention(runner.launchArgs)
     launchEnvironmentVariables.convention(runner.launchEnvironmentVariables)
-    customBrowserExecutable.convention(runner.customBrowserExecutable)
+    customBrowserExecutable.convention(
+        runner.customBrowserExecutable.map { executable ->
+            if (!executable.asFile.exists()) {
+                throw InvalidUserDataException(
+                    "Custom browser executable for runner '${runner.name}' does not exist: ${executable.asFile}"
+                )
+            }
+            executable
+        }
+    )
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -7,7 +7,6 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.Directory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.provider.Provider
@@ -31,7 +30,6 @@ import java.nio.file.Path
 import java.time.Duration
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -42,7 +40,7 @@ import kotlin.time.Duration.Companion.hours
 
 class KotlinPlaywrightTestFrameworkWiringTest {
 
-    @field:TempDir
+    @TempDir
     lateinit var tempDirectory: Path
 
     @Test
@@ -240,27 +238,6 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         assertEquals(mockLocation4, webkit2Runner.testsLocation.get())
     }
 
-    @Test
-    fun `non-existent custom browser executable is rejected`() {
-        val customChromeExecutable = tempDirectory.resolve("missing-chrome-executable").toFile()
-        val setup = buildBrowserTestProject {
-            chromium {
-                it.customBrowserExecutable.set(customChromeExecutable)
-            }
-        }
-
-        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
-        val chromeRunner = framework.frameworkTaskInputs.chromiumRunners.get().single()
-        val queryException = assertFails {
-            chromeRunner.customBrowserExecutable.get()
-        }
-        val validationException = assertIs<InvalidUserDataException>(queryException.cause)
-
-        assertEquals(
-            "Custom browser executable for runner 'chromium' does not exist: $customChromeExecutable",
-            validationException.message,
-        )
-    }
 }
 
 private class BrowserTestProject(

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPlaywrightTestFrameworkWiringTest.kt
@@ -7,6 +7,7 @@
 
 package org.jetbrains.kotlin.gradle.unitTests
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.Directory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.provider.Provider
@@ -24,11 +25,13 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PLAYWRIGHT_VERS
 import org.jetbrains.kotlin.gradle.targets.js.testing.playwright.PlaywrightBrowserInstall
 import org.jetbrains.kotlin.gradle.testing.prettyPrinted
 import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
-import java.io.File
+import org.junit.jupiter.api.io.TempDir
 import java.net.URI
+import java.nio.file.Path
 import java.time.Duration
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -38,6 +41,9 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 
 class KotlinPlaywrightTestFrameworkWiringTest {
+
+    @field:TempDir
+    lateinit var tempDirectory: Path
 
     @Test
     fun `declaring a runner replaces the test framework with playwright`() {
@@ -179,7 +185,9 @@ class KotlinPlaywrightTestFrameworkWiringTest {
         val mockLocation3 = mockLocation()
         val mockLocation4 = mockLocation()
 
-        val customChromeExecutable = File("custom-chrome-executable.txt").absoluteFile
+        val customChromeExecutable = tempDirectory.resolve("custom-chrome-executable").toFile().apply {
+            createNewFile()
+        }
 
         val setup = buildBrowserTestProject {
             testsLocation.set(mockLocation1)
@@ -230,6 +238,28 @@ class KotlinPlaywrightTestFrameworkWiringTest {
 
         val webkit2Runner = inputs.webkitRunners.get().find { it.name.get() == "webki2" }!!
         assertEquals(mockLocation4, webkit2Runner.testsLocation.get())
+    }
+
+    @Test
+    fun `non-existent custom browser executable is rejected`() {
+        val customChromeExecutable = tempDirectory.resolve("missing-chrome-executable").toFile()
+        val setup = buildBrowserTestProject {
+            chromium {
+                it.customBrowserExecutable.set(customChromeExecutable)
+            }
+        }
+
+        val framework = assertIs<KotlinPlaywrightJsTestFramework>(setup.jsBrowserTestTask.testFramework)
+        val chromeRunner = framework.frameworkTaskInputs.chromiumRunners.get().single()
+        val queryException = assertFails {
+            chromeRunner.customBrowserExecutable.get()
+        }
+        val validationException = assertIs<InvalidUserDataException>(queryException.cause)
+
+        assertEquals(
+            "Custom browser executable for runner 'chromium' does not exist: $customChromeExecutable",
+            validationException.message,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- validate `customBrowserExecutable` lazily when Gradle resolves browser runner inputs
- report the runner name and invalid path instead of only Gradle's generic missing-input error
- preserve configuration-cache compatibility by avoiding eager property resolution

## Testing
- `./gradlew :kotlin-gradle-plugin:functionalTest --tests 'org.jetbrains.kotlin.gradle.unitTests.KotlinPlaywrightTestFrameworkWiringTest' -q`

Issue: [KT-87502](https://youtrack.jetbrains.com/issue/KT-87502)