### PR TITLE
[BTA] Separate unsafe KMP incremental compilation per target

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/CommonCodeWithPlatformSymbolsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/CommonCodeWithPlatformSymbolsIT.kt
@@ -33,12 +33,17 @@ abstract class CommonCodeWithPlatformSymbolsITBase(
         get() = super.defaultBuildOptions.copy(
             logLevel = LogLevel.DEBUG,
             languageVersion = "2.0",
-            enableUnsafeIncrementalCompilationForMultiplatform = false,
             isolatedProjects = when (platformType) {
                 KotlinPlatformType.js -> BuildOptions.IsolatedProjectsMode.DISABLED
                 else -> super.defaultBuildOptions.isolatedProjects
             }
-        )
+        ).withUnsafeOptimizationsForMultiplatform(false)
+
+    private fun BuildOptions.withUnsafeOptimizationsForMultiplatform(enabled: Boolean): BuildOptions = when (platformType) {
+        KotlinPlatformType.js -> copy(enableJsUnsafeIncrementalCompilationForMultiplatform = enabled)
+        KotlinPlatformType.wasm -> copy(enableWasmUnsafeIncrementalCompilationForMultiplatform = enabled)
+        else -> copy(enableJvmUnsafeIncrementalCompilationForMultiplatform = enabled)
+    }
 
     private val platformSourceSet = "${platformType.name}Main"
 
@@ -49,7 +54,7 @@ abstract class CommonCodeWithPlatformSymbolsITBase(
         project(
             "kt-62686-mpp-source-set-boundary",
             gradleVersion,
-            buildOptions = defaultBuildOptions.copy(enableUnsafeIncrementalCompilationForMultiplatform = true)
+            buildOptions = defaultBuildOptions.withUnsafeOptimizationsForMultiplatform(true)
         ) {
             buildScriptInjection(setupBuildScript)
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/JvmClasspathMetadataIncrementalIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/JvmClasspathMetadataIncrementalIT.kt
@@ -24,7 +24,7 @@ class JvmClasspathMetadataIncrementalIT : KGPBaseTest() {
         get() = super.defaultBuildOptions.copy(
             logLevel = LogLevel.DEBUG,
             languageVersion = "2.0",
-            enableUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJvmUnsafeIncrementalCompilationForMultiplatform = true,
         )
 
     @GradleTest

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/KmpIncrementalCompilationMiscIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/KmpIncrementalCompilationMiscIT.kt
@@ -29,7 +29,9 @@ class KmpIncrementalCompilationWithLocalClassesIT : KGPBaseTest() {
 
     override val defaultBuildOptions: BuildOptions
         get() = super.defaultBuildOptions.copy(
-            enableUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJvmUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJsUnsafeIncrementalCompilationForMultiplatform = true,
+            enableWasmUnsafeIncrementalCompilationForMultiplatform = true,
         ).disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
 
     @Disabled("Broken, see KT-59153")
@@ -166,7 +168,9 @@ class KmpIncrementalCompilationSetExpansionIT : KGPBaseTest() {
     override val defaultBuildOptions: BuildOptions
         get() = super.defaultBuildOptions.copy(
             // it's more convenient to set up the test project using common sourceset
-            enableUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJvmUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJsUnsafeIncrementalCompilationForMultiplatform = true,
+            enableWasmUnsafeIncrementalCompilationForMultiplatform = true,
         ).disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
 
     @DisplayName("Inline cycle with monotonous expansion")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/KmpIncrementalITBase.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/KmpIncrementalITBase.kt
@@ -28,7 +28,9 @@ abstract class KmpIncrementalITBase : KGPBaseTest() {
             /**
              * disable IC-breaking feature; it's tested separately in [org.jetbrains.kotlin.gradle.mpp.CommonCodeWithPlatformSymbolsITBase]
              */
-            enableUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJvmUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJsUnsafeIncrementalCompilationForMultiplatform = true,
+            enableWasmUnsafeIncrementalCompilationForMultiplatform = true,
         ).disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
 
     protected open val gradleTask = "assemble"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/PerTargetUnsafeOptimizationsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/PerTargetUnsafeOptimizationsIT.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.mpp
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.build.report.metrics.BuildAttribute
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.test.TestMetadata
+import org.jetbrains.kotlin.testFederation.AffectedByBuildToolsApi
+import org.jetbrains.kotlin.testFederation.AffectedByCompiler
+import org.junit.jupiter.api.DisplayName
+import kotlin.io.path.writeText
+
+/**
+ * `enableUnsafeOptimizationsForMultiplatform` is configured per target (KT-87522), so enabling it for one target
+ * must not change the incremental compilation behavior of the others.
+ *
+ * These tests check incremental compilation behavior, not KGP configuration, but the Build Tools API tests do not
+ * support KMP compilation scenarios yet. Move them there once they do.
+ */
+@MppGradlePluginTests
+@DisplayName("Per-target unsafe optimizations for KMP incremental compilation")
+@AffectedByCompiler
+@AffectedByBuildToolsApi
+class PerTargetUnsafeOptimizationsIT : KGPBaseTest() {
+
+    override val defaultBuildOptions: BuildOptions
+        get() = super.defaultBuildOptions.copy(
+            logLevel = LogLevel.DEBUG,
+            languageVersion = "2.0",
+        ).disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
+
+    @GradleTest
+    @DisplayName("Enabling it for JVM only keeps the whole-module rebuild for JS")
+    @TestMetadata("kt-62686-mpp-source-set-boundary")
+    fun testEnabledForJvmOnly(gradleVersion: GradleVersion) {
+        project(
+            "kt-62686-mpp-source-set-boundary",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.copy(
+                enableJvmUnsafeIncrementalCompilationForMultiplatform = true,
+                enableJsUnsafeIncrementalCompilationForMultiplatform = false,
+            )
+        ) {
+            setupJvmAndJsTargets()
+
+            build(JVM_TASK, JS_TASK)
+            changeCommonSource()
+
+            build(JVM_TASK) {
+                assertIncrementalCompilation()
+            }
+            build(JS_TASK) {
+                assertNonIncrementalCompilation(BuildAttribute.UNSAFE_INCREMENTAL_CHANGE_KT_62686)
+            }
+        }
+    }
+
+    @GradleTest
+    @DisplayName("Enabling it for JS only keeps the whole-module rebuild for JVM")
+    @TestMetadata("kt-62686-mpp-source-set-boundary")
+    fun testEnabledForJsOnly(gradleVersion: GradleVersion) {
+        project(
+            "kt-62686-mpp-source-set-boundary",
+            gradleVersion,
+            buildOptions = defaultBuildOptions.copy(
+                enableJvmUnsafeIncrementalCompilationForMultiplatform = false,
+                enableJsUnsafeIncrementalCompilationForMultiplatform = true,
+            )
+        ) {
+            setupJvmAndJsTargets()
+
+            build(JVM_TASK, JS_TASK)
+            changeCommonSource()
+
+            build(JS_TASK) {
+                assertIncrementalCompilation()
+            }
+            build(JVM_TASK) {
+                assertNonIncrementalCompilation(BuildAttribute.UNSAFE_INCREMENTAL_CHANGE_KT_62686)
+            }
+        }
+    }
+
+    private fun TestProject.setupJvmAndJsTargets() = buildScriptInjection {
+        kotlinMultiplatform.js()
+        kotlinMultiplatform.jvm().compilations.all { compilation ->
+            compilation.compileTaskProvider.configure { task ->
+                // log level isn't properly used to set `verbose` in the default configuration, fix is WIP in KT-64698
+                task.compilerOptions.verbose.convention(true)
+            }
+        }
+    }
+
+    /** A change in a common source file that is safe to compile incrementally for every target. */
+    private fun TestProject.changeCommonSource() {
+        projectPath.resolve("src/commonMain/kotlin/dependedOnByRiskyCode.kt")
+            .writeText("val dependedOnByRiskyCode = 2\n")
+    }
+
+    private companion object {
+        const val JVM_TASK = ":compileKotlinJvm"
+        const val JS_TASK = ":compileKotlinJs"
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/smoke/AbstractExpectActualIncrementalCompilationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/smoke/AbstractExpectActualIncrementalCompilationIT.kt
@@ -26,7 +26,9 @@ abstract class AbstractExpectActualIncrementalCompilationIT : KGPBaseTest() {
     override val defaultBuildOptions: BuildOptions
         get() = super.defaultBuildOptions.copyEnsuringK2().copy(
             // disable IC-breaking feature; it's tested separately in [org.jetbrains.kotlin.gradle.mpp.CommonCodeWithPlatformSymbolsITBase]
-            enableUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJvmUnsafeIncrementalCompilationForMultiplatform = true,
+            enableJsUnsafeIncrementalCompilationForMultiplatform = true,
+            enableWasmUnsafeIncrementalCompilationForMultiplatform = true,
             logLevel = LogLevel.DEBUG,
         )
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/BuildOptions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/BuildOptions.kt
@@ -61,7 +61,9 @@ data class BuildOptions(
     val languageApiVersion: String? = null,
     val freeArgs: List<String> = emptyList(),
     val statisticsForceValidation: Boolean = true,
-    val enableUnsafeIncrementalCompilationForMultiplatform: Boolean? = null,
+    val enableJvmUnsafeIncrementalCompilationForMultiplatform: Boolean? = null,
+    val enableJsUnsafeIncrementalCompilationForMultiplatform: Boolean? = null,
+    val enableWasmUnsafeIncrementalCompilationForMultiplatform: Boolean? = null,
     val enableMonotonousIncrementalCompileSetExpansion: Boolean? = null,
     val useDaemonFallbackStrategy: Boolean = false,
     val useParsableDiagnosticsFormatting: Boolean = true,
@@ -303,8 +305,16 @@ data class BuildOptions(
             arguments.add("-Pkotlin.test.languageVersion=$languageVersion")
         }
 
-        if (enableUnsafeIncrementalCompilationForMultiplatform != null) {
-            arguments.add("-Pkotlin.internal.incremental.enableUnsafeOptimizationsForMultiplatform=$enableUnsafeIncrementalCompilationForMultiplatform")
+        if (enableJvmUnsafeIncrementalCompilationForMultiplatform != null) {
+            arguments.add("-Pkotlin.internal.jvm.enableUnsafeOptimizationsForMultiplatform=$enableJvmUnsafeIncrementalCompilationForMultiplatform")
+        }
+
+        if (enableJsUnsafeIncrementalCompilationForMultiplatform != null) {
+            arguments.add("-Pkotlin.internal.js.enableUnsafeOptimizationsForMultiplatform=$enableJsUnsafeIncrementalCompilationForMultiplatform")
+        }
+
+        if (enableWasmUnsafeIncrementalCompilationForMultiplatform != null) {
+            arguments.add("-Pkotlin.internal.wasm.enableUnsafeOptimizationsForMultiplatform=$enableWasmUnsafeIncrementalCompilationForMultiplatform")
         }
 
         if (enableMonotonousIncrementalCompileSetExpansion != null) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
@@ -618,8 +618,16 @@ internal class PropertiesProvider private constructor(private val project: Proje
      * Without unsafe optimization: in k2, if common source is dirty, module will be rebuilt.
      * With unsafe optimization: regular IC logic is used. Common sources might see declarations from platform sources. See KT-62686
      */
-    val enableUnsafeOptimizationsForMultiplatform: Boolean
-        get() = booleanProperty(PropertyNames.KOTLIN_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION) ?: false
+    val enableJvmUnsafeOptimizationsForMultiplatform: Provider<Boolean>
+        get() = booleanProvider(PropertyNames.KOTLIN_JVM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION).orElse(false)
+
+    /** See [enableJvmUnsafeOptimizationsForMultiplatform] */
+    val enableJsUnsafeOptimizationsForMultiplatform: Provider<Boolean>
+        get() = booleanProvider(PropertyNames.KOTLIN_JS_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION).orElse(false)
+
+    /** See [enableJvmUnsafeOptimizationsForMultiplatform] */
+    val enableWasmUnsafeOptimizationsForMultiplatform: Provider<Boolean>
+        get() = booleanProvider(PropertyNames.KOTLIN_WASM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION).orElse(false)
 
     /**
      * Context: assume that incremental compilation of a.kt makes b.kt dirty (for example, because some function needs to be re-inlined)
@@ -866,8 +874,18 @@ internal class PropertiesProvider private constructor(private val project: Proje
         val KOTLIN_CREATE_ARCHIVE_TASKS_FOR_CUSTOM_COMPILATIONS =
             property("$KOTLIN_INTERNAL_NAMESPACE.mpp.createArchiveTasksForCustomCompilations")
         val KOTLIN_COMPILER_ARGUMENTS_LOG_LEVEL = property("$KOTLIN_INTERNAL_NAMESPACE.compiler.arguments.log.level")
+        /**
+         * Replaced by the per-target properties below, kept only to report
+         * [org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics.DeprecatedErrorGradleProperties] on its usage.
+         */
         val KOTLIN_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION =
             property("$KOTLIN_INTERNAL_NAMESPACE.incremental.enableUnsafeOptimizationsForMultiplatform")
+        val KOTLIN_JVM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION =
+            property("$KOTLIN_INTERNAL_NAMESPACE.jvm.enableUnsafeOptimizationsForMultiplatform")
+        val KOTLIN_JS_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION =
+            property("$KOTLIN_INTERNAL_NAMESPACE.js.enableUnsafeOptimizationsForMultiplatform")
+        val KOTLIN_WASM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION =
+            property("$KOTLIN_INTERNAL_NAMESPACE.wasm.enableUnsafeOptimizationsForMultiplatform")
         val KOTLIN_INTERNAL_JVM_CLASSPATH_METADATA =
             property("$KOTLIN_INTERNAL_NAMESPACE.jvm.enableKmpClasspathMetadataForIncrementalCompilation")
         val KOTLIN_MONOTONOUS_COMPILE_SET_EXPANSION = property("$KOTLIN_INTERNAL_NAMESPACE.incremental.enableMonotonousCompileSetExpansion")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/GradleDeprecatedPropertyChecker.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/GradleDeprecatedPropertyChecker.kt
@@ -10,9 +10,13 @@ import org.jetbrains.kotlin.cli.common.toBooleanLenient
 import org.jetbrains.kotlin.gradle.internal.properties.PropertiesBuildService
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginLifecycle
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_DEPRECATED_TEST_PROPERTY
+import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_JS_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION
+import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_JVM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_MPP_ENABLE_PLATFORM_INTEGER_COMMONIZATION
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_MPP_ENABLE_OPTIMISTIC_NUMBER_COMMONIZATION
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_PUBLISH_JVM_ENVIRONMENT_ATTRIBUTE
+import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION
+import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.PropertyNames.KOTLIN_WASM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION
 import org.jetbrains.kotlin.gradle.plugin.await
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.*
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinGradleProjectChecker
@@ -131,6 +135,14 @@ internal object GradleDeprecatedPropertyChecker : KotlinGradleProjectChecker {
             KOTLIN_MPP_ENABLE_PLATFORM_INTEGER_COMMONIZATION,
             "See https://kotl.in/KT-75161 for details.",
         ),
+        DeprecatedProperty(
+            propertyName = KOTLIN_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION,
+            details = "This property has no effect. Unsafe incremental compilation optimizations are now enabled per target: use " +
+                    "$KOTLIN_JVM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION, " +
+                    "$KOTLIN_JS_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION or " +
+                    "$KOTLIN_WASM_UNSAFE_MULTIPLATFORM_INCREMENTAL_COMPILATION instead. " +
+                    "See https://kotl.in/KT-87522 for details.",
+        ), // since 2.5.0
     )
 
     override suspend fun KotlinGradleProjectCheckerContext.runChecks(collector: KotlinToolingDiagnosticsCollector) {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/AbstractKotlinCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/AbstractKotlinCompileConfig.kt
@@ -67,9 +67,6 @@ internal abstract class AbstractKotlinCompileConfig<TASK : AbstractKotlinCompile
             task.taskOutputsBackupExcludes.add(task.destinationDirectory.asFile)
             task.taskOutputsBackupExcludes.add(task.taskBuildLocalStateDirectory.asFile)
             task.taskOutputsBackupExcludes.add(task.taskBuildCacheableOutputDirectory.asFile)
-            task.enableUnsafeIncrementalCompilationForMultiplatform
-                .convention(propertiesProvider.enableUnsafeOptimizationsForMultiplatform)
-                .finalizeValueOnRead()
             task.enableMonotonousIncrementalCompileSetExpansion
                 .convention(propertiesProvider.enableMonotonousIncrementalCompileSetExpansion)
                 .finalizeValueOnRead()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/Kotlin2JsCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/Kotlin2JsCompileConfig.kt
@@ -62,6 +62,15 @@ internal open class BaseKotlin2JsCompileConfig<TASK : Kotlin2JsCompile>(
                 KotlinPlatformType.wasm -> task.runViaBuildToolsApi.convention(propertiesProvider.runKotlinWasmCompilerViaBuildToolsApi)
                 else -> task.runViaBuildToolsApi.value(false).disallowChanges()
             }
+            task.enableUnsafeIncrementalCompilationForMultiplatform
+                .convention(
+                    when (compilation.platformType) {
+                        KotlinPlatformType.js -> propertiesProvider.enableJsUnsafeOptimizationsForMultiplatform
+                        KotlinPlatformType.wasm -> propertiesProvider.enableWasmUnsafeOptimizationsForMultiplatform
+                        else -> project.providers.provider { false }
+                    }
+                )
+                .finalizeValueOnRead()
             task.generateCompilerRefIndex.value(false).disallowChanges()
             task.getIsWasmPlatform.value(compilation.platformType == KotlinPlatformType.wasm).disallowChanges()
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
@@ -52,6 +52,9 @@ internal open class BaseKotlinCompileConfig<TASK : KotlinCompile> : AbstractKotl
                 task.incremental = propertiesProvider.incrementalJvm ?: true
                 task.useFirRunner.convention(propertiesProvider.incrementalJvmFir)
                 task.enableJvmClasspathMetadata.convention(propertiesProvider.enableJvmClasspathMetadata)
+                task.enableUnsafeIncrementalCompilationForMultiplatform
+                    .convention(propertiesProvider.enableJvmUnsafeOptimizationsForMultiplatform)
+                    .finalizeValueOnRead()
                 task.usePreciseJavaTracking = propertiesProvider.usePreciseJavaTracking ?: true
                 task.jvmTargetValidationMode.convention(propertiesProvider.jvmTargetValidationMode).finalizeValueOnRead()
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/UnsafeOptimizationsForMultiplatformTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/UnsafeOptimizationsForMultiplatformTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.unitTests
+
+import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.util.assertContainsDiagnostic
+import org.jetbrains.kotlin.gradle.util.buildKMPWithAllBackends
+import org.jetbrains.kotlin.gradle.util.buildProjectWithJvm
+import org.jetbrains.kotlin.gradle.utils.withType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UnsafeOptimizationsForMultiplatformTest {
+
+    @Test
+    fun disabledByDefaultForEveryTarget() {
+        assertEnabledTargets(
+            enabledProperty = null,
+            expectedJvm = false, expectedJs = false, expectedWasm = false,
+        )
+    }
+
+    @Test
+    fun jvmPropertyAffectsOnlyJvmTasks() {
+        assertEnabledTargets(
+            enabledProperty = "kotlin.internal.jvm.enableUnsafeOptimizationsForMultiplatform",
+            expectedJvm = true, expectedJs = false, expectedWasm = false,
+        )
+    }
+
+    @Test
+    fun jsPropertyAffectsOnlyJsTasks() {
+        assertEnabledTargets(
+            enabledProperty = "kotlin.internal.js.enableUnsafeOptimizationsForMultiplatform",
+            expectedJvm = false, expectedJs = true, expectedWasm = false,
+        )
+    }
+
+    @Test
+    fun wasmPropertyAffectsOnlyWasmTasks() {
+        assertEnabledTargets(
+            enabledProperty = "kotlin.internal.wasm.enableUnsafeOptimizationsForMultiplatform",
+            expectedJvm = false, expectedJs = false, expectedWasm = true,
+        )
+    }
+
+    @Test
+    fun deprecatedGlobalPropertySetToTrueIsReportedAsError() {
+        assertDeprecationReported(propertyValue = "true")
+    }
+
+    @Test
+    fun deprecatedGlobalPropertySetToFalseIsReportedAsError() {
+        assertDeprecationReported(propertyValue = "false")
+    }
+
+    private fun assertDeprecationReported(propertyValue: String) {
+        val project = buildProjectWithJvm(preApplyCode = {
+            extraProperties.set("kotlin.internal.incremental.enableUnsafeOptimizationsForMultiplatform", propertyValue)
+        }).evaluate()
+
+        project.assertContainsDiagnostic(KotlinToolingDiagnostics.DeprecatedErrorGradleProperties)
+    }
+
+    private fun assertEnabledTargets(
+        enabledProperty: String?,
+        expectedJvm: Boolean,
+        expectedJs: Boolean,
+        expectedWasm: Boolean,
+    ) {
+        val project = buildKMPWithAllBackends(preApplyCode = {
+            if (enabledProperty != null) extraProperties.set(enabledProperty, "true")
+        })
+
+        project.evaluate()
+
+        val jvmTasks = project.tasks.withType<KotlinCompile>().toList()
+        val (wasmTasks, jsTasks) = project.tasks.withType<Kotlin2JsCompile>().partition { it.getIsWasmPlatform.get() }
+        assertTrue(jvmTasks.isNotEmpty() && jsTasks.isNotEmpty() && wasmTasks.isNotEmpty(), "Missing compile tasks to check")
+
+        val expected = jvmTasks.associate { it.path to expectedJvm } +
+                jsTasks.associate { it.path to expectedJs } +
+                wasmTasks.associate { it.path to expectedWasm }
+        val actual = jvmTasks.associate { it.path to it.enableUnsafeIncrementalCompilationForMultiplatform.get() } +
+                (jsTasks + wasmTasks).associate { it.path to it.enableUnsafeIncrementalCompilationForMultiplatform.get() }
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
kotlin.internal.incremental.enableUnsafeOptimizationsForMultiplatform was a convention on every compile task, so enabling JVM classpath metadata, which requires it, also forced unsafe incremental compilation onto the JS and Wasm runners. Replace it with one internal property per target; being internal, it is removed in place.

^[KT-87522](https://youtrack.jetbrains.com/issue/KT-87522) 