### PR TITLE
Add tests for callable references to composable functions with context parameters (and fix lowering)

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ContextParametersTransformTests/testFunctionReference.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.ContextParametersTransformTests/testFunctionReference.txt
@@ -1,0 +1,93 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.Composable
+
+
+@Composable
+fun Test(foo: Foo) {
+    with(foo) {
+        val refA: @Composable (Int) -> Unit = ::A
+        refA(42)
+        Caller(foo, Foo::ExtA)
+
+        val refB: @Composable String.(Int) -> Unit = String::B
+        "Hello".refB(42)
+    }
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+@Composable
+@FunctionKeyMeta(key = 526939746, startOffset = 57, endOffset = 288)
+fun Test(foo: Foo, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(Test)N(foo)*<refA(4...>,<Foo::E...>,<Caller...>,<refB(4...>:Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+      %composer.changed(foo)
+    } else {
+      %composer.changedInstance(foo)
+    }
+    ) 0b0100 else 0b0010
+  }
+  if (%composer.shouldExecute(%dirty and 0b0011 != 0b0010, %dirty and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    with(foo) {
+      val refA = ::A {
+        @Composable
+        @FunctionKeyMeta(key = -951514801, startOffset = 140, endOffset = 143)
+        fun A(c0: Foo, p0: @[ParameterName(name = 'a')] Int, %composer: Composer?, %changed: Int) {
+          sourceInformationMarkerStart(%composer, <>, "C(A)N(c0,p0)<::A>:Test.kt")
+          if (isTraceInProgress()) {
+            traceEventStart(<>, %changed, -1, <>)
+          }
+          A(c0, p0, %composer, Foo.%stable or 0b1110 and %changed or 0b01110000 and %changed)
+          if (isTraceInProgress()) {
+            traceEventEnd()
+          }
+          sourceInformationMarkerEnd(%composer)
+        }
+      }
+      refA(42, %composer, 6)
+      Caller(foo, <block>{
+        sourceInformationMarkerStart(%composer, <>, "CC(remember):Test.kt#9igjgp")
+        val tmp0_group = %composer.cache(false) {
+          ::ExtA
+        }
+        sourceInformationMarkerEnd(%composer)
+        tmp0_group
+      }, %composer, 0b00110000 or Foo.%stable or 0b1110 and %dirty)
+      val refB = ::B {
+        @Composable
+        @FunctionKeyMeta(key = -357558262, startOffset = 246, endOffset = 255)
+        fun B(c0: Foo, p0: String, p1: @[ParameterName(name = 'a')] Int, %composer: Composer?, %changed: Int) {
+          sourceInformationMarkerStart(%composer, <>, "C(B)N(c0,p0,p1)<String...>:Test.kt")
+          if (isTraceInProgress()) {
+            traceEventStart(<>, %changed, -1, <>)
+          }
+          p0.B(c0, p1, %composer, Foo.%stable or 0b1110 and %changed or 0b01110000 and %changed or 0b001110000000 and %changed)
+          if (isTraceInProgress()) {
+            traceEventEnd()
+          }
+          sourceInformationMarkerEnd(%composer)
+        }
+      }
+      refB("Hello", 42, %composer, 54)
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Test(foo, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ContextParametersTransformTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ContextParametersTransformTests.kt
@@ -30,7 +30,8 @@ class ContextParametersTransformTests : AbstractIrTransformTest() {
             languageVersion = languageVersionSettings.languageVersion,
             apiVersion = languageVersionSettings.apiVersion,
             specificFeatures = mapOf(
-                LanguageFeature.ContextParameters to LanguageFeature.State.ENABLED
+                LanguageFeature.ContextParameters to LanguageFeature.State.ENABLED,
+                LanguageFeature.CallableReferencesToContextual to LanguageFeature.State.ENABLED,
             )
         )
     }
@@ -316,6 +317,44 @@ class ContextParametersTransformTests : AbstractIrTransformTest() {
                 state: T,
                 content: @Composable (T) -> Unit
             ) {
+            }
+        """
+    )
+
+    @Test
+    fun testFunctionReference() = contextReceivers(
+        """
+            class Foo { }
+
+            context(foo: Foo)
+            @Composable
+            fun A(a: Int) { }
+
+            context(foo: Foo)
+            @Composable
+            fun String.B(a: Int) { }
+
+            @Composable
+            fun Foo.ExtA(a: Int) { }
+
+            @Composable
+            fun Caller(foo: Foo, block: @Composable context(Foo) (Int) -> Unit) {
+                with(foo) {
+                    block(10)
+                }
+            }
+        """,
+        """
+            @Composable
+            fun Test(foo: Foo) {
+                with(foo) {
+                    val refA: @Composable (Int) -> Unit = ::A
+                    refA(42)
+                    Caller(foo, Foo::ExtA)
+
+                    val refB: @Composable String.(Int) -> Unit = String::B
+                    "Hello".refB(42)
+                }
             }
         """
     )

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/RuntimeTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/RuntimeTests.kt
@@ -8,6 +8,9 @@ package androidx.compose.compiler.plugins.kotlin
 import androidx.compose.compiler.plugins.kotlin.facade.SourceFile
 import com.intellij.util.containers.orNull
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.testFederation.SmokeTest
 import org.junit.jupiter.api.DynamicContainer.dynamicContainer
 import org.junit.jupiter.api.DynamicNode
@@ -124,6 +127,14 @@ private class RuntimeTestCompiler(
                 )
             )
         }
+        languageVersionSettings = LanguageVersionSettingsImpl(
+            languageVersion = languageVersionSettings.languageVersion,
+            apiVersion = languageVersionSettings.apiVersion,
+            specificFeatures = mapOf(
+                LanguageFeature.ContextParameters to LanguageFeature.State.ENABLED,
+                LanguageFeature.CallableReferencesToContextual to LanguageFeature.State.ENABLED,
+            )
+        )
     }
 
     fun compileRuntimeClasses() =

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/FunctionReferenceTests.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/FunctionReferenceTests.kt
@@ -232,7 +232,39 @@ class FunctionReferenceTests {
             }
         }
     }
+
+    @Test
+    fun functionReferenceWithContext() = compositionTest {
+        val context = TextContext("Context")
+        compose {
+            with(context) {
+                val ref: @Composable (Int) -> Unit = ::TextWithContext
+                ref(10)
+            }
+        }
+
+        validate {
+            Text("Context 10")
+        }
+    }
+
+    @Test
+    fun extensionFunctionReferenceWithContext() = compositionTest {
+        val context = TextContext("Context")
+        compose {
+            with(context) {
+                val ref: @Composable String.(Int) -> Unit =
+                    String::TextExtensionWithContext
+                "Ext".ref(30)
+            }
+        }
+
+        validate {
+            Text("Context Ext 30")
+        }
+    }
 }
+
 
 @Composable
 private fun SimpleText() {
@@ -326,4 +358,24 @@ private class FunctionRefClass {
 @Composable
 private fun FunctionRefClass.TextDefaultExt(int: Int = 0) {
     Text("TextDefault $int")
+}
+
+private class TextContext(val prefix: String)
+
+context(ctx: TextContext)
+@Composable
+private fun TextWithContext(int: Int) {
+    Text("${ctx.prefix} $int")
+}
+
+@Composable
+private fun TextContext.TextExtWithContext(int: Int) {
+    Text("$prefix $int")
+}
+
+
+context(ctx: TextContext)
+@Composable
+private fun String.TextExtensionWithContext(int: Int) {
+    Text("${ctx.prefix} $this $int")
 }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
@@ -193,10 +193,19 @@ class ComposerParamTransformer(
     }
 
     override fun visitRichFunctionReference(expression: IrRichFunctionReference): IrExpression {
-        expression.overriddenFunctionSymbol = expression.overriddenFunctionSymbol.owner.withComposerParamIfNeeded().symbol
+        if (expression.type.isKComposableFunction() || expression.type.isSyntheticComposableFunction()) {
+            expression.invokeFunction.createComposableAnnotationIfAbsent()
+            expression.overriddenFunctionSymbol =
+                expression.overriddenFunctionSymbol.owner.lambdaInvokeWithComposerParam(context).symbol
+        } else {
+            expression.overriddenFunctionSymbol =
+                expression.overriddenFunctionSymbol.owner.withComposerParamIfNeeded().symbol
+        }
 
         return super.visitRichFunctionReference(expression)
     }
+
+
 
     private fun IrFunction.findCallInBody(): IrCall? {
         var call: IrCall? = null

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/IrSourcePrinter.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/IrSourcePrinter.kt
@@ -451,7 +451,7 @@ class IrSourcePrinterVisitor(
         }
     }
 
-    private fun IrMemberAccessExpression<*>.printExplicitReceiver(
+    private fun IrExpression.printExplicitReceiver(
         suffix: String? = null,
         superQualifierSymbol: IrClassSymbol? = null,
     ) {
@@ -460,7 +460,7 @@ class IrSourcePrinterVisitor(
 
         when (this) {
             is IrFunctionAccessExpression, is IrFunctionReference -> {
-                val owner = symbol.owner
+                val owner = (this as IrMemberAccessExpression<*>).symbol.owner as IrFunction
                 val dispatchReceiver = owner.firstParameterOfKind(IrParameterKind.DispatchReceiver)
                 val extensionReceiver = owner.firstParameterOfKind(IrParameterKind.ExtensionReceiver)
                 dispatchReceiverArg = dispatchReceiver?.let { arguments[it.indexInParameters] }
@@ -469,6 +469,24 @@ class IrSourcePrinterVisitor(
             is IrPropertyReference -> {
                 dispatchReceiverArg = arguments.firstOrNull()
                 extensionReceiverArg = null
+            }
+            is IrRichFunctionReference -> {
+                val boundMapping = invokeFunction.parameters.zip(boundValues)
+                dispatchReceiverArg = boundMapping.firstOrNull {
+                    it.first.kind == IrParameterKind.DispatchReceiver
+                }?.second
+                extensionReceiverArg = boundMapping.firstOrNull {
+                    it.first.kind == IrParameterKind.ExtensionReceiver
+                }?.second
+            }
+            is IrRichPropertyReference -> {
+                val boundMapping = getterFunction.parameters.zip(boundValues)
+                dispatchReceiverArg = boundMapping.firstOrNull {
+                    it.first.kind == IrParameterKind.DispatchReceiver
+                }?.second
+                extensionReceiverArg = boundMapping.firstOrNull {
+                    it.first.kind == IrParameterKind.ExtensionReceiver
+                }?.second
             }
             else -> {
                 error("Unknown expression type: ${dump()}")
@@ -1336,6 +1354,32 @@ class IrSourcePrinterVisitor(
         }
     }
 
+    override fun visitRichFunctionReference(expression: IrRichFunctionReference) {
+        val function = expression.reflectionTargetSymbol?.owner ?: expression.invokeFunction
+
+        expression.printExplicitReceiver()
+        print("::")
+
+        val prop = (function as? IrSimpleFunction)?.correspondingPropertySymbol?.owner
+
+        if (prop != null) {
+            val propName = prop.name.asString()
+            print(propName)
+            if (function == prop.setter) {
+                print("::set")
+            } else if (function == prop.getter) {
+                print("::get")
+            }
+        } else {
+            print(function.name.asString())
+        }
+        println(" {")
+        indented {
+            expression.invokeFunction.print()
+        }
+        println("}")
+    }
+
     override fun visitInstanceInitializerCall(expression: IrInstanceInitializerCall) {
         val constructedClass = expression.classSymbol.owner
         val name = constructedClass.name
@@ -1386,6 +1430,20 @@ class IrSourcePrinterVisitor(
         expression.printExplicitReceiver()
         print("::")
         print(property.name)
+    }
+
+    override fun visitRichPropertyReference(expression: IrRichPropertyReference) {
+        val propertyName = (expression.reflectionTargetSymbol?.owner as? IrDeclarationWithName)?.name
+            ?: expression.getterFunction.name
+        expression.printExplicitReceiver()
+        print("::")
+        print(propertyName)
+        println(" {")
+        indented {
+            expression.getterFunction.print()
+            expression.setterFunction?.print()
+        }
+        println("}")
     }
 
     override fun visitSpreadElement(spread: IrSpreadElement) {


### PR DESCRIPTION
- Fix abstract method errors when referencing a @Composable function with context parameters by remapping the overridden symbol of IrRichFunctionReference from Function1.invoke to FunctionN.invoke and annotating the wrapper invoke function with @Composable.
- Support printing IrRichFunctionReference and IrRichPropertyReference with explicit receivers and inner function block syntax in IrSourcePrinter.
- Add compiler IR transform tests (ContextParametersTransformTests.testFunctionReference) and runtime tests (FunctionReferenceTests) for function and extension function references with context parameters.