### PR TITLE
[CLI] Introduce PluginsLoader and ClassLoadersCache to compiler

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginCliParser.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginCliParser.kt
@@ -38,7 +38,7 @@ object PluginCliParser {
     @JvmStatic
     @Deprecated(
         "Use loadPluginsSafe with order constraints instead",
-        ReplaceWith("loadPluginsSafe(pluginClasspaths, pluginOptions, pluginConfigurations, emptyList(), configuration, parentDisposable)")
+        ReplaceWith("loadPluginsSafe(pluginClasspaths, pluginOptions, pluginConfigurations, emptyList(), configuration, parentDisposable, null)")
     )
     fun loadPluginsSafe(
         pluginClasspaths: Array<String>?,
@@ -54,6 +54,7 @@ object PluginCliParser {
             emptyList(),
             configuration,
             parentDisposable,
+            pluginsLoader = null,
         )
     }
 
@@ -65,6 +66,7 @@ object PluginCliParser {
         pluginOrderConstraints: Array<String>?,
         configuration: CompilerConfiguration,
         parentDisposable: Disposable,
+        pluginsLoader: PluginsLoader?,
     ): ExitCode {
         return loadPluginsSafe(
             pluginClasspaths?.asList().orEmpty(),
@@ -73,13 +75,14 @@ object PluginCliParser {
             pluginOrderConstraints?.asList().orEmpty(),
             configuration,
             parentDisposable,
+            pluginsLoader,
         )
     }
 
     @JvmStatic
     @Deprecated(
         "Use loadPluginsSafe with order constraints instead",
-        ReplaceWith("loadPluginsSafe(pluginClasspaths, pluginOptions, pluginConfigurations, emptyList(), configuration, parentDisposable)")
+        ReplaceWith("loadPluginsSafe(pluginClasspaths, pluginOptions, pluginConfigurations, emptyList(), configuration, parentDisposable, null)")
     )
     fun loadPluginsSafe(
         pluginClasspaths: Collection<String>,
@@ -88,7 +91,15 @@ object PluginCliParser {
         configuration: CompilerConfiguration,
         parentDisposable: Disposable,
     ): ExitCode {
-        return loadPluginsSafe(pluginClasspaths, pluginOptions, pluginConfigurations, emptyList(), configuration, parentDisposable)
+        return loadPluginsSafe(
+            pluginClasspaths,
+            pluginOptions,
+            pluginConfigurations,
+            emptyList(),
+            configuration,
+            parentDisposable,
+            pluginsLoader = null
+        )
     }
 
     @JvmStatic
@@ -99,6 +110,7 @@ object PluginCliParser {
         pluginOrderConstraints: Collection<String>,
         configuration: CompilerConfiguration,
         parentDisposable: Disposable,
+        pluginsLoader: PluginsLoader?,
     ): ExitCode = loadPluginsSafe(configuration) {
         // Parse order constraints before creating class loaders and loading services.
         val orderConstraints = pluginOrderConstraints.map { rawConstraint ->
@@ -106,8 +118,8 @@ object PluginCliParser {
                 ?: throw PluginProcessingException("Could not parse plugin order constraint: $rawConstraint")
         }
 
-        loadPluginsLegacyStyle(pluginClasspaths, orderConstraints, pluginOptions, configuration, parentDisposable)
-        loadPluginsModernStyle(pluginConfigurations, orderConstraints, configuration, parentDisposable)
+        loadPluginsLegacyStyle(pluginClasspaths, orderConstraints, pluginOptions, configuration, parentDisposable, pluginsLoader)
+        loadPluginsModernStyle(pluginConfigurations, orderConstraints, configuration, parentDisposable, pluginsLoader)
     }
 
     /**
@@ -187,12 +199,13 @@ object PluginCliParser {
         rawPluginConfigurations: Iterable<String>,
         orderConstraints: List<PluginOrderConstraint>,
         parentDisposable: Disposable,
+        pluginsLoader: PluginsLoader?,
     ): List<RegisteredPluginInfo> {
         val pluginConfigurations = extractPluginClasspathAndOptions(rawPluginConfigurations)
 
         val pluginInfos = pluginConfigurations.map { pluginConfiguration ->
-            val classLoader = createClassLoader(pluginConfiguration.classpath, parentDisposable)
-            val compilerPluginRegistrars = ServiceLoaderLite.loadImplementations(CompilerPluginRegistrar::class.java, classLoader)
+            val pluginsLoader = pluginsLoader ?: ClassLoaderBased(createClassLoader(pluginConfiguration.classpath, parentDisposable))
+            val compilerPluginRegistrars = pluginsLoader.loadCompilerPluginRegistrars(pluginConfiguration.classpath, parentDisposable)
 
             fun multiplePluginsErrorMessage(pluginObjects: List<Any>): String {
                 return buildString {
@@ -209,7 +222,7 @@ object PluginCliParser {
                 else -> throw PluginProcessingException(multiplePluginsErrorMessage(compilerPluginRegistrars))
             }
 
-            val commandLineProcessors = ServiceLoaderLite.loadImplementations(CommandLineProcessor::class.java, classLoader)
+            val commandLineProcessors = pluginsLoader.loadCommandLineProcessors(pluginConfiguration.classpath, parentDisposable)
             if (commandLineProcessors.size > 1) {
                 throw PluginProcessingException(multiplePluginsErrorMessage(commandLineProcessors))
             }
@@ -258,8 +271,9 @@ object PluginCliParser {
         orderConstraints: List<PluginOrderConstraint>,
         configuration: CompilerConfiguration,
         parentDisposable: Disposable,
+        pluginsLoader: PluginsLoader?,
     ) {
-        val pluginInfos = loadRegisteredPluginsInfo(rawPluginConfigurations, orderConstraints, parentDisposable)
+        val pluginInfos = loadRegisteredPluginsInfo(rawPluginConfigurations, orderConstraints, parentDisposable, pluginsLoader)
         for (pluginInfo in pluginInfos) {
             pluginInfo.compilerPluginRegistrar?.let { configuration.add(CompilerPluginRegistrar.COMPILER_PLUGIN_REGISTRARS, it) }
 
@@ -341,14 +355,16 @@ object PluginCliParser {
     @JvmStatic
     @Suppress("DEPRECATION_ERROR")
     private fun loadPluginsLegacyStyle(
-        pluginClasspaths: Iterable<String>?,
+        pluginClasspaths: Collection<String>?,
         orderConstraints: List<PluginOrderConstraint>,
         pluginOptions: Iterable<String>?,
         configuration: CompilerConfiguration,
         parentDisposable: Disposable,
+        pluginsLoader: PluginsLoader?,
     ) {
-        val classLoader = createClassLoader(pluginClasspaths ?: emptyList(), parentDisposable)
-        val compilerPluginRegistrars = ServiceLoaderLite.loadImplementations(CompilerPluginRegistrar::class.java, classLoader)
+        if (pluginClasspaths.isNullOrEmpty()) return
+        val pluginsLoader = pluginsLoader ?: ClassLoaderBased(createClassLoader(pluginClasspaths, parentDisposable))
+        val compilerPluginRegistrars = pluginsLoader.loadCompilerPluginRegistrars(pluginClasspaths, parentDisposable)
 
         val registrarsById = compilerPluginRegistrars
             .filter {
@@ -380,18 +396,12 @@ object PluginCliParser {
 
         configuration.addAll(CompilerPluginRegistrar.COMPILER_PLUGIN_REGISTRARS, topologicalSort.asReversed())
 
-        processPluginOptions(pluginOptions, configuration, classLoader)
-    }
-
-    private fun processPluginOptions(
-        pluginOptions: Iterable<String>?,
-        configuration: CompilerConfiguration,
-        classLoader: URLClassLoader
-    ) {
         // TODO issue a warning on using deprecated command line processors when all official plugin migrate to the newer convention
-        val commandLineProcessors = ServiceLoaderLite.loadImplementations(CommandLineProcessor::class.java, classLoader)
-
-        processCompilerPluginsOptions(configuration, pluginOptions, commandLineProcessors)
+        processCompilerPluginsOptions(
+            configuration,
+            pluginOptions,
+            pluginsLoader.loadCommandLineProcessors(pluginClasspaths, parentDisposable)
+        )
     }
 
     private fun createClassLoader(classpath: Iterable<String>, parentDisposable: Disposable): URLClassLoader {
@@ -415,5 +425,22 @@ object PluginCliParser {
         }
     }
 
+    private class ClassLoaderBased(val classLoader: URLClassLoader) : PluginsLoader {
+        override fun loadCompilerPluginRegistrars(
+            pluginClasspath: Collection<String>,
+            parentDisposable: Disposable,
+        ): List<CompilerPluginRegistrar> {
+            return ServiceLoaderLite.loadImplementations(CompilerPluginRegistrar::class.java, classLoader)
+        }
+
+        override fun loadCommandLineProcessors(
+            pluginClasspath: Collection<String>,
+            parentDisposable: Disposable,
+        ): List<CommandLineProcessor> {
+            return ServiceLoaderLite.loadImplementations(CommandLineProcessor::class.java, classLoader)
+        }
+    }
+
     class PluginProcessingError(message: String, cause: Throwable?) : Error(message, cause)
 }
+

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginsLoader.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/plugins/PluginsLoader.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.cli.jvm.plugins
+
+import com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.config.Services
+
+/**
+ * Represents a loader for plugins that can dynamically load Kotlin compiler plugins and their
+ * associated command-line processors from a specified classpath.
+ *
+ * When provided through compiler [Services] it allows for overriding the default plugin loading behavior to provide custom logic,
+ * such as but not limited to, customizing the classloading mechanism, adding caching, or injecting different versions of plugins.
+ */
+interface PluginsLoader {
+    fun loadCompilerPluginRegistrars(pluginClasspath: Collection<String>, parentDisposable: Disposable): List<CompilerPluginRegistrar>
+    fun loadCommandLineProcessors(pluginClasspath: Collection<String>, parentDisposable: Disposable): List<CommandLineProcessor>
+}

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/pipeline/AbstractConfigurationPhase.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/pipeline/AbstractConfigurationPhase.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.cli.common.CLICompiler.Companion.SCRIPT_PLUGIN_K2_RE
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.cli.diagnosticFactoriesStorage
 import org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
 import org.jetbrains.kotlin.cli.plugins.extractPluginClasspathAndOptions
 import org.jetbrains.kotlin.cli.plugins.processCompilerPluginsOptions
 import org.jetbrains.kotlin.cli.reportInfo
@@ -72,7 +73,7 @@ abstract class AbstractConfigurationPhase<A : CommonCompilerArguments>(
     protected open fun provideCustomScriptingPluginOptions(arguments: A): List<String> = emptyList()
 
     private fun CompilerConfiguration.setupCommonConfiguration(input: ArgumentsPipelineArtifact<A>) {
-        (val arguments, val _ = services, val _ = rootDisposable, val _ = messageCollector, val performanceManager) = input
+        (val arguments, val services, val _ = rootDisposable, val _ = messageCollector, val performanceManager) = input
         perfManager = performanceManager
         printVersion = arguments.version
         // TODO(KT-73711): move script-related configuration to JVM CLI
@@ -83,13 +84,14 @@ abstract class AbstractConfigurationPhase<A : CommonCompilerArguments>(
         val paths = computeKotlinPaths(this, arguments)?.also {
             kotlinPaths = it
         }
-        loadCompilerPlugins(paths, input, this)
+        loadCompilerPlugins(paths, input, this, services[PluginsLoader::class.java])
     }
 
     private fun loadCompilerPlugins(
         paths: KotlinPaths?,
         input: ArgumentsPipelineArtifact<A>,
         configuration: CompilerConfiguration,
+        pluginsLoader: PluginsLoader?,
     ) {
         val arguments = input.arguments
         val pluginClasspaths = arguments.pluginClasspaths.toMutableList()
@@ -149,7 +151,8 @@ abstract class AbstractConfigurationPhase<A : CommonCompilerArguments>(
             pluginConfigurations,
             pluginOrderConstraints,
             configuration,
-            input.rootDisposable
+            input.rootDisposable,
+            pluginsLoader,
         )
     }
 

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/pipeline/AbstractConfigurationPhase.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/pipeline/AbstractConfigurationPhase.kt
@@ -23,7 +23,9 @@ import org.jetbrains.kotlin.cli.reportInfo
 import org.jetbrains.kotlin.cli.reportLog
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.components.ClassLoadersCache
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.classloadersCache
 import org.jetbrains.kotlin.config.perfManager
 import org.jetbrains.kotlin.config.phaser.Action
 import org.jetbrains.kotlin.ir.validation.IrValidationDiagnostics
@@ -84,6 +86,7 @@ abstract class AbstractConfigurationPhase<A : CommonCompilerArguments>(
         val paths = computeKotlinPaths(this, arguments)?.also {
             kotlinPaths = it
         }
+        classloadersCache = services[ClassLoadersCache::class.java]
         loadCompilerPlugins(paths, input, this, services[PluginsLoader::class.java])
     }
 

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/CommonConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/CommonConfigurationKeysContainer.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.config.keys.generator
 
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.components.ClassLoadersCache
 import org.jetbrains.kotlin.config.HmppCliModuleStructure
 import org.jetbrains.kotlin.config.IrVerificationMode
 import org.jetbrains.kotlin.config.LanguageVersionSettings
@@ -73,4 +74,6 @@ object CommonConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.co
     )
 
     val TARGET_PLATFORM by key<TargetPlatform>()
+
+    val CLASSLOADERS_CACHE by key<ClassLoadersCache>("Cache for classloaders to be used by compiler plugins (e.g. Kapt)", throwOnNull = false)
 }

--- a/compiler/config/gen/org/jetbrains/kotlin/config/CommonConfigurationKeys.kt
+++ b/compiler/config/gen/org/jetbrains/kotlin/config/CommonConfigurationKeys.kt
@@ -13,6 +13,7 @@ package org.jetbrains.kotlin.config
  */
 
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.components.ClassLoadersCache
 import org.jetbrains.kotlin.config.phaser.PhaseConfig
 import org.jetbrains.kotlin.incremental.components.EnumWhenTracker
 import org.jetbrains.kotlin.incremental.components.ExpectActualTracker
@@ -135,6 +136,10 @@ object CommonConfigurationKeys {
 
     @JvmField
     val TARGET_PLATFORM = CompilerConfigurationKey.create<TargetPlatform>("TARGET_PLATFORM")
+
+    // Cache for classloaders to be used by compiler plugins (e.g. Kapt)
+    @JvmField
+    val CLASSLOADERS_CACHE = CompilerConfigurationKey.create<ClassLoadersCache>("CLASSLOADERS_CACHE")
 
 }
 
@@ -274,4 +279,8 @@ var CompilerConfiguration.detailedPerf: Boolean
 var CompilerConfiguration.targetPlatform: TargetPlatform?
     get() = get(CommonConfigurationKeys.TARGET_PLATFORM)
     set(value) { put(CommonConfigurationKeys.TARGET_PLATFORM, requireNotNull(value) { "nullable values are not allowed" }) }
+
+var CompilerConfiguration.classloadersCache: ClassLoadersCache?
+    get() = get(CommonConfigurationKeys.CLASSLOADERS_CACHE)
+    set(value) { putIfNotNull(CommonConfigurationKeys.CLASSLOADERS_CACHE, value) }
 

--- a/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/script/scriptTestUtil.kt
+++ b/compiler/test-infrastructure-utils/testFixtures/org/jetbrains/kotlin/script/scriptTestUtil.kt
@@ -12,10 +12,10 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 
 fun loadScriptingPlugin(configuration: CompilerConfiguration, parentDisposable: Disposable) {
     val pluginClasspath = ForTestCompileRuntime.scriptingPluginFilesForTests()
-    PluginCliParser.loadPluginsSafe(pluginClasspath.map { it.path }, emptyList(), emptyList(), emptyList(), configuration, parentDisposable)
+    PluginCliParser.loadPluginsSafe(pluginClasspath.map { it.path }, emptyList(), emptyList(), emptyList(), configuration, parentDisposable, pluginsLoader = null)
 }
 
 fun loadScriptingPlugin(configuration: CompilerConfiguration, parentDisposable: Disposable, pluginClasspath: Collection<String>) {
-    PluginCliParser.loadPluginsSafe(pluginClasspath, emptyList(), emptyList(), emptyList(), configuration, parentDisposable)
+    PluginCliParser.loadPluginsSafe(pluginClasspath, emptyList(), emptyList(), emptyList(), configuration, parentDisposable, pluginsLoader = null)
 }
 

--- a/core/compiler.common/src/org/jetbrains/kotlin/components/ClassLoadersCache.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/components/ClassLoadersCache.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.components
+
+import java.io.File
+import java.net.URLClassLoader
+
+/**
+ * Cache for classloaders to be used by compiler plugins that need to load additional classes dynamically.
+ *
+ * May be passed into compiler `Services` to be used by compiler plugins.
+ * A compiler plugin must add explicit support for using the `ClassLoadersCache` to benefit from it.
+ */
+interface ClassLoadersCache {
+    fun getForClassPath(files: List<File>): ClassLoader
+}

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle80Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle80Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle811Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle811Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle813Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle813Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle81Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle81Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle82Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle82Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle85Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle85Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle86Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle86Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle88Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle88Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle96Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Gradle96Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Jar.deprecations
+++ b/libraries/tools/kotlin-gradle-plugin/asm-deprecation/Jar.deprecations
@@ -32,6 +32,7 @@ package org.jetbrains.kotlin.compilerRunner.btapi.js
 package org.jetbrains.kotlin.compilerRunner.btapi.jvm
 package org.jetbrains.kotlin.compilerRunner.btapi.metadata
 package org.jetbrains.kotlin.compilerRunner.btapi.wasm
+package org.jetbrains.kotlin.components
 package org.jetbrains.kotlin.config
 package org.jetbrains.kotlin.incremental
 package org.jetbrains.kotlin.incremental.components

--- a/native/cli-native/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/native/cli-native/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.cli.create
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
 import org.jetbrains.kotlin.cli.pipeline.CheckCompilationErrors.CheckDiagnosticCollector
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.*
@@ -124,7 +125,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
             try {
                 setIdeaIoUseFallback()
 
-                val code = doExecute(arguments, configuration, rootDisposable)
+                val code = doExecute(arguments, configuration, rootDisposable, services)
 
                 performanceManager.notifyCompilationFinished()
                 if (arguments.reportPerf) {
@@ -171,6 +172,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
         @NotNull arguments: K2NativeCompilerArguments,
         @NotNull configuration: CompilerConfiguration,
         @NotNull rootDisposable: Disposable,
+        services: Services,
     ): ExitCode {
 
         if (arguments.version) {
@@ -186,6 +188,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                 arguments.pluginOrderConstraints,
                 configuration,
                 rootDisposable,
+                services[PluginsLoader::class.java],
             )
             if (pluginLoadResult != ExitCode.OK) return pluginLoadResult
 

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/compilationContext.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/compilationContext.kt
@@ -330,7 +330,8 @@ private fun createInitialCompilerConfiguration(
                 pluginConfigurations,
                 pluginOrderConstraints,
                 this,
-                parentDisposable
+                parentDisposable,
+                pluginsLoader = null,
             )
         } else {
             loadPluginsFromClassloader(CompilerConfiguration::class.java.classLoader)


### PR DESCRIPTION
As part of the efforts to bring Kapt to BTA, we need a way to make running it as a compiler plugin more efficient.
These commits introduce two mechanisms for two levels of caching:

* PluginsLoader - which can be passed from the outside into the compiler to cache loaded compiler plugins
* ClassLoadersCache -  which can be passed from the outside and used by compiler plugins to load additional classes, for example Kapt loads annotation processor