### PR TITLE
Apply `returnsResultOf` contract to kotlin-stdlib and cinterop

### DIFF
--- a/compiler/testData/diagnostics/tests/crv/scopes.kt
+++ b/compiler/testData/diagnostics/tests/crv/scopes.kt
@@ -20,7 +20,7 @@ fun returnsString(): String {
 fun main() {
     stringF().<!RETURN_VALUE_NOT_USED!>myLet<!> { it }
     stringF().<!RETURN_VALUE_NOT_USED!>myLet<!> { 2 }
-    stringF().let { 2 }
+    stringF().<!RETURN_VALUE_NOT_USED!>let<!> { 2 }
 }
 
 /* GENERATED_FIR_TAGS: annotationUseSiteTargetFile, funWithExtensionReceiver, functionDeclaration, functionalType,

--- a/generators/builtins/contextParameters.kt
+++ b/generators/builtins/contextParameters.kt
@@ -46,6 +46,7 @@ class GenerateContextFunctions(out: PrintWriter) : BuiltInsSourceGenerator(out) 
 public inline fun <$types, $resultType> context($parameters, block: context($types) () -> $resultType): $resultType {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block($arguments)
 }

--- a/kotlin-native/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
+++ b/kotlin-native/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
@@ -350,6 +350,7 @@ public fun <T : CVariable> CValues<T>.getBytes(): ByteArray = memScoped {
 public inline fun <reified T : CStructVar, R> CValue<T>.useContents(block: T.() -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
 
     return memScoped {
@@ -712,9 +713,10 @@ public class MemScope : ArenaBase() {
  */
 @ExperimentalForeignApi
 @OptIn(kotlin.contracts.ExperimentalContracts::class)
-public inline fun <R> memScoped(block: MemScope.()->R): R {
+public inline fun <R> memScoped(block: MemScope.() -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
 
     val memScope = MemScope()

--- a/kotlin-native/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCUtils.kt
+++ b/kotlin-native/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCUtils.kt
@@ -5,9 +5,16 @@
 
 package kotlinx.cinterop
 
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
 @BetaInteropApi
 @OptIn(ExperimentalForeignApi::class)
 public inline fun <R> autoreleasepool(block: () -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
+    }
     val pool = objc_autoreleasePoolPush()
     return try {
         block()

--- a/kotlin-native/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/Pinning.kt
+++ b/kotlin-native/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/Pinning.kt
@@ -5,6 +5,8 @@
 @file:OptIn(ExperimentalForeignApi::class)
 package kotlinx.cinterop
 
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.native.*
 import kotlin.native.internal.GCUnsafeCall
 
@@ -31,6 +33,10 @@ public inline fun <T : Any> T.pin(): Pinned<T> = Pinned(this)
 
 @ExperimentalForeignApi
 public inline fun <T : Any, R> T.usePinned(block: (Pinned<T>) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
+    }
     val pinned = this.pin()
     return try {
         block(pinned)

--- a/libraries/stdlib/jdk7/src/kotlin/io/path/PathReadWrite.kt
+++ b/libraries/stdlib/jdk7/src/kotlin/io/path/PathReadWrite.kt
@@ -266,10 +266,10 @@ public inline fun Path.readLines(charset: Charset = Charsets.UTF_8): List<String
 @SinceKotlin("1.5")
 @Throws(IOException::class)
 @kotlin.internal.InlineOnly
-@IgnorableReturnValue // KT-72691
 public inline fun <T> Path.useLines(charset: Charset = Charsets.UTF_8, block: (Sequence<String>) -> T): T {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return Files.newBufferedReader(this, charset).use { block(it.lineSequence()) }
 }

--- a/libraries/stdlib/jdk7/src/kotlin/io/path/PathUtils.kt
+++ b/libraries/stdlib/jdk7/src/kotlin/io/path/PathUtils.kt
@@ -395,8 +395,11 @@ public fun Path.listDirectoryEntries(glob: String = "*"): List<Path> {
 @SinceKotlin("1.5")
 @Throws(IOException::class)
 @kotlin.internal.InlineOnly
-@IgnorableReturnValue // KT-72691
 public inline fun <T> Path.useDirectoryEntries(glob: String = "*", block: (Sequence<Path>) -> T): T {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
+    }
     return Files.newDirectoryStream(this, glob).use { block(it.asSequence()) }
 }
 

--- a/libraries/stdlib/jvm/src/kotlin/io/Closeable.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/Closeable.kt
@@ -18,10 +18,10 @@ import kotlin.internal.*
  * @return the result of [block] function invoked on this resource.
  */
 @InlineOnly
-@IgnorableReturnValue
 public inline fun <T : Closeable?, R> T.use(block: (T) -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     var exception: Throwable? = null
     try {

--- a/libraries/stdlib/jvm/src/kotlin/io/FileReadWrite.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/FileReadWrite.kt
@@ -288,6 +288,7 @@ public fun File.readLines(charset: Charset = Charsets.UTF_8): List<String> {
 public inline fun <T> File.useLines(charset: Charset = Charsets.UTF_8, block: (Sequence<String>) -> T): T {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return bufferedReader(charset).use { block(it.lineSequence()) }
 }

--- a/libraries/stdlib/jvm/src/kotlin/io/ReadWrite.kt
+++ b/libraries/stdlib/jvm/src/kotlin/io/ReadWrite.kt
@@ -58,10 +58,10 @@ public fun Reader.readLines(): List<String> {
  * the processing is complete.
  * @return the value returned by [block].
  */
-@IgnorableReturnValue
 public inline fun <T> Reader.useLines(block: (Sequence<String>) -> T): T {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return buffered().use { block(it.lineSequence()) }
 }

--- a/libraries/stdlib/jvm/src/kotlin/util/Synchronized.kt
+++ b/libraries/stdlib/jvm/src/kotlin/util/Synchronized.kt
@@ -14,10 +14,10 @@ import kotlin.jvm.internal.unsafe.*
  * Executes the given function [block] while holding the monitor of the given object [lock].
  */
 @kotlin.internal.InlineOnly
-@IgnorableReturnValue
 public inline fun <R> synchronized(lock: Any, block: () -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
 
     // Force the lock object into a local and use that local for monitor enter/exit.

--- a/libraries/stdlib/src/kotlin/contextParameters/Context.kt
+++ b/libraries/stdlib/src/kotlin/contextParameters/Context.kt
@@ -24,6 +24,7 @@ package kotlin
 public inline fun <T, R> context(with: T, block: context(T) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block(with)
 }
@@ -42,6 +43,7 @@ public inline fun <T, R> context(with: T, block: context(T) () -> R): R {
 public inline fun <A, B, R> context(a: A, b: B, block: context(A, B) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block(a, b)
 }
@@ -60,6 +62,7 @@ public inline fun <A, B, R> context(a: A, b: B, block: context(A, B) () -> R): R
 public inline fun <A, B, C, R> context(a: A, b: B, c: C, block: context(A, B, C) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block(a, b, c)
 }
@@ -78,6 +81,7 @@ public inline fun <A, B, C, R> context(a: A, b: B, c: C, block: context(A, B, C)
 public inline fun <A, B, C, D, R> context(a: A, b: B, c: C, d: D, block: context(A, B, C, D) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block(a, b, c, d)
 }
@@ -96,6 +100,7 @@ public inline fun <A, B, C, D, R> context(a: A, b: B, c: C, d: D, block: context
 public inline fun <A, B, C, D, E, R> context(a: A, b: B, c: C, d: D, e: E, block: context(A, B, C, D, E) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block(a, b, c, d, e)
 }
@@ -114,7 +119,7 @@ public inline fun <A, B, C, D, E, R> context(a: A, b: B, c: C, d: D, e: E, block
 public inline fun <A, B, C, D, E, F, R> context(a: A, b: B, c: C, d: D, e: E, f: F, block: context(A, B, C, D, E, F) () -> R): R {
     kotlin.contracts.contract {
         callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block(a, b, c, d, e, f)
 }
-

--- a/libraries/stdlib/src/kotlin/util/Standard.kt
+++ b/libraries/stdlib/src/kotlin/util/Standard.kt
@@ -37,10 +37,10 @@ public inline fun TODO(reason: String): Nothing = throw NotImplementedError("An 
  * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#run).
  */
 @kotlin.internal.InlineOnly
-@IgnorableReturnValue
 public inline fun <R> run(block: () -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block()
 }
@@ -51,10 +51,10 @@ public inline fun <R> run(block: () -> R): R {
  * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#run).
  */
 @kotlin.internal.InlineOnly
-@IgnorableReturnValue
 public inline fun <T, R> T.run(block: T.() -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block()
 }
@@ -65,10 +65,10 @@ public inline fun <T, R> T.run(block: T.() -> R): R {
  * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#with).
  */
 @kotlin.internal.InlineOnly
-@IgnorableReturnValue
 public inline fun <T, R> with(receiver: T, block: T.() -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return receiver.block()
 }
@@ -110,10 +110,10 @@ public inline fun <T> T.also(block: (T) -> Unit): T {
  * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#let).
  */
 @kotlin.internal.InlineOnly
-@IgnorableReturnValue
 public inline fun <T, R> T.let(block: (T) -> R): R {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returnsResultOf(block)
     }
     return block(this)
 }


### PR DESCRIPTION
These are the same commits that were in 2.4 and later reverted because of KT-86027