### PR TITLE
[Native] Fix Kotlin/Native full bundle

### DIFF
--- a/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/platformLibs/updateDefFileDependencies.kt
+++ b/kotlin-native/build-tools/src/main/kotlin/org/jetbrains/kotlin/platformLibs/updateDefFileDependencies.kt
@@ -33,7 +33,8 @@ fun Project.familyDefFiles(family: Family) = fileTree("src/platform/${family.vis
 fun Project.registerUpdateDefFileDependenciesForAppleFamiliesTasks(aggregateTask: TaskProvider<*>): Map<Family, TaskProvider<*>> {
     val shouldUpdate = project.kotlinBuildProperties.booleanProperty(updateDefFileDependenciesFlag, false).get()
 
-    val updateDefFilesTaskPerFamily = KonanTarget.predefinedTargets.values.filter { it.family.isAppleFamily }.groupBy { it.family }.mapValues {
+    val targets = KonanTarget.predefinedTargets.values.filter { it.name != "watchos_arm32" }
+    val updateDefFilesTaskPerFamily = targets.filter { it.family.isAppleFamily }.groupBy { it.family }.mapValues {
         registerUpdateDefFileDependenciesTask(
                 family = it.key,
                 targets = it.value,


### PR DESCRIPTION
After the drop of watchOSArm32 target we encountered a failure on CI of running a full bundle. The reason for that failure is the fact that we are using predefined targets that come from bootstrap for updating def files.

This commit filters out the dropped target name.