### PR TITLE
[WasmWasi] Mark WasmExport declarations as Explicitly Exported to IrFileSerializer

### DIFF
--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/lower/serialization/ir/JsIrFileSerializer.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/lower/serialization/ir/JsIrFileSerializer.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ir.backend.js.lower.serialization.ir
 import org.jetbrains.kotlin.backend.common.serialization.DeclarationTable
 import org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer
 import org.jetbrains.kotlin.backend.common.serialization.IrSerializationSettings
+import org.jetbrains.kotlin.ir.backend.js.wasm.isWasmExportDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrFile
 
@@ -24,7 +25,7 @@ class JsIrFileSerializer(
     declarationTable: DeclarationTable.Default,
     private val jsIrFileMetadataFactory: JsIrFileMetadataFactory
 ) : IrFileSerializer(settings, declarationTable) {
-    override fun backendSpecificExplicitRoot(node: IrAnnotationContainer) = node.isJsExportDeclaration()
+    override fun backendSpecificExplicitRoot(node: IrAnnotationContainer) = node.isJsExportDeclaration() || node.isWasmExportDeclaration()
     override fun backendSpecificExplicitRootExclusion(node: IrAnnotationContainer) = node.isJsExportIgnoreDeclaration()
     override fun backendSpecificMetadata(irFile: IrFile) = jsIrFileMetadataFactory.createJsIrFileMetadata(irFile)
 }

--- a/compiler/testData/codegen/boxWasmWasi/wasmExportInDependency.kt
+++ b/compiler/testData/codegen/boxWasmWasi/wasmExportInDependency.kt
@@ -1,0 +1,18 @@
+// MODULE: second
+// FILE: second.kt
+
+import kotlin.wasm.WasmExport
+
+@WasmExport()
+fun exportedFunction(x: Int): Int = x + 1
+
+// MODULE: main(second)
+// FILE: main.kt
+
+fun box() = "OK"
+
+// FILE: entry.mjs
+
+import { exportedFunction } from "./index.mjs" // "index" is a value of `const val WASM_BASE_FILE_NAME`
+
+if (exportedFunction(42) !== 43) throw "Error"


### PR DESCRIPTION
Fixed [KT-88068](https://youtrack.jetbrains.com/issue/KT-88068/WasmWasi-WasmExported-declaration-not-exported-from-dependencies)

Wasm Extra tests [runned](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_WasmTestAggregate/1015246928)