### PR TITLE
[JKLIB] Map Java signatures to Kotlin signatures in jklib to leverage jvmTypeSystem resolution

### DIFF
--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -30,8 +30,10 @@ import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageFragment
 import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
 class JKlibIrLinker(
@@ -47,6 +49,22 @@ class JKlibIrLinker(
         get() = false
 
     private val javaName = Name.identifier("java")
+
+    private fun resolveMappedBuiltInSymbol(
+        idSig: IdSignature,
+        mappedSig: IdSignature,
+        symbolKind: BinarySymbolData.SymbolKind,
+    ): IrSymbol? {
+        if (symbolKind == BinarySymbolData.SymbolKind.CLASS_SYMBOL && mappedSig != idSig && mappedSig is IdSignature.CommonSignature) {
+            val classId = if (mappedSig.packageFqName.isEmpty()) {
+                ClassId.topLevel(FqName(mappedSig.declarationFqName))
+            } else {
+                ClassId(FqName(mappedSig.packageFqName), FqName(mappedSig.declarationFqName), false)
+            }
+            return JKlibSignatureMapper.getBuiltInClassSymbol(classId, stubGenerator.irBuiltIns)
+        }
+        return null
+    }
 
     private fun DeclarationDescriptor.isJavaDescriptor(): Boolean {
         if (this is PackageFragmentDescriptor) {
@@ -138,7 +156,18 @@ class JKlibIrLinker(
             idSig: IdSignature,
             symbolKind: BinarySymbolData.SymbolKind,
         ): IrSymbol? {
-            val descriptor = resolveDescriptor(idSig) ?: return null
+            val mappedSig = JKlibSignatureMapper.mapJavaSignatureToKotlinSignature(idSig)
+            resolveMappedBuiltInSymbol(idSig, mappedSig, symbolKind)?.let { return it }
+
+            val descriptor = resolveDescriptor(idSig) ?: resolveDescriptor(mappedSig) ?: return null
+
+            if (symbolKind == BinarySymbolData.SymbolKind.CLASS_SYMBOL && descriptor is ClassDescriptor) {
+                val fqName = descriptor.fqNameOrNull()
+                if (fqName != null) {
+                    val symbol = JKlibSignatureMapper.getBuiltInClassSymbolForMappedJavaClass(fqName, stubGenerator.irBuiltIns)
+                    if (symbol != null) return symbol
+                }
+            }
 
             val declaration = stubGenerator.run {
                 when (symbolKind) {
@@ -159,6 +188,13 @@ class JKlibIrLinker(
         override fun deserializedSymbolNotFound(idSig: IdSignature): Nothing = error("No descriptor found for $idSig")
 
         override fun declareIrSymbol(symbol: IrSymbol) {
+            val descriptor = symbol.descriptor
+            if (descriptor is ClassDescriptor) {
+                val fqName = descriptor.fqNameOrNull()
+                if (fqName != null && JKlibSignatureMapper.isMappedJavaPlatformClass(fqName)) {
+                    return
+                }
+            }
             if (symbol is IrFieldSymbol) {
                 declareJavaFieldStub(symbol)
             } else {
@@ -217,15 +253,38 @@ class JKlibIrLinker(
             idSig: IdSignature,
             symbolKind: BinarySymbolData.SymbolKind,
         ): IrSymbol? {
-            super.tryDeserializeIrSymbol(idSig, symbolKind)?.let {
-                return it
+            deserializedSymbols[idSig]?.let { return it }
+            val mappedSig = JKlibSignatureMapper.mapJavaSignatureToKotlinSignature(idSig)
+            if (mappedSig != idSig) {
+                deserializedSymbols[mappedSig]?.let { return it }
             }
-            deserializedSymbols[idSig]?.let {
-                return it
+
+            resolveMappedBuiltInSymbol(idSig, mappedSig, symbolKind)?.let { return it }
+
+            super.tryDeserializeIrSymbol(mappedSig, symbolKind)?.let { return it }
+            if (mappedSig != idSig) {
+                super.tryDeserializeIrSymbol(idSig, symbolKind)?.let { return it }
             }
-            val descriptor = descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) ?: return null
+
+            val descriptor = descriptorByIdSignatureFinder.findDescriptorBySignature(mappedSig)
+                ?: descriptorByIdSignatureFinder.findDescriptorBySignature(idSig)
+                ?: return null
+
+            if (symbolKind == BinarySymbolData.SymbolKind.CLASS_SYMBOL && descriptor is ClassDescriptor) {
+                val fqName = descriptor.fqNameOrNull()
+                if (fqName != null) {
+                    val symbol = JKlibSignatureMapper.getBuiltInClassSymbolForMappedJavaClass(fqName, stubGenerator.irBuiltIns)
+                    if (symbol != null) {
+                        deserializedSymbols[idSig] = symbol
+                        deserializedSymbols[mappedSig] = symbol
+                        return symbol
+                    }
+                }
+            }
+
             val symbol = (stubGenerator.generateMemberStub(descriptor) as IrSymbolOwner).symbol
             deserializedSymbols[idSig] = symbol
+            deserializedSymbols[mappedSig] = symbol
             return symbol
         }
     }
@@ -239,6 +298,13 @@ class JKlibIrLinker(
     ) : CurrentModuleDeserializer(moduleFragment) {
         override fun declareIrSymbol(symbol: IrSymbol) {
             val descriptor = symbol.descriptor
+
+            if (descriptor is ClassDescriptor) {
+                val fqName = descriptor.fqNameOrNull()
+                if (fqName != null && JKlibSignatureMapper.isMappedJavaPlatformClass(fqName)) {
+                    return
+                }
+            }
 
             if (descriptor.isJavaDescriptor()) {
                 // Wrap java declaration with lazy ir

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrMangler.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.ir.backend.jvm.serialization.BaseJvmIrMangler
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
@@ -29,6 +30,7 @@ import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.load.java.typeEnhancement.hasEnhancedNullability
 import org.jetbrains.kotlin.load.kotlin.*
 import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.SimpleType
 import org.jetbrains.kotlin.types.TypeUtils
@@ -54,10 +56,26 @@ import org.jetbrains.kotlin.utils.DFS.ifAny as ifAnyDFS
 class JKlibIrMangler : BaseJvmIrMangler() {
     @OptIn(ObsoleteDescriptorBasedAPI::class)
     override fun IrDeclaration.signatureString(compatibleMode: Boolean): String {
-        if (!getPackageFragment().packageFqName.asString().isKotlinPackage() && isJavaBackedCallable()) {
-            (descriptor as? CallableDescriptor)?.computeJvmSignatureSafe()?.let {
-                return it
+        if (this is IrClass) {
+            val fqName = fqNameWhenAvailable
+            if (fqName != null && JKlibSignatureMapper.isMappedJavaPlatformClass(fqName)) {
+                val kotlinClassId = JKlibSignatureMapper.mapJavaToKotlinClassId(fqName)
+                if (kotlinClassId != null) {
+                    return kotlinClassId.asString()
+                }
             }
+        }
+        if (!getPackageFragment().packageFqName.asString().isKotlinPackage() && isJavaBackedCallable()) {
+        if (this is IrProperty && getter == null && setter == null && backingField == null) {
+            val overridden = overriddenSymbols.firstOrNull()?.owner
+            if (overridden != null) {
+                return overridden.signatureString(compatibleMode)
+            }
+            val parentClass = parentClassOrNull
+            if (parentClass != null) {
+                return "${parentClass.signatureString(compatibleMode)}#${name.asString()}"
+            }
+            return name.asString()
         }
         return getMangleComputer(MangleMode.SIGNATURE, compatibleMode).computeMangle(this)
     }
@@ -83,8 +101,17 @@ class JKlibIrMangler : BaseJvmIrMangler() {
 class JKlibDescriptorMangler(private val mainDetector: MainFunctionDetector?) : JvmDescriptorMangler(mainDetector) {
 
     override fun DeclarationDescriptor.signatureString(compatibleMode: Boolean): String {
+        if (this is ClassDescriptor) {
+            val fqName = fqNameOrNull()
+            if (fqName != null && JKlibSignatureMapper.isMappedJavaPlatformClass(fqName)) {
+                val kotlinClassId = JKlibSignatureMapper.mapJavaToKotlinClassId(fqName)
+                if (kotlinClassId != null) {
+                    return kotlinClassId.asString()
+                }
+            }
+        }
         if (this.containingPackage()?.asString()
-                ?.isKotlinPackage() == false && this is JavaCallableMemberDescriptor || containingDeclaration is JavaClassDescriptor
+                ?.isKotlinPackage() == false && (this is JavaCallableMemberDescriptor || containingDeclaration is JavaClassDescriptor)
         ) {
             (this as? CallableDescriptor)?.computeJvmSignatureSafe()?.let {
                 return it

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibSignatureMapper.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibSignatureMapper.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.jklib
+
+import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
+import org.jetbrains.kotlin.ir.InternalSymbolFinderAPI
+import org.jetbrains.kotlin.ir.IrBuiltIns
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.util.IdSignature
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+object JKlibSignatureMapper {
+
+  fun isMappedJavaPlatformClass(fqName: FqName): Boolean =
+    JavaToKotlinClassMap.isJavaPlatformClass(fqName)
+
+  fun isMappedJavaPlatformClass(classId: ClassId): Boolean =
+    isMappedJavaPlatformClass(classId.asSingleFqName())
+
+  fun mapJavaToKotlinClassId(fqName: FqName): ClassId? =
+    JavaToKotlinClassMap.mapJavaToKotlin(fqName)
+
+  fun mapJavaToKotlinClassId(classId: ClassId): ClassId? =
+    mapJavaToKotlinClassId(classId.asSingleFqName())
+
+  fun mapJavaToKotlinSignature(fqName: FqName): IdSignature.CommonSignature? {
+    val kotlinClassId = mapJavaToKotlinClassId(fqName) ?: return null
+    return IdSignature.CommonSignature(
+      packageFqName = kotlinClassId.packageFqName.asString(),
+      declarationFqName = kotlinClassId.relativeClassName.asString(),
+      id = null,
+      mask = 0,
+      description = kotlinClassId.asString(),
+    )
+  }
+
+  fun mapJavaToKotlinSignature(classId: ClassId): IdSignature.CommonSignature? =
+    mapJavaToKotlinSignature(classId.asSingleFqName())
+
+  fun mapJavaSignatureToKotlinSignature(idSig: IdSignature): IdSignature {
+    if (idSig is IdSignature.CommonSignature) {
+      if (!idSig.packageFqName.startsWith("java")) return idSig
+      val classId =
+        if (idSig.packageFqName.isEmpty()) {
+          ClassId.topLevel(FqName(idSig.declarationFqName))
+        } else {
+          ClassId(FqName(idSig.packageFqName), FqName(idSig.declarationFqName), false)
+        }
+      val mapped = mapJavaToKotlinSignature(classId)
+      if (mapped != null) {
+        return mapped
+      }
+    }
+    return idSig
+  }
+
+  fun getBuiltInClassSymbolForMappedJavaClass(
+    fqName: FqName,
+    irBuiltIns: IrBuiltIns,
+  ): IrClassSymbol? {
+    val kotlinClassId = mapJavaToKotlinClassId(fqName) ?: return null
+    return getBuiltInClassSymbol(kotlinClassId, irBuiltIns)
+  }
+
+  fun getBuiltInClassSymbolForMappedJavaClass(
+    classId: ClassId,
+    irBuiltIns: IrBuiltIns,
+  ): IrClassSymbol? = getBuiltInClassSymbolForMappedJavaClass(classId.asSingleFqName(), irBuiltIns)
+
+  @OptIn(InternalSymbolFinderAPI::class)
+  fun getBuiltInClassSymbol(kotlinClassId: ClassId, irBuiltIns: IrBuiltIns): IrClassSymbol? {
+    val pkg = kotlinClassId.packageFqName.asString()
+    val name = kotlinClassId.relativeClassName.asString()
+    return when {
+      pkg == "kotlin" ->
+        when (name) {
+          "Any" -> irBuiltIns.anyClass
+          "String" -> irBuiltIns.stringClass
+          "CharSequence" -> irBuiltIns.charSequenceClass
+          "Throwable" -> irBuiltIns.throwableClass
+          "Number" -> irBuiltIns.numberClass
+          "Comparable" -> irBuiltIns.comparableClass
+          "Boolean" -> irBuiltIns.booleanClass
+          "Char" -> irBuiltIns.charClass
+          "Byte" -> irBuiltIns.byteClass
+          "Short" -> irBuiltIns.shortClass
+          "Int" -> irBuiltIns.intClass
+          "Long" -> irBuiltIns.longClass
+          "Float" -> irBuiltIns.floatClass
+          "Double" -> irBuiltIns.doubleClass
+          "Function" -> irBuiltIns.functionClass
+          "Enum" -> irBuiltIns.enumClass
+          "Annotation" -> irBuiltIns.annotationClass
+          else -> irBuiltIns.symbolFinder.findClass(kotlinClassId)
+        }
+      pkg == "kotlin.collections" ->
+        when (name) {
+          "Iterable" -> irBuiltIns.iterableClass
+          "Iterator" -> irBuiltIns.iteratorClass
+          "Collection" -> irBuiltIns.collectionClass
+          "List" -> irBuiltIns.listClass
+          "Set" -> irBuiltIns.setClass
+          "ListIterator" -> irBuiltIns.listIteratorClass
+          "Map" -> irBuiltIns.mapClass
+          "Map.Entry" -> irBuiltIns.mapEntryClass
+          "MutableIterable" -> irBuiltIns.mutableIterableClass
+          "MutableIterator" -> irBuiltIns.mutableIteratorClass
+          "MutableCollection" -> irBuiltIns.mutableCollectionClass
+          "MutableList" -> irBuiltIns.mutableListClass
+          "MutableSet" -> irBuiltIns.mutableSetClass
+          "MutableListIterator" -> irBuiltIns.mutableListIteratorClass
+          "MutableMap" -> irBuiltIns.mutableMapClass
+          "MutableMap.Entry" -> irBuiltIns.mutableMapEntryClass
+          else -> irBuiltIns.symbolFinder.findClass(kotlinClassId)
+        }
+      pkg == "kotlin.reflect" ->
+        when (name) {
+          "KClass" -> irBuiltIns.kClassClass
+          "KCallable" -> irBuiltIns.kCallableClass
+          "KProperty" -> irBuiltIns.kPropertyClass
+          else -> irBuiltIns.symbolFinder.findClass(kotlinClassId)
+        }
+      else -> irBuiltIns.symbolFinder.findClass(kotlinClassId)
+    }
+  }
+}

--- a/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibJavaInteropIntegrationTest.kt
+++ b/compiler/jklib.tests/tests/org/jetbrains/kotlin/jklib/test/JKlibJavaInteropIntegrationTest.kt
@@ -16,12 +16,20 @@ import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
 import org.jetbrains.kotlin.test.MockLibraryUtilExt
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import java.io.File
 
+@OptIn(UnsafeDuringIrConstructionAPI::class)
 class JKlibJavaInteropIntegrationTest {
 
     @Test
@@ -125,6 +133,183 @@ class JKlibJavaInteropIntegrationTest {
             if (artifact == null) {
                 error("compileKlibAndDeserializeIr returned null. Messages:\n" + messageCollector.messages.joinToString("\n"))
             }
+        } finally {
+            disposeRootInWriteAction(disposable)
+        }
+    }
+
+    @Test
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    fun testJavaPlatformTypeSignatureMapping(@TempDir tempDir: File) {
+        val stdlibKlib = ForTestCompileRuntime.jklibStdlibForTests().path
+        val stdlibJar = ForTestCompileRuntime.runtimeJarForTests().path
+
+        val javaDir = File(tempDir, "javaLib").apply { mkdirs() }
+        File(javaDir, "JavaClass.java").apply {
+            writeText(
+                """
+                package test;
+                import java.util.List;
+                import java.util.Map;
+
+                public class JavaClass {
+                    public String getString() { return "hello"; }
+                    public List<String> getList() { return null; }
+                    public Map.Entry<String, String> getMapEntry() { return null; }
+                    public Integer getInteger() { return 42; }
+                    public Throwable getThrowable() { return null; }
+                }
+                """.trimIndent()
+            )
+        }
+
+        val javaJar = MockLibraryUtilExt.compileJavaFilesLibraryToJar(
+            javaDir.path,
+            "javaLib",
+            extraClasspath = listOf(stdlibJar)
+        )
+
+        val mainDir = File(tempDir, "main").apply { mkdirs() }
+        val mainKt = File(mainDir, "Main.kt").apply {
+            writeText(
+                """
+                package test
+                import java.util.Map
+
+                fun test(j: JavaClass) {
+                    val s = j.getString()
+                    val l = j.getList()
+                    val e = j.getMapEntry()
+                    val i = j.getInteger()
+                    val t = j.getThrowable()
+                }
+                """.trimIndent()
+            )
+        }
+
+        val mainKlib = File(tempDir, "main.klib")
+        val compiler = K2JKlibCompiler()
+        val args = compiler.createArguments()
+        compiler.parseArguments(
+            arrayOf(
+                mainKt.path,
+                "-d", mainKlib.path,
+                "-module-name", "main",
+                "-no-stdlib",
+                "-classpath", javaJar.path,
+                "-Xklib=$stdlibKlib"
+            ),
+            args
+        )
+
+        val messageCollector = MessageCollectorImpl()
+        val disposable = Disposer.newDisposable()
+        try {
+            val artifact = compiler.compileKlibAndDeserializeIr(args, messageCollector, disposable)
+            if (artifact == null) {
+                val msgs = messageCollector.messages.joinToString("\n") { "${it.severity}: ${it.message}" }
+                error("compileKlibAndDeserializeIr returned null. Messages:\n$msgs")
+            }
+            val irBuiltIns = artifact.pluginContext.irBuiltIns
+            val typeSystemContext = org.jetbrains.kotlin.backend.jvm.JvmIrTypeSystemContext(irBuiltIns)
+
+            val testFun = artifact.moduleFragment.files.flatMap { it.declarations }
+                .filterIsInstance<IrFunction>()
+                .first { it.name.asString() == "test" }
+
+            val body = testFun.body as IrBlockBody
+            val statements = body.statements
+
+            val valS = statements[0] as IrVariable
+            val getStringCall = valS.initializer as IrCall
+            val getStringFun = getStringCall.symbol.owner
+            val getStringReturnTypeClassifier = (getStringFun.returnType as IrSimpleType).classifier
+
+            // Assertion 1: java.lang.String return type constructor == kotlin.String type constructor (pointer equality c1 == c2)
+            val kotlinStringClassSymbol = irBuiltIns.stringClass
+            assertSame(
+                kotlinStringClassSymbol,
+                getStringReturnTypeClassifier,
+                "Expected java.lang.String return type symbol to be identical (c1 == c2) to kotlin.String symbol"
+            )
+
+            val valL = statements[1] as IrVariable
+            val getListCall = valL.initializer as IrCall
+            val getListFun = getListCall.symbol.owner
+            val getListReturnType = getListFun.returnType
+
+            // Assertion 2: java.util.List should be flexible mutability (List vs MutableList)
+            with(typeSystemContext) {
+                assertTrue(
+                    getListReturnType.isFlexible(),
+                    "Expected java.util.List return type to be flexible"
+                )
+                assertTrue(
+                    getListReturnType.isFlexibleWithDifferentTypeConstructors(),
+                    "Expected java.util.List return type to have flexible mutability (List vs MutableList)"
+                )
+                val flexType = getListReturnType.asFlexibleType()!!
+                val lowerBoundClassifier = flexType.lowerBound().classifier
+                val upperBoundClassifier = flexType.upperBound().classifier
+                assertSame(
+                    irBuiltIns.mutableListClass,
+                    lowerBoundClassifier,
+                    "Expected lower bound of java.util.List to be kotlin.collections.MutableList"
+                )
+                assertSame(
+                    irBuiltIns.listClass,
+                    upperBoundClassifier,
+                    "Expected upper bound of java.util.List to be kotlin.collections.List"
+                )
+            }
+
+            // Assertion 3: java.util.Map.Entry mapping to irBuiltIns.mapEntryClass
+            val valE = statements[2] as IrVariable
+            val getMapEntryCall = valE.initializer as IrCall
+            val getMapEntryFun = getMapEntryCall.symbol.owner
+            val getMapEntryReturnType = getMapEntryFun.returnType
+            with(typeSystemContext) {
+                assertTrue(
+                    getMapEntryReturnType.isFlexible(),
+                    "Expected java.util.Map.Entry return type to be flexible"
+                )
+                val mapEntryFlexType = getMapEntryReturnType.asFlexibleType()!!
+                val mapEntryLowerBoundClassifier = mapEntryFlexType.lowerBound().classifier
+                val mapEntryUpperBoundClassifier = mapEntryFlexType.upperBound().classifier
+                assertSame(
+                    irBuiltIns.mutableMapEntryClass,
+                    mapEntryLowerBoundClassifier,
+                    "Expected lower bound of java.util.Map.Entry to be kotlin.collections.MutableMap.Entry"
+                )
+                assertSame(
+                    irBuiltIns.mapEntryClass,
+                    mapEntryUpperBoundClassifier,
+                    "Expected upper bound of java.util.Map.Entry to be kotlin.collections.Map.Entry"
+                )
+            }
+
+            // Assertion 4: java.lang.Integer mapping to irBuiltIns.intClass
+            val valI = statements[3] as IrVariable
+            val getIntegerCall = valI.initializer as IrCall
+            val getIntegerFun = getIntegerCall.symbol.owner
+            val getIntegerReturnTypeClassifier = (getIntegerFun.returnType as IrSimpleType).classifier
+            assertSame(
+                irBuiltIns.intClass,
+                getIntegerReturnTypeClassifier,
+                "Expected java.lang.Integer return type symbol to be identical to kotlin.Int symbol"
+            )
+
+            // Assertion 5: java.lang.Throwable mapping to irBuiltIns.throwableClass
+            val valT = statements[4] as IrVariable
+            val getThrowableCall = valT.initializer as IrCall
+            val getThrowableFun = getThrowableCall.symbol.owner
+            val getThrowableReturnTypeClassifier = (getThrowableFun.returnType as IrSimpleType).classifier
+            assertSame(
+                irBuiltIns.throwableClass,
+                getThrowableReturnTypeClassifier,
+                "Expected java.lang.Throwable return type symbol to be identical to kotlin.Throwable symbol"
+            )
+
         } finally {
             disposeRootInWriteAction(disposable)
         }


### PR DESCRIPTION
## The problem

5 cases are currently failing:
- Fake overrides for java superclasses
- Fake overrides for mapped java and kotlin type
- Fake overrides for functions like toArray which have different parameter variance in java and kotlin
- Anonymous local objects signatures
- Properties declared in java, overriden in kotlin
- Fake overrides for flexible types, types that may be nullable or not, or that have different constructors but are mapped.

All of these have a common culprit, using jvm plain signatures rather than kotlin signatures. This was done originally to avoid mismatches and modifications between k2, the frontend and k1 the linker. 

## The fix
Mapping the plain jvm signatures to kotlin signatures including builtIns before any typeSystemChecks in order to leverage jvm fully and avoid re-implementing any of this logic