### PR TITLE
IR inliner: Enable cross-module mode for stdlib & kotlin-test

### DIFF
--- a/kotlin-native/runtime/build.gradle.kts
+++ b/kotlin-native/runtime/build.gradle.kts
@@ -670,7 +670,6 @@ val stdlibBuildTask = tasks.register("stdlibBuildTask", KonanCompileTask::class)
             "-Xallow-kotlin-package",
             "-Xexplicit-api=strict",
             "-Xexpect-actual-classes",
-            "-Xklib-ir-inliner=intra-module",
             "-Xcontext-parameters",
             "-Xname-based-destructuring=complete",
             "-Xcollection-literals",

--- a/libraries/kotlin.test/build.gradle.kts
+++ b/libraries/kotlin.test/build.gradle.kts
@@ -124,7 +124,6 @@ kotlin {
         nodejs {}
         compilations["main"].compileTaskProvider.configure {
             compilerOptions.freeCompilerArgs.addAll(
-                "-Xklib-ir-inliner=intra-module",
                 "-Xir-module-name=$KOTLINTEST_MODULE_NAME",
             )
             compilerOptions.addReturnValueCheckerInfo()
@@ -137,9 +136,6 @@ kotlin {
         compilerOptions {
             sourceMap = false
             sourceMapEmbedSources.unsetConvention()
-            freeCompilerArgs.addAll(
-                "-Xklib-ir-inliner=intra-module",
-            )
         }
         compilations["main"].compileTaskProvider.configure {
             compilerOptions.freeCompilerArgs.add("-Xir-module-name=$KOTLINTEST_MODULE_NAME")
@@ -154,9 +150,6 @@ kotlin {
         (this as KotlinJsTargetDsl).compilerOptions {
             sourceMap = false
             sourceMapEmbedSources.unsetConvention()
-            freeCompilerArgs.addAll(
-                "-Xklib-ir-inliner=intra-module",
-            )
         }
         compilations["main"].compileTaskProvider.configure {
             compilerOptions.freeCompilerArgs.add("-Xir-module-name=$KOTLINTEST_MODULE_NAME")

--- a/libraries/stdlib/build.gradle.kts
+++ b/libraries/stdlib/build.gradle.kts
@@ -283,7 +283,6 @@ kotlin {
                 listOf(
                     "-Xallow-kotlin-package",
                     "-Xexpect-actual-classes",
-                    "-Xklib-ir-inliner=intra-module",
                 )
             )
         }
@@ -325,7 +324,6 @@ kotlin {
                 listOfNotNull(
                     "-Xallow-kotlin-package",
                     "-Xexpect-actual-classes",
-                    "-Xklib-ir-inliner=intra-module",
                     diagnosticNamesArg
                 )
             )


### PR DESCRIPTION
^KT-88020 Fixed

Note: Leaving `-Xklib-ir-inliner=intra-module` CLI argument in build scripts for stdlib & kotlin-test would mean we are still building them with the reduced (i.e. "intra-module") mode instead of the full (i.e. "cross-module") mode.