### PR TITLE
[Wasm, Tests] Test Federation: include more paths in domains.yaml (^KT-87621)

### DIFF
--- a/repo/domains.dump.txt
+++ b/repo/domains.dump.txt
@@ -94,19 +94,26 @@ Js:
  - compiler/ir/serialization.js
  - js/ReadMe.md
  - js/js.ast
- - js/js.config
+ - js/js.config/ReadMe.md
+ - js/js.config/build.gradle.kts
+ - js/js.config/gen
+ - js/js.config/src/org/jetbrains/kotlin/incremental
+ - js/js.config/src/org/jetbrains/kotlin/js/artifacts
+ - js/js.config/src/org/jetbrains/kotlin/platform
+ - js/js.config/src/org/jetbrains/kotlin/utils
  - js/js.frontend
  - js/js.frontend.common
  - js/js.parser
- - js/js.sourcemap
- - js/js.tests
+ - js/js.tests/ReadMe.md
+ - js/js.tests/build.gradle.kts
+ - js/js.tests/klib-compatibility
+ - js/js.tests/testFixtures/com
+ - js/js.tests/tests
  - js/js.translator/ReadMe.md
  - js/js.translator/build.gradle.kts
  - js/js.translator/src
  - js/npm
- - js/typescript-export-model
  - js/typescript-export-standalone
- - js/typescript-printer
 
 Native:
  - compiler/ir/backend.native
@@ -272,7 +279,6 @@ Unknown:
  - libraries/tools/abi-validation
  - libraries/tools/atomicfu
  - libraries/tools/binary-compatibility-validator
- - libraries/tools/dukat
  - libraries/tools/ide-plugin-dependencies-validator
  - libraries/tools/js-plain-objects
  - libraries/tools/klib-abi-reader
@@ -322,7 +328,13 @@ Unknown:
  - third-party
 
 Js, Wasm:
+ - js/js.config/src/org/jetbrains/kotlin/js/config
+ - js/js.sourcemap
+ - js/js.tests/testFixtures/org/jetbrains/kotlin
  - js/js.translator/testData
+ - js/typescript-export-model
+ - js/typescript-printer
+ - libraries/tools/dukat
 
 Compiler, CoreLibs:
  - core/descriptors.runtime

--- a/repo/domains.yaml
+++ b/repo/domains.yaml
@@ -30,6 +30,12 @@ Wasm:
     - "compiler/ir/backend.wasm"
     - "wasm"
     - "js/js.translator/testData"
+    - "js/js.sourcemap"
+    - "js/typescript-export-model"
+    - "js/typescript-printer"
+    - "libraries/tools/dukat"
+    - "js/js.tests/testFixtures/org/jetbrains/kotlin"
+    - "js/js.config/src/org/jetbrains/kotlin/js/config"
   fullyAffectedBy:
     - Compiler
     - CoreLibs
@@ -39,6 +45,7 @@ Js:
     - "compiler/ir/backend.js"
     - "compiler/ir/serialization.js"
     - "libraries/tools/analysis-api-based-klib-reader"
+    - "libraries/tools/dukat"
   fullyAffectedBy:
     - Compiler
     - CoreLibs

--- a/repo/gradle-build-conventions/test-federation-convention/src/main/generated/domains.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/main/generated/domains.kt
@@ -31,14 +31,14 @@ internal object CompilerDomainInfo : DomainInfo {
 
 internal object WasmDomainInfo : DomainInfo {
     override val domain = Domain.Wasm
-    override val include: List<String> = listOf("compiler/ir/backend.wasm", "wasm", "js/js.translator/testData")
+    override val include: List<String> = listOf("compiler/ir/backend.wasm", "wasm", "js/js.translator/testData", "js/js.sourcemap", "js/typescript-export-model", "js/typescript-printer", "libraries/tools/dukat", "js/js.tests/testFixtures/org/jetbrains/kotlin", "js/js.config/src/org/jetbrains/kotlin/js/config")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, CoreLibsDomainInfo) }
 }
 
 internal object JsDomainInfo : DomainInfo {
     override val domain = Domain.Js
-    override val include: List<String> = listOf("js", "compiler/ir/backend.js", "compiler/ir/serialization.js", "libraries/tools/analysis-api-based-klib-reader")
+    override val include: List<String> = listOf("js", "compiler/ir/backend.js", "compiler/ir/serialization.js", "libraries/tools/analysis-api-based-klib-reader", "libraries/tools/dukat")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, CoreLibsDomainInfo) }
 }


### PR DESCRIPTION
There are a few shared "Web" classes/components under `js/` paths that should trigger Wasm tests.

Completely marking Wasm fullyAffectedBy JS would trigger way more CI runs, even though since the test federation has been engaged, these missing paths have never caused a problem. So marking a few more paths should be way lighter on CI resources, but still cover a bit more of the remaining 1% not-covered cases of JS <-> Wasm interdependence.

There are a few remaining `TODO(REVIEW)` comments that I'll remove with a fixup commit before merging.