### PR TITLE
[JVM] Remap inlined bound receivers to the accessor's dispatch receiver

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
@@ -175,7 +175,7 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
         val originalThis = parentAsClass.thisReceiver
 
         fun remapReceiverIfNeeded(accessor: IrSimpleFunction) = if (backingField == null) {
-            boundValueOrNull?.remapReceiver(originalThis, accessor.getReceiverParameterOrNull())
+            boundValueOrNull?.remapReceiver(originalThis, accessor.dispatchReceiverParameter)
         } else {
             null
         }

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnother/memberExtensionWithBoundReceiver.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnother/memberExtensionWithBoundReceiver.kt
@@ -1,0 +1,20 @@
+// WITH_STDLIB
+
+class D {
+    var y: String = "initial"
+}
+
+class A
+
+class C {
+    val d = D()
+    var A.x: String by d::y
+}
+
+fun box(): String {
+    val a = A()
+    with(C()) {
+        a.x = "OK"
+        return a.x
+    }
+}

--- a/compiler/testData/codegen/box/delegatedProperty/delegateToAnother/memberExtensionWithBoundReceiverSameType.kt
+++ b/compiler/testData/codegen/box/delegatedProperty/delegateToAnother/memberExtensionWithBoundReceiverSameType.kt
@@ -1,0 +1,11 @@
+// WITH_STDLIB
+
+class A(val prop: String) {
+    val A.x: String by ::prop
+}
+
+fun box(): String {
+    with(A("OK")) {
+        return A("fail").x
+    }
+}


### PR DESCRIPTION
^KT-87983: Fixed