### PR TITLE
[FIR] Improve memory usage of `FirIntersectionOverrideStorage` and `FirGeneratedMemberDeclarationsStorage`

### DIFF
--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCachesFactory.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeCachesFactory.kt
@@ -14,7 +14,9 @@ import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.FirCacheInternals
 import org.jetbrains.kotlin.fir.caches.FirCachesFactory
 import org.jetbrains.kotlin.fir.caches.FirLazyValue
+import org.jetbrains.kotlin.fir.caches.FirLazyValueWithContext
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 
@@ -80,6 +82,9 @@ internal class FirThreadSafeCachesFactory(private val project: Project) : FirCac
 
     override fun <V> createLazyValue(createValue: () -> V): FirLazyValue<V> =
         FirThreadSafeValue(createValue)
+
+    override fun <V, CONTEXT> createLazyValueWithContext(createValue: (CONTEXT) -> V): FirLazyValueWithContext<V, CONTEXT> =
+        FirThreadSafeValueWithContext(createValue)
 
     override fun <V> createPossiblySoftLazyValue(createValue: () -> V): FirLazyValue<V> =
         LLFirSoftLazyValue(project, createValue)

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeValueWithContext.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/caches/FirThreadSafeValueWithContext.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.analysis.low.level.api.fir.caches
+
+import org.jetbrains.kotlin.fir.caches.FirLazyValueWithContext
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+
+/**
+ * A thread-safe implementation of [FirLazyValueWithContext].
+ *
+ * We cannot use a standard lazy value here because we would have no way to thread the context into the initializer.
+ */
+internal class FirThreadSafeValueWithContext<V, CONTEXT>(
+    createValue: (CONTEXT) -> V,
+) : FirLazyValueWithContext<V, CONTEXT>() {
+    private object NotComputed
+
+    @Volatile
+    private var createValue: ((CONTEXT) -> V)? = createValue
+
+    @Volatile
+    private var value: Any? = NotComputed
+
+    // An artificial final field that ensures initialization safety (JLS 17.5): a `final` field forces a freeze at the end of the
+    // constructor, which keeps the constructor's writes from being reordered past the publication of the instance. So a reader cannot
+    // observe a partially initialized instance even when it is published unsafely, e.g. via a plain field. Without any final field, such
+    // a reader might see the default values of `value` and `createValue`, and return `null` instead of the computed value.
+    // `kotlin.SafePublicationLazyImpl` uses the same trick.
+    @Suppress("unused")
+    private val final: Any = NotComputed
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getValue(context: CONTEXT): V {
+        value.let { if (it !== NotComputed) return it as V }
+
+        // A `null` `createValue` means another thread has already computed the value; we fall through to read it below.
+        //
+        // The context is only used for the first computation. Under a race, `createValue` may run more than once, but `compareAndSet`
+        // ensures every thread observes the single winning value. `createValue` is released only by the thread that wins the CAS.
+        val createValue = createValue
+        if (createValue != null) {
+            val newValue = createValue(context)
+            val isSuccessful = valueUpdater.compareAndSet(this, NotComputed, newValue)
+            if (isSuccessful) {
+                this.createValue = null
+                return newValue
+            }
+        }
+
+        return value as V
+    }
+
+    companion object {
+        private val valueUpdater = AtomicReferenceFieldUpdater.newUpdater(
+            FirThreadSafeValueWithContext::class.java,
+            Any::class.java,
+            "value",
+        )
+    }
+}

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirGeneratedScopes.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirGeneratedScopes.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.runIf
 class FirGeneratedClassDeclaredMemberScope private constructor(
     classId: ClassId,
     private val storage: FirGeneratedMemberDeclarationsStorage.CallableStorage,
+    private val generationContext: MemberGenerationContext,
     private val nestedClassifierScope: FirNestedClassifierScope?
 ) : FirClassDeclaredMemberScope(classId) {
     companion object {
@@ -38,6 +39,8 @@ class FirGeneratedClassDeclaredMemberScope private constructor(
             regularDeclaredScope: FirClassDeclaredMemberScope?,
             scopeForGeneratedClass: Boolean
         ): FirGeneratedClassDeclaredMemberScope? {
+            val generationContext = MemberGenerationContext(classSymbol, regularDeclaredScope)
+
             /*
              * Extensions can modify source classes of the same session in which they are enabled
              * This implies the contract that if declaration-site session and use-site session
@@ -47,7 +50,7 @@ class FirGeneratedClassDeclaredMemberScope private constructor(
             val storage = classSymbol.moduleData
                 .session
                 .generatedDeclarationsStorage
-                .getCallableStorage(classSymbol, regularDeclaredScope, scopeForGeneratedClass)
+                .getCallableStorage(classSymbol, generationContext, scopeForGeneratedClass)
                 ?: return null
 
             val nestedClassifierScope = runIf(scopeForGeneratedClass) {
@@ -57,7 +60,8 @@ class FirGeneratedClassDeclaredMemberScope private constructor(
             return FirGeneratedClassDeclaredMemberScope(
                 classSymbol.classId,
                 storage,
-                nestedClassifierScope
+                generationContext,
+                nestedClassifierScope,
             )
         }
     }
@@ -78,20 +82,20 @@ class FirGeneratedClassDeclaredMemberScope private constructor(
 
     override fun processFunctionsByName(name: Name, processor: (FirNamedFunctionSymbol) -> Unit) {
         if (name !in getCallableNames()) return
-        for (functionSymbol in storage.functionCache.getValue(name)) {
+        for (functionSymbol in storage.functionCache.getValue(name, generationContext)) {
             processor(functionSymbol)
         }
     }
 
     override fun processPropertiesByName(name: Name, processor: (FirVariableSymbol<*>) -> Unit) {
         if (name !in getCallableNames()) return
-        for (propertySymbol in storage.propertyCache.getValue(name)) {
+        for (propertySymbol in storage.propertyCache.getValue(name, generationContext)) {
             processor(propertySymbol)
         }
     }
 
     override fun processDeclaredConstructors(processor: (FirConstructorSymbol) -> Unit) {
-        for (constructorSymbol in storage.constructorCache.getValue()) {
+        for (constructorSymbol in storage.constructorCache.getValue(generationContext)) {
             processor(constructorSymbol)
         }
     }
@@ -105,7 +109,8 @@ class FirGeneratedClassDeclaredMemberScope private constructor(
 class FirGeneratedClassNestedClassifierScope private constructor(
     useSiteSession: FirSession,
     klass: FirClass,
-    private val storage: FirGeneratedMemberDeclarationsStorage.ClassifierStorage
+    private val storage: FirGeneratedMemberDeclarationsStorage.ClassifierStorage,
+    private val generationContext: NestedClassGenerationContext,
 ) : FirNestedClassifierScope(klass, useSiteSession) {
     companion object {
         fun create(
@@ -113,6 +118,8 @@ class FirGeneratedClassNestedClassifierScope private constructor(
             classSymbol: FirClassSymbol<*>,
             regularNestedClassifierScope: FirNestedClassifierScope?,
         ): FirGeneratedClassNestedClassifierScope? {
+            val generationContext = NestedClassGenerationContext(classSymbol, regularNestedClassifierScope)
+
             /*
              * Extensions can modify source classes of the same session in which they are enabled
              * This implies the contract that if declaration-site session and use-site session
@@ -122,15 +129,20 @@ class FirGeneratedClassNestedClassifierScope private constructor(
             val storage = classSymbol.moduleData
                 .session
                 .generatedDeclarationsStorage
-                .getClassifierStorage(classSymbol, regularNestedClassifierScope)
+                .getClassifierStorage(classSymbol, generationContext)
                 ?: return null
 
-            return FirGeneratedClassNestedClassifierScope(useSiteSession, classSymbol.fir, storage)
+            return FirGeneratedClassNestedClassifierScope(
+                useSiteSession,
+                classSymbol.fir,
+                storage,
+                generationContext,
+            )
         }
     }
 
     override fun getNestedClassSymbol(name: Name): FirRegularClassSymbol? {
-        return storage.classifiersCache.getValue(name)
+        return storage.classifiersCache.getValue(name, generationContext)
     }
 
     override fun isEmpty(): Boolean {
@@ -147,73 +159,81 @@ class FirGeneratedClassNestedClassifierScope private constructor(
     }
 }
 
+/**
+ * A storage for caching compiler plugin-generated callables and classifiers. Centralized caching ensures the uniqueness of these
+ * declarations, while avoiding injection of the declarations into the original FIR.
+ *
+ * @see CallableStorage
+ * @see ClassifierStorage
+ */
 class FirGeneratedMemberDeclarationsStorage(private val session: FirSession) : FirSessionComponent {
     private val cachesFactory = session.firCachesFactory
 
     internal fun getCallableStorage(
         classSymbol: FirClassSymbol<*>,
-        regularDeclaredScope: FirClassDeclaredMemberScope?,
+        generationContext: MemberGenerationContext,
         scopeForGeneratedClass: Boolean
     ): CallableStorage? {
-        val generationContext = MemberGenerationContext(classSymbol, regularDeclaredScope)
         val extensionsByCallableName = groupExtensionsByName(classSymbol) { getCallableNamesForClass(it, generationContext) }
         if (extensionsByCallableName.isEmpty() && !scopeForGeneratedClass) return null
-        return callableStorageByClass.getValue(classSymbol, StorageContext(generationContext, extensionsByCallableName))
+        return callableStorageByClass.getValue(classSymbol, extensionsByCallableName)
     }
 
     internal fun getClassifierStorage(
         classSymbol: FirClassSymbol<*>,
-        regularNestedClassifierScope: FirNestedClassifierScope?
+        generationContext: NestedClassGenerationContext,
     ): ClassifierStorage? {
-        val generationContext = NestedClassGenerationContext(classSymbol, regularNestedClassifierScope)
         val extensionsByClassifierName = groupExtensionsByName(classSymbol) { getNestedClassifiersNames(it, generationContext) }
         if (extensionsByClassifierName.isEmpty()) return null
-        return classifierStorageByClass.getValue(classSymbol, StorageContext(generationContext, extensionsByClassifierName))
+        return classifierStorageByClass.getValue(classSymbol, extensionsByClassifierName)
     }
 
-    private data class StorageContext<C>(
-        val generationContext: C,
-        val extensionsByName: Map<Name, List<FirDeclarationGenerationExtension>>
-    )
+    private typealias ExtensionsByName = Map<Name, List<FirDeclarationGenerationExtension>>
 
-    private val callableStorageByClass: FirCache<FirClassSymbol<*>, CallableStorage, StorageContext<MemberGenerationContext>> =
-        cachesFactory.createCache { _, (val context = generationContext, val extensionsMap = extensionsByName) ->
-            CallableStorage(cachesFactory, context, extensionsMap)
+    private val callableStorageByClass: FirCache<FirClassSymbol<*>, CallableStorage, ExtensionsByName> =
+        cachesFactory.createCache { classSymbol, extensionsMap ->
+            CallableStorage(cachesFactory, classSymbol, extensionsMap)
         }
 
-    private val classifierStorageByClass: FirCache<FirClassSymbol<*>, ClassifierStorage, StorageContext<NestedClassGenerationContext>> =
-        cachesFactory.createCache { classSymbol, (val context = generationContext, val extensionsMap = extensionsByName) ->
-            ClassifierStorage(cachesFactory, classSymbol, context, extensionsMap)
+    private val classifierStorageByClass: FirCache<FirClassSymbol<*>, ClassifierStorage, ExtensionsByName> =
+        cachesFactory.createCache { classSymbol, extensionsMap ->
+            ClassifierStorage(cachesFactory, classSymbol, extensionsMap)
         }
 
+    /**
+     * A storage for compiler plugin-generated callables.
+     *
+     * The storage avoids caching the [MemberGenerationContext] that is used to generate declarations. This is crucial, as we would
+     * otherwise cache the heavy member scope embedded into the context. Instead, the storage requires passing a generation context on each
+     * cache access.
+     *
+     * @see FirGeneratedMemberDeclarationsStorage
+     */
     internal class CallableStorage(
         cachesFactory: FirCachesFactory,
-        private val generationContext: MemberGenerationContext,
+        val classSymbol: FirClassSymbol<*>,
         private val extensionsByCallableName: Map<Name, List<FirDeclarationGenerationExtension>>
     ) {
-        val functionCache: FirCache<Name, List<FirNamedFunctionSymbol>, Nothing?> =
-            cachesFactory.createCache { name -> generateMemberFunctions(name) }
+        val functionCache: FirCache<Name, List<FirNamedFunctionSymbol>, MemberGenerationContext> =
+            cachesFactory.createCache { name, context -> generateMemberFunctions(name, context) }
 
-        val propertyCache: FirCache<Name, List<FirVariableSymbol<*>>, Nothing?> =
-            cachesFactory.createCache { name -> generateMemberProperties(name) }
+        val propertyCache: FirCache<Name, List<FirVariableSymbol<*>>, MemberGenerationContext> =
+            cachesFactory.createCache { name, context -> generateMemberProperties(name, context) }
 
-        val constructorCache: FirLazyValue<List<FirConstructorSymbol>> =
-            cachesFactory.createLazyValue { generateConstructors() }
+        val constructorCache: FirLazyValueWithContext<List<FirConstructorSymbol>, MemberGenerationContext> =
+            cachesFactory.createLazyValueWithContext { context -> generateConstructors(context) }
 
         val allCallableNames: Set<Name>
             get() = extensionsByCallableName.keys
 
-        private val classSymbol: FirClassSymbol<*>
-            get() = generationContext.owner
-
-        private fun generateMemberFunctions(name: Name): List<FirNamedFunctionSymbol> {
+        private fun generateMemberFunctions(name: Name, generationContext: MemberGenerationContext): List<FirNamedFunctionSymbol> {
             if (name == SpecialNames.INIT) return emptyList()
             return extensionsByCallableName[name].orEmpty()
                 .flatMap { it.generateFunctions(CallableId(classSymbol.classId, name), generationContext) }
                 .onEach { it.fir.validate() }
         }
 
-        private fun generateMemberProperties(name: Name): List<FirVariableSymbol<*>> {
+        private fun generateMemberProperties(name: Name, generationContext: MemberGenerationContext): List<FirVariableSymbol<*>> {
             if (name == SpecialNames.INIT) return emptyList()
             val extensions = extensionsByCallableName[name] ?: return emptyList()
             return buildList {
@@ -226,26 +246,34 @@ class FirGeneratedMemberDeclarationsStorage(private val session: FirSession) : F
             }.onEach { it.fir.validate() }
         }
 
-        private fun generateConstructors(): List<FirConstructorSymbol> {
+        private fun generateConstructors(generationContext: MemberGenerationContext): List<FirConstructorSymbol> {
             return extensionsByCallableName[SpecialNames.INIT].orEmpty()
                 .flatMap { it.generateConstructors(generationContext) }
                 .onEach { it.fir.validate() }
         }
     }
 
+    /**
+     * A storage for compiler plugin-generated classifiers.
+     *
+     * The storage avoids caching the [NestedClassGenerationContext] that is used to generate declarations. This is crucial, as we would
+     * otherwise cache the heavy member scope embedded into the context. Instead, the storage requires passing a generation context on each
+     * cache access.
+     *
+     * @see FirGeneratedMemberDeclarationsStorage
+     */
     internal class ClassifierStorage(
         cachesFactory: FirCachesFactory,
         private val classSymbol: FirClassSymbol<*>,
-        private val generationContext: NestedClassGenerationContext,
         private val extensionsByClassifierName: Map<Name, List<FirDeclarationGenerationExtension>>
     ) {
-        val classifiersCache: FirCache<Name, FirRegularClassSymbol?, Nothing?> =
-            cachesFactory.createCache { name -> generateNestedClassifier(name) }
+        val classifiersCache: FirCache<Name, FirRegularClassSymbol?, NestedClassGenerationContext> =
+            cachesFactory.createCache { name, context -> generateNestedClassifier(name, context) }
 
         val allClassifierNames: Set<Name>
             get() = extensionsByClassifierName.keys
 
-        private fun generateNestedClassifier(name: Name): FirRegularClassSymbol? {
+        private fun generateNestedClassifier(name: Name, generationContext: NestedClassGenerationContext): FirRegularClassSymbol? {
             if (classSymbol is FirRegularClassSymbol) {
                 val companion = classSymbol.companionObjectSymbol
                 if (companion != null && companion.origin.generated && companion.classId.shortClassName == name) {

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScope.kt
@@ -66,7 +66,7 @@ class FirTypeIntersectionScope private constructor(
 
     @Suppress("UNCHECKED_CAST")
     fun <S : FirCallableSymbol<*>> getDirectOverriddenSymbols(symbol: S): Collection<MemberWithBaseScope<S>> {
-        val intersectionOverride = intersectionContext.intersectionOverrides.getValueIfComputed(symbol)
+        val intersectionOverride = intersectionContext.getIntersectionOverrideIfComputed(symbol)
         val allDirectOverridden = overriddenSymbols[symbol].orEmpty() + intersectionOverride?.let {
             overriddenSymbols[it.member]
         }.orEmpty()

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScopeContext.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScopeContext.kt
@@ -44,8 +44,7 @@ class FirTypeIntersectionScopeContext(
     private val dispatchClassSymbol: FirRegularClassSymbol? = dispatchReceiverType.toRegularClassSymbol(session)
     private val isReceiverClassExpect = dispatchClassSymbol?.isExpect == true
 
-    val intersectionOverrides: FirCache<FirCallableSymbol<*>, MemberWithBaseScope<FirCallableSymbol<*>>, ResultOfIntersection.NonTrivial<*>> =
-        session.intersectionOverrideStorage.cacheByScope.getValue(dispatchReceiverType)
+    private val intersectionOverrideStorage = session.intersectionOverrideStorage
 
     sealed class ResultOfIntersection<D : FirCallableSymbol<*>>(
         val overriddenMembers: List<MemberWithBaseScope<D>>,
@@ -71,7 +70,11 @@ class FirTypeIntersectionScopeContext(
         ) : ResultOfIntersection<D>(overriddenMembers) {
             override val chosenSymbol: D by lazy {
                 @Suppress("UNCHECKED_CAST")
-                context.intersectionOverrides.getValue(keySymbol, this).member as D
+                context.intersectionOverrideStorage.getOrCompute(
+                    context.dispatchReceiverType,
+                    keySymbol,
+                    this,
+                ).member as D
             }
 
             val keySymbol: D
@@ -195,6 +198,12 @@ class FirTypeIntersectionScopeContext(
 
         return result
     }
+
+    /**
+     * @see FirIntersectionOverrideStorage.getIfComputed
+     */
+    fun getIntersectionOverrideIfComputed(symbol: FirCallableSymbol<*>): MemberWithBaseScope<FirCallableSymbol<*>>? =
+        intersectionOverrideStorage.getIfComputed(dispatchReceiverType, symbol)
 
     private fun MemberWithBaseScope<*>.isVisible(): Boolean {
         // Checking for private is not enough because package-private declarations can be hidden, too, if they're in a different package.
@@ -526,15 +535,52 @@ private fun <D : FirCallableSymbol<*>> D.withScope(baseScope: FirTypeScope) = Me
 typealias FirIntersectionOverrideCache =
         FirCache<FirCallableSymbol<*>, MemberWithBaseScope<FirCallableSymbol<*>>, ResultOfIntersection.NonTrivial<*>>
 
+/**
+ * A storage for computed intersection overrides based on [non-trivial intersection results][ResultOfIntersection.NonTrivial].
+ *
+ * The storage has two cache layers:
+ *
+ * 1. An outer cache that maps dispatch receiver types in the form of [ConeKotlinType] to individual [FirIntersectionOverrideCache]s.
+ * 2. An inner [FirIntersectionOverrideCache] that maps original callable symbols to generated intersection overrides.
+ *
+ * In most cases, the inner cache would be *empty*. The storage avoids the creation of the inner cache until there is a legitimate write to
+ * the cache from a non-trivial intersection with [getOrCompute].
+ */
 class FirIntersectionOverrideStorage(val session: FirSession) : FirSessionComponent {
     private val cachesFactory = session.firCachesFactory
 
-    val cacheByScope: FirCache<ConeKotlinType, FirIntersectionOverrideCache, Nothing?> =
+    private val cacheByScope: FirCache<ConeKotlinType, FirIntersectionOverrideCache, Nothing?> =
         cachesFactory.createCache { _ ->
             cachesFactory.createCache { _, result ->
                 result.context.createIntersectionOverride(result.mostSpecific, result.overriddenMembers, result.containsMultipleNonSubsumed)
             }
         }
+
+    /**
+     * Returns the intersection override for [symbol] in the scope of [dispatchReceiverType], computing and caching it on first request.
+     *
+     * The inner cache is created lazily here, on the first actually materialized override for that scope.
+     */
+    fun getOrCompute(
+        dispatchReceiverType: ConeKotlinType,
+        symbol: FirCallableSymbol<*>,
+        result: ResultOfIntersection.NonTrivial<*>,
+    ): MemberWithBaseScope<FirCallableSymbol<*>> =
+        cacheByScope.getValue(dispatchReceiverType).getValue(symbol, result)
+
+    /**
+     * Returns the already-computed intersection override for [symbol] in the scope of [dispatchReceiverType], or `null` if none has been
+     * computed yet.
+     *
+     * The function consciously avoids creating the inner cache. Dispatch receiver types that never materialize an intersection override
+     * with [getOrCompute] therefore don't retain an empty inner cache. That is crucial for keeping the storage small, since the vast
+     * majority of scopes are only ever probed and never materialize an override.
+     */
+    fun getIfComputed(
+        dispatchReceiverType: ConeKotlinType,
+        symbol: FirCallableSymbol<*>,
+    ): MemberWithBaseScope<FirCallableSymbol<*>>? =
+        cacheByScope.getValueIfComputed(dispatchReceiverType)?.getValueIfComputed(symbol)
 }
 
 private val FirSession.intersectionOverrideStorage: FirIntersectionOverrideStorage by FirSession.sessionComponentAccessor()

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/FirCorrespondingSupertypesCache.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/types/FirCorrespondingSupertypesCache.kt
@@ -18,6 +18,39 @@ import org.jetbrains.kotlin.types.model.CaptureStatus
 import org.jetbrains.kotlin.types.model.RigidTypeMarker
 import org.jetbrains.kotlin.types.model.TypeConstructorMarker
 
+/**
+ * A per-session cache of the *corresponding supertypes* of a class.
+ *
+ * For a given class, a corresponding supertype is a concrete instantiation of any supertype reachable through the class's inheritance
+ * hierarchy. The supertype is instantiated from the class's default type arguments, to be substituted in a separate step.
+ *
+ * For each class, the cache maps from each superclass's lookup tag to the corresponding supertype(s).
+ *
+ * Computing a corresponding supertype requires walking the supertype graph and substituting type arguments through the whole inheritance
+ * chain (e.g. `ArrayList<String>` has `Collection<String>` as its corresponding `Collection` supertype). This is expensive and happens very
+ * frequently during subtyping checks, so the graph walk is cached once per class (keyed by [ConeClassLikeLookupTag], computed on the
+ * class's default type). [getCorrespondingSupertypes] then only substitutes the queried type's actual arguments onto the cached result.
+ *
+ * #### Example
+ *
+ * Take the following classes:
+ *
+ * ```kotlin
+ * class B<S>
+ * class D<T>
+ * class C<U> : D<U>
+ * class A<X> : B<X>, C<List<X>>
+ * ```
+ *
+ * The cache maps `A`'s lookup tag to the corresponding supertypes computed from `A`'s default type `A<X>`:
+ *
+ * - `B` -> `B<X>`
+ * - `C` -> `C<List<X>>`
+ * - `D` -> `D<List<X>>`
+ *
+ * A query for the corresponding `D` supertype of `A<String>` then reuses the cached `D<List<X>>` and substitutes `X = String` to yield
+ * `D<List<String>>`.
+ */
 @ThreadSafeMutableState
 class FirCorrespondingSupertypesCache(private val session: FirSession) : FirSessionComponent {
     private val cache =
@@ -80,7 +113,7 @@ class FirCorrespondingSupertypesCache(private val session: FirSession) : FirSess
         }
 
         return resultingMap.also {
-            it.remove(subtypeLookupTag) // Just optimization: do not preserve mapping from MyClass to MyClas itself
+            it.remove(subtypeLookupTag) // Just optimization: do not preserve mapping from MyClass to MyClass itself
         }
     }
 

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirCacheWithPostCompute.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirCacheWithPostCompute.kt
@@ -49,3 +49,19 @@ abstract class FirLazyValue<out V> {
 operator fun <V> FirLazyValue<V>.getValue(thisRef: Any?, property: KProperty<*>): V {
     return getValue()
 }
+
+/**
+ * A lazily computed single value which uses a [CONTEXT] supplied at access time to compute the value [V].
+ *
+ * Unlike [FirLazyValue], whose computation is captured at construction time, [FirLazyValueWithContext] receives its [CONTEXT] transiently
+ * via [getValue], so the context does not have to be retained until the value's computation, nor after. This is useful when the context
+ * should not be kept indefinitely.
+ *
+ * Just like [FirCache]:
+ *
+ * - The [CONTEXT] is only used for the *first* computation of the value and ignored on subsequent accesses.
+ * - The value might be computed more than once when accessed concurrently, but all threads will always observe the same value.
+ */
+abstract class FirLazyValueWithContext<out V, in CONTEXT> {
+    abstract fun getValue(context: CONTEXT): V
+}

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirCachesFactory.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirCachesFactory.kt
@@ -123,6 +123,14 @@ abstract class FirCachesFactory : FirSessionComponent {
     abstract fun <V> createLazyValue(createValue: () -> V): FirLazyValue<V>
 
     /**
+     * Creates a [FirLazyValueWithContext] which computes its value on demand, using a [CONTEXT] passed to
+     * [FirLazyValueWithContext.getValue]. The [CONTEXT] is only used for the first computation.
+     *
+     * [createValue] might be called multiple times for the same value, but all threads will always get the same value.
+     */
+    abstract fun <V, CONTEXT> createLazyValueWithContext(createValue: (CONTEXT) -> V): FirLazyValueWithContext<V, CONTEXT>
+
+    /**
      * Creates a [FirLazyValue] which possibly references its value softly. If the referenced value is garbage-collected, it will be
      * recomputed with the [createValue] function.
      *

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirThreadUnsafeCachesFactory.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/caches/FirThreadUnsafeCachesFactory.kt
@@ -40,6 +40,9 @@ object FirThreadUnsafeCachesFactory : FirCachesFactory() {
 
     override fun <V> createPossiblySoftLazyValue(createValue: () -> V): FirLazyValue<V> =
         createLazyValue(createValue)
+
+    override fun <V, CONTEXT> createLazyValueWithContext(createValue: (CONTEXT) -> V): FirLazyValueWithContext<V, CONTEXT> =
+        FirThreadUnsafeValueWithContext(createValue)
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -89,4 +92,23 @@ private class FirThreadUnsafeCacheWithPostCompute<K : Any, V, CONTEXT, DATA>(
 private class FirThreadUnsafeValue<V>(createValue: () -> V) : FirLazyValue<V>() {
     private val lazyValue by lazy(LazyThreadSafetyMode.NONE, createValue)
     override fun getValue(): V = lazyValue
+}
+
+private class FirThreadUnsafeValueWithContext<V, CONTEXT>(
+    createValue: (CONTEXT) -> V,
+) : FirLazyValueWithContext<V, CONTEXT>() {
+    private object NotComputed
+
+    private var createValue: ((CONTEXT) -> V)? = createValue
+
+    private var value: Any? = NotComputed
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getValue(context: CONTEXT): V {
+        if (value === NotComputed) {
+            value = createValue!!(context)
+            createValue = null
+        }
+        return value as V
+    }
 }


### PR DESCRIPTION
I'm looking into session components in the scope of [KT-70489](https://youtrack.jetbrains.com/issue/KT-70489). The changes in this PR are the improvements that can be merged without symbol IDs as a prerequisite.

For `FirIntersectionOverrideStorage`, we avoid creating empty inner caches.

For `FirGeneratedMemberDeclarationsStorage`, we avoid caching the generation context. This has no practical effect on the compiler mode, as the generation context is cached in the corresponding declaration scope, which is cached in `FirDeclaredMemberScopeProvider` for the lifetime of the session. However, in the Analysis API mode, declaration scopes can be evicted from `FirDeclaredMemberScopeProvider`, so the generation context is not always strongly referenced from another cache. And it is especially important to avoid caching the generation context since it stores a base declaration scope which might otherwise have been collected.

Both compiler and IntelliJ performance tests are looking OK.