### PR TITLE
[Inline] Do not attempt to deserialize inline functions from current module

### DIFF
--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/NonLinkingIrInlineFunctionDeserializer.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/NonLinkingIrInlineFunctionDeserializer.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrFileEntry
 import org.jetbrains.kotlin.ir.LineAndColumn
 import org.jetbrains.kotlin.ir.SourceRangeInfo
+import org.jetbrains.kotlin.ir.declarations.IrExternalPackageFragment
 import org.jetbrains.kotlin.ir.declarations.IrFactory
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
@@ -59,6 +60,9 @@ class NonLinkingIrInlineFunctionDeserializer(
         if (function.body != null) return null
 
         check(!function.isEffectivelyPrivate()) { "Deserialization of private inline functions is not supported: ${function.render()}" }
+
+        // We can deserialize only functions from other modules
+        if (function.getPackageFragment() !is IrExternalPackageFragment) return null
 
         val deserializedContainerSource = function.containerSource
         check(deserializedContainerSource is KlibDeserializedContainerSource) {


### PR DESCRIPTION
We encountered a problem with compiling Native stdlib. It contains inline functions without bodies. We attempt to inline them, and since the body is missing, we are looking for it in the KotlinLibrary. Since stdlib is compiled as a "current" module, we don't have any KotlinLibrary associated with such inline declaration and fail. The solution: deserialize declaration only if they come from an external module.

#KT-88020

This is prerequisite for #7045 