### PR TITLE
[K/N] Support APINotes/SwiftName in more imported modules

### DIFF
--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
@@ -97,7 +97,15 @@ public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boole
 
     private val apiNotes: ApiNotes? by lazy {
         if (library.apiNotesSwiftName) {
-            ApiNotes.load(library)
+            ApiNotes.load(library).also { apiNotes ->
+                if (apiNotes == null) {
+                    val modules = (library.headerFilter as? NativeLibraryHeaderFilter.Predefined)?.modules.orEmpty()
+                    val forModules = if (modules.isEmpty()) "" else " for module(s) ${modules.joinToString()}"
+                    System.err.println(
+                            "warning: apiNotesSwiftName is enabled${forModules}, but no API notes were found."
+                    )
+                }
+            }
         } else {
             null
         }

--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
@@ -1052,6 +1052,22 @@ fun NativeLibrary.getHeaderPaths(): NativeLibraryHeaders<String> {
 fun ObjCMethodOrUnavailableMethod.replaces(other: ObjCMethodOrUnavailableMethod): Boolean =
         this.isClass == other.isClass && this.selector == other.selector
 
+/**
+ * Whether this method is declared identically to [other] apart from its [ObjCMethod.swiftName].
+ *
+ * Used to drop a subclass's redeclaration of an inherited method: in Kotlin such a redeclaration is
+ * already represented by the inherited member, so re-emitting it would produce a spurious duplicate.
+ *
+ * `swiftName` is intentionally excluded from the comparison. Objective-C/Swift treat the Swift name of an
+ * overriding member as inherited from the declaration that introduces it: e.g. `NSArrayController.addObject:`,
+ * which redeclares (overrides) `NSObjectController.addObject:` without its own `swift_name`, still exposes the
+ * Swift name that API notes attach to the base declaration. The two therefore denote the same member here,
+ * even though their recorded `swiftName`s differ. Comparing via data class `equals` (which does include
+ * `swiftName`) would miss this and keep the duplicate.
+ */
+fun ObjCMethod.isSameDeclarationIgnoringSwiftName(other: ObjCMethod): Boolean =
+        this.copy(swiftName = other.swiftName) == other
+
 fun ObjCProperty.replaces(other: ObjCProperty): Boolean =
         this.getter.replaces(other.getter)
 

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -445,8 +445,11 @@ internal abstract class ObjCContainerStubBuilder(
         // Add all methods declared in the class or protocol:
         var methods = container.declaredMethods(isMeta)
 
-        // Exclude those which are identically declared in super types:
-        methods -= superMethods
+        // Exclude those which are identically declared in super types.
+        // `swiftName` is excluded from the comparison (see isSameDeclarationIgnoringSwiftName): a subclass
+        // that redeclares an inherited method without its own `swift_name` still inherits the base's Swift
+        // name, so such a redeclaration must be dropped rather than re-emitted as a duplicate.
+        methods = methods.filter { declared -> superMethods.none { declared.isSameDeclarationIgnoringSwiftName(it) } }
 
         // Add some special methods from super types:
         methods += superMethods.filter { it.containsInstancetype() || it.isInit }

--- a/kotlin-native/platformLibs/src/platform/ios/AVFAudio.def
+++ b/kotlin-native/platformLibs/src/platform/ios/AVFAudio.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.AVFAudio
 
 modules = AVFAudio
+apiNotesSwiftName = true
 compilerOpts = -framework AVFAudio
 linkerOpts = -framework AVFAudio

--- a/kotlin-native/platformLibs/src/platform/ios/AVKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/AVKit.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork CoreA
 language = Objective-C
 package = platform.AVKit
 modules = AVKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework AVKit
 linkerOpts = -framework AVKit

--- a/kotlin-native/platformLibs/src/platform/ios/Accelerate.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Accelerate.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Accelerate
 modules = Accelerate
+apiNotesSwiftName = true
 
 compilerOpts = -framework Accelerate
 linkerOpts = -framework Accelerate

--- a/kotlin-native/platformLibs/src/platform/ios/AdSupport.def
+++ b/kotlin-native/platformLibs/src/platform/ios/AdSupport.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.AdSupport
 modules = AdSupport
+apiNotesSwiftName = true
 
 compilerOpts = -framework AdSupport
 linkerOpts = -framework AdSupport

--- a/kotlin-native/platformLibs/src/platform/ios/AudioToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/ios/AudioToolbox.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudioTypes CoreFoundation CoreFoundationBase C
 language = Objective-C
 package = platform.AudioToolbox
 modules = AudioToolbox AudioUnit
+apiNotesSwiftName = true
 
 compilerOpts = -framework AudioToolbox
 linkerOpts = -framework AudioToolbox

--- a/kotlin-native/platformLibs/src/platform/ios/AuthenticationServices.def
+++ b/kotlin-native/platformLibs/src/platform/ios/AuthenticationServices.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.AuthenticationServices
 modules = AuthenticationServices
+apiNotesSwiftName = true
 
 compilerOpts = -framework AuthenticationServices
 linkerOpts = -framework AuthenticationServices

--- a/kotlin-native/platformLibs/src/platform/ios/BackgroundAssets.def
+++ b/kotlin-native/platformLibs/src/platform/ios/BackgroundAssets.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.BackgroundAssets
 
 modules = BackgroundAssets
+apiNotesSwiftName = true
 compilerOpts = -framework BackgroundAssets
 linkerOpts = -framework BackgroundAssets

--- a/kotlin-native/platformLibs/src/platform/ios/BackgroundTasks.def
+++ b/kotlin-native/platformLibs/src/platform/ios/BackgroundTasks.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.BackgroundTasks
 modules = BackgroundTasks
+apiNotesSwiftName = true
 
 compilerOpts = -framework BackgroundTasks
 linkerOpts = -framework BackgroundTasks

--- a/kotlin-native/platformLibs/src/platform/ios/CallKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CallKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CallKit
 modules = CallKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CallKit
 linkerOpts = -framework CallKit

--- a/kotlin-native/platformLibs/src/platform/ios/CarPlay.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CarPlay.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundation CoreFounda
 language = Objective-C
 package = platform.CarPlay
 modules = CarPlay
+apiNotesSwiftName = true
 
 compilerOpts = -framework CarPlay
 linkerOpts = -framework CarPlay

--- a/kotlin-native/platformLibs/src/platform/ios/CloudKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CloudKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreLocation Fou
 language = Objective-C
 package = platform.CloudKit
 modules = CloudKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CloudKit
 linkerOpts = -framework CloudKit

--- a/kotlin-native/platformLibs/src/platform/ios/Contacts.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Contacts.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.Contacts
 modules = Contacts
+apiNotesSwiftName = true
 
 compilerOpts = -framework Contacts
 linkerOpts = -framework Contacts

--- a/kotlin-native/platformLibs/src/platform/ios/CoreAudioTypes.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreAudioTypes.def
@@ -2,5 +2,6 @@ depends = CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.CoreAudioTypes
 modules = CoreAudioTypes
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreAudioTypes

--- a/kotlin-native/platformLibs/src/platform/ios/CoreBluetooth.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreBluetooth.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreBluetooth
 modules = CoreBluetooth
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreBluetooth
 linkerOpts = -framework CoreBluetooth

--- a/kotlin-native/platformLibs/src/platform/ios/CoreData.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreData.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CloudKit CoreFoundation CoreFoundationBase CoreLoc
 language = Objective-C
 package = platform.CoreData
 modules = CoreData
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreData
 linkerOpts = -framework CoreData

--- a/kotlin-native/platformLibs/src/platform/ios/CoreGraphics.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreGraphics.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.CoreGraphics
 modules = CoreGraphics
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreGraphics
 linkerOpts = -framework CoreGraphics

--- a/kotlin-native/platformLibs/src/platform/ios/CoreHaptics.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreHaptics.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreHaptics
 modules = CoreHaptics
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreHaptics
 linkerOpts = -framework CoreHaptics

--- a/kotlin-native/platformLibs/src/platform/ios/CoreImage.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreImage.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreImage
 modules = CoreImage
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreImage
 linkerOpts = -framework CoreImage

--- a/kotlin-native/platformLibs/src/platform/ios/CoreLocation.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreLocation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreLocation
 modules = CoreLocation
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreLocation
 linkerOpts = -framework CoreLocation

--- a/kotlin-native/platformLibs/src/platform/ios/CoreML.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreML.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreML
 modules = CoreML
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreML
 linkerOpts = -framework CoreML

--- a/kotlin-native/platformLibs/src/platform/ios/CoreMedia.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreMedia.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundation CoreFounda
 language = Objective-C
 package = platform.CoreMedia
 modules = CoreMedia
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreMedia
 linkerOpts = -framework CoreMedia

--- a/kotlin-native/platformLibs/src/platform/ios/CoreNFC.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreNFC.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreNFC
 modules = CoreNFC
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreNFC
 linkerOpts = -framework CoreNFC

--- a/kotlin-native/platformLibs/src/platform/ios/CoreSpotlight.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreSpotlight.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreSpotlight
 modules = CoreSpotlight
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreSpotlight
 linkerOpts = -framework CoreSpotlight

--- a/kotlin-native/platformLibs/src/platform/ios/CoreText.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CoreText.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics darwin posix
 language = Objective-C
 package = platform.CoreText
 modules = CoreText
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreText
 linkerOpts = -framework CoreText

--- a/kotlin-native/platformLibs/src/platform/ios/CryptoTokenKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/CryptoTokenKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CryptoTokenKit
 modules = CryptoTokenKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CryptoTokenKit
 linkerOpts = -framework CryptoTokenKit

--- a/kotlin-native/platformLibs/src/platform/ios/EventKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/EventKit.def
@@ -2,6 +2,7 @@ depends = AddressBook CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Core
 language = Objective-C
 package = platform.EventKit
 modules = EventKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework EventKit
 linkerOpts = -framework EventKit

--- a/kotlin-native/platformLibs/src/platform/ios/EventKitUI.def
+++ b/kotlin-native/platformLibs/src/platform/ios/EventKitUI.def
@@ -2,6 +2,7 @@ depends = AddressBook CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Core
 language = Objective-C
 package = platform.EventKitUI
 modules = EventKitUI
+apiNotesSwiftName = true
 
 compilerOpts = -framework EventKitUI
 linkerOpts = -framework EventKitUI

--- a/kotlin-native/platformLibs/src/platform/ios/ExternalAccessory.def
+++ b/kotlin-native/platformLibs/src/platform/ios/ExternalAccessory.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.ExternalAccessory
 modules = ExternalAccessory
+apiNotesSwiftName = true
 
 compilerOpts = -framework ExternalAccessory
 linkerOpts = -framework ExternalAccessory

--- a/kotlin-native/platformLibs/src/platform/ios/GLKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/GLKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.GLKit
 modules = GLKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GLKit
 linkerOpts = -framework GLKit

--- a/kotlin-native/platformLibs/src/platform/ios/GameKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/GameKit.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork Conta
 language = Objective-C
 package = platform.GameKit
 modules = GameKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GameKit
 linkerOpts = -framework GameKit

--- a/kotlin-native/platformLibs/src/platform/ios/GameplayKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/GameplayKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.GameplayKit
 modules = GameplayKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GameplayKit
 linkerOpts = -framework GameplayKit

--- a/kotlin-native/platformLibs/src/platform/ios/HealthKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/HealthKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.HealthKit
 modules = HealthKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework HealthKit
 linkerOpts = -framework HealthKit

--- a/kotlin-native/platformLibs/src/platform/ios/HomeKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/HomeKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.HomeKit
 modules = HomeKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework HomeKit
 linkerOpts = -framework HomeKit

--- a/kotlin-native/platformLibs/src/platform/ios/IdentityLookup.def
+++ b/kotlin-native/platformLibs/src/platform/ios/IdentityLookup.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.IdentityLookup
 modules = IdentityLookup
+apiNotesSwiftName = true
 
 compilerOpts = -framework IdentityLookup
 linkerOpts = -framework IdentityLookup

--- a/kotlin-native/platformLibs/src/platform/ios/Intents.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Intents.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Intents
 modules = Intents
+apiNotesSwiftName = true
 
 compilerOpts = -framework Intents
 linkerOpts = -framework Intents

--- a/kotlin-native/platformLibs/src/platform/ios/IntentsUI.def
+++ b/kotlin-native/platformLibs/src/platform/ios/IntentsUI.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.IntentsUI
 modules = IntentsUI
+apiNotesSwiftName = true
 
 compilerOpts = -framework IntentsUI
 linkerOpts = -framework IntentsUI

--- a/kotlin-native/platformLibs/src/platform/ios/LocalAuthentication.def
+++ b/kotlin-native/platformLibs/src/platform/ios/LocalAuthentication.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.LocalAuthentication
 modules = LocalAuthentication
+apiNotesSwiftName = true
 
 compilerOpts = -framework LocalAuthentication
 linkerOpts = -framework LocalAuthentication

--- a/kotlin-native/platformLibs/src/platform/ios/MapKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/MapKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MapKit
 modules = MapKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework MapKit
 linkerOpts = -framework MapKit

--- a/kotlin-native/platformLibs/src/platform/ios/Matter.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Matter.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.Matter
 
 modules = Matter
+apiNotesSwiftName = true
 compilerOpts = -framework Matter
 linkerOpts = -framework Matter

--- a/kotlin-native/platformLibs/src/platform/ios/MediaToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/ios/MediaToolbox.def
@@ -2,6 +2,7 @@ depends = AudioToolbox CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundati
 language = Objective-C
 package = platform.MediaToolbox
 modules = MediaToolbox
+apiNotesSwiftName = true
 
 compilerOpts = -framework MediaToolbox
 linkerOpts = -framework MediaToolbox

--- a/kotlin-native/platformLibs/src/platform/ios/MessageUI.def
+++ b/kotlin-native/platformLibs/src/platform/ios/MessageUI.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MessageUI
 modules = MessageUI
+apiNotesSwiftName = true
 
 compilerOpts = -framework MessageUI
 linkerOpts = -framework MessageUI

--- a/kotlin-native/platformLibs/src/platform/ios/Metal.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Metal.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation IOSur
 language = Objective-C
 package = platform.Metal
 modules = Metal
+apiNotesSwiftName = true
 
 compilerOpts = -framework Metal
 linkerOpts = -framework Metal

--- a/kotlin-native/platformLibs/src/platform/ios/MetalFX.def
+++ b/kotlin-native/platformLibs/src/platform/ios/MetalFX.def
@@ -1,6 +1,7 @@
 depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation IOSurface Metal Security darwin posix
 language = Objective-C
 package = platform.MetalFX
+apiNotesSwiftName = true
 
 modules.ios_arm64 = MetalFX
 compilerOpts.ios_arm64 = -framework MetalFX

--- a/kotlin-native/platformLibs/src/platform/ios/MetalKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/MetalKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MetalKit
 modules = MetalKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework MetalKit
 linkerOpts = -framework MetalKit

--- a/kotlin-native/platformLibs/src/platform/ios/MetalPerformanceShaders.def
+++ b/kotlin-native/platformLibs/src/platform/ios/MetalPerformanceShaders.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Fou
 language = Objective-C
 package = platform.MetalPerformanceShaders
 modules = MetalPerformanceShaders
+apiNotesSwiftName = true
 
 compilerOpts = -framework MetalPerformanceShaders
 linkerOpts = -framework MetalPerformanceShaders

--- a/kotlin-native/platformLibs/src/platform/ios/ModelIO.def
+++ b/kotlin-native/platformLibs/src/platform/ios/ModelIO.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Fou
 language = Objective-C
 package = platform.ModelIO
 modules = ModelIO
+apiNotesSwiftName = true
 
 compilerOpts = -framework ModelIO
 linkerOpts = -framework ModelIO

--- a/kotlin-native/platformLibs/src/platform/ios/MultipeerConnectivity.def
+++ b/kotlin-native/platformLibs/src/platform/ios/MultipeerConnectivity.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MultipeerConnectivity
 modules = MultipeerConnectivity
+apiNotesSwiftName = true
 
 compilerOpts = -framework MultipeerConnectivity
 linkerOpts = -framework MultipeerConnectivity

--- a/kotlin-native/platformLibs/src/platform/ios/Network.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Network.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.Network
 modules = Network
+apiNotesSwiftName = true
 
 compilerOpts = -framework Network
 linkerOpts = -framework Network

--- a/kotlin-native/platformLibs/src/platform/ios/NetworkExtension.def
+++ b/kotlin-native/platformLibs/src/platform/ios/NetworkExtension.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Netwo
 language = Objective-C
 package = platform.NetworkExtension
 modules = NetworkExtension
+apiNotesSwiftName = true
 
 compilerOpts = -framework NetworkExtension
 linkerOpts = -framework NetworkExtension

--- a/kotlin-native/platformLibs/src/platform/ios/OpenGLES.def
+++ b/kotlin-native/platformLibs/src/platform/ios/OpenGLES.def
@@ -1,6 +1,7 @@
 depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase EAGL Foundation OpenGLESCommon Security darwin posix
 language = Objective-C
 package = platform.gles
+apiNotesSwiftName = true
 headers = OpenGLES/ES1/gl.h OpenGLES/ES1/glext.h
 
 headerFilter = OpenGLES/ES1/**

--- a/kotlin-native/platformLibs/src/platform/ios/PDFKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/PDFKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.PDFKit
 modules = PDFKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PDFKit
 linkerOpts = -framework PDFKit

--- a/kotlin-native/platformLibs/src/platform/ios/PassKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/PassKit.def
@@ -2,6 +2,7 @@ depends = AddressBook CFCGTypes CFNetwork Contacts CoreFoundation CoreFoundation
 language = Objective-C
 package = platform.PassKit
 modules = PassKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PassKit
 linkerOpts = -framework PassKit

--- a/kotlin-native/platformLibs/src/platform/ios/PencilKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/PencilKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.PencilKit
 modules = PencilKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PencilKit
 linkerOpts = -framework PencilKit

--- a/kotlin-native/platformLibs/src/platform/ios/Photos.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Photos.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork CoreA
 language = Objective-C
 package = platform.Photos
 modules = Photos
+apiNotesSwiftName = true
 
 compilerOpts = -framework Photos
 linkerOpts = -framework Photos

--- a/kotlin-native/platformLibs/src/platform/ios/PushKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/PushKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.PushKit
 modules = PushKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PushKit
 linkerOpts = -framework PushKit

--- a/kotlin-native/platformLibs/src/platform/ios/QuickLook.def
+++ b/kotlin-native/platformLibs/src/platform/ios/QuickLook.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.QuickLook
 modules = QuickLook
+apiNotesSwiftName = true
 
 compilerOpts = -framework QuickLook
 linkerOpts = -framework QuickLook

--- a/kotlin-native/platformLibs/src/platform/ios/SafariServices.def
+++ b/kotlin-native/platformLibs/src/platform/ios/SafariServices.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.SafariServices
 modules = SafariServices
+apiNotesSwiftName = true
 
 compilerOpts = -framework SafariServices
 linkerOpts = -framework SafariServices

--- a/kotlin-native/platformLibs/src/platform/ios/SceneKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/SceneKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.SceneKit
 modules = SceneKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SceneKit
 linkerOpts = -framework SceneKit

--- a/kotlin-native/platformLibs/src/platform/ios/Security.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Security.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.Security
 modules = Security
+apiNotesSwiftName = true
 
 compilerOpts = -framework Security
 linkerOpts = -framework Security

--- a/kotlin-native/platformLibs/src/platform/ios/SensorKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/SensorKit.def
@@ -2,5 +2,6 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork CoreA
 language = Objective-C
 package = platform.SensorKit
 modules = SensorKit
+apiNotesSwiftName = true
 compilerOpts = -framework SensorKit
 linkerOpts = -framework SensorKit

--- a/kotlin-native/platformLibs/src/platform/ios/ShazamKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/ShazamKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.ShazamKit
 
 modules = ShazamKit
+apiNotesSwiftName = true
 compilerOpts = -framework ShazamKit
 linkerOpts = -framework ShazamKit

--- a/kotlin-native/platformLibs/src/platform/ios/SoundAnalysis.def
+++ b/kotlin-native/platformLibs/src/platform/ios/SoundAnalysis.def
@@ -2,6 +2,7 @@ depends = AVFAudio AudioToolbox CFCGTypes CFNetwork CoreAudio CoreAudioTypes Cor
 language = Objective-C
 package = platform.SoundAnalysis
 modules = SoundAnalysis
+apiNotesSwiftName = true
 
 compilerOpts = -framework SoundAnalysis
 linkerOpts = -framework SoundAnalysis

--- a/kotlin-native/platformLibs/src/platform/ios/Speech.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Speech.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork CoreA
 language = Objective-C
 package = platform.Speech
 modules = Speech
+apiNotesSwiftName = true
 
 compilerOpts = -framework Speech
 linkerOpts = -framework Speech

--- a/kotlin-native/platformLibs/src/platform/ios/SpriteKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/SpriteKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.SpriteKit
 modules = SpriteKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SpriteKit
 linkerOpts = -framework SpriteKit

--- a/kotlin-native/platformLibs/src/platform/ios/StoreKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/StoreKit.def
@@ -2,6 +2,7 @@ depends = BackgroundAssets CFCGTypes CFNetwork CoreFoundation CoreFoundationBase
 language = Objective-C
 package = platform.StoreKit
 modules = StoreKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework StoreKit
 linkerOpts = -framework StoreKit

--- a/kotlin-native/platformLibs/src/platform/ios/UIKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/UIKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.UIKit
 modules = UIKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework UIKit
 linkerOpts = -framework UIKit

--- a/kotlin-native/platformLibs/src/platform/ios/UniformTypeIdentifiers.def
+++ b/kotlin-native/platformLibs/src/platform/ios/UniformTypeIdentifiers.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.UniformTypeIdentifiers
 modules = UniformTypeIdentifiers
+apiNotesSwiftName = true
 compilerOpts = -framework UniformTypeIdentifiers
 linkerOpts = -framework UniformTypeIdentifiers

--- a/kotlin-native/platformLibs/src/platform/ios/UserNotifications.def
+++ b/kotlin-native/platformLibs/src/platform/ios/UserNotifications.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.UserNotifications
 modules = UserNotifications
+apiNotesSwiftName = true
 
 compilerOpts = -framework UserNotifications
 linkerOpts = -framework UserNotifications

--- a/kotlin-native/platformLibs/src/platform/ios/VideoSubscriberAccount.def
+++ b/kotlin-native/platformLibs/src/platform/ios/VideoSubscriberAccount.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.VideoSubscriberAccount
 modules = VideoSubscriberAccount
+apiNotesSwiftName = true
 
 compilerOpts = -framework VideoSubscriberAccount
 linkerOpts = -framework VideoSubscriberAccount

--- a/kotlin-native/platformLibs/src/platform/ios/VideoToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/ios/VideoToolbox.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundation CoreFounda
 language = Objective-C
 package = platform.VideoToolbox
 modules = VideoToolbox
+apiNotesSwiftName = true
 
 compilerOpts = -framework VideoToolbox
 linkerOpts = -framework VideoToolbox

--- a/kotlin-native/platformLibs/src/platform/ios/Vision.def
+++ b/kotlin-native/platformLibs/src/platform/ios/Vision.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundation CoreFounda
 language = Objective-C
 package = platform.Vision
 modules = Vision
+apiNotesSwiftName = true
 
 compilerOpts = -framework Vision
 linkerOpts = -framework Vision

--- a/kotlin-native/platformLibs/src/platform/ios/VisionKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/VisionKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.VisionKit
 modules = VisionKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework VisionKit
 linkerOpts = -framework VisionKit

--- a/kotlin-native/platformLibs/src/platform/ios/WatchConnectivity.def
+++ b/kotlin-native/platformLibs/src/platform/ios/WatchConnectivity.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.WatchConnectivity
 modules = WatchConnectivity
+apiNotesSwiftName = true
 
 compilerOpts = -framework WatchConnectivity
 linkerOpts = -framework WatchConnectivity

--- a/kotlin-native/platformLibs/src/platform/ios/WebKit.def
+++ b/kotlin-native/platformLibs/src/platform/ios/WebKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.WebKit
 modules = WebKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework WebKit
 linkerOpts = -framework WebKit

--- a/kotlin-native/platformLibs/src/platform/ios/iAd.def
+++ b/kotlin-native/platformLibs/src/platform/ios/iAd.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.iAd
 modules = iAd
+apiNotesSwiftName = true
 
 compilerOpts = -framework iAd
 linkerOpts = -framework iAd

--- a/kotlin-native/platformLibs/src/platform/osx/AVFAudio.def
+++ b/kotlin-native/platformLibs/src/platform/osx/AVFAudio.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.AVFAudio
 
 modules = AVFAudio
+apiNotesSwiftName = true
 compilerOpts = -framework AVFAudio
 linkerOpts = -framework AVFAudio

--- a/kotlin-native/platformLibs/src/platform/osx/AVFoundation.def
+++ b/kotlin-native/platformLibs/src/platform/osx/AVFoundation.def
@@ -2,6 +2,7 @@ depends = AVFAudio ApplicationServices AudioToolbox CFCGTypes CFNetwork CoreAudi
 language = Objective-C
 package = platform.AVFoundation
 modules = AVFoundation
+apiNotesSwiftName = true
 
 compilerOpts = -framework AVFoundation
 linkerOpts = -framework AVFoundation

--- a/kotlin-native/platformLibs/src/platform/osx/AVKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/AVKit.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AppKit ApplicationServices AudioToolbox CFCGType
 language = Objective-C
 package = platform.AVKit
 modules = AVKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework AVKit
 linkerOpts = -framework AVKit

--- a/kotlin-native/platformLibs/src/platform/osx/Accelerate.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Accelerate.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CoreFoundation CoreFoundationB
 language = Objective-C
 package = platform.Accelerate
 modules = Accelerate
+apiNotesSwiftName = true
 
 compilerOpts = -framework Accelerate
 linkerOpts = -framework Accelerate

--- a/kotlin-native/platformLibs/src/platform/osx/AdSupport.def
+++ b/kotlin-native/platformLibs/src/platform/osx/AdSupport.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.AdSupport
 modules = AdSupport
+apiNotesSwiftName = true
 
 compilerOpts = -framework AdSupport
 linkerOpts = -framework AdSupport

--- a/kotlin-native/platformLibs/src/platform/osx/AppKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/AppKit.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreFoundati
 language = Objective-C
 package = platform.AppKit
 modules = AppKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework AppKit
 linkerOpts = -framework AppKit

--- a/kotlin-native/platformLibs/src/platform/osx/ApplicationServices.def
+++ b/kotlin-native/platformLibs/src/platform/osx/ApplicationServices.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.ApplicationServices
 modules = ApplicationServices ColorSync
+apiNotesSwiftName = true
 
 excludedFunctions = kSpeechSynthesizerInfoManufacturer
 

--- a/kotlin-native/platformLibs/src/platform/osx/AuthenticationServices.def
+++ b/kotlin-native/platformLibs/src/platform/osx/AuthenticationServices.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.AuthenticationServices
 modules = AuthenticationServices
+apiNotesSwiftName = true
 
 compilerOpts = -framework AuthenticationServices
 linkerOpts = -framework AuthenticationServices

--- a/kotlin-native/platformLibs/src/platform/osx/BackgroundAssets.def
+++ b/kotlin-native/platformLibs/src/platform/osx/BackgroundAssets.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.BackgroundAssets
 
 modules = BackgroundAssets
+apiNotesSwiftName = true
 compilerOpts = -framework BackgroundAssets
 linkerOpts = -framework BackgroundAssets

--- a/kotlin-native/platformLibs/src/platform/osx/BackgroundTasks.def
+++ b/kotlin-native/platformLibs/src/platform/osx/BackgroundTasks.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.BackgroundTasks
 modules = BackgroundTasks
+apiNotesSwiftName = true
 
 compilerOpts = -framework BackgroundTasks
 linkerOpts = -framework BackgroundTasks

--- a/kotlin-native/platformLibs/src/platform/osx/CallKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CallKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CallKit
 modules = CallKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CallKit
 linkerOpts = -framework CallKit

--- a/kotlin-native/platformLibs/src/platform/osx/CloudKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CloudKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CloudKit
 modules = CloudKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CloudKit
 linkerOpts = -framework CloudKit

--- a/kotlin-native/platformLibs/src/platform/osx/Contacts.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Contacts.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Contacts
 modules = Contacts
+apiNotesSwiftName = true
 
 compilerOpts = -framework Contacts
 linkerOpts = -framework Contacts

--- a/kotlin-native/platformLibs/src/platform/osx/CoreAudioTypes.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreAudioTypes.def
@@ -2,5 +2,6 @@ depends = CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.CoreAudioTypes
 modules = CoreAudioTypes
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreAudioTypes

--- a/kotlin-native/platformLibs/src/platform/osx/CoreBluetooth.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreBluetooth.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreBluetooth
 modules = CoreBluetooth
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreBluetooth
 linkerOpts = -framework CoreBluetooth

--- a/kotlin-native/platformLibs/src/platform/osx/CoreData.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreData.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CloudKit CoreFoundation CoreFoundationBase CoreGra
 language = Objective-C
 package = platform.CoreData
 modules = CoreData
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreData
 linkerOpts = -framework CoreData

--- a/kotlin-native/platformLibs/src/platform/osx/CoreGraphics.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreGraphics.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase IOKit darwin libkern posix
 language = Objective-C
 package = platform.CoreGraphics
 modules = CoreGraphics
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreGraphics
 linkerOpts = -framework CoreGraphics

--- a/kotlin-native/platformLibs/src/platform/osx/CoreHaptics.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreHaptics.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreHaptics
 modules = CoreHaptics
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreHaptics
 linkerOpts = -framework CoreHaptics

--- a/kotlin-native/platformLibs/src/platform/osx/CoreImage.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreImage.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CoreFoundation CoreFoundationB
 language = Objective-C
 package = platform.CoreImage
 modules = CoreImage
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreImage
 linkerOpts = -framework CoreImage

--- a/kotlin-native/platformLibs/src/platform/osx/CoreLocation.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreLocation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreLocation
 modules = CoreLocation
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreLocation
 linkerOpts = -framework CoreLocation

--- a/kotlin-native/platformLibs/src/platform/osx/CoreML.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreML.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CoreFoundation CoreFoundationB
 language = Objective-C
 package = platform.CoreML
 modules = CoreML
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreML
 linkerOpts = -framework CoreML

--- a/kotlin-native/platformLibs/src/platform/osx/CoreMedia.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreMedia.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreF
 language = Objective-C
 package = platform.CoreMedia
 modules = CoreMedia
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreMedia
 linkerOpts = -framework CoreMedia

--- a/kotlin-native/platformLibs/src/platform/osx/CoreSpotlight.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreSpotlight.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreSpotlight
 modules = CoreSpotlight
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreSpotlight
 linkerOpts = -framework CoreSpotlight

--- a/kotlin-native/platformLibs/src/platform/osx/CoreText.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreText.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics IOKit darwin 
 language = Objective-C
 package = platform.CoreText
 modules = CoreText
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreText
 linkerOpts = -framework CoreText

--- a/kotlin-native/platformLibs/src/platform/osx/CoreWLAN.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CoreWLAN.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreWLAN
 modules = CoreWLAN
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreWLAN
 linkerOpts = -framework CoreWLAN

--- a/kotlin-native/platformLibs/src/platform/osx/CryptoTokenKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/CryptoTokenKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CryptoTokenKit
 modules = CryptoTokenKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CryptoTokenKit
 linkerOpts = -framework CryptoTokenKit

--- a/kotlin-native/platformLibs/src/platform/osx/EventKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/EventKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.EventKit
 modules = EventKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework EventKit
 linkerOpts = -framework EventKit

--- a/kotlin-native/platformLibs/src/platform/osx/ExternalAccessory.def
+++ b/kotlin-native/platformLibs/src/platform/osx/ExternalAccessory.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.ExternalAccessory
 modules = ExternalAccessory
+apiNotesSwiftName = true
 
 compilerOpts = -framework ExternalAccessory
 linkerOpts = -framework ExternalAccessory

--- a/kotlin-native/platformLibs/src/platform/osx/GLKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/GLKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.GLKit
 modules = GLKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GLKit
 linkerOpts = -framework GLKit

--- a/kotlin-native/platformLibs/src/platform/osx/GameKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/GameKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit Cocoa Contacts
 language = Objective-C
 package = platform.GameKit
 modules = GameKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GameKit
 linkerOpts = -framework GameKit

--- a/kotlin-native/platformLibs/src/platform/osx/GameplayKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/GameplayKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit Cocoa CoreData
 language = Objective-C
 package = platform.GameplayKit
 modules = GameplayKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GameplayKit
 linkerOpts = -framework GameplayKit

--- a/kotlin-native/platformLibs/src/platform/osx/IdentityLookup.def
+++ b/kotlin-native/platformLibs/src/platform/osx/IdentityLookup.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.IdentityLookup
 modules = IdentityLookup
+apiNotesSwiftName = true
 
 compilerOpts = -framework IdentityLookup
 linkerOpts = -framework IdentityLookup

--- a/kotlin-native/platformLibs/src/platform/osx/Intents.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Intents.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Intents
 modules = Intents
+apiNotesSwiftName = true
 compilerOpts = -framework Intents
 linkerOpts = -framework Intents

--- a/kotlin-native/platformLibs/src/platform/osx/IntentsUI.def
+++ b/kotlin-native/platformLibs/src/platform/osx/IntentsUI.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.IntentsUI
 
 modules = IntentsUI
+apiNotesSwiftName = true
 compilerOpts = -framework IntentsUI
 linkerOpts = -framework IntentsUI

--- a/kotlin-native/platformLibs/src/platform/osx/LocalAuthentication.def
+++ b/kotlin-native/platformLibs/src/platform/osx/LocalAuthentication.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.LocalAuthentication
 modules = LocalAuthentication
+apiNotesSwiftName = true
 
 compilerOpts = -framework LocalAuthentication
 linkerOpts = -framework LocalAuthentication

--- a/kotlin-native/platformLibs/src/platform/osx/MapKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/MapKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.MapKit
 modules = MapKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework MapKit
 linkerOpts = -framework MapKit

--- a/kotlin-native/platformLibs/src/platform/osx/Matter.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Matter.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.Matter
 
 modules = Matter
+apiNotesSwiftName = true
 compilerOpts = -framework Matter
 linkerOpts = -framework Matter

--- a/kotlin-native/platformLibs/src/platform/osx/MediaPlayer.def
+++ b/kotlin-native/platformLibs/src/platform/osx/MediaPlayer.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation ApplicationServices AudioToolbox CFCGTypes CFNet
 language = Objective-C
 package = platform.MediaPlayer
 modules = MediaPlayer
+apiNotesSwiftName = true
 
 compilerOpts = -framework MediaPlayer
 linkerOpts = -framework MediaPlayer

--- a/kotlin-native/platformLibs/src/platform/osx/MediaToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/osx/MediaToolbox.def
@@ -2,6 +2,7 @@ depends = ApplicationServices AudioToolbox CFCGTypes CFNetwork CoreAudio CoreAud
 language = Objective-C
 package = platform.MediaToolbox
 modules = MediaToolbox
+apiNotesSwiftName = true
 
 compilerOpts = -framework MediaToolbox
 linkerOpts = -framework MediaToolbox

--- a/kotlin-native/platformLibs/src/platform/osx/Metal.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Metal.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Metal
 modules = Metal
+apiNotesSwiftName = true
 
 excludedFunctions = MTLRenderPipelineErrorDomain
 compilerOpts = -framework Metal

--- a/kotlin-native/platformLibs/src/platform/osx/MetalKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/MetalKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.MetalKit
 modules = MetalKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework MetalKit
 linkerOpts = -framework MetalKit

--- a/kotlin-native/platformLibs/src/platform/osx/MetalPerformanceShaders.def
+++ b/kotlin-native/platformLibs/src/platform/osx/MetalPerformanceShaders.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MetalPerformanceShaders
 modules = MetalPerformanceShaders
+apiNotesSwiftName = true
 
 compilerOpts = -framework MetalPerformanceShaders
 linkerOpts = -framework MetalPerformanceShaders

--- a/kotlin-native/platformLibs/src/platform/osx/ModelIO.def
+++ b/kotlin-native/platformLibs/src/platform/osx/ModelIO.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.ModelIO
 modules = ModelIO
+apiNotesSwiftName = true
 
 compilerOpts = -framework ModelIO
 linkerOpts = -framework ModelIO

--- a/kotlin-native/platformLibs/src/platform/osx/MultipeerConnectivity.def
+++ b/kotlin-native/platformLibs/src/platform/osx/MultipeerConnectivity.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit Cocoa CoreData
 language = Objective-C
 package = platform.MultipeerConnectivity
 modules = MultipeerConnectivity
+apiNotesSwiftName = true
 
 compilerOpts = -framework MultipeerConnectivity
 linkerOpts = -framework MultipeerConnectivity

--- a/kotlin-native/platformLibs/src/platform/osx/Network.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Network.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Network
 modules = Network
+apiNotesSwiftName = true
 
 compilerOpts = -framework Network
 linkerOpts = -framework Network

--- a/kotlin-native/platformLibs/src/platform/osx/NetworkExtension.def
+++ b/kotlin-native/platformLibs/src/platform/osx/NetworkExtension.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.NetworkExtension
 modules = NetworkExtension
+apiNotesSwiftName = true
 
 compilerOpts = -framework NetworkExtension
 linkerOpts = -framework NetworkExtension

--- a/kotlin-native/platformLibs/src/platform/osx/NotificationCenter.def
+++ b/kotlin-native/platformLibs/src/platform/osx/NotificationCenter.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.NotificationCenter
 modules = NotificationCenter
+apiNotesSwiftName = true
 
 compilerOpts = -framework NotificationCenter
 linkerOpts = -framework NotificationCenter

--- a/kotlin-native/platformLibs/src/platform/osx/PassKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/PassKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.PassKit
 
 modules = PassKit
+apiNotesSwiftName = true
 compilerOpts = -framework PassKit
 linkerOpts = -framework PassKit

--- a/kotlin-native/platformLibs/src/platform/osx/PencilKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/PencilKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit Cocoa CoreData
 language = Objective-C
 package = platform.PencilKit
 modules = PencilKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PencilKit
 linkerOpts = -framework PencilKit

--- a/kotlin-native/platformLibs/src/platform/osx/Photos.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Photos.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation ApplicationServices AudioToolbox CFCGTypes CFNet
 language = Objective-C
 package = platform.Photos
 modules = Photos
+apiNotesSwiftName = true
 
 compilerOpts = -framework Photos
 linkerOpts = -framework Photos

--- a/kotlin-native/platformLibs/src/platform/osx/PhotosUI.def
+++ b/kotlin-native/platformLibs/src/platform/osx/PhotosUI.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AppKit ApplicationServices AudioToolbox CFCGType
 language = Objective-C
 package = platform.PhotosUI
 modules = PhotosUI
+apiNotesSwiftName = true
 
 compilerOpts = -framework PhotosUI
 linkerOpts = -framework PhotosUI

--- a/kotlin-native/platformLibs/src/platform/osx/PushKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/PushKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.PushKit
 modules = PushKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PushKit
 linkerOpts = -framework PushKit

--- a/kotlin-native/platformLibs/src/platform/osx/QuickLookUI.def
+++ b/kotlin-native/platformLibs/src/platform/osx/QuickLookUI.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.QuickLookUI
 
 modules = QuickLookUI
+apiNotesSwiftName = true
 compilerOpts = -framework QuickLookUI
 linkerOpts = -framework QuickLookUI

--- a/kotlin-native/platformLibs/src/platform/osx/SceneKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/SceneKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.SceneKit
 modules = SceneKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SceneKit
 linkerOpts = -framework SceneKit

--- a/kotlin-native/platformLibs/src/platform/osx/ScreenSaver.def
+++ b/kotlin-native/platformLibs/src/platform/osx/ScreenSaver.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.ScreenSaver
 modules = ScreenSaver
+apiNotesSwiftName = true
 
 compilerOpts = -framework ScreenSaver
 linkerOpts = -framework ScreenSaver

--- a/kotlin-native/platformLibs/src/platform/osx/ScriptingBridge.def
+++ b/kotlin-native/platformLibs/src/platform/osx/ScriptingBridge.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CoreFoundation CoreFoundationB
 language = Objective-C
 package = platform.ScriptingBridge
 modules = ScriptingBridge
+apiNotesSwiftName = true
 
 compilerOpts = -framework ScriptingBridge
 linkerOpts = -framework ScriptingBridge

--- a/kotlin-native/platformLibs/src/platform/osx/Security.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Security.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase darwin osx posix
 language = Objective-C
 package = platform.Security
 modules = Security
+apiNotesSwiftName = true
 
 excludedFunctions = CSSMOID_APPLE_EXTENSION_DEVELOPER_AUTHENTICATION CSSMOID_APPLE_EXTENSION_PROVISIONING_PROFILE_SIGNING \
                     CSSMOID_APPLE_EXTENSION_SERVER_AUTHENTICATION CSSMOID_APPLE_TP_PCS_ESCROW_SERVICE \

--- a/kotlin-native/platformLibs/src/platform/osx/SensorKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/SensorKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.SensorKit
 
 modules = SensorKit
+apiNotesSwiftName = true
 compilerOpts = -framework SensorKit
 linkerOpts = -framework SensorKit

--- a/kotlin-native/platformLibs/src/platform/osx/ShazamKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/ShazamKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.ShazamKit
 
 modules = ShazamKit
+apiNotesSwiftName = true
 compilerOpts = -framework ShazamKit
 linkerOpts = -framework ShazamKit

--- a/kotlin-native/platformLibs/src/platform/osx/SoundAnalysis.def
+++ b/kotlin-native/platformLibs/src/platform/osx/SoundAnalysis.def
@@ -2,6 +2,7 @@ depends = AVFAudio ApplicationServices AudioToolbox CFCGTypes CFNetwork CoreAudi
 language = Objective-C
 package = platform.SoundAnalysis
 modules = SoundAnalysis
+apiNotesSwiftName = true
 
 compilerOpts = -framework SoundAnalysis
 linkerOpts = -framework SoundAnalysis

--- a/kotlin-native/platformLibs/src/platform/osx/Speech.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Speech.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation ApplicationServices AudioToolbox CFCGTypes CFNet
 language = Objective-C
 package = platform.Speech
 modules = Speech
+apiNotesSwiftName = true
 
 compilerOpts = -framework Speech
 linkerOpts = -framework Speech

--- a/kotlin-native/platformLibs/src/platform/osx/SpriteKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/SpriteKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit Cocoa CoreData
 language = Objective-C
 package = platform.SpriteKit
 modules = SpriteKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SpriteKit
 linkerOpts = -framework SpriteKit

--- a/kotlin-native/platformLibs/src/platform/osx/StoreKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/StoreKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices BackgroundAssets CFCGTypes CFNetwork CloudK
 language = Objective-C
 package = platform.StoreKit
 modules = StoreKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework StoreKit
 linkerOpts = -framework StoreKit

--- a/kotlin-native/platformLibs/src/platform/osx/UniformTypeIdentifiers.def
+++ b/kotlin-native/platformLibs/src/platform/osx/UniformTypeIdentifiers.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.UniformTypeIdentifiers
 
 modules = UniformTypeIdentifiers
+apiNotesSwiftName = true
 compilerOpts = -framework UniformTypeIdentifiers
 linkerOpts = -framework UniformTypeIdentifiers

--- a/kotlin-native/platformLibs/src/platform/osx/UserNotifications.def
+++ b/kotlin-native/platformLibs/src/platform/osx/UserNotifications.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.UserNotifications
 modules = UserNotifications
+apiNotesSwiftName = true
 
 compilerOpts = -framework UserNotifications
 linkerOpts = -framework UserNotifications

--- a/kotlin-native/platformLibs/src/platform/osx/VideoSubscriberAccount.def
+++ b/kotlin-native/platformLibs/src/platform/osx/VideoSubscriberAccount.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.VideoSubscriberAccount
 modules = VideoSubscriberAccount
+apiNotesSwiftName = true
 compilerOpts = -framework VideoSubscriberAccount
 linkerOpts = -framework VideoSubscriberAccount

--- a/kotlin-native/platformLibs/src/platform/osx/VideoToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/osx/VideoToolbox.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreF
 language = Objective-C
 package = platform.VideoToolbox
 modules = VideoToolbox
+apiNotesSwiftName = true
 
 compilerOpts = -framework VideoToolbox
 linkerOpts = -framework VideoToolbox

--- a/kotlin-native/platformLibs/src/platform/osx/Vision.def
+++ b/kotlin-native/platformLibs/src/platform/osx/Vision.def
@@ -2,6 +2,7 @@ depends = ApplicationServices CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreF
 language = Objective-C
 package = platform.Vision
 modules = Vision
+apiNotesSwiftName = true
 
 compilerOpts = -framework Vision
 linkerOpts = -framework Vision

--- a/kotlin-native/platformLibs/src/platform/osx/WebKit.def
+++ b/kotlin-native/platformLibs/src/platform/osx/WebKit.def
@@ -2,6 +2,7 @@ depends = AppKit ApplicationServices CFCGTypes CFNetwork CloudKit CoreData CoreF
 language = Objective-C
 package = platform.WebKit
 modules = WebKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework WebKit
 linkerOpts = -framework WebKit

--- a/kotlin-native/platformLibs/src/platform/tvos/AVFAudio.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/AVFAudio.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.AVFAudio
 
 modules = AVFAudio
+apiNotesSwiftName = true
 compilerOpts = -framework AVFAudio
 linkerOpts = -framework AVFAudio

--- a/kotlin-native/platformLibs/src/platform/tvos/AVKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/AVKit.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork CoreA
 language = Objective-C
 package = platform.AVKit
 modules = AVKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework AVKit
 linkerOpts = -framework AVKit

--- a/kotlin-native/platformLibs/src/platform/tvos/Accelerate.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Accelerate.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Accelerate
 modules = Accelerate
+apiNotesSwiftName = true
 
 compilerOpts = -framework Accelerate
 linkerOpts = -framework Accelerate

--- a/kotlin-native/platformLibs/src/platform/tvos/AdSupport.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/AdSupport.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.AdSupport
 modules = AdSupport
+apiNotesSwiftName = true
 
 compilerOpts = -framework AdSupport
 linkerOpts = -framework AdSupport

--- a/kotlin-native/platformLibs/src/platform/tvos/AudioToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/AudioToolbox.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudioTypes CoreFoundation CoreFoundationBase C
 language = Objective-C
 package = platform.AudioToolbox
 modules = AudioToolbox AudioUnit
+apiNotesSwiftName = true
 
 compilerOpts = -framework AudioToolbox
 linkerOpts = -framework AudioToolbox

--- a/kotlin-native/platformLibs/src/platform/tvos/AuthenticationServices.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/AuthenticationServices.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.AuthenticationServices
 modules = AuthenticationServices
+apiNotesSwiftName = true
 
 compilerOpts = -framework AuthenticationServices
 linkerOpts = -framework AuthenticationServices

--- a/kotlin-native/platformLibs/src/platform/tvos/BackgroundAssets.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/BackgroundAssets.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.BackgroundAssets
 
 modules = BackgroundAssets
+apiNotesSwiftName = true
 compilerOpts = -framework BackgroundAssets
 linkerOpts = -framework BackgroundAssets

--- a/kotlin-native/platformLibs/src/platform/tvos/BackgroundTasks.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/BackgroundTasks.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.BackgroundTasks
 modules = BackgroundTasks
+apiNotesSwiftName = true
 
 compilerOpts = -framework BackgroundTasks
 linkerOpts = -framework BackgroundTasks

--- a/kotlin-native/platformLibs/src/platform/tvos/CloudKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CloudKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreLocation Fou
 language = Objective-C
 package = platform.CloudKit
 modules = CloudKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CloudKit
 linkerOpts = -framework CloudKit

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreAudioTypes.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreAudioTypes.def
@@ -2,5 +2,6 @@ depends = CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.CoreAudioTypes
 modules = CoreAudioTypes
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreAudioTypes

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreBluetooth.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreBluetooth.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreBluetooth
 modules = CoreBluetooth
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreBluetooth
 linkerOpts = -framework CoreBluetooth

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreData.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreData.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CloudKit CoreFoundation CoreFoundationBase CoreLoc
 language = Objective-C
 package = platform.CoreData
 modules = CoreData
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreData
 linkerOpts = -framework CoreData

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreGraphics.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreGraphics.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.CoreGraphics
 modules = CoreGraphics
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreGraphics
 linkerOpts = -framework CoreGraphics

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreHaptics.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreHaptics.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreHaptics
 modules = CoreHaptics
+apiNotesSwiftName = true
 compilerOpts = -framework CoreHaptics
 linkerOpts = -framework CoreHaptics

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreImage.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreImage.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreImage
 modules = CoreImage
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreImage
 linkerOpts = -framework CoreImage

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreLocation.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreLocation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreLocation
 modules = CoreLocation
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreLocation
 linkerOpts = -framework CoreLocation

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreML.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreML.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.CoreML
 modules = CoreML
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreML
 linkerOpts = -framework CoreML

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreMedia.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreMedia.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundation CoreFounda
 language = Objective-C
 package = platform.CoreMedia
 modules = CoreMedia
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreMedia
 linkerOpts = -framework CoreMedia

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreSpotlight.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreSpotlight.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CoreSpotlight
 modules = CoreSpotlight
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreSpotlight
 linkerOpts = -framework CoreSpotlight

--- a/kotlin-native/platformLibs/src/platform/tvos/CoreText.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CoreText.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics darwin posix
 language = Objective-C
 package = platform.CoreText
 modules = CoreText
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreText
 linkerOpts = -framework CoreText

--- a/kotlin-native/platformLibs/src/platform/tvos/CryptoTokenKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/CryptoTokenKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.CryptoTokenKit
 modules = CryptoTokenKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CryptoTokenKit
 linkerOpts = -framework CryptoTokenKit

--- a/kotlin-native/platformLibs/src/platform/tvos/ExternalAccessory.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/ExternalAccessory.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.ExternalAccessory
 modules = ExternalAccessory
+apiNotesSwiftName = true
 
 compilerOpts = -framework ExternalAccessory
 linkerOpts = -framework ExternalAccessory

--- a/kotlin-native/platformLibs/src/platform/tvos/GLKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/GLKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.GLKit
 modules = GLKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GLKit
 linkerOpts = -framework GLKit

--- a/kotlin-native/platformLibs/src/platform/tvos/GameKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/GameKit.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork CoreA
 language = Objective-C
 package = platform.GameKit
 modules = GameKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GameKit
 linkerOpts = -framework GameKit

--- a/kotlin-native/platformLibs/src/platform/tvos/GameplayKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/GameplayKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.GameplayKit
 modules = GameplayKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GameplayKit
 linkerOpts = -framework GameplayKit

--- a/kotlin-native/platformLibs/src/platform/tvos/HomeKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/HomeKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.HomeKit
 modules = HomeKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework HomeKit
 linkerOpts = -framework HomeKit

--- a/kotlin-native/platformLibs/src/platform/tvos/Intents.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Intents.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.Intents
 modules = Intents
+apiNotesSwiftName = true
 compilerOpts = -framework Intents
 linkerOpts = -framework Intents

--- a/kotlin-native/platformLibs/src/platform/tvos/IntentsUI.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/IntentsUI.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.IntentsUI
 modules = IntentsUI
+apiNotesSwiftName = true
 compilerOpts = -framework IntentsUI
 linkerOpts = -framework IntentsUI

--- a/kotlin-native/platformLibs/src/platform/tvos/MapKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/MapKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MapKit
 modules = MapKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework MapKit
 linkerOpts = -framework MapKit

--- a/kotlin-native/platformLibs/src/platform/tvos/Matter.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Matter.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.Matter
 
 modules = Matter
+apiNotesSwiftName = true
 compilerOpts = -framework Matter
 linkerOpts = -framework Matter

--- a/kotlin-native/platformLibs/src/platform/tvos/MediaToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/MediaToolbox.def
@@ -2,6 +2,7 @@ depends = AudioToolbox CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundati
 language = Objective-C
 package = platform.MediaToolbox
 modules = MediaToolbox
+apiNotesSwiftName = true
 
 compilerOpts = -framework MediaToolbox
 linkerOpts = -framework MediaToolbox

--- a/kotlin-native/platformLibs/src/platform/tvos/Metal.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Metal.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation IOSur
 language = Objective-C
 package = platform.Metal
 modules = Metal
+apiNotesSwiftName = true
 
 compilerOpts = -framework Metal
 linkerOpts = -framework Metal

--- a/kotlin-native/platformLibs/src/platform/tvos/MetalKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/MetalKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MetalKit
 modules = MetalKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework MetalKit
 linkerOpts = -framework MetalKit

--- a/kotlin-native/platformLibs/src/platform/tvos/MetalPerformanceShaders.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/MetalPerformanceShaders.def
@@ -1,6 +1,7 @@
 depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Foundation IOSurface Metal Security darwin posix
 language = Objective-C
 package = platform.MetalPerformanceShaders
+apiNotesSwiftName = true
 modules.arm64 = MetalPerformanceShaders
 
 compilerOpts.arm64 = -framework MetalPerformanceShaders

--- a/kotlin-native/platformLibs/src/platform/tvos/ModelIO.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/ModelIO.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Fou
 language = Objective-C
 package = platform.ModelIO
 modules = ModelIO
+apiNotesSwiftName = true
 
 compilerOpts = -framework ModelIO
 linkerOpts = -framework ModelIO

--- a/kotlin-native/platformLibs/src/platform/tvos/MultipeerConnectivity.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/MultipeerConnectivity.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.MultipeerConnectivity
 modules = MultipeerConnectivity
+apiNotesSwiftName = true
 
 compilerOpts = -framework MultipeerConnectivity
 linkerOpts = -framework MultipeerConnectivity

--- a/kotlin-native/platformLibs/src/platform/tvos/Network.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Network.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.Network
 modules = Network
+apiNotesSwiftName = true
 
 compilerOpts = -framework Network
 linkerOpts = -framework Network

--- a/kotlin-native/platformLibs/src/platform/tvos/NetworkExtension.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/NetworkExtension.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.NetworkExtension
 
 modules = NetworkExtension
+apiNotesSwiftName = true
 compilerOpts = -framework NetworkExtension
 linkerOpts = -framework NetworkExtension

--- a/kotlin-native/platformLibs/src/platform/tvos/OpenGLES.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/OpenGLES.def
@@ -1,6 +1,7 @@
 depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase EAGL Foundation OpenGLESCommon Security darwin posix
 language = Objective-C
 package = platform.gles
+apiNotesSwiftName = true
 headers = OpenGLES/ES1/gl.h OpenGLES/ES1/glext.h
 
 headerFilter = OpenGLES/ES1/**

--- a/kotlin-native/platformLibs/src/platform/tvos/Photos.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Photos.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation AVRouting AudioToolbox CFCGTypes CFNetwork CoreA
 language = Objective-C
 package = platform.Photos
 modules = Photos
+apiNotesSwiftName = true
 
 compilerOpts = -framework Photos
 linkerOpts = -framework Photos

--- a/kotlin-native/platformLibs/src/platform/tvos/SceneKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/SceneKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.SceneKit
 modules = SceneKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SceneKit
 linkerOpts = -framework SceneKit

--- a/kotlin-native/platformLibs/src/platform/tvos/Security.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Security.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.Security
 modules = Security
+apiNotesSwiftName = true
 
 compilerOpts = -framework Security
 linkerOpts = -framework Security

--- a/kotlin-native/platformLibs/src/platform/tvos/ShazamKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/ShazamKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.ShazamKit
 
 modules = ShazamKit
+apiNotesSwiftName = true
 compilerOpts = -framework ShazamKit
 linkerOpts = -framework ShazamKit

--- a/kotlin-native/platformLibs/src/platform/tvos/SoundAnalysis.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/SoundAnalysis.def
@@ -2,6 +2,7 @@ depends = AVFAudio AudioToolbox CFCGTypes CFNetwork CoreAudio CoreAudioTypes Cor
 language = Objective-C
 package = platform.SoundAnalysis
 modules = SoundAnalysis
+apiNotesSwiftName = true
 
 compilerOpts = -framework SoundAnalysis
 linkerOpts = -framework SoundAnalysis

--- a/kotlin-native/platformLibs/src/platform/tvos/SpriteKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/SpriteKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.SpriteKit
 modules = SpriteKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SpriteKit
 linkerOpts = -framework SpriteKit

--- a/kotlin-native/platformLibs/src/platform/tvos/StoreKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/StoreKit.def
@@ -2,6 +2,7 @@ depends = BackgroundAssets CFCGTypes CFNetwork CoreFoundation CoreFoundationBase
 language = Objective-C
 package = platform.StoreKit
 modules = StoreKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework StoreKit
 linkerOpts = -framework StoreKit

--- a/kotlin-native/platformLibs/src/platform/tvos/TVMLKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/TVMLKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.TVMLKit
 modules = TVMLKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework TVMLKit
 linkerOpts = -framework TVMLKit

--- a/kotlin-native/platformLibs/src/platform/tvos/TVServices.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/TVServices.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Fou
 language = Objective-C
 package = platform.TVServices
 modules = TVServices
+apiNotesSwiftName = true
 
 compilerOpts = -framework TVServices
 linkerOpts = -framework TVServices

--- a/kotlin-native/platformLibs/src/platform/tvos/UIKit.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/UIKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase CoreGraphics Cor
 language = Objective-C
 package = platform.UIKit
 modules = UIKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework UIKit
 linkerOpts = -framework UIKit

--- a/kotlin-native/platformLibs/src/platform/tvos/UniformTypeIdentifiers.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/UniformTypeIdentifiers.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.UniformTypeIdentifiers
 modules = UniformTypeIdentifiers
+apiNotesSwiftName = true
 compilerOpts = -framework UniformTypeIdentifiers
 linkerOpts = -framework UniformTypeIdentifiers

--- a/kotlin-native/platformLibs/src/platform/tvos/UserNotifications.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/UserNotifications.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.UserNotifications
 modules = UserNotifications
+apiNotesSwiftName = true
 
 compilerOpts = -framework UserNotifications
 linkerOpts = -framework UserNotifications

--- a/kotlin-native/platformLibs/src/platform/tvos/VideoSubscriberAccount.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/VideoSubscriberAccount.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreFoundation CoreFoundationBase Foundation Secur
 language = Objective-C
 package = platform.VideoSubscriberAccount
 modules = VideoSubscriberAccount
+apiNotesSwiftName = true
 
 compilerOpts = -framework VideoSubscriberAccount
 linkerOpts = -framework VideoSubscriberAccount

--- a/kotlin-native/platformLibs/src/platform/tvos/VideoToolbox.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/VideoToolbox.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundation CoreFounda
 language = Objective-C
 package = platform.VideoToolbox
 modules = VideoToolbox
+apiNotesSwiftName = true
 
 compilerOpts = -framework VideoToolbox
 linkerOpts = -framework VideoToolbox

--- a/kotlin-native/platformLibs/src/platform/tvos/Vision.def
+++ b/kotlin-native/platformLibs/src/platform/tvos/Vision.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CFNetwork CoreAudio CoreAudioTypes CoreFoundation CoreFounda
 language = Objective-C
 package = platform.Vision
 modules = Vision
+apiNotesSwiftName = true
 
 compilerOpts = -framework Vision
 linkerOpts = -framework Vision

--- a/kotlin-native/platformLibs/src/platform/watchos/AVFAudio.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/AVFAudio.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.AVFAudio
 
 modules = AVFAudio
+apiNotesSwiftName = true
 compilerOpts = -framework AVFAudio
 linkerOpts = -framework AVFAudio

--- a/kotlin-native/platformLibs/src/platform/watchos/AVFoundation.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/AVFoundation.def
@@ -2,6 +2,7 @@ depends = AVFAudio CFCGTypes CoreAudio CoreAudioTypes CoreFoundation CoreFoundat
 language = Objective-C
 package = platform.AVFoundation
 modules = AVFoundation
+apiNotesSwiftName = true
 
 excludedFunctions = AVCaptureLensPositionCurrent
 

--- a/kotlin-native/platformLibs/src/platform/watchos/AVKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/AVKit.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.AVKit
 modules = AVKit
+apiNotesSwiftName = true
 compilerOpts = -framework AVKit
 linkerOpts = -framework AVKit

--- a/kotlin-native/platformLibs/src/platform/watchos/Accelerate.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/Accelerate.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreVideo dar
 language = Objective-C
 package = platform.Accelerate
 modules = Accelerate
+apiNotesSwiftName = true
 
 compilerOpts = -framework Accelerate
 linkerOpts = -framework Accelerate

--- a/kotlin-native/platformLibs/src/platform/watchos/AuthenticationServices.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/AuthenticationServices.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreText Core
 language = Objective-C
 package = platform.AuthenticationServices
 modules = AuthenticationServices
+apiNotesSwiftName = true
 
 compilerOpts = -framework AuthenticationServices
 linkerOpts = -framework AuthenticationServices

--- a/kotlin-native/platformLibs/src/platform/watchos/CallKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CallKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.CallKit
 
 modules = CallKit
+apiNotesSwiftName = true
 compilerOpts = -framework CallKit
 linkerOpts = -framework CallKit

--- a/kotlin-native/platformLibs/src/platform/watchos/CloudKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CloudKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreLocation Foundation Se
 language = Objective-C
 package = platform.CloudKit
 modules = CloudKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework CloudKit
 linkerOpts = -framework CloudKit

--- a/kotlin-native/platformLibs/src/platform/watchos/Contacts.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/Contacts.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.Contacts
 modules = Contacts
+apiNotesSwiftName = true
 
 compilerOpts = -framework Contacts
 linkerOpts = -framework Contacts

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreAudioTypes.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreAudioTypes.def
@@ -2,5 +2,6 @@ depends = CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.CoreAudioTypes
 modules = CoreAudioTypes
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreAudioTypes

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreBluetooth.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreBluetooth.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.CoreBluetooth
 modules = CoreBluetooth
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreBluetooth
 linkerOpts = -framework CoreBluetooth

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreData.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreData.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CloudKit CoreFoundation CoreFoundationBase CoreLocation Foun
 language = Objective-C
 package = platform.CoreData
 modules = CoreData
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreData
 linkerOpts = -framework CoreData

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreGraphics.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreGraphics.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.CoreGraphics
 modules = CoreGraphics
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreGraphics
 linkerOpts = -framework CoreGraphics

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreLocation.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreLocation.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security _Locat
 language = Objective-C
 package = platform.CoreLocation
 modules = CoreLocation
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreLocation
 linkerOpts = -framework CoreLocation

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreML.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreML.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreVideo Fou
 language = Objective-C
 package = platform.CoreML
 modules = CoreML
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreML
 linkerOpts = -framework CoreML

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreMedia.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreMedia.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreAudio CoreAudioTypes CoreFoundation CoreFoundationBase C
 language = Objective-C
 package = platform.CoreMedia
 modules = CoreMedia
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreMedia
 linkerOpts = -framework CoreMedia

--- a/kotlin-native/platformLibs/src/platform/watchos/CoreText.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CoreText.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics darwin posix
 language = Objective-C
 package = platform.CoreText
 modules = CoreText
+apiNotesSwiftName = true
 
 compilerOpts = -framework CoreText
 linkerOpts = -framework CoreText

--- a/kotlin-native/platformLibs/src/platform/watchos/CryptoTokenKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/CryptoTokenKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.CryptoTokenKit
 
 modules = CryptoTokenKit
+apiNotesSwiftName = true
 compilerOpts = -framework CryptoTokenKit
 linkerOpts = -framework CryptoTokenKit

--- a/kotlin-native/platformLibs/src/platform/watchos/EventKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/EventKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreLocation 
 language = Objective-C
 package = platform.EventKit
 modules = EventKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework EventKit
 linkerOpts = -framework EventKit

--- a/kotlin-native/platformLibs/src/platform/watchos/GameKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/GameKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes Contacts CoreFoundation CoreFoundationBase CoreGraphics Core
 language = Objective-C
 package = platform.GameKit
 modules = GameKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework GameKit
 linkerOpts = -framework GameKit

--- a/kotlin-native/platformLibs/src/platform/watchos/HealthKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/HealthKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security Unifor
 language = Objective-C
 package = platform.HealthKit
 modules = HealthKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework HealthKit
 linkerOpts = -framework HealthKit

--- a/kotlin-native/platformLibs/src/platform/watchos/HomeKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/HomeKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreText Core
 language = Objective-C
 package = platform.HomeKit
 modules = HomeKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework HomeKit
 linkerOpts = -framework HomeKit

--- a/kotlin-native/platformLibs/src/platform/watchos/Intents.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/Intents.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreLocation 
 language = Objective-C
 package = platform.Intents
 modules = Intents
+apiNotesSwiftName = true
 
 compilerOpts = -framework Intents
 linkerOpts = -framework Intents

--- a/kotlin-native/platformLibs/src/platform/watchos/LocalAuthentication.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/LocalAuthentication.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.LocalAuthentication
 
 modules = LocalAuthentication
+apiNotesSwiftName = true
 compilerOpts = -framework LocalAuthentication
 linkerOpts = -framework LocalAuthentication

--- a/kotlin-native/platformLibs/src/platform/watchos/MapKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/MapKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreLocation 
 language = Objective-C
 package = platform.MapKit
 modules = MapKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework MapKit
 linkerOpts = -framework MapKit

--- a/kotlin-native/platformLibs/src/platform/watchos/Matter.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/Matter.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.Matter
 
 modules = Matter
+apiNotesSwiftName = true
 compilerOpts = -framework Matter
 linkerOpts = -framework Matter

--- a/kotlin-native/platformLibs/src/platform/watchos/MediaPlayer.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/MediaPlayer.def
@@ -2,6 +2,7 @@ depends = AVFAudio AVFoundation CFCGTypes CoreAudio CoreAudioTypes CoreFoundatio
 language = Objective-C
 package = platform.MediaPlayer
 modules = MediaPlayer
+apiNotesSwiftName = true
 
 compilerOpts = -framework MediaPlayer
 linkerOpts = -framework MediaPlayer

--- a/kotlin-native/platformLibs/src/platform/watchos/Network.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/Network.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.Network
 modules = Network
+apiNotesSwiftName = true
 
 compilerOpts = -framework Network
 linkerOpts = -framework Network

--- a/kotlin-native/platformLibs/src/platform/watchos/NetworkExtension.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/NetworkExtension.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Network Securit
 language = Objective-C
 package = platform.NetworkExtension
 modules = NetworkExtension
+apiNotesSwiftName = true
 compilerOpts = -framework NetworkExtension
 linkerOpts = -framework NetworkExtension

--- a/kotlin-native/platformLibs/src/platform/watchos/PassKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/PassKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes Contacts CoreFoundation CoreFoundationBase CoreGraphics Foun
 language = Objective-C
 package = platform.PassKit
 modules = PassKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PassKit
 linkerOpts = -framework PassKit

--- a/kotlin-native/platformLibs/src/platform/watchos/PushKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/PushKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.PushKit
 modules = PushKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework PushKit
 linkerOpts = -framework PushKit

--- a/kotlin-native/platformLibs/src/platform/watchos/SceneKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/SceneKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics Foundation Se
 language = Objective-C
 package = platform.SceneKit
 modules = SceneKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SceneKit
 linkerOpts = -framework SceneKit

--- a/kotlin-native/platformLibs/src/platform/watchos/Security.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/Security.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase darwin posix
 language = Objective-C
 package = platform.Security
 modules = Security
+apiNotesSwiftName = true
 
 compilerOpts = -framework Security
 linkerOpts = -framework Security

--- a/kotlin-native/platformLibs/src/platform/watchos/ShazamKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/ShazamKit.def
@@ -3,5 +3,6 @@ language = Objective-C
 package = platform.ShazamKit
 
 modules = ShazamKit
+apiNotesSwiftName = true
 compilerOpts = -framework ShazamKit
 linkerOpts = -framework ShazamKit

--- a/kotlin-native/platformLibs/src/platform/watchos/SoundAnalysis.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/SoundAnalysis.def
@@ -2,6 +2,7 @@ depends = AVFAudio CFCGTypes CoreAudio CoreAudioTypes CoreFoundation CoreFoundat
 language = Objective-C
 package = platform.SoundAnalysis
 modules = SoundAnalysis
+apiNotesSwiftName = true
 
 compilerOpts = -framework SoundAnalysis
 linkerOpts = -framework SoundAnalysis

--- a/kotlin-native/platformLibs/src/platform/watchos/SpriteKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/SpriteKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreText Core
 language = Objective-C
 package = platform.SpriteKit
 modules = SpriteKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework SpriteKit
 linkerOpts = -framework SpriteKit

--- a/kotlin-native/platformLibs/src/platform/watchos/StoreKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/StoreKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.StoreKit
 modules = StoreKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework StoreKit
 linkerOpts = -framework StoreKit

--- a/kotlin-native/platformLibs/src/platform/watchos/UIKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/UIKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreText Core
 language = Objective-C
 package = platform.UIKit
 modules = UIKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework UIKit
 linkerOpts = -framework UIKit

--- a/kotlin-native/platformLibs/src/platform/watchos/UniformTypeIdentifiers.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/UniformTypeIdentifiers.def
@@ -2,5 +2,6 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.UniformTypeIdentifiers
 modules = UniformTypeIdentifiers
+apiNotesSwiftName = true
 compilerOpts = -framework UniformTypeIdentifiers
 linkerOpts = -framework UniformTypeIdentifiers

--- a/kotlin-native/platformLibs/src/platform/watchos/WatchConnectivity.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/WatchConnectivity.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase Foundation Security darwin
 language = Objective-C
 package = platform.WatchConnectivity
 modules = WatchConnectivity
+apiNotesSwiftName = true
 
 compilerOpts = -framework WatchConnectivity
 linkerOpts = -framework WatchConnectivity

--- a/kotlin-native/platformLibs/src/platform/watchos/WatchKit.def
+++ b/kotlin-native/platformLibs/src/platform/watchos/WatchKit.def
@@ -2,6 +2,7 @@ depends = CFCGTypes CoreFoundation CoreFoundationBase CoreGraphics CoreLocation 
 language = Objective-C
 package = platform.WatchKit
 modules = WatchKit
+apiNotesSwiftName = true
 
 compilerOpts = -framework WatchKit
 linkerOpts = -framework WatchKit

--- a/native/native.tests/testData/CInterop/swiftNameOverride/include/module.modulemap
+++ b/native/native.tests/testData/CInterop/swiftNameOverride/include/module.modulemap
@@ -1,0 +1,4 @@
+module swiftNameOverrideLib {
+    header "swiftNameOverrideLib.h"
+    export *
+}

--- a/native/native.tests/testData/CInterop/swiftNameOverride/include/swiftNameOverrideLib.h
+++ b/native/native.tests/testData/CInterop/swiftNameOverride/include/swiftNameOverrideLib.h
@@ -1,0 +1,54 @@
+// Method override / inheritance interacting with `swift_name`.
+//
+// In Objective-C/Swift the Swift name of an overriding method is owned by the declaration that
+// introduces the selector; overrides inherit it, and an explicit name on a derived-only override is
+// dropped. In cinterop a subclass redeclaration that only differs from the inherited method by its
+// `swift_name` must therefore be dropped rather than re-emitted as a duplicate member.
+
+// A1: base explicit, child implicit override.
+//     Both `a1` denote the same member; the subclass must not re-emit it.
+@interface A1Base
+- (void)a1 __attribute__((swift_name("a1_renamed()")));
+@end
+@interface A1Child : A1Base
+- (void)a1;
+@end
+
+// A2: base implicit, child explicit.
+//     The child's `swift_name` is dropped (Swift owns the name at the introducing base declaration);
+//     the redeclaration must still be deduplicated away.
+@interface A2Base
+- (void)a2;
+@end
+@interface A2Child : A2Base
+- (void)a2 __attribute__((swift_name("a2_renamed()")));
+@end
+
+// A3: both explicit, matching.
+@interface A3Base
+- (void)a3 __attribute__((swift_name("a3_renamed()")));
+@end
+@interface A3Child : A3Base
+- (void)a3 __attribute__((swift_name("a3_renamed()")));
+@end
+
+// A4: 3-level; the middle class neutralizes with an implicit override.
+@interface A4Base
+- (void)a4 __attribute__((swift_name("a4_renamed()")));
+@end
+@interface A4Middle : A4Base
+- (void)a4;
+@end
+@interface A4Grand : A4Middle
+- (void)a4;
+@end
+
+// A5: skip-level (gap) override — A5Middle does not declare a5 at all.
+@interface A5Base
+- (void)a5 __attribute__((swift_name("a5_renamed()")));
+@end
+@interface A5Middle : A5Base
+@end
+@interface A5Grand : A5Middle
+- (void)a5;
+@end

--- a/native/native.tests/testData/CInterop/swiftNameOverride/swiftNameOverrideDefs/pod1/contents.gold.txt
+++ b/native/native.tests/testData/CInterop/swiftNameOverride/swiftNameOverrideDefs/pod1/contents.gold.txt
@@ -1,0 +1,311 @@
+library {
+  // module name: <pod1.def>
+
+  library fragment {
+    // package name: pod1
+
+    // class name: pod1/A1Base
+    // class name: pod1/A1Base.Companion
+    // class name: pod1/A1BaseMeta
+    // class name: pod1/A1Child
+    // class name: pod1/A1Child.Companion
+    // class name: pod1/A1ChildMeta
+    // class name: pod1/A2Base
+    // class name: pod1/A2Base.Companion
+    // class name: pod1/A2BaseMeta
+    // class name: pod1/A2Child
+    // class name: pod1/A2Child.Companion
+    // class name: pod1/A2ChildMeta
+    // class name: pod1/A3Base
+    // class name: pod1/A3Base.Companion
+    // class name: pod1/A3BaseMeta
+    // class name: pod1/A3Child
+    // class name: pod1/A3Child.Companion
+    // class name: pod1/A3ChildMeta
+    // class name: pod1/A4Base
+    // class name: pod1/A4Base.Companion
+    // class name: pod1/A4BaseMeta
+    // class name: pod1/A4Grand
+    // class name: pod1/A4Grand.Companion
+    // class name: pod1/A4GrandMeta
+    // class name: pod1/A4Middle
+    // class name: pod1/A4Middle.Companion
+    // class name: pod1/A4MiddleMeta
+    // class name: pod1/A5Base
+    // class name: pod1/A5Base.Companion
+    // class name: pod1/A5BaseMeta
+    // class name: pod1/A5Grand
+    // class name: pod1/A5Grand.Companion
+    // class name: pod1/A5GrandMeta
+    // class name: pod1/A5Middle
+    // class name: pod1/A5Middle.Companion
+    // class name: pod1/A5MiddleMeta
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A1Base : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      @kotlinx/cinterop/ObjCMethod(selector = "a1", encoding = "v16@0:8", isStret = false)
+      public open external fun a1(): kotlin/Unit
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A1Base.Companion : pod1/A1BaseMeta, kotlinx/cinterop/ObjCClassOf<pod1/A1Base> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A1BaseMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A1Child : pod1/A1Base {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A1Child.Companion : pod1/A1ChildMeta, kotlinx/cinterop/ObjCClassOf<pod1/A1Child> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A1ChildMeta : pod1/A1BaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A2Base : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      @kotlinx/cinterop/ObjCMethod(selector = "a2", encoding = "v16@0:8", isStret = false)
+      public open external fun a2(): kotlin/Unit
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A2Base.Companion : pod1/A2BaseMeta, kotlinx/cinterop/ObjCClassOf<pod1/A2Base> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A2BaseMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A2Child : pod1/A2Base {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A2Child.Companion : pod1/A2ChildMeta, kotlinx/cinterop/ObjCClassOf<pod1/A2Child> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A2ChildMeta : pod1/A2BaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A3Base : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      @kotlinx/cinterop/ObjCMethod(selector = "a3", encoding = "v16@0:8", isStret = false)
+      public open external fun a3(): kotlin/Unit
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A3Base.Companion : pod1/A3BaseMeta, kotlinx/cinterop/ObjCClassOf<pod1/A3Base> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A3BaseMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A3Child : pod1/A3Base {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A3Child.Companion : pod1/A3ChildMeta, kotlinx/cinterop/ObjCClassOf<pod1/A3Child> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A3ChildMeta : pod1/A3BaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A4Base : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      @kotlinx/cinterop/ObjCMethod(selector = "a4", encoding = "v16@0:8", isStret = false)
+      public open external fun a4(): kotlin/Unit
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A4Base.Companion : pod1/A4BaseMeta, kotlinx/cinterop/ObjCClassOf<pod1/A4Base> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A4BaseMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A4Grand : pod1/A4Middle {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A4Grand.Companion : pod1/A4GrandMeta, kotlinx/cinterop/ObjCClassOf<pod1/A4Grand> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A4GrandMeta : pod1/A4MiddleMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A4Middle : pod1/A4Base {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A4Middle.Companion : pod1/A4MiddleMeta, kotlinx/cinterop/ObjCClassOf<pod1/A4Middle> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A4MiddleMeta : pod1/A4BaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A5Base : kotlinx/cinterop/ObjCObjectBase {
+
+      protected /* secondary */ constructor()
+
+      @kotlinx/cinterop/ObjCMethod(selector = "a5", encoding = "v16@0:8", isStret = false)
+      public open external fun a5(): kotlin/Unit
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A5Base.Companion : pod1/A5BaseMeta, kotlinx/cinterop/ObjCClassOf<pod1/A5Base> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A5BaseMeta : kotlinx/cinterop/ObjCObjectBaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A5Grand : pod1/A5Middle {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A5Grand.Companion : pod1/A5GrandMeta, kotlinx/cinterop/ObjCClassOf<pod1/A5Grand> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A5GrandMeta : pod1/A5MiddleMeta {
+
+      protected /* secondary */ constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A5Middle : pod1/A5Base {
+
+      protected /* secondary */ constructor()
+
+      // companion object: Companion
+
+      // nested class: Companion
+    }
+
+    public final companion object pod1/A5Middle.Companion : pod1/A5MiddleMeta, kotlinx/cinterop/ObjCClassOf<pod1/A5Middle> {
+
+      private constructor()
+    }
+
+    @kotlinx/cinterop/ExternalObjCClass
+    public open class pod1/A5MiddleMeta : pod1/A5BaseMeta {
+
+      protected /* secondary */ constructor()
+    }
+  }
+}

--- a/native/native.tests/testData/CInterop/swiftNameOverride/swiftNameOverrideDefs/pod1/pod1.def
+++ b/native/native.tests/testData/CInterop/swiftNameOverride/swiftNameOverrideDefs/pod1/pod1.def
@@ -1,0 +1,2 @@
+language = Objective-C
+modules = swiftNameOverrideLib

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateNativeTests.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateNativeTests.kt
@@ -84,6 +84,7 @@ fun main(args: Array<String>) {
                 model("builtins/builtinsDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("cCallMode/cCallMode", pattern = "^([^_](.+))$", recursive = false)
                 model("swiftName/swiftNameDefs", pattern = "^([^_](.+))$", recursive = false)
+                model("swiftNameOverride/swiftNameOverrideDefs", pattern = "^([^_](.+))$", recursive = false)
             }
             testClass<AbstractNativeCInteropNoFModulesTest>(
                 suiteTestClassName = "CInteropNoFModulesTestGenerated",
@@ -94,6 +95,7 @@ fun main(args: Array<String>) {
                 model("builtins/builtinsDefs", pattern = "^([^_](.+))$", recursive = false)
                 model("cCallMode/cCallMode", pattern = "^([^_](.+))$", recursive = false)
                 model("swiftName/swiftNameDefs", pattern = "^([^_](.+))$", recursive = false)
+                model("swiftNameOverride/swiftNameOverrideDefs", pattern = "^([^_](.+))$", recursive = false)
             }
             testClass<AbstractNativeCInteropHeaderModeTest>(
                 suiteTestClassName = "CInteropHeaderModeTestGenerated",


### PR DESCRIPTION
- Enable support for reading SwiftName from APINotes in most of the platform libraries on Apple OSes
- Fix duplication of an overriding method when its `swiftName` doesn't match `swiftName` of the super's method.

^ KT-81934 Fixed