### PR TITLE
Move UnitStatsSerializationTest to compiler.common

### DIFF
--- a/compiler/tests-integration/build.gradle.kts
+++ b/compiler/tests-integration/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
     testFixturesCompileOnly(toolsJarApi())
     testRuntimeOnly(toolsJar())
 
+    testImplementation(commonDependency("com.google.code.gson:gson"))
+
     antLauncherJar(commonDependency("org.apache.ant", "ant"))
     antLauncherJar(toolsJar())
 }

--- a/compiler/tests-integration/tests/org/jetbrains/kotlin/util/UnitStatsSerializationTest.kt
+++ b/compiler/tests-integration/tests/org/jetbrains/kotlin/util/UnitStatsSerializationTest.kt
@@ -1,16 +1,15 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.gradle.unitTests.report
+package org.jetbrains.kotlin.util
 
 import com.google.gson.GsonBuilder
-import org.jetbrains.kotlin.util.*
-import kotlin.test.Test
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class UnitStatsSerializationTest {
     @Test


### PR DESCRIPTION
The UnitStatsSerializationTest tests a class in the compiler.common project. It is unrelated to KGP.

Moving it helps because it moves the test closer to the actual class under test. Currently, if the test is modified a KGP codeowner has to review it, which doesn't make sense and they may not have the right context.

To run the test this commit also adds build config for running tests in compiler.common project.

The test was originally added in `316af4b9959cb488d8d02b21e74c38d062706115` for KT-76498.