### PR TITLE
Cherry-pick "Ensure that `ComposableTypeRemapper` never transforms a function more than once" to 2.4.20

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ComposeCrossModuleTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ComposeCrossModuleTests.kt
@@ -1657,6 +1657,44 @@ class ComposeCrossModuleTests : AbstractCodegenTest() {
         )
     }
 
+    /**
+     * This is a regression test against a bug that caused miscompilation of cross-module calls to
+     * getters and setters. For more details, see https://issuetracker.google.com/issues/537617330.
+     */
+    @Test
+    fun testComposableTypeRemappingOfExternalSetter() {
+        compile(
+            mapOf(
+                "Base" to mapOf(
+                    "base/Base.kt" to """
+                        import androidx.compose.runtime.Composable
+
+                        var fakePrompt: (@Composable (
+                            onSuccess: () -> Unit,
+                            onError: () -> Unit,
+                            onCancel: () -> Unit,
+                            onUsePin: () -> Unit,
+                        ) -> Unit)? = null
+                    """
+                ),
+                "Main" to mapOf(
+                    "Main.kt" to """
+                        fun main() {
+                            fakePrompt = { _, _, _, _ -> }
+                        }
+                    """
+                )
+            ),
+            validate = { bytecode ->
+                val matcher = Regex("setFakePrompt ?\\(Lkotlin\\/jvm\\/functions\\/Function\\d*;\\)V", RegexOption.MULTILINE)
+                val matches = matcher.findAll(bytecode)
+                matches.forEach {
+                    assertTrue(it.value.contains("Function6"))
+                }
+            }
+        )
+    }
+
     private fun compile(
         modules: Map<String, Map<String, String>>,
         dumpClasses: Boolean = false,

--- a/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
+++ b/plugins/compose/compiler-hosted/runtime-tests/src/commonTest/kotlin/androidx/compose/compiler/test/CompositionTests.kt
@@ -555,6 +555,19 @@ class CompositionTests {
         advance()
         assertEquals(true, result.value)
     }
+
+    /**
+     * This is a regression test against a bug that caused miscompilation of cross-module calls to
+     * getters and setters. For more details, see https://issuetracker.google.com/issues/537617330.
+     */
+    @Test
+    @OptIn(InternalComposeApi::class)
+    fun testComposableTypeRemappingOfExternalGetter() = compositionTest {
+        compose {
+            val movableContent = MovableContent<Unit> {}
+            movableContent.content
+        }
+    }
 }
 
 @Composable

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTypeRemapper.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTypeRemapper.kt
@@ -70,11 +70,7 @@ internal class ComposableTypeTransformer(
     private val externalTransformedDecls = mutableSetOf<IrDeclaration>()
 
     private fun visitFunctionIfExternal(function: IrFunction): IrFunction {
-        if (
-            function.isExternalFunction() &&
-            function.needsComposableRemapping() &&
-            externalTransformedDecls.add(function)
-        ) {
+        if (function.isExternalFunction() && function.needsComposableRemapping()) {
             return function.transform(this, null) as IrFunction
         }
         return function
@@ -242,8 +238,13 @@ internal class ComposableTypeTransformer(
     }
 
     override fun visitFunction(declaration: IrFunction): IrStatement {
-        declaration.returnType = declaration.returnType.remapType()
-        return super.visitFunction(declaration)
+        val isExternalFunctionThatNeedsRemapping = declaration.isExternalFunction() && declaration.needsComposableRemapping()
+        if (!isExternalFunctionThatNeedsRemapping || externalTransformedDecls.add(declaration)) {
+            declaration.returnType = declaration.returnType.remapType()
+            return super.visitFunction(declaration)
+        } else {
+            return declaration
+        }
     }
 
     override fun visitField(declaration: IrField): IrStatement {

--- a/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.ir.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.ir.txt
@@ -1,0 +1,74 @@
+MODULE_FRAGMENT
+  FILE fqName:<root> fileName:module_main_composableTypeRemappingOfExternalAccessors.kt
+    CLASS OBJECT name:ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt modality:FINAL visibility:internal superTypes:[]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt
+      PROPERTY name:lambda$-1010009659 visibility:internal modality:FINAL [val]
+        FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static]
+          EXPRESSION_BODY
+            CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
+              ARG key: CONST Int type=kotlin.Int value=-1010009659
+              ARG tracked: CONST Boolean type=kotlin.Boolean value=false
+              ARG block: FUN_EXPR type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:0 type:kotlin.Function0<kotlin.Unit>
+                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:1 type:kotlin.Function0<kotlin.Unit>
+                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:2 type:kotlin.Function0<kotlin.Unit>
+                  VALUE_PARAMETER UNDERSCORE_PARAMETER kind:Regular name:$unused$var$ index:3 type:kotlin.Function0<kotlin.Unit>
+                  VALUE_PARAMETER kind:Regular name:$composer index:4 type:androidx.compose.runtime.Composer? [assignable]
+                  VALUE_PARAMETER kind:Regular name:$changed index:5 type:kotlin.Int
+                  annotations:
+                    Composable
+                    FunctionKeyMeta(key = -1010009659, startOffset = 134, endOffset = 151)
+                  BLOCK_BODY
+                    CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                      ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                      ARG sourceInformation: CONST String type=kotlin.String value="C:module_main_composableTypeRemappingOfExternalAccessors.kt"
+                    WHEN type=kotlin.Unit origin=IF
+                      BRANCH
+                        if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                          ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                              ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=kotlin.Int origin=null
+                                ARG other: CONST Int type=kotlin.Int value=8193
+                              ARG arg1: CONST Int type=kotlin.Int value=8192
+                          ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                            ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=kotlin.Int origin=null
+                            ARG other: CONST Int type=kotlin.Int value=1
+                        then: BLOCK type=kotlin.Unit origin=null
+                          WHEN type=kotlin.Unit origin=IF
+                            BRANCH
+                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                              then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                                ARG key: CONST Int type=kotlin.Int value=-1010009659
+                                ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=kotlin.Int origin=null
+                                ARG dirty2: CONST Int type=kotlin.Int value=-1
+                                ARG info: CONST String type=kotlin.String value="ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous> (module_main_composableTypeRemappingOfExternalAccessors.kt:20)"
+                          GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                          WHEN type=kotlin.Unit origin=IF
+                            BRANCH
+                              if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                              then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                      BRANCH
+                        if: CONST Boolean type=kotlin.Boolean value=true
+                        then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+                          ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.lambda$-1010009659.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-lambda$-1010009659> visibility:internal modality:FINAL returnType:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+          VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt
+          correspondingProperty: PROPERTY name:lambda$-1010009659 visibility:internal modality:FINAL [val]
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='internal final fun <get-lambda$-1010009659> (): kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt'
+              GET_FIELD 'FIELD name:lambda$-1010009659 type:kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+                receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt.<get-lambda$-1010009659>' type=<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt modality:FINAL visibility:internal superTypes:[]' type=kotlin.Unit
+    FUN name:main visibility:public modality:FINAL returnType:kotlin.Unit
+      BLOCK_BODY
+        VAR name:fp type:kotlin.Function6<@[ParameterName(name = "onSuccess")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onError")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onCancel")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onUsePin")] kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? [val]
+          CALL 'public final fun <get-fakePrompt> (): kotlin.Function6<@[ParameterName(name = "onSuccess")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onError")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onCancel")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onUsePin")] kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? [companion] declared in <root>.Module_lib_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Function6<@[ParameterName(name = "onSuccess")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onError")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onCancel")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onUsePin")] kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=GET_PROPERTY
+        CALL 'public final fun <set-fakePrompt> (<set-?>: kotlin.Function6<@[ParameterName(name = "onSuccess")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onError")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onCancel")] kotlin.Function0<kotlin.Unit>, @[ParameterName(name = "onUsePin")] kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>?): kotlin.Unit [companion] declared in <root>.Module_lib_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Unit origin=EQ
+          ARG <set-?>: CALL 'internal final fun <get-lambda$-1010009659> (): kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt' type=kotlin.Function6<kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, kotlin.Function0<kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+            ARG <this>: GET_OBJECT 'CLASS OBJECT name:ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt modality:FINAL visibility:internal superTypes:[]' type=<root>.ComposableSingletons$Module_main_composableTypeRemappingOfExternalAccessorsKt

--- a/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.kt
+++ b/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.kt
@@ -1,0 +1,22 @@
+// DUMP_IR
+
+// This is a regression test against a bug that caused miscompilation of cross-module calls to
+// getters and setters. For more details, see https://issuetracker.google.com/issues/537617330.
+
+// MODULE: lib
+import androidx.compose.runtime.Composable
+
+var fakePrompt: (@Composable (
+    onSuccess: () -> Unit,
+    onError: () -> Unit,
+    onCancel: () -> Unit,
+    onUsePin: () -> Unit,
+) -> Unit)? = null
+
+// MODULE: main(lib)
+import androidx.compose.runtime.Composable
+
+fun main() {
+    val fp = fakePrompt
+    fakePrompt = { _, _, _, _ -> }
+}

--- a/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/composableTypeRemappingOfExternalAccessors.txt
@@ -1,0 +1,5 @@
+public final class Module_main_composableTypeRemappingOfExternalAccessorsKt {
+    // source: 'module_main_composableTypeRemappingOfExternalAccessors.kt'
+    public final static method main(): void
+    public synthetic static method main(p0: java.lang.String[]): void
+}

--- a/plugins/compose/compiler-hosted/tests-gen/androidx/compose/compiler/plugins/kotlin/CompilerFacilityTestForComposeCompilerPluginGenerated.java
+++ b/plugins/compose/compiler-hosted/tests-gen/androidx/compose/compiler/plugins/kotlin/CompilerFacilityTestForComposeCompilerPluginGenerated.java
@@ -46,6 +46,12 @@ public class CompilerFacilityTestForComposeCompilerPluginGenerated extends Abstr
   }
 
   @Test
+  @TestMetadata("composableTypeRemappingOfExternalAccessors.kt")
+  public void testComposableTypeRemappingOfExternalAccessors() {
+    run("composableTypeRemappingOfExternalAccessors.kt");
+  }
+
+  @Test
   @TestMetadata("composeNavigationWithDataClass.kt")
   public void testComposeNavigationWithDataClass() {
     run("composeNavigationWithDataClass.kt");


### PR DESCRIPTION
This PR moves the `if (externalTransformedDecls.add(declaration))` check in `visitFunctionIfExternal` to `visitFunction`, because there is no code path on which a function declaration can be mutated by `ComposableTypeTransformer` before `visitFunction` is reached.

Relnote: "Fixed a bug that caused miscompilation of cross-module calls to getters and setters, causing spurious runtime errors."

Test: `ComposeCrossModuleTests.testComposableTypeRemappingOfExternalSetter`, `CompositionTests.testComposableTypeRemappingOfExternalGetter`, and `testComposableTypeRemappingOfExternalAccessors`
Bug: 537617330