### PR TITLE
[BTA] Keep ApplicationEnvironment during BuildSession for in-process

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/build.gradle.kts
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/build.gradle.kts
@@ -202,6 +202,7 @@ val businessLogicTestSuits = setOf(
     "testAbiValidation",
     "testRestrictedArguments",
     "testClasspathMetadata",
+    "testBuildSession",
 )
 
 fun JvmTestSuite.addStdLibClasspaths() {

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestAnnotations.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestAnnotations.kt
@@ -56,6 +56,20 @@ annotation class BtaVersionsOnlyCompilationTest
 )
 annotation class BtaV2StrategyAndPlatformAgnosticCompilationTest
 
+/**
+ * Annotation for parameterized tests that evaluate compilation behavior using only BTAv2 on all supported platforms,
+ * without fixing an execution policy. The test receives a [ProjectWithPolicyCreator] and the `KotlinToolchains`, and
+ * chooses the execution policy itself (e.g. in-process, to observe in-process compiler state a daemon run would not
+ * expose).
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest(name = "{0}: {displayName}")
+@ArgumentsSource(
+    BtaV2PlatformAgnosticCompilationTestArgumentProvider::class
+)
+annotation class BtaV2PlatformAgnosticCompilationTest
+
 
 /**
  * Annotation for parameterized tests that evaluate compilation behavior using both BTA implementations on all supported platforms

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/TestArgumentProviders.kt
@@ -54,35 +54,15 @@ class BtaV2StrategyAndPlatformAgnosticCompilationTestArgumentProvider : Argument
 
     companion object {
         fun namedStrategyArguments(): List<Named<ProjectCreator>> {
-            return BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments().flatMap { executionStrategyConfiguration ->
-                listOfNotNull(
-                    named(
-                        "${executionStrategyConfiguration.name}[JVM]"
-                    ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                        baseTest.jvmProject(executionStrategyConfiguration.payload, testAction)
-                    },
-                    if (executionStrategyConfiguration.payload.first.supportsJs()) {
-                        named(
-                            "${executionStrategyConfiguration.name}[JS]"
-                        ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                            baseTest.jsProject(executionStrategyConfiguration.payload, testAction)
+            return BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments().flatMap { strategy ->
+                val toolchain = strategy.payload.first
+                val policy = strategy.payload.second
+                BtaV2PlatformAgnosticCompilationTestArgumentProvider.projectWithPolicyCreators(toolchain, strategy.name)
+                    .map { platform ->
+                        named(platform.name) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
+                            platform.payload(baseTest, policy, testAction)
                         }
-                    } else null,
-                    if (executionStrategyConfiguration.payload.first.supportsWasm()) {
-                        named(
-                            "${executionStrategyConfiguration.name}[Wasm]"
-                        ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                            baseTest.wasmProject(executionStrategyConfiguration.payload, testAction)
-                        }
-                    } else null,
-                    if (executionStrategyConfiguration.payload.first.supportsMetadata()) {
-                        named(
-                            "${executionStrategyConfiguration.name}[Metadata]"
-                        ) { baseTest: BaseCompilationTest, testAction: ProjectAction ->
-                            baseTest.metadataProject(executionStrategyConfiguration.payload, testAction)
-                        }
-                    } else null,
-                )
+                    }
             }
         }
     }
@@ -111,6 +91,38 @@ class DefaultStrategyAgnosticCompilationTestArgumentProvider : ArgumentsProvider
                     } else null
                 )
             }
+        }
+    }
+}
+
+/**
+ * Fans out over every platform BTAv2 supports without fixing an
+ * execution policy. Each argument is a [ProjectWithPolicyCreator] plus the [KotlinToolchains]; the test chooses the policy
+ * itself (e.g. in-process) via the toolchain and passes it to the opener.
+ */
+class BtaV2PlatformAgnosticCompilationTestArgumentProvider : ArgumentsProvider {
+    override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> {
+        val toolchain = KotlinToolchains.loadImplementation(btaClassloader)
+        return projectWithPolicyCreators(toolchain, "[v2][${toolchain.getCompilerVersion()}]")
+            .map { Arguments.of(it, toolchain) }.stream()
+    }
+
+    companion object {
+        fun projectWithPolicyCreators(toolchain: KotlinToolchains, labelPrefix: String): List<Named<ProjectWithPolicyCreator>> {
+            return listOfNotNull(
+                named("$labelPrefix[JVM]") { baseTest: BaseCompilationTest, policy: ExecutionPolicy, action: ProjectAction ->
+                    baseTest.jvmProject(toolchain, policy, action)
+                },
+                if (toolchain.supportsJs()) named("$labelPrefix[JS]") { baseTest: BaseCompilationTest, policy: ExecutionPolicy, action: ProjectAction ->
+                    baseTest.jsProject(toolchain, policy, action)
+                } else null,
+                if (toolchain.supportsWasm()) named("$labelPrefix[Wasm]") { baseTest: BaseCompilationTest, policy: ExecutionPolicy, action: ProjectAction ->
+                    baseTest.wasmProject(toolchain, policy, action)
+                } else null,
+                if (toolchain.supportsMetadata()) named("$labelPrefix[Metadata]") { baseTest: BaseCompilationTest, policy: ExecutionPolicy, action: ProjectAction ->
+                    baseTest.metadataProject(toolchain, policy, action)
+                } else null,
+            )
         }
     }
 }
@@ -246,6 +258,7 @@ class BtaVersionsCompilationTestArgumentProvider : ArgumentsProvider {
 }
 
 typealias ProjectCreator = BaseCompilationTest.(ProjectAction) -> Unit
+typealias ProjectWithPolicyCreator = BaseCompilationTest.(ExecutionPolicy, ProjectAction) -> Unit
 typealias ProjectAction = AbstractProject<out BaseCompilationOperation, out BaseCompilationOperation.Builder, out BaseIncrementalCompilationConfiguration.Builder>.() -> Unit
 
 typealias ScenarioCreator = BaseCompilationTest.(ScenarioAction) -> Unit

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testBuildSession/kotlin/BuildSessionApplicationEnvironmentReuseTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testBuildSession/kotlin/BuildSessionApplicationEnvironmentReuseTest.kt
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.compilation
+
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2PlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectWithPolicyCreator
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectCreator
+import org.jetbrains.kotlin.buildtools.tests.compilation.util.btaClassloader
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests that the shared ApplicationEnvironment is kept alive within the BuildSession lifetime.
+ *
+ * Disposal is observed directly through IntelliJ's `Disposer`: a child observer is
+ * registered on the shared application environment's `parentDisposable`, so its callback fires exactly when — and
+ * each time — the environment is actually disposed.
+ */
+class BuildSessionApplicationEnvironmentReuseTest : BaseCompilationTest() {
+    private var previousKeepalive: String? = null
+
+    @BeforeEach
+    fun disableKeepalive() {
+        // ensure keepalive is disabled to observe disposals
+        previousKeepalive = System.getProperty(KEEPALIVE_PROPERTY)
+        System.clearProperty(KEEPALIVE_PROPERTY)
+    }
+
+    @AfterEach
+    fun restoreKeepalive() {
+        val previous = previousKeepalive
+        if (previous == null) {
+            System.clearProperty(KEEPALIVE_PROPERTY)
+        } else {
+            System.setProperty(KEEPALIVE_PROPERTY, previous)
+        }
+    }
+
+    @DisplayName("Multiple compilations within same session should NOT dispose ApplicationEnvironment")
+    @BtaV2PlatformAgnosticCompilationTest
+    fun multipleCompilationsInSameSessionReuseEnvironment(projectCreator: ProjectWithPolicyCreator, toolchains: KotlinToolchains) {
+        val project = projectCreator.inProcess(toolchains)
+        lateinit var disposalCount: AtomicInteger
+        project {
+            val module = module(MODULE_A)
+            module.compile() // the first in-process compilation creates and pins the shared environment
+
+            // The environment now exists: start observing its disposal.
+            disposalCount = EnvironmentDisposal.observeCurrentEnvironment()
+
+            module.compile()
+            module.compile()
+
+            assertEquals(
+                0, disposalCount.get(),
+                "Expected no ApplicationEnvironment disposal while the session is still open"
+            )
+        }
+
+        assertEquals(
+            1, disposalCount.get(),
+            "Expected exactly one ApplicationEnvironment disposal at session end"
+        )
+    }
+
+    @DisplayName("ApplicationEnvironment should be disposed when BuildSession ends and new one created")
+    @BtaV2PlatformAgnosticCompilationTest
+    fun environmentDisposedBetweenSessions(projectCreator: ProjectWithPolicyCreator, toolchains: KotlinToolchains) {
+        val project = projectCreator.inProcess(toolchains)
+        lateinit var disposalCount1: AtomicInteger
+        project {
+            module(MODULE_A).compile()
+            disposalCount1 = EnvironmentDisposal.observeCurrentEnvironment()
+            assertEquals(
+                0, disposalCount1.get(),
+                "Expected no ApplicationEnvironment disposal while the first session is still open"
+            )
+        }
+
+        assertEquals(
+            1, disposalCount1.get(),
+            "Expected exactly one ApplicationEnvironment disposal when BuildSession ends"
+        )
+
+        lateinit var disposalCount2: AtomicInteger
+        project {
+            // A different module than the first session, so the two sessions don't share a module directory.
+            module(MODULE_B).compile()
+
+            // The second session created a fresh environment (and a fresh parentDisposable); observe it separately.
+            disposalCount2 = EnvironmentDisposal.observeCurrentEnvironment()
+            assertEquals(
+                0, disposalCount2.get(),
+                "Expected no ApplicationEnvironment disposal while the second session is still open"
+            )
+        }
+
+        assertEquals(
+            1, disposalCount2.get(),
+            "Expected exactly one ApplicationEnvironment disposal when BuildSession ends"
+        )
+    }
+
+    @DisplayName("Overlapping sessions share one ApplicationEnvironment, disposed only when the last one ends")
+    @BtaV2PlatformAgnosticCompilationTest
+    fun environmentSharedAcrossOverlappingSessions(projectCreator: ProjectWithPolicyCreator, toolchains: KotlinToolchains) {
+        val project = projectCreator.inProcess(toolchains)
+        lateinit var disposalCount: AtomicInteger
+        project {
+            module(MODULE_A).compile()
+
+            // The environment now exists; observe the single shared instance both sessions pin.
+            disposalCount = EnvironmentDisposal.observeCurrentEnvironment()
+
+            // A nested session whose lifetime overlaps this one; it uses a different module so the two sessions
+            // don't share a module directory. The nested project closes its session first.
+            this@BuildSessionApplicationEnvironmentReuseTest.project {
+                module(MODULE_B).compile()
+            }
+
+            // The first session has ended, but the second still pins the shared environment: it must stay alive.
+            assertEquals(
+                0, disposalCount.get(),
+                "Expected the shared environment to stay alive while the second session is still open"
+            )
+        }
+
+        // Both sessions have ended: the shared environment must be disposed exactly once.
+        assertEquals(
+            1, disposalCount.get(),
+            "Expected the shared environment to be disposed once the last session ends"
+        )
+    }
+
+    private fun ProjectWithPolicyCreator.inProcess(toolchains: KotlinToolchains): ProjectCreator {
+        val inProcess = toolchains.createInProcessExecutionPolicy()
+        return { action -> this@inProcess(this, inProcess, action) }
+    }
+
+    /**
+     * Observes disposal of the shared `ApplicationEnvironment` that BTA keeps
+     * alive for the duration of a [KotlinToolchains.BuildSession].
+     *
+     * The implementation runs in the isolated [btaClassloader], so the compiler's static environment state and the
+     * IntelliJ `Disposer`/`Disposable` types are not the ones on this test's own class path. Everything here
+     * is therefore resolved reflectively: the environment state comes from the compiler [Companion][companionInstance],
+     * and the `Disposable`/`Disposer` types are recovered — with their real relocated names and class loader — from
+     * the signature of the compiler's own `getOrCreateApplicationEnvironmentForProduction` method.
+     */
+    private object EnvironmentDisposal {
+        private val kotlinCoreEnvironmentClass: Class<*> =
+            btaClassloader.loadClass("org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment")
+
+        // The `Companion` object holds the shared-environment state and the public `applicationEnvironment` accessor.
+        private val companionInstance: Any =
+            kotlinCoreEnvironmentClass.getField("Companion").get(null)
+
+        private val getApplicationEnvironment =
+            companionInstance.javaClass.getMethod("getApplicationEnvironment")
+
+        /**
+         * The IntelliJ `Disposable` interface, taken from the first parameter of the compiler's
+         * `getOrCreateApplicationEnvironmentForProduction(Disposable, CompilerConfiguration)` — this yields the exact
+         * class, loaded by the exact class loader the compiler uses.
+         * Used to derive Disposer class regardless of the package relocation to not hardcode relocated FQN.
+         */
+        private val disposableInterface: Class<*> =
+            companionInstance.javaClass.methods
+                .first { it.name == "getOrCreateApplicationEnvironmentForProduction" }
+                .parameterTypes[0]
+
+        private val disposerRegister =
+            disposableInterface.classLoader
+                .loadClass(disposableInterface.name.removeSuffix("Disposable") + "util.Disposer")
+                .getMethod("register", disposableInterface, disposableInterface)
+
+        private fun currentApplicationEnvironment(): Any? = getApplicationEnvironment.invoke(companionInstance)
+
+        /**
+         * Registers a disposal observer on the currently alive shared application environment and returns a counter
+         * that is incremented each time that specific environment is disposed. Registering a child on the
+         * environment's `parentDisposable` does not affect the environment's reference count, so it does not keep the
+         * environment alive.
+         */
+        fun observeCurrentEnvironment(): AtomicInteger {
+            val applicationEnvironment = currentApplicationEnvironment()
+                ?: error("Expected a live application environment to observe, but none has been created yet")
+
+            val parentDisposable = applicationEnvironment.javaClass
+                .getMethod("getParentDisposable").invoke(applicationEnvironment)
+
+            val disposalCount = AtomicInteger(0)
+            val observer = Proxy.newProxyInstance(
+                disposableInterface.classLoader, arrayOf(disposableInterface)
+            ) { proxy, method, args ->
+                when (method.name) {
+                    "dispose" -> {
+                        disposalCount.incrementAndGet()
+                        null
+                    }
+                    "equals" -> proxy === args?.getOrNull(0)
+                    "hashCode" -> System.identityHashCode(proxy)
+                    "toString" -> "EnvironmentDisposalObserver@${System.identityHashCode(proxy)}"
+                    else -> null
+                }
+            }
+            disposerRegister.invoke(null, parentDisposable, observer)
+            return disposalCount
+        }
+    }
+
+    private companion object {
+        const val KEEPALIVE_PROPERTY = "kotlin.environment.keepalive"
+
+        const val MODULE_A = "basic-multimodule-project/module-1"
+        const val MODULE_B = "basic-multimodule-project/module-3"
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
@@ -56,6 +56,10 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
     @UseFromImplModuleRestricted
     override fun <V> get(key: BaseCompilationOperation.Option<V>): V = options[key]
 
+    // In-process compilation and linking run a CLICompiler, which creates and uses the shared application environment.
+    override val usesApplicationEnvironment: Boolean
+        get() = true
+
     @UseFromImplModuleRestricted
     override fun <V> set(key: BaseCompilationOperation.Option<V>, value: V) {
         checkOptionIsAvailableForVersion(key)

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
@@ -47,6 +47,14 @@ internal abstract class BuildOperationImpl<R> : BuildOperation<R>, BuildOperatio
         sessionIsAliveFlagFile: Lazy<File>
     ): R
 
+    /**
+     * `true` if this operation uses [org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment], so the [org.jetbrains.kotlin.buildtools.api.KotlinToolchains.BuildSession] can reuse it across operations.
+     *
+     * The value is checked only for in-process executions. The daemon uses `keepalive` mechanism of the compiler to cache it for the entire
+     * lifetime of the daemon.
+     */
+    abstract val usesApplicationEnvironment: Boolean
+
     operator fun <V> get(key: Option<V>): V = options[key]
 
     @OptIn(UseFromImplModuleRestricted::class)

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
@@ -5,6 +5,9 @@
 
 package org.jetbrains.kotlin.buildtools.internal
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.CoreEnvironmentDeprecation
 import org.jetbrains.kotlin.buildtools.api.*
 import org.jetbrains.kotlin.buildtools.api.ProjectId.Companion.RandomProjectUUID
 import org.jetbrains.kotlin.buildtools.api.abi.AbiValidationToolchain
@@ -19,6 +22,10 @@ import org.jetbrains.kotlin.buildtools.internal.js.JsPlatformToolchainImpl
 import org.jetbrains.kotlin.buildtools.internal.jvm.JvmPlatformToolchainImpl
 import org.jetbrains.kotlin.buildtools.internal.metadata.KotlinMetadataPlatformToolchainImpl
 import org.jetbrains.kotlin.buildtools.internal.wasm.WasmPlatformToolchainImpl
+import org.jetbrains.kotlin.cli.create
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.setupIdeaStandaloneExecution
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.incremental.clearJarCaches
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
@@ -69,6 +76,23 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
         }
         private val executor by executorDelegate
 
+        private val applicationEnvironmentPin: Disposable = Disposer.newDisposable("kotlin-dsl BTA application environment pin")
+
+        /**
+         * Pins the shared application environment to this session so it is reused across build operations and
+         * disposed when the session ends (see [close]).
+         *
+         * Initialized lazily on the first in-process operation that uses the environment (see
+         * [BuildOperationImpl.usesApplicationEnvironment]).
+         */
+        private val applicationEnvironmentInitialization = lazy {
+            setupIdeaStandaloneExecution()
+            @OptIn(CoreEnvironmentDeprecation::class)
+            KotlinCoreEnvironment.getOrCreateApplicationEnvironmentForProduction(
+                applicationEnvironmentPin, CompilerConfiguration.create()
+            )
+        }
+
         override fun <R> executeOperation(operation: BuildOperation<R>): R {
             return executeOperation(operation, logger = null)
         }
@@ -81,6 +105,11 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
             check(operation is BuildOperationImpl<R>) { "Unknown operation type: ${operation::class.qualifiedName}" }
             val operationBody: Callable<R> = { operation.execute(projectId, executionPolicy, logger, sessionIsAliveFlagFile) }
             return if (executionPolicy is ExecutionPolicy.InProcess) {
+                // For an operation that uses the shared application environment, pin it just before, so that it is kept
+                // alive for reuse by subsequent operations and only disposed when the session ends.
+                if (operation.usesApplicationEnvironment) {
+                    applicationEnvironmentInitialization.value
+                }
                 unwrapExecutionException(executor.submit(operationBody))
             } else {
                 operationBody.call()
@@ -101,6 +130,9 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
 
         override fun close() {
             clearJarCaches()
+            if (applicationEnvironmentInitialization.isInitialized()) {
+                Disposer.dispose(applicationEnvironmentPin)
+            }
             if (executorDelegate.isInitialized()) {
                 executor.shutdown()
             }
@@ -123,4 +155,3 @@ internal sealed interface BtaApiVersion {
     object Before2_4_20 : BtaApiVersion
     class Exact(val version: KotlinToolingVersion) : BtaApiVersion
 }
-

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/CompareAbiTextFilesOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/CompareAbiTextFilesOperationImpl.kt
@@ -36,6 +36,9 @@ internal class CompareAbiTextFilesOperationImpl private constructor(
         initializeOptions(this::class, options)
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpJvmAbiToStringOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpJvmAbiToStringOperationImpl.kt
@@ -39,6 +39,9 @@ internal class DumpJvmAbiToStringOperationImpl private constructor(
         initializeOptions(this::class, options)
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpKlibAbiToStringOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpKlibAbiToStringOperationImpl.kt
@@ -40,6 +40,9 @@ internal class DumpKlibAbiToStringOperationImpl private constructor(
         initializeOptions(this::class, options)
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriFileIdToPathDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriFileIdToPathDataDeserializationOperationImpl.kt
@@ -25,6 +25,9 @@ internal class CriFileIdToPathDataDeserializationOperationImpl(
         initializeOptions(this::class, options)
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriLookupDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriLookupDataDeserializationOperationImpl.kt
@@ -25,6 +25,9 @@ internal class CriLookupDataDeserializationOperationImpl(
         initializeOptions(this::class, options)
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriSubtypeDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriSubtypeDataDeserializationOperationImpl.kt
@@ -25,6 +25,9 @@ internal class CriSubtypeDataDeserializationOperationImpl(
         initializeOptions(this::class, options)
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
@@ -88,6 +88,9 @@ internal class JsDtsGenerationOperationImpl private constructor(
         return CompilationResult.COMPILATION_SUCCESS
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = true
+
     private fun transformKlibsIntoKlibInputModule(
         klibs: List<Path>,
         logger: KotlinLogger?,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/DiscoverScriptExtensionsOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/DiscoverScriptExtensionsOperationImpl.kt
@@ -27,6 +27,9 @@ internal class DiscoverScriptExtensionsOperationImpl private constructor(
         initializeOptions(this::class, options)
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmClasspathSnapshottingOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmClasspathSnapshottingOperationImpl.kt
@@ -46,6 +46,9 @@ internal class JvmClasspathSnapshottingOperationImpl private constructor(
         options[key] = value
     }
 
+    override val usesApplicationEnvironment: Boolean
+        get() = false
+
     override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/CancellableOperationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/CancellableOperationTest.kt
@@ -32,6 +32,9 @@ private class ExampleCancellableOperation(override val options: Options = Option
             cancellationHandle.checkCanceled()
         }
     }
+
+    override val usesApplicationEnvironment: Boolean
+        get() = false
 }
 
 


### PR DESCRIPTION
This helps to keep ApplicationEnvironment from being disposed even without the keepalive property. BuildSession marks here a minimal lifetime of the ApplicationEnvironment to guarantee things are efficiently cached during operations in the same session. ^KT-87743 Verification Pending