### PR TITLE
Build: Stabilize order in compose compile plugin tests `RuntimeTestsK2`

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/RuntimeTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/RuntimeTests.kt
@@ -98,9 +98,9 @@ private fun createRuntimeTestClasses(): List<Pair<String, List<Class<*>>>> {
         val description = compiler.description
         compiler.disposeTestRootDisposable()
         iterator.remove()
-        result.add(description to classes)
+        result.add(description to classes.sortedBy { it.name })
     }
-    return result
+    return result.sortedBy { it.first }
 }
 
 


### PR DESCRIPTION
Unstable test generation order breaks test history on TeamCity

 #KTI-3486