### PR TITLE
Make the applier inferencer support repeated `ComposableTarget` annotations

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/analysis/ComposableTargetCheckerTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/analysis/ComposableTargetCheckerTests.kt
@@ -18,7 +18,13 @@ package androidx.compose.compiler.plugins.kotlin.analysis
 
 import androidx.compose.compiler.plugins.kotlin.AbstractComposeDiagnosticsTest
 import androidx.compose.compiler.plugins.kotlin.Classpath
+import androidx.compose.compiler.plugins.kotlin.facade.SourceFile
+import com.intellij.openapi.util.io.FileUtil
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.backend.common.output.OutputFile
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 class ComposableTargetCheckerTests : AbstractComposeDiagnosticsTest() {
     @Test
@@ -564,4 +570,225 @@ class ComposableTargetCheckerTests : AbstractComposeDiagnosticsTest() {
         }
         """
     )
+
+    @Test
+    fun testDeserializeRepeatedComposableTarget() {
+        checkCrossModule(
+            dependencySource = """
+            import androidx.compose.runtime.*
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "A W Composable")
+            @Target(AnnotationTarget.FUNCTION)
+            annotation class WComposable
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "An X Composable")
+            @Target(AnnotationTarget.FUNCTION)
+            annotation class XComposable
+
+            @Composable @WComposable @XComposable fun WX() { }
+
+            @Composable
+            fun CallWX() {
+                WX()
+            }
+        """,
+            expectedText = """
+                import androidx.compose.runtime.*
+
+                @Composable
+                @ComposableTarget("z")
+                fun WXInZ() {
+                    <!COMPOSE_APPLIER_CALL_MISMATCH!>CallWX<!>()
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testDeserializePositionalComposableInferredTargetConstraints() {
+        checkCrossModule(
+            dependencySource = """
+            import androidx.compose.runtime.*
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "A W Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class WComposable
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "An X Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class XComposable
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "A Y Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class YComposable
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "A Z Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class ZComposable
+
+            @Composable @WComposable @XComposable fun WX() { }
+
+            @Composable
+            fun CallWX(content: @Composable @YComposable @ZComposable () -> Unit):
+                    @Composable @WComposable @XComposable (
+                        content: @Composable @YComposable @ZComposable () -> Unit,
+                    ) -> Unit 
+            {
+                WX()
+                return {}
+            }
+        """,
+            expectedText = """
+                import androidx.compose.runtime.*
+
+                @Composable
+                @ZComposable
+                fun WXInZ() {
+                    <!COMPOSE_APPLIER_CALL_MISMATCH!>CallWX<!> {}
+                }
+
+                @Composable
+                fun WXInYZ() {
+                    CallWX { <!COMPOSE_APPLIER_CALL_MISMATCH!>WX<!>() }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testDeserializeIndexedComposableInferredTargetConstraints() {
+        checkCrossModule(
+            dependencySource = """
+            import androidx.compose.runtime.*
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "A W Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class WComposable
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "An X Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class XComposable
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "A Y Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class YComposable
+
+            @Retention(AnnotationRetention.BINARY)
+            @ComposableTargetMarker(description = "A Z Composable")
+            @Target(
+                AnnotationTarget.FUNCTION,
+                AnnotationTarget.TYPE,
+            )
+            annotation class ZComposable
+
+            @Composable @YComposable fun Y() { }
+
+            @Composable
+            fun CallContent(content: @Composable @WComposable @XComposable () -> Unit):
+                    @Composable @ComposableOpenTarget(1) @YComposable @ZComposable (
+                        content: @Composable @ComposableOpenTarget(1) @YComposable @ZComposable () -> Unit,
+                    ) -> Unit 
+            {
+                content()
+                return {}
+            }
+        """,
+            expectedText = """
+                import androidx.compose.runtime.*
+                
+                @Composable
+                @ZComposable
+                fun WXInZ() {
+                    <!COMPOSE_APPLIER_CALL_MISMATCH!>CallContent<!> {}
+                }
+
+                @Composable
+                fun YInWX() {
+                    CallContent { <!COMPOSE_APPLIER_CALL_MISMATCH!>Y<!>() }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testFileScopeTargetConstraints() = check(
+        """
+        @file:ComposableTarget("Y")
+        @file:ComposableTarget("Z")
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.ComposableTarget
+
+        @Composable @ComposableTarget("X") fun X() {}
+
+        @Composable
+        fun AssumesYZ() {
+            <!COMPOSE_APPLIER_CALL_MISMATCH!>X<!>()
+        }
+        """
+    )
+
+    /**
+     * Confirms that when the source code in [expectedText] is analyzed, the diagnostics specified
+     * in [expectedText] are found as expected.
+     *
+     * @param dependencySource Source compiled as a different module than [expectedText], that
+     * [expectedText] may depend on. This source will not be analyzed.
+     */
+    private fun checkCrossModule(
+        @Language("kotlin")
+        dependencySource: String,
+        @Language("kotlin")
+        expectedText: String,
+        ignoreParseErrors: Boolean = false,
+    ) {
+        createClassLoader(
+            platformSourceFiles = listOf(SourceFile("extra.kt", dependencySource)),
+        ).allGeneratedFiles.writeToDir(classesDirectory)
+
+        check(
+            expectedText = expectedText,
+            ignoreParseErrors = ignoreParseErrors,
+            additionalPaths = listOf(classesDirectory)
+        )
+    }
+
+    @field:TempDir
+    lateinit var classesDirectory: File
 }
+
+private fun OutputFile.writeToDir(directory: File) =
+    FileUtil.writeToFile(File(directory, relativePath), asByteArray())
+
+private fun Collection<OutputFile>.writeToDir(directory: File) = forEach { it.writeToDir(directory) }
+

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeFqNames.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeFqNames.kt
@@ -44,6 +44,7 @@ object ComposeClassIds {
 
     val Composable = classIdFor("Composable")
     val ComposableInferredTarget = classIdFor("ComposableInferredTarget")
+    val ComposableInferredTargetConstraints = classIdFor("ComposableInferredTargetConstraints")
     val ComposableLambda = internalClassIdFor("ComposableLambda")
     val ComposableOpenTarget = classIdFor("ComposableOpenTarget")
     val ComposableTarget = classIdFor("ComposableTarget")
@@ -115,6 +116,8 @@ object ComposeFqNames {
     val ComposableOpenTargetIndexArgument = Name.identifier("index")
     val ComposableInferredTarget = ComposeClassIds.ComposableInferredTarget.asSingleFqName()
     val ComposableInferredTargetSchemeArgument = Name.identifier("scheme")
+    val ComposableInferredTargetConstraintsPositionalArgument = Name.identifier("positional")
+    val ComposableInferredTargetConstraintsIndexedArgument = Name.identifier("indexed")
     val CurrentComposerIntrinsic = fqNameFor("<get-currentComposer>")
     val getCurrentComposerFullName = composablesFqNameFor("<get-currentComposer>")
     val DisallowComposableCalls = ComposeClassIds.DisallowComposableCalls.asSingleFqName()

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
@@ -182,6 +182,7 @@ class ComposeIrGenerationExtension(
             moduleFragment,
             metrics,
             stabilityInferencer,
+            targetRuntimeVersion,
             featureFlags,
         ).lower(moduleFragment)
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/RuntimeFeatures.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/RuntimeFeatures.kt
@@ -8,6 +8,7 @@ package androidx.compose.compiler.plugins.kotlin
 enum class ComposeRuntimeVersion(val value: String) {
     v1_8("1.8"),
     v1_9("1.9"),
+    v1_13("1.13"),
     ;
 
     fun supportsFeature(feature: ComposeRuntimeFeature): Boolean {
@@ -26,6 +27,7 @@ enum class ComposeRuntimeVersion(val value: String) {
 
 enum class ComposeRuntimeFeature(val targetVersion: ComposeRuntimeVersion) {
     SourceInfoParameterNames(ComposeRuntimeVersion.v1_9),
+    ComposableInferredTargetConstraints(ComposeRuntimeVersion.v1_13),
     ;
 }
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/ApplierInferencer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/ApplierInferencer.kt
@@ -127,14 +127,16 @@ private inline fun <Node> LazySchemeStorage<Node>.getOrPut(
  */
 interface ErrorReporter<Node> {
     /**
-     * Report a call node applier is not correct.
+     * Report that a call node is not compatible with the appliers expected by the body containing
+     * the call.
      */
-    fun reportCallError(node: Node, expected: String, received: String)
+    fun reportCallError(node: Node, expected: Set<String>, received: Set<String>)
 
     /**
-     * Report that the value or lambda passed to a parameter to a call was not correct.
+     * Report that a value or lambda passed as a call argument is not compatible with the appliers
+     * expected by the corresponding parameter.
      */
-    fun reportParameterError(node: Node, index: Int, expected: String, received: String)
+    fun reportParameterError(node: Node, index: Int, expected: Set<String>, received: Set<String>)
 
     /**
      * Log internal errors detected that indicate problems in the inference algorithm or when the
@@ -221,9 +223,6 @@ class ApplierInferencer<Type, Node>(
             anyParameters = anyParameters
         )
 
-    // Produce a token that can be used in error messages.
-    private val Binding.safeToken: String get() = token ?: "unbound"
-
     /**
      * Perform structural unification of two call bindings. All bindings that are in the same
      * structural place must unify or there is an error in the source. That is the targets are
@@ -235,9 +234,10 @@ class ApplierInferencer<Type, Node>(
     private fun Bindings.unify(call: Node?, a: CallBindings, b: CallBindings): Boolean {
         if (!unify(a.target, b.target)) {
             if (call != null) {
-                val aName = a.target.safeToken
-                val bName = b.target.safeToken
-                errorReporter.reportCallError(call, aName, bName)
+                // It's not possible for unification to fail when either `a` or `b` are allowed to
+                // be bound to every target, so within this if-branch, `effectiveAllowedTokens` must
+                // be non-null for both.
+                errorReporter.reportCallError(call, a.target.effectiveAllowedTokens!!, b.target.effectiveAllowedTokens!!)
             }
             return false
         }
@@ -253,16 +253,15 @@ class ApplierInferencer<Type, Node>(
             val bp = b.parameters[i]
             if (!unify(null, ap, bp)) {
                 if (call != null) {
-                    val aToken = ap.target.token
-                    val bToken = bp.target.token
-                    if (aToken != null && bToken != null) {
-                        errorReporter.reportParameterError(
-                            call,
-                            i,
-                            bp.target.token!!,
-                            ap.target.token!!
-                        )
-                    } else unify(call, ap, bp)
+                    // It's not possible for unification to fail when either `a` or `b` are allowed
+                    // to be bound to every target, so within this if-branch,
+                    // `effectiveAllowedTokens` must be non-null for both.
+                    errorReporter.reportParameterError(
+                        call,
+                        i,
+                        bp.target.effectiveAllowedTokens!!,
+                        ap.target.effectiveAllowedTokens!!
+                    )
                 }
             }
         }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Bindings.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Bindings.kt
@@ -17,11 +17,13 @@
 package androidx.compose.compiler.plugins.kotlin.inference
 
 /**
- * The value of a binding. If [token] is not null, the binding is bound to [token]. [size] is the
- * number of [Binding] instances that share this value. This is used to optimize unifying open
- * bindings. [index] is not used directly but makes debugging easier.
+ * The value of a binding. If [token] is not null, the binding is bound to [token]. If [token] is
+ * null, the binding is open. If [allowedTokens] is not null, then the binding may only be bound to
+ * an element of [allowedTokens]. [size] is the number of [Binding] instances that share this value.
+ * This is used to optimize unifying open bindings. [index] is not used directly but makes debugging
+ * easier.
  */
-class Value(var token: String?, var observers: Set<Bindings>) {
+class Value(var token: String?, var observers: Set<Bindings>, var allowedTokens: Set<String>? = null) {
     var size: Int = 1
     val index = valueIndex++
 }
@@ -29,23 +31,39 @@ class Value(var token: String?, var observers: Set<Bindings>) {
 private var valueIndex = 0
 
 /**
- * A binding that is either closed (with a non-null [token]) or open. Unified bindings are linked
- * together in a circular list by [Bindings]. All linked bindings are all closed simultaneously
- * when anyone of them is unified to a closed binding.
+ * A binding that is either closed (with a non-null [token]) or open. If [allowedTokens] is not
+ * null, then the binding may only be bound to an element of [allowedTokens]. Unified bindings are
+ * linked together in a circular list by [Bindings]. All linked bindings are all closed
+ * simultaneously when anyone of them is unified to a closed binding.
  *
  * @param token the applier token the binding is bound to if it is closed.
+ * @param allowedTokens the set of tokens that this binding may be bound to, or null if this binding
+ *        may be bound to any token
  */
-class Binding(token: String? = null, observers: Set<Bindings>) {
+class Binding(token: String? = null, observers: Set<Bindings>, allowedTokens: Set<String>? = null) {
     /**
      * The token that is bound to this binding. If [token] is null then the binding is still open.
      */
     val token: String? get() = value.token
+    val allowedTokens: Set<String>? get() = value.allowedTokens
+
+    /**
+     * The set of tokens that this binding is effectively allowed to be bound to, or null if it may
+     * be to be bound to any token.
+     *
+     * A binding that has a non-null `token` field always has a null `allowedTokens` field, but we
+     * consider it to effectively have one allowed token, the one in its `token` field.
+     */
+    val effectiveAllowedTokens: Set<String>?
+        get() = token?.let {
+            setOf(it)
+        } ?: allowedTokens
 
     /**
      * The value of the binding. All linked bindings share the same value which also maintains
      * the count of linked bindings.
      */
-    var value: Value = Value(token, observers)
+    var value: Value = Value(token, observers, allowedTokens)
 
     /**
      * The linked list next pointer. The list is circular an always non-empty as a binding will
@@ -55,7 +73,12 @@ class Binding(token: String? = null, observers: Set<Bindings>) {
     var next = this
 
     override fun toString(): String {
-        return value.token?.let { "Binding(token = $it)" } ?: "Binding(${value.index})"
+        val sb = StringBuilder()
+        sb.append("Binding(")
+        value.token?.let { sb.append("token = $it") } ?: sb.append(value.index)
+        value.allowedTokens?.let { sb.append(", allowedTokens = ${it.joinToString(separator = ", ", prefix = "{", postfix = "}")}") }
+        sb.append(")")
+        return sb.toString()
     }
 }
 
@@ -71,9 +94,13 @@ class Bindings {
     private val listeners = mutableListOf<() -> Unit>()
 
     /**
-     * Create a fresh open applier binding variable
+     * Create a fresh open applier binding variable. If [allowedTokens] is not null, then the
+     * binding variable may only be bound to an element of [allowedTokens].
      */
-    fun open() = Binding(observers = setOf(this))
+    fun open(allowedTokens: Set<String>? = null): Binding {
+        assert(allowedTokens == null || allowedTokens.size > 1)
+        return Binding(token = null, observers = setOf(this), allowedTokens)
+    }
 
     /**
      * Create a closed applier binding variable
@@ -129,16 +156,37 @@ class Bindings {
         val aValue = a.value
         val bValue = b.value
         if (aValue == bValue) return true
+
         val aValueSize = aValue.size
         val bValueSize = bValue.size
         val newObservers = aValue.observers + bValue.observers
+
+        val aEffectiveAllowedTokens = a.effectiveAllowedTokens
+        val bEffectiveAllowedTokens = b.effectiveAllowedTokens
+
+        val newAllowedTokens = when {
+            aEffectiveAllowedTokens != null && bEffectiveAllowedTokens != null ->
+                (aEffectiveAllowedTokens intersect bEffectiveAllowedTokens).also {
+                    if (it.isEmpty()) return false
+                }
+            aEffectiveAllowedTokens != null -> aEffectiveAllowedTokens
+            else -> bEffectiveAllowedTokens
+        }
+
+        if (newAllowedTokens != null && newAllowedTokens.size == 1) {
+            val token = newAllowedTokens.single()
+            return bind(a, token) && bind(b, token)
+        }
+
         if (aValueSize > bValueSize) {
             aValue.size += bValueSize
             aValue.observers = newObservers
+            aValue.allowedTokens = newAllowedTokens
             unifyValues(b, aValue)
         } else {
             bValue.size += aValueSize
             bValue.observers = newObservers
+            bValue.allowedTokens = newAllowedTokens
             unifyValues(a, bValue)
         }
 
@@ -160,6 +208,16 @@ class Bindings {
     // Bind the binding to a token. It binds all bindings in the same list to the token.
     private fun bind(binding: Binding, token: String): Boolean {
         val value = binding.value
+
+        val allowedTokens = value.allowedTokens
+        if (allowedTokens != null) {
+            if (token in allowedTokens) {
+                value.allowedTokens = null
+            } else {
+                return false
+            }
+        }
+
         value.token = token
         bindingValueChanged(value)
         value.observers = emptySet()

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/LazyScheme.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/LazyScheme.kt
@@ -57,7 +57,7 @@ class LazyScheme(
         }
 
         fun itemOf(binding: Binding) = binding.token?.let { Token(it) }
-            ?: context[binding.value]?.let { Open(it) } ?: Open(-1)
+            ?: context[binding.value]?.let { Open(it, binding.allowedTokens) } ?: Open(-1, binding.allowedTokens)
 
         fun schemeOf(lazyScheme: LazyScheme): Scheme = Scheme(
             itemOf(lazyScheme.target),

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Scheme.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Scheme.kt
@@ -23,7 +23,20 @@ sealed class Item {
     internal abstract val isAnonymous: Boolean
     internal open val isUnspecified: Boolean get() = false
     internal abstract fun toBinding(bindings: Bindings, context: MutableList<Binding>): Binding
-    internal abstract fun serializeTo(writer: SchemeStringSerializationWriter)
+
+    /**
+     * @param schemeWriter A writer that will be used to write a string in the format expected by
+     *   the `scheme` parameter of `ComposableInferredTarget`.
+     * @param positionalWriter A writer that will be used to write a string in the format expected
+     *   by the `positional` parameter of `ComposableInferredTargetConstraints`.
+     * @param indexed An out-parameter that will become a string in the format expected by the
+     *   `indexed` parameter of `ComposableInferredTargetConstraints` when serialized to JSON.
+     */
+    internal abstract fun serializeTo(
+        schemeWriter: SchemeStringSerializationWriter,
+        positionalWriter: SchemeStringSerializationWriter,
+        indexed: MutableList<Set<String>?>,
+    )
 }
 
 /**
@@ -37,35 +50,89 @@ class Token(val value: String) : Item() {
     override fun toString() = value
     override fun equals(other: Any?) = other is Token && other.value == value
     override fun hashCode(): Int = value.hashCode() * 31
-    override fun serializeTo(writer: SchemeStringSerializationWriter) {
-        writer.writeToken(value)
+    override fun serializeTo(
+        schemeWriter: SchemeStringSerializationWriter,
+        positionalWriter: SchemeStringSerializationWriter,
+        indexed: MutableList<Set<String>?>,
+    ) {
+        schemeWriter.writeToken(value)
+        positionalWriter.writeUnderscore()
     }
 }
 
 /**
- * An open part of a [Scheme]. All [Open] items with the same non-negative index should be bound
+ * An open part of a [Scheme]. If [allowedTokens] is non-null, then this part may only be bound to
+ * an element of [allowedTokens]. All [Open] items with the same non-negative index should be bound
  * together to the  same applier. [Open] items with a negative index are considered anonymous and
  * are treated as independent.
  */
-class Open(val index: Int, override val isUnspecified: Boolean = false) : Item() {
+class Open(val index: Int, val allowedTokens: Set<String>? = null, override val isUnspecified: Boolean = false) : Item() {
     override val isAnonymous: Boolean get() = index < 0
     override fun toBinding(bindings: Bindings, context: MutableList<Binding>): Binding {
-        if (index < 0) return bindings.open()
+        if (index < 0) return bindings.open(allowedTokens)
         while (index >= context.size) {
             context.add(bindings.open())
         }
-        return context[index]
+        val result = context[index]
+        if (allowedTokens != null) {
+            bindings.unify(result, bindings.open(allowedTokens))
+        }
+        return result
     }
 
-    override fun toString() = if (index < 0) "_" else "$index"
+    override fun toString(): String {
+        val sb = StringBuilder()
+        sb.append("Open(")
+        sb.append(if (index < 0) '_' else index)
+        allowedTokens?.let { sb.append(", allowedTokens = ${it.joinToString(separator = ", ", prefix = "{", postfix = "}")}") }
+        sb.append(")")
+        return sb.toString()
+    }
+
     override fun equals(other: Any?) =
-        other is Open && (other.index == index || (other.index < 0 && index < 0))
+        other is Open && (other.index == index || (other.index < 0 && index < 0)) && other.allowedTokens == allowedTokens
 
     override fun hashCode(): Int = if (index < 0) -31 else index * 31
-    override fun serializeTo(writer: SchemeStringSerializationWriter) {
-        writer.writeNumber(index)
+
+    override fun serializeTo(
+        schemeWriter: SchemeStringSerializationWriter,
+        positionalWriter: SchemeStringSerializationWriter,
+        indexed: MutableList<Set<String>?>,
+    ) {
+        schemeWriter.writeNumber(index)
+
+        if (index < 0) {
+            if (allowedTokens?.isNotEmpty() == true) {
+                positionalWriter.writeTokenSet(allowedTokens)
+            } else {
+                positionalWriter.writeUnderscore()
+            }
+        } else {
+            positionalWriter.writeUnderscore()
+            while (indexed.size <= index) {
+                indexed.add(null)
+            }
+            if (allowedTokens != null) {
+                indexed[index] = allowedTokens
+            }
+        }
     }
 }
+
+/**
+ * An object whose fields are jointly the serialization of a [Scheme].
+ *
+ * @param scheme a string that encodes all details about a scheme, except what `allowedTokens`
+ *   constraints are on items. This string is in the format expected by the `scheme` parameter of
+ *   `ComposableInferredTarget`.
+ * @param positional a string that encodes what `allowedTokens` constraints are on each
+ *   negative-indexed [Open] item in a scheme. This string is in the format expected by the
+ *   `positional` parameter of `ComposableInferredTargetConstraints`.
+ * @param indexed a string that encodes what `allowedTokens` constraints are on each
+ *   non-negative-indexed [Open] item in a scheme. This string is in the format expected by the
+ *   `indexed` parameter of `ComposableInferredTargetConstraints`.
+ */
+data class SerializedScheme(val scheme: String, val positional: String, val indexed: String)
 
 /**
  * A [Scheme] declares the applier the type expects and which appliers are expected of the
@@ -92,10 +159,39 @@ class Scheme(
     }
 
     /**
-     * Produce a string serialization of the scheme. This is not necessarily readable, use
-     * [toString] for debugging instead.
+     * Returns a [SerializedScheme] whose fields are jointly the serialization of this scheme.
+     *
+     * [toString] should be used for debugging instead of this method because its output is easier
+     * for a human to read.
      */
-    fun serialize(): String = buildString { serializeTo(SchemeStringSerializationWriter(this)) }
+    fun serialize(): SerializedScheme {
+        val schemeWriter = SchemeStringSerializationWriter(StringBuilder())
+        val positionalWriter = SchemeStringSerializationWriter(StringBuilder())
+        val indexed = mutableListOf<Set<String>?>()
+
+        serializeTo(schemeWriter, positionalWriter, indexed)
+        var indexedWriter: SchemeStringSerializationWriter? = null
+        if (indexed.filterNotNull().isNotEmpty()) {
+            indexedWriter = SchemeStringSerializationWriter(StringBuilder())
+            indexedWriter.writeOpen()
+            indexed.forEachIndexed { i, allowedTokens ->
+                if (allowedTokens?.isNotEmpty() == true) {
+                    indexedWriter.writeTokenSet(allowedTokens)
+                } else {
+                    indexedWriter.writeUnderscore()
+                }
+                if (i < indexed.size - 1) {
+                    indexedWriter.writeComma()
+                }
+            }
+            indexedWriter.writeClose()
+        }
+        return SerializedScheme(
+            scheme = schemeWriter.toString(),
+            positional = if (positionalWriter.hasWrittenToken) positionalWriter.toString() else "",
+            indexed = indexedWriter?.toString() ?: ""
+        )
+    }
 
     override fun toString(): String = "[$target$parametersStr$resultStr]"
 
@@ -143,20 +239,38 @@ class Scheme(
     private fun List<Scheme>.hashOfElements() = if (isEmpty()) 0 else
         map { it.simpleHashCode() }.reduceRight { h, acc -> h + acc * 31 }
 
-    private fun serializeTo(writer: SchemeStringSerializationWriter) {
-        writer.writeOpen()
-        target.serializeTo(writer)
+    /**
+     * @param schemeWriter A writer that will be used to write a string in the format expected by
+     *   the `scheme` parameter of `ComposableInferredTarget`.
+     * @param positionalWriter A writer that will be used to write a string in the format expected
+     *   by the `positional` parameter of `ComposableInferredTargetConstraints`.
+     * @param indexed An out-parameter that will become a string in the format expected by the
+     *   `indexed` parameter of `ComposableInferredTargetConstraints` when serialized to JSON.
+     */
+    private fun serializeTo(
+        schemeWriter: SchemeStringSerializationWriter,
+        positionalWriter: SchemeStringSerializationWriter,
+        indexed: MutableList<Set<String>?>,
+    ) {
+        schemeWriter.writeOpen()
+        positionalWriter.writeOpen()
+
+        target.serializeTo(schemeWriter, positionalWriter, indexed)
+
         if (anyParameters) {
-            writer.writeAnyParameters()
+            schemeWriter.writeAnyParameters()
         } else {
-            parameters.forEach { it.serializeTo(writer) }
+            parameters.forEach { it.serializeTo(schemeWriter, positionalWriter, indexed) }
         }
         if (result != null) {
-            writer.writeResultPrefix()
-            result.serializeTo(writer)
+            schemeWriter.writeResultPrefix()
+            positionalWriter.writeResultPrefix()
+            result.serializeTo(schemeWriter, positionalWriter, indexed)
         }
-        writer.writeClose()
+        schemeWriter.writeClose()
+        positionalWriter.writeClose()
     }
+
 
     /**
      * Both hashCode and equals are in terms of alpha rename equivalents. That means that the scheme
@@ -219,15 +333,58 @@ private fun schemeParseError(): Nothing {
 }
 
 /**
- * Given a string produce a [Scheme] if the string is a valid serialization of a [Scheme] or null
- * otherwise.
+ * Given the fields of a [SerializedScheme], produce a [Scheme] if the fields are jointly a valid
+ * serialization of a [Scheme], or null otherwise.
  */
-fun deserializeScheme(value: String): Scheme? {
-    val reader = SchemeStringSerializationReader(value)
+fun deserializeScheme(scheme: String, positional: String? = null, indexed: String? = null): Scheme? {
+    val reader = SchemeStringSerializationReader(scheme)
+    val positionalReader = if (positional?.isNotEmpty() == true) {
+        SchemeStringSerializationReader(positional)
+    } else {
+        null
+    }
+    val indexedList = run {
+        if (indexed?.isNotEmpty() != true) {
+            return@run null
+        }
+        val result = mutableListOf<Set<String>?>()
+        val indexedStringReader = SchemeStringSerializationReader(indexed)
+        try {
+            indexedStringReader.expect(ItemKind.Open)
+            while (true) {
+                val allowedTokens = indexedStringReader.tokenSet()
+                result.add(allowedTokens)
+                if (indexedStringReader.kind == ItemKind.Comma) {
+                    indexedStringReader.expect(ItemKind.Comma)
+                } else {
+                    indexedStringReader.expect(ItemKind.Close)
+                    break
+                }
+            }
+            return@run result
+        } catch (_: SchemeParseError) {
+            return@deserializeScheme null
+        }
+    }
 
-    fun item(): Item = when (reader.kind) {
+    fun allowedTokensFromPositional(): Set<String>? {
+        if (positionalReader == null) {
+            return null
+        }
+
+        return positionalReader.tokenSet()
+    }
+
+    fun item(allowedTokensFromPositional: Set<String>?): Item = when (reader.kind) {
         ItemKind.Token -> Token(reader.token())
-        ItemKind.Number -> Open(reader.number())
+        ItemKind.Number -> {
+            val index = reader.number()
+            if (indexedList != null && index in indexedList.indices) {
+                Open(index, indexedList[index])
+            } else {
+                Open(index, allowedTokensFromPositional)
+            }
+        }
         else -> schemeParseError()
     }
 
@@ -246,8 +403,10 @@ fun deserializeScheme(value: String): Scheme? {
         content: () -> T,
     ) = run {
         reader.expect(prefix)
+        positionalReader?.expect(prefix)
         content().also {
             reader.expect(postfix)
+            positionalReader?.expect(postfix)
         }
     }
 
@@ -268,7 +427,7 @@ fun deserializeScheme(value: String): Scheme? {
 
     fun scheme(): Scheme =
         delimited(ItemKind.Open, ItemKind.Close) {
-            val target = item()
+            val target = item(allowedTokensFromPositional())
             val anyParameters = isItem(ItemKind.AnyParameters)
             val parameters = if (anyParameters) emptyList() else list { scheme() }
             val result = optional(ItemKind.ResultPrefix) { scheme() }
@@ -283,6 +442,12 @@ fun deserializeScheme(value: String): Scheme? {
 }
 
 internal class SchemeStringSerializationWriter(private val builder: StringBuilder) {
+    /**
+     * Returns true if since the instantiation of this object, its [writeToken] or [writeTokenSet]
+     * method has been called.
+     */
+    var hasWrittenToken = false
+        private set
 
     fun writeToken(token: String) {
         if (isNormal(token)) {
@@ -292,6 +457,7 @@ internal class SchemeStringSerializationWriter(private val builder: StringBuilde
             builder.append(token.replace("\\", "\\\\").replace("\"", "\\\""))
             builder.append('"')
         }
+        hasWrittenToken = true
     }
 
     fun writeNumber(number: Int) {
@@ -318,6 +484,27 @@ internal class SchemeStringSerializationWriter(private val builder: StringBuilde
         builder.append('*')
     }
 
+    fun writeBraceOpen() {
+        builder.append('{')
+    }
+
+    fun writeBraceClose() {
+        builder.append('}')
+    }
+
+    fun writeComma() {
+        builder.append(",")
+    }
+
+    fun writeUnderscore() {
+        builder.append('_')
+    }
+
+    fun writeTokenSet(tokenSet: Set<String>) {
+        builder.append(tokenSet.joinToString(separator = ",", prefix = "{", postfix = "}"))
+        hasWrittenToken = true
+    }
+
     override fun toString(): String = builder.toString()
 
     private fun isNormal(value: String) = value.all { it == '.' || it.isLetter() }
@@ -330,6 +517,9 @@ private enum class ItemKind {
     AnyParameters,
     Token,
     Number,
+    BraceOpen,
+    BraceClose,
+    Comma,
     End,
     Invalid
 }
@@ -348,6 +538,9 @@ private class SchemeStringSerializationReader(private val value: String) {
                 ':' -> ItemKind.ResultPrefix
                 '*' -> ItemKind.AnyParameters
                 '"' -> ItemKind.Token
+                '{' -> ItemKind.BraceOpen
+                '}' -> ItemKind.BraceClose
+                ',' -> ItemKind.Comma
                 else -> {
                     when {
                         ch.isLetter() -> ItemKind.Token
@@ -420,9 +613,40 @@ private class SchemeStringSerializationReader(private val value: String) {
                 ItemKind.AnyParameters -> expect('*')
                 ItemKind.Token -> token()
                 ItemKind.Number -> number()
+                ItemKind.BraceOpen -> expect('{')
+                ItemKind.BraceClose -> expect('}')
+                ItemKind.Comma -> expect(',')
                 ItemKind.End -> end()
                 else -> schemeParseError()
             }
+        }
+    }
+
+    fun tokenSet(): Set<String>? {
+        if (kind == ItemKind.Number) {
+            if (number() == -1) {
+                // An empty token set is serialized as '_', which is interpreted by the reader as
+                // -1.
+                return null
+            } else {
+                schemeParseError()
+            }
+        } else {
+            expect(ItemKind.BraceOpen)
+            val tokens = mutableSetOf<String>()
+            while (true) {
+                if (kind != ItemKind.Token) {
+                    schemeParseError()
+                }
+                tokens.add(token())
+                if (kind == ItemKind.Comma) {
+                    expect(ItemKind.Comma)
+                } else {
+                    expect(ItemKind.BraceClose)
+                    break
+                }
+            }
+            return tokens
         }
     }
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/k2/ComposableTargetChecker.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/k2/ComposableTargetChecker.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 import java.util.concurrent.ConcurrentHashMap
@@ -174,7 +175,13 @@ fun FirCallableSymbol<*>.parameters(): List<FirValueParameterSymbol> =
 context(session: FirSession)
 private fun FirCallableSymbol<*>.fileScopeTarget(): Item? {
     fun findFileScope(element: FirElement): Item? =
-        (element as? FirFile)?.compositionTarget()?.let { Token(it) } ?: element.parent?.let { findFileScope(it) }
+        (element as? FirFile)?.targetsFromAnnotations()?.let { targets ->
+            when {
+                targets.size == 1 -> Token(targets.first())
+                targets.size > 1 -> Open(-1, allowedTokens = targets)
+                else -> null
+            }
+        } ?: element.parent?.let { findFileScope(it) }
     return findFileScope(fir)
 }
 
@@ -184,15 +191,24 @@ fun FirCallableSymbol<*>.declaredScheme() =
         ComposeClassIds.ComposableInferredTarget,
         ComposeFqNames.ComposableInferredTargetSchemeArgument
     ) as? String)?.let {
-        deserializeScheme(it)
+        val positional = annotationArgument(
+            ComposeClassIds.ComposableInferredTargetConstraints,
+            ComposeFqNames.ComposableInferredTargetConstraintsPositionalArgument
+        ) as String?
+        val indexed = annotationArgument(
+            ComposeClassIds.ComposableInferredTargetConstraints,
+            ComposeFqNames.ComposableInferredTargetConstraintsIndexedArgument
+        ) as String?
+        deserializeScheme(it, positional, indexed)
     }
 
 context(session: FirSession)
 fun FirCallableSymbol<*>.schemeItem(): Item {
-    val explicitTarget = compositionTarget()
+    val targets = targetsFromAnnotations()
     val explicitOpen = compositionOpenTarget()
     return when {
-        explicitTarget != null -> Token(explicitTarget)
+        targets.size == 1 -> Token(targets.first())
+        targets.size > 1 -> Open(explicitOpen ?: -1, allowedTokens = targets)
         explicitOpen != null -> Open(explicitOpen)
         else -> Open(-1, isUnspecified = true)
     }
@@ -200,18 +216,26 @@ fun FirCallableSymbol<*>.schemeItem(): Item {
 
 @OptIn(SymbolInternals::class)
 context(session: FirSession)
-fun FirCallableSymbol<*>.compositionTarget(): String? {
-    val annotationArg = annotationArgument(ComposeClassIds.ComposableTarget, ComposeFqNames.ComposableTargetApplierArgument) as? String
-    if (annotationArg != null) return annotationArg
+fun FirCallableSymbol<*>.targetsFromAnnotations(): Set<String> {
+    val targets = mutableSetOf<String>()
 
     if (this is FirValueParameterSymbol) {
-        val paramTarget = resolvedReturnType.typeAnnotations.firstNotNullOfOrNull { it.resolvedType.targetName() }
-        if (paramTarget != null) return paramTarget
+        resolvedReturnTypeRef.coneType.typeAnnotations.forEach { annotation ->
+            annotation.targetName()?.let { targets.add(it) }
+        }
+    } else {
+        annotations.forEach { annotation ->
+            annotation.targetName()?.let { targets.add(it) }
+        }
     }
 
-    return annotations.firstNotNullOfOrNull { it.resolvedType.targetName() }
+    return targets
 }
 
+/**
+ * If the class corresponding to this type is annotated with `ComposableTargetMarker`, returns the
+ * fully qualified name of the class. Otherwise, returns null.
+ */
 context(session: FirSession)
 fun ConeKotlinType.targetName(): String? = toClassSymbol(session)?.let { cls ->
     cls.annotationArgument(ComposeClassIds.ComposableTargetMarker, ComposeFqNames.ComposableTargetMarkerDescriptionName)?.let {
@@ -229,21 +253,27 @@ fun FirBasedSymbol<*>.annotationArgument(classId: ClassId, argumentName: Name) =
 
 @OptIn(SymbolInternals::class)
 context(session: FirSession)
-fun FirAnnotationContainer.compositionTarget(): String? =
-    annotationArgument(ComposeClassIds.ComposableTarget, ComposeFqNames.ComposableTargetApplierArgument) as? String ?: run {
-        annotations.firstNotNullOfOrNull {
-            it.resolvedType.targetName()
-        }
-    }
-
-context(session: FirSession)
-fun FirAnnotationContainer.annotationArgument(classId: ClassId, argumentName: Name) =
-    getAnnotationByClassId(classId, session)?.argument(argumentName)
+fun FirAnnotationContainer.targetsFromAnnotations(): Set<String> = annotations.mapNotNull { annotation ->
+    annotation.targetName()
+}.toSet()
 
 fun FirAnnotation.argument(name: Name): Any? = argumentMapping.mapping[name]?.let {
     if ((it.resolvedType.isString || it.resolvedType.isPrimitive) && it is FirLiteralExpression)
         it.value
     else null
+}
+
+/**
+ * If this is a `ComposableTarget` annotation, or the class of this annotation is annotated with
+ * `ComposableTargetMarker`, returns the corresponding target name. Otherwise, returns null.
+ */
+context(session: FirSession)
+fun FirAnnotation.targetName(): String? {
+    return if (toAnnotationClassId(session) == ComposeClassIds.ComposableTarget) {
+        argument(ComposeFqNames.ComposableTargetApplierArgument) as? String
+    } else {
+        resolvedType.targetName()
+    }
 }
 
 object ComposableTargetChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
@@ -306,17 +336,33 @@ internal class FirApplierInferencer(
             override fun referencedContainerOf(node: FirInferenceNode): FirInferenceNode? = node.referenceContainer
         },
         errorReporter = object : ErrorReporter<FirInferenceNode> {
-            private fun descriptionFrom(token: String): String =
+            private fun descriptionFrom(effectiveAllowedTokens: Set<String>): String =
                 with(session) {
-                    val symbol = symbolProvider.getClassLikeSymbolByClassId(ClassId.fromString(token.replace('.', '/')))
-                    val description = symbol?.annotationArgument(
-                        ComposeClassIds.ComposableTargetMarker,
-                        ComposeFqNames.ComposableTargetMarkerDescriptionName
-                    ) as? String
-                    description ?: token
+                    val descriptionsOrFqNamesOfTokens = effectiveAllowedTokens.map {
+                        val symbol = symbolProvider.getClassLikeSymbolByClassId(ClassId.fromString(it.replace('.', '/')))
+                        val description = symbol?.annotationArgument(
+                            ComposeClassIds.ComposableTargetMarker,
+                            ComposeFqNames.ComposableTargetMarkerDescriptionName
+                        ) as? String
+                        description ?: it
+                    }
+                    if (descriptionsOrFqNamesOfTokens.size == 1) {
+                        descriptionsOrFqNamesOfTokens.first()
+                    } else {
+                        val sb = StringBuilder()
+                        descriptionsOrFqNamesOfTokens.forEachIndexed { index, value ->
+                            sb.append(value)
+                            if (index < descriptionsOrFqNamesOfTokens.size - 2) {
+                                sb.append(", ")
+                            } else if (index == descriptionsOrFqNamesOfTokens.size - 2) {
+                                sb.append(" or ")
+                            }
+                        }
+                        sb.toString()
+                    }
                 }
 
-            override fun reportCallError(node: FirInferenceNode, expected: String, received: String) {
+            override fun reportCallError(node: FirInferenceNode, expected: Set<String>, received: Set<String>) {
                 if (expected != received) {
                     val expectedDescription = descriptionFrom(expected)
                     val receivedDescription = descriptionFrom(received)
@@ -331,14 +377,18 @@ internal class FirApplierInferencer(
                 }
             }
 
-            override fun reportParameterError(node: FirInferenceNode, index: Int, expected: String, received: String) {
-                with(context) {
-                    reporter.reportOn(
-                        source = node.element.source,
-                        factory = ComposeErrors.COMPOSE_APPLIER_PARAMETER_MISMATCH,
-                        a = expected,
-                        b = received
-                    )
+            override fun reportParameterError(node: FirInferenceNode, index: Int, expected: Set<String>, received: Set<String>) {
+                if (expected != received) {
+                    val expectedDescription = descriptionFrom(expected)
+                    val receivedDescription = descriptionFrom(received)
+                    with(context) {
+                        reporter.reportOn(
+                            source = node.element.source,
+                            factory = ComposeErrors.COMPOSE_APPLIER_PARAMETER_MISMATCH,
+                            a = expectedDescription,
+                            b = receivedDescription,
+                        )
+                    }
                 }
             }
 

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -53,11 +53,21 @@ class ComposableTargetAnnotationsTransformer(
     irModule: IrModuleFragment,
     metrics: ModuleMetrics,
     stabilityInferencer: StabilityInferencer,
+    targetRuntimeVersion: ComposeRuntimeVersion?,
     featureFlags: FeatureFlags,
 ) : AbstractComposeLowering(context, irModule, metrics, stabilityInferencer, featureFlags) {
     private val ComposableTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableTarget)
     private val ComposableOpenTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableOpenTarget)
     private val ComposableInferredTargetClass = getTopLevelClassOrNull(ComposeClassIds.ComposableInferredTarget)
+    private val ComposableInferredTargetConstraintsClass =
+        if (targetRuntimeVersion.supportsFeature(ComposeRuntimeFeature.ComposableInferredTargetConstraints) {
+                // If [targetRuntimeVersion] is null, use the result of `getTopLevelClassOrNull`.
+                true
+            }) {
+            getTopLevelClassOrNull(ComposeClassIds.ComposableInferredTargetConstraints)
+        } else {
+            null
+        }
 
     /**
      * A map of element to the owning function of the element.
@@ -135,15 +145,15 @@ class ComposableTargetAnnotationsTransformer(
             }
         },
         errorReporter = object : ErrorReporter<InferenceNode> {
-            override fun reportCallError(node: InferenceNode, expected: String, received: String) {
+            override fun reportCallError(node: InferenceNode, expected: Set<String>, received: Set<String>) {
                 // Ignored, should be reported by the front-end
             }
 
             override fun reportParameterError(
                 node: InferenceNode,
                 index: Int,
-                expected: String,
-                received: String,
+                expected: Set<String>,
+                received: Set<String>,
             ) {
                 // Ignored, should be reported by the front-end
             }
@@ -332,23 +342,37 @@ class ComposableTargetAnnotationsTransformer(
         }
 
     val List<IrAnnotation>.target: Item
-        get() =
-            firstOrNull { it.isComposableTarget }?.let { constructor ->
-                constructor.getConstArgument<String>("applier")?.let { Token(it) }
-            } ?: firstOrNull { it.isComposableOpenTarget }?.let { constructor ->
-                constructor.getConstArgument<Int>("index")?.let { Open(it) }
-            } ?: firstOrNull { it.isComposableTargetMarked }?.let { constructor ->
-                val fqName = constructor.classSymbol.owner.fqNameWhenAvailable
-                fqName?.let {
-                    Token(it.asString())
-                }
-            } ?: Open(-1, isUnspecified = true)
+        get() {
+            val targetsFromAnnotations =
+                mapNotNull {
+                    if (it.isComposableTarget) {
+                        it.getConstArgument<String>("applier")
+                    } else if (it.isComposableTargetMarked) {
+                        val fqName = it.classSymbol.owner.fqNameWhenAvailable
+                        fqName?.asString()
+                    } else {
+                        null
+                    }
+                }.toSet()
+
+            val explicitOpen = firstOrNull { it.isComposableOpenTarget }?.getConstArgument<Int>("index")
+
+            return when {
+                targetsFromAnnotations.size == 1 -> Token(targetsFromAnnotations.first())
+                targetsFromAnnotations.size > 1 -> Open(explicitOpen ?: -1, allowedTokens = targetsFromAnnotations)
+                explicitOpen != null -> Open(explicitOpen)
+                else -> Open(-1, isUnspecified = true)
+            }
+        }
 
     val IrFunction.scheme: Scheme?
         get() =
             annotations.firstOrNull { it.isComposableInferredTarget }?.let { constructor ->
                 constructor.getConstArgument<String>("scheme")?.let {
-                    deserializeScheme(it)
+                    val constraints = annotations.firstOrNull { it.isComposableInferredTargetConstraints }
+                    val positional = constraints?.getConstArgument<String>("positional")
+                    val indexed = constraints?.getConstArgument<String>("indexed")
+                    deserializeScheme(it, positional, indexed)
                 }
             }
 
@@ -427,29 +451,53 @@ class ComposableTargetAnnotationsTransformer(
         symbol.owner.body?.findTransformedLambda()
             ?: error("Could not find the singleton lambda for ${dump()}")
 
-    private fun Item.toAnnotation(): IrAnnotation? =
-        if (ComposableTargetClass != null && ComposableOpenTargetClass != null) {
-            when (this) {
-                is Token -> annotation(ComposableTargetClass).also {
+    private fun Item.toAnnotations(): List<IrAnnotation> {
+        if (ComposableTargetClass == null || ComposableOpenTargetClass == null) return emptyList()
+        return when (this) {
+            is Token -> listOf(
+                annotation(ComposableTargetClass).also {
                     it.arguments[0] = irConst(value)
                 }
-                is Open ->
-                    if (index < 0) null else annotation(
-                        ComposableOpenTargetClass
-                    ).also {
-                        it.arguments[0] = irConst(index)
-                    }
-            }
-        } else null
+            )
+            is Open -> {
+                val annotations = mutableListOf<IrAnnotation>()
 
-    private fun Item.toAnnotations(): List<IrAnnotation> =
-        toAnnotation()?.let { listOf(it) } ?: emptyList()
+                if (index >= 0) {
+                    annotations.add(
+                        annotation(ComposableOpenTargetClass).also {
+                            it.arguments[0] = irConst(index)
+                        }
+                    )
+                }
+                allowedTokens?.forEach { token ->
+                    annotations.add(
+                        annotation(ComposableTargetClass).also {
+                            it.arguments[0] = irConst(token)
+                        }
+                    )
+                }
+
+                annotations
+            }
+        }
+    }
 
     private fun Scheme.toAnnotations(): List<IrAnnotation> =
         if (ComposableInferredTargetClass != null) {
-            listOf(
+            val serialized = serialize()
+            listOfNotNull(
                 annotation(ComposableInferredTargetClass).also {
-                    it.arguments[0] = irConst(serialize())
+                    it.arguments[0] = irConst(serialized.scheme)
+                },
+                if ((serialized.positional.isNotEmpty() || serialized.indexed.isNotEmpty()) &&
+                    ComposableInferredTargetConstraintsClass != null
+                ) {
+                    annotation(ComposableInferredTargetConstraintsClass).also {
+                        it.arguments[0] = irConst(serialized.positional)
+                        it.arguments[1] = irConst(serialized.indexed)
+                    }
+                } else {
+                    null
                 }
             )
         } else emptyList()
@@ -469,7 +517,10 @@ class ComposableTargetAnnotationsTransformer(
         annotations.filterNot(::isComposableTargetAnnotation)
 
     private fun isComposableTargetAnnotation(it: IrAnnotation): Boolean =
-        it.isComposableTarget || it.isComposableOpenTarget || it.isComposableInferredTarget
+        it.isComposableTarget ||
+                it.isComposableOpenTarget ||
+                it.isComposableInferredTarget ||
+                it.isComposableInferredTargetConstraints
 
     fun addAnnotationToType(type: IrSimpleTypeBuilder, target: Item) {
         type.annotations = filteredAnnotations(type.annotations) + target.toAnnotations()
@@ -1007,6 +1058,9 @@ private val IrAnnotation.isComposableTargetMarked: Boolean
 
 private val IrAnnotation.isComposableInferredTarget
     get() = classId == ComposeClassIds.ComposableInferredTarget
+
+private val IrAnnotation.isComposableInferredTargetConstraints
+    get() = classId == ComposeClassIds.ComposableInferredTargetConstraints
 
 private val IrAnnotation.isComposableOpenTarget
     get() = classId == ComposeClassIds.ComposableOpenTarget

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/FakeAst.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/FakeAst.kt
@@ -476,13 +476,26 @@ private fun <T> List<T>.sameContentAs(other: List<T>) =
 private fun <K, V> Map<K, V>.toPairs() =
     entries.map { entry -> entry.key to entry.value }
 
-private fun List<Annotation>.item(): Item? =
-    firstOrNull { it.name == "ComposableTarget" }?.let { Token(it.value) }
-        ?: firstOrNull { it.name == "ComposableOpenTarget" }?.let { Open(it.value.toInt()) }
+private fun List<Annotation>.item(): Item? {
+    val targetsFromAnnotations = filter { it.name == "ComposableTarget" }.map { it.value }.toSet()
+    val explicitOpen = firstOrNull { it.name == "ComposableOpenTarget" }?.value?.toInt()
+    return when {
+        targetsFromAnnotations.size == 1 -> Token(targetsFromAnnotations.first())
+        targetsFromAnnotations.size > 1 -> Open(
+            explicitOpen ?: -1, allowedTokens = targetsFromAnnotations
+        )
+        explicitOpen != null -> Open(explicitOpen)
+        else -> null
+    }
+}
 
 val composable = listOf(Annotation("Composable"))
 val uiTarget = listOf(Annotation("ComposableTarget", "UI"))
 val vectorTarget = listOf(Annotation("ComposableTarget", "Vector"))
+val wTarget = listOf(Annotation("ComposableTarget", "w"))
+val xTarget = listOf(Annotation("ComposableTarget", "x"))
+val yTarget = listOf(Annotation("ComposableTarget", "y"))
+val zTarget = listOf(Annotation("ComposableTarget", "z"))
 fun composableLambda() = FunctionType("lambda", annotations = composable)
 fun call(name: String, vararg args: Node) = Call(Ref(name), arguments = args.toList())
 fun lambda(vararg body: Node) = Lambda(type = composableLambda(), body = body.toList())

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/FakeData.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/FakeData.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.compiler.plugins.kotlin.inference
 
+import kotlin.random.Random
+
 val data = mapOf(
     "identity" to fresh { t ->
         Function(
@@ -425,6 +427,64 @@ val data = mapOf(
         )
     ),
 
+    "WX" to Function(
+        "WX",
+        annotations = composable + wTarget + xTarget,
+    ),
+
+    "CallWX/0" to Function(
+        "CallWX/0",
+        annotations = composable,
+        body = listOf(
+            call(
+                "WX",
+            )
+        )
+    ),
+
+    "CallWX/1" to Function(
+        "CallWX/1",
+        annotations = composable,
+        parameters = listOf(
+            Parameter(
+                "content",
+                FunctionType(
+                    "lambda",
+                    annotations = yTarget + zTarget,
+                )
+            )
+        ),
+        body = listOf(
+            call(
+                "WX",
+            )
+        )
+    ),
+
+    "CallContent" to Function(
+        "CallContent",
+        annotations = composable,
+        parameters = listOf(
+            Parameter(
+                "content",
+                FunctionType(
+                    "lambda",
+                    annotations = wTarget + xTarget,
+                )
+            )
+        ),
+        body = listOf(
+            call(
+                "content",
+            )
+        ),
+        result =
+            FunctionType(
+                "lambda",
+                annotations = yTarget + zTarget,
+            )
+    ),
+
     "e1" to Function(
         "e1",
         annotations = composable,
@@ -451,7 +511,20 @@ val data = mapOf(
                 )
             )
         )
-    )
+    ),
+
+    "e3" to Function(
+        "e3",
+        annotations = composable,
+        body = listOf(
+            call(
+                "CallWX/1",
+                lambda(
+                    call("CallWX/0")
+                )
+            ),
+        )
+    ),
 )
 
 fun walkData(visitor: Visitor) {
@@ -460,7 +533,12 @@ fun walkData(visitor: Visitor) {
     }
 }
 
-fun randomlyWalkData(visitor: Visitor) {
+/**
+ * Randomly walks the fake data.
+ *
+ * @param seed The integer that will be used to seed the source of randomness
+ */
+fun randomlyWalkData(visitor: Visitor, seed: Int) {
     val nodes = mutableListOf<Node>()
     for (function in data.values) {
         walk(
@@ -500,7 +578,7 @@ fun randomlyWalkData(visitor: Visitor) {
             }
         )
     }
-    nodes.shuffle()
+    nodes.shuffle(Random(seed))
     nodes.forEach { walk(it, visitor) }
 }
 

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestBindings.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestBindings.kt
@@ -75,6 +75,82 @@ class TestBindings {
     }
 
     @Test
+    fun canCreateOpenBindingWithAllowedTokens() {
+        val bindings = Bindings()
+        val open = bindings.open(setOf("W", "X"))
+        assertNull(open.token)
+        assertEquals(setOf("W", "X"), open.allowedTokens)
+    }
+
+    @Test
+    fun unifyConstrainedAndUnconstrainedOpenBindings() {
+        val bindings = Bindings()
+        val open1 = bindings.open(setOf("W", "X"))
+        val open2 = bindings.open()
+        
+        assertTrue(bindings.unify(open1, open2))
+        assertNull(open1.token)
+        assertEquals(setOf("W", "X"), open1.allowedTokens)
+        assertNull(open2.token)
+        assertEquals(setOf("W", "X"), open2.allowedTokens)
+    }
+
+    @Test
+    fun unifyTwoOpenBindingsWithDisjointAllowedTokensFails() {
+        val bindings = Bindings()
+        val open1 = bindings.open(setOf("W", "X"))
+        val open2 = bindings.open(setOf("Y", "Z"))
+        
+        assertFalse(bindings.unify(open1, open2))
+        assertNull(open1.token)
+        assertEquals(setOf("W", "X"), open1.allowedTokens)
+        assertNull(open2.token)
+        assertEquals(setOf("Y", "Z"), open2.allowedTokens)
+    }
+
+    @Test
+    fun unifyTwoOpenBindingsWithIntersectingAllowedTokens() {
+        val bindings = Bindings()
+        val open1 = bindings.open(setOf("W", "X", "Y"))
+        val open2 = bindings.open(setOf("X", "Y", "Z"))
+        
+        assertTrue(bindings.unify(open1, open2))
+        assertNull(open1.token)
+        assertEquals(setOf("X", "Y"), open1.allowedTokens)
+        assertNull(open2.token)
+        assertEquals(setOf("X", "Y"), open2.allowedTokens)
+    }
+
+    @Test
+    fun unifyTwoOpenBindingsWithIntersectionOfOneTokenClosesThem() {
+        val bindings = Bindings()
+        val open1 = bindings.open(setOf("W", "X"))
+        val open2 = bindings.open(setOf("X", "Y", "Z"))
+        
+        assertTrue(bindings.unify(open1, open2))
+        assertEquals("X", open1.token)
+        assertNull(open1.allowedTokens)
+        assertEquals("X", open2.token)
+        assertNull(open2.allowedTokens)
+    }
+
+    @Test
+    fun unifyConstrainedOpenBindingAndClosedBinding() {
+        val bindings = Bindings()
+        val open = bindings.open(setOf("W", "X"))
+        val closed1 = bindings.closed("W")
+        val closed2 = bindings.closed("Y")
+        
+        assertFalse(bindings.unify(open, closed2))
+        assertNull(open.token)
+        assertEquals(setOf("W", "X"), open.allowedTokens)
+        
+        assertTrue(bindings.unify(open, closed1))
+        assertEquals("W", open.token)
+        assertNull(open.allowedTokens)
+    }
+
+    @Test
     fun canBindLargeGroupsOfBindingsTogether() {
         val bindings = Bindings()
         val opens1 = Array(100) { bindings.open() }

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestInferApplier.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestInferApplier.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.compiler.plugins.kotlin.inference
 
+import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -77,7 +78,7 @@ class TestInferApplier {
     private fun errorReporter(): Pair<ErrorReporter<Node>, List<Call>> {
         val errors = mutableListOf<Call>()
         return object : ErrorReporter<Node> {
-            override fun reportCallError(node: Node, expected: String, received: String) {
+            override fun reportCallError(node: Node, expected: Set<String>, received: Set<String>) {
                 val call = node as? Call ?: (node as? ResolvedExpression)?.node as? Call ?: return
                 errors.add(call)
             }
@@ -85,8 +86,8 @@ class TestInferApplier {
             override fun reportParameterError(
                 node: Node,
                 index: Int,
-                expected: String,
-                received: String
+                expected: Set<String>,
+                received: Set<String>,
             ) {
                 val call = node as? Call ?: (node as? ResolvedExpression)?.node as? Call ?: return
                 errors.add(call)
@@ -139,15 +140,15 @@ class TestInferApplier {
         expect("Text", "[UI]")
         expect("Circle", "[Vector]")
         expect("Square", "[Vector]")
-        expect("Provider", "[0, [0]]")
+        expect("Provider", "[Open(0), [Open(0)]]")
         expect("Row", "[UI, [UI]]")
         expect("Button", "[UI, [UI]]")
         expect("Layer", "[Vector, [Vector]]")
         expect("Drawing", "[UI, [Vector]]")
-        expect("SimpleOpen", "[_]")
-        expect("OpenRecursive", "[_]")
+        expect("SimpleOpen", "[Open(_)]")
+        expect("OpenRecursive", "[Open(_)]")
         expect("ClosedRecursive", "[UI]")
-        expect("OpenIndirectRecursive", "[_]")
+        expect("OpenIndirectRecursive", "[Open(_)]")
         expect("p1", "[UI]")
         expect("p2", "[Vector]")
         expect("p3", "[UI]")
@@ -157,10 +158,14 @@ class TestInferApplier {
         expect("p7", "[UI]")
         expect("p8", "[UI]")
         expect("p9", "[UI, [UI, [UI]]]")
-        expect("useVar", "[0, [0]]")
-        expect("useIdentity", "[0, [0]]")
+        expect("useVar", "[Open(0), [Open(0)]]")
+        expect("useIdentity", "[Open(0), [Open(0)]]")
         expect("useRun", "[UI, [UI]]")
         expect("useVarAndIdentity", "[UI, [UI], [Vector]]")
+        expect("WX", "[Open(_, allowedTokens = {w, x})]")
+        expect("CallWX/0", "[Open(_, allowedTokens = {w, x})]")
+        expect("CallWX/1", "[Open(_, allowedTokens = {w, x}), [Open(_, allowedTokens = {y, z})]]")
+        expect("CallContent", "[Open(0, allowedTokens = {w, x}), [Open(0, allowedTokens = {w, x})]: [Open(_, allowedTokens = {y, z})]]")
 
         assertEquals(expectations.joinToString("\n"), results.joinToString("\n"))
     }
@@ -227,7 +232,11 @@ class TestInferApplier {
             findNode("e2", "Provider", "Circle") in errors,
             "Expected Circle in e2 to be in error"
         )
-        assertEquals(2, errors.size, "Unexpected errors reported")
+        assertTrue(
+            findNode("e3", "CallWX/1", "CallWX/0") in errors,
+            "Expected CallWX/0 in e3 to be in error"
+        )
+        assertEquals(3, errors.size, "Unexpected errors reported")
     }
 
     @Test
@@ -242,10 +251,16 @@ class TestInferApplier {
         )
         val visitor = dataVisitor(inferApplier)
 
-        randomlyWalkData(visitor)
+        val seed = Random.nextInt()
+        randomlyWalkData(visitor, seed)
 
-        expectCorrectInference {
-            inferApplier.toFinalScheme(it)
+        try {
+            expectCorrectInference {
+                inferApplier.toFinalScheme(it)
+            }
+        } catch (e: AssertionError) {
+            println("Test failed when using seed $seed")
+            throw e
         }
 
         // Randomly walking the tree produces random errors as well for trees that can be interpreted multiple ways

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestLazyScheme.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestLazyScheme.kt
@@ -55,7 +55,7 @@ class TestLazyScheme {
     }
 
     @Test
-    fun canUpdateResult() {
+    fun canUpdateResultThroughUnificationWithClosedBindings() {
         val lazyScheme = LazyScheme(schemeOf("[0, [1], [2]:[0, [2], [1]]"))
         val bindings = lazyScheme.bindings
         val a = bindings.closed("a")
@@ -65,6 +65,30 @@ class TestLazyScheme {
         bindings.unify(lazyScheme.parameters[0].target, b)
         bindings.unify(lazyScheme.parameters[1].target, c)
         assertEquals(schemeOf("[a, [b], [c]:[a, [c], [b]]]"), lazyScheme.toScheme())
+    }
+
+    @Test
+    fun canUpdateResultThroughUnificationWithConstrainedOpenBindings() {
+        val lazyScheme = LazyScheme(schemeOf("[0, [1], [2]:[0, [2], [1]]"))
+        val bindings = lazyScheme.bindings
+        val a = bindings.open(allowedTokens = setOf("U", "V"))
+        val b = bindings.open(allowedTokens = setOf("W", "X"))
+        val c = bindings.open(allowedTokens = setOf("Y", "Z"))
+        bindings.unify(lazyScheme.target, a)
+        bindings.unify(lazyScheme.parameters[0].target, b)
+        bindings.unify(lazyScheme.parameters[1].target, c)
+        assertEquals(
+            "[" +
+                    "Open(0, allowedTokens = {U, V}), " +
+                    "[Open(2, allowedTokens = {W, X})], [Open(1, allowedTokens = {Y, Z})]" +
+                    ": " +
+                    "[" +
+                    "Open(0, allowedTokens = {U, V}), " +
+                    "[Open(1, allowedTokens = {Y, Z})], [Open(2, allowedTokens = {W, X})]" +
+                    "]" +
+                    "]",
+            lazyScheme.toScheme().toString()
+        )
     }
 
     @Test

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestScheme.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestScheme.kt
@@ -30,19 +30,41 @@ class TestScheme {
     @Test
     fun canCreateASchemeWithOpenAppliers() {
         val scheme = Scheme(Open(0), listOf(Scheme(Open(0))))
-        assertEquals("[0, [0]]", scheme.toString())
+        assertEquals("[Open(0), [Open(0)]]", scheme.toString())
+    }
+
+    @Test
+    fun canCreateASchemeWithConstrainedOpenItems() {
+        val scheme =
+            Scheme(
+                Open(0, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(0, allowedTokens = setOf("W", "X")))),
+                result =
+                    Scheme(Open(-1, allowedTokens = setOf("Y", "Z")), listOf(Scheme(Open(-1, allowedTokens = setOf("Y", "Z"))))),
+            )
+
+        assertEquals(
+            "[" +
+                    "Open(0, allowedTokens = {W, X}), " +
+                    "[Open(0, allowedTokens = {W, X})]: " +
+                    "[" +
+                    "Open(_, allowedTokens = {Y, Z}), " +
+                    "[Open(_, allowedTokens = {Y, Z})]" +
+                    "]" +
+                    "]",
+            scheme.toString()
+        )
     }
 
     @Test
     fun canCreateASchemeWithAnonymousOpens() {
         val scheme = Scheme(Open(-1), listOf(Scheme(Open(-1))))
-        assertEquals("[_, [_]]", scheme.toString())
+        assertEquals("[Open(_), [Open(_)]]", scheme.toString())
     }
 
     @Test
     fun canCreateASchemeWithAResultScheme() {
         val scheme = Scheme(Open(0), result = Scheme(Open(0)))
-        assertEquals("[0: [0]]", scheme.toString())
+        assertEquals("[Open(0): [Open(0)]]", scheme.toString())
     }
 
     @Test
@@ -132,21 +154,23 @@ class TestScheme {
             Scheme(uiToken, listOf(ui, ui, ui, ui, ui, ui)),
             Scheme(a, listOf(aScheme, aScheme, aScheme)),
             Scheme(one, listOf(oneScheme, aScheme, oneScheme, aScheme)),
-            Scheme(Open(Int.MAX_VALUE), listOf(Scheme(Open(Int.MAX_VALUE)))),
             Scheme(Open(Int.MIN_VALUE), listOf(Scheme(Open(Int.MIN_VALUE)))),
+            Scheme(Open(-1, allowedTokens = setOf("W", "X"))),
             Scheme(
-                target = z,
-                result = oneScheme
+                Open(-1, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(-1, allowedTokens = setOf("Y", "Z")))),
+                result =
+                    Scheme(Open(-1, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(-1, allowedTokens = setOf("Y", "Z"))))),
             ),
             Scheme(
-                target = z,
-                anyParameters = true
-            )
+                Open(0, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(0, allowedTokens = setOf("W", "X")))),
+                result =
+                    Scheme(Open(1, allowedTokens = setOf("Y", "Z")), listOf(Scheme(Open(1, allowedTokens = setOf("Y", "Z"))))),
+            ),
         )
 
         for (scheme in schemes) {
             val serialized = scheme.serialize()
-            val processedScheme = deserializeScheme(serialized)
+            val processedScheme = deserializeScheme(serialized.scheme, serialized.positional, serialized.indexed)
             assertEquals(scheme, processedScheme)
         }
     }
@@ -154,19 +178,27 @@ class TestScheme {
     @Test
     fun invalidDeserializationCanBeCaught() {
         val invalids = listOf(
-            "",
-            "[ ]",
-            "[123123123123123123123123123123123123]",
-            "[\"",
-            "[a[a[a[a[a",
-            "[a[a[a[a[a[\"",
-            "[UI] ",
-            "[\"\\u0000\"]",
-            "[0*[0]]",
-            "[0[0]*]"
+            SerializedScheme(scheme = "", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[ ]", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[123123123123123123123123123123123123]", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[\"", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[a[a[a[a[a", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[a[a[a[a[a[\"", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[UI] ", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[\"\\u0000\"]", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[0*[0]]", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[0[0]*]", positional = "", indexed = ""),
+            SerializedScheme(scheme = "[0[0]]", positional = "[]", indexed = ""),
+            SerializedScheme(scheme = "[0[0]]", positional = "[0", indexed = ""),
+            SerializedScheme(scheme = "[0[0]]", positional = "[{,", indexed = ""),
+            SerializedScheme(scheme = "[0[0]]", positional = "[{a,b}}", indexed = ""),
+            SerializedScheme(scheme = "[0[0]]", positional = "", indexed = "[]"),
+            SerializedScheme(scheme = "[0[0]]", positional = "", indexed = "[0"),
+            SerializedScheme(scheme = "[0[0]]", positional = "", indexed = "[{,"),
+            SerializedScheme(scheme = "[0[0]]", positional = "", indexed = "[{a,b},,"),
         )
         for (invalid in invalids) {
-            val result = deserializeScheme(invalid)
+            val result = deserializeScheme(invalid.scheme, invalid.positional, invalid.indexed)
             assertNull(result)
         }
     }

--- a/plugins/compose/compiler-hosted/testData/codegen/composableInferredTargetConstraints.ir.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/composableInferredTargetConstraints.ir.txt
@@ -1,0 +1,373 @@
+MODULE_FRAGMENT
+  FILE fqName:<root> fileName:module_main_composableInferredTargetConstraints.kt
+    CLASS ANNOTATION_CLASS name:WComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+      annotations:
+        Retention(value = AnnotationRetention.BINARY)
+        ComposableTargetMarker(description = "A W Composable")
+        Target(allowedTargets = [AnnotationTarget.FUNCTION, AnnotationTarget.TYPE] type=kotlin.Array<out kotlin.annotation.AnnotationTarget> varargElementType=kotlin.annotation.AnnotationTarget)
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.WComposable
+      CONSTRUCTOR visibility:public returnType:<root>.WComposable [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:WComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+    CLASS ANNOTATION_CLASS name:XComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+      annotations:
+        Retention(value = AnnotationRetention.BINARY)
+        ComposableTargetMarker(description = "An X Composable")
+        Target(allowedTargets = [AnnotationTarget.FUNCTION, AnnotationTarget.TYPE] type=kotlin.Array<out kotlin.annotation.AnnotationTarget> varargElementType=kotlin.annotation.AnnotationTarget)
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.XComposable
+      CONSTRUCTOR visibility:public returnType:<root>.XComposable [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:XComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+    CLASS ANNOTATION_CLASS name:YComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+      annotations:
+        Retention(value = AnnotationRetention.BINARY)
+        ComposableTargetMarker(description = "A Y Composable")
+        Target(allowedTargets = [AnnotationTarget.FUNCTION, AnnotationTarget.TYPE] type=kotlin.Array<out kotlin.annotation.AnnotationTarget> varargElementType=kotlin.annotation.AnnotationTarget)
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.YComposable
+      CONSTRUCTOR visibility:public returnType:<root>.YComposable [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:YComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+    CLASS ANNOTATION_CLASS name:ZComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+      annotations:
+        Retention(value = AnnotationRetention.BINARY)
+        ComposableTargetMarker(description = "A Z Composable")
+        Target(allowedTargets = [AnnotationTarget.FUNCTION, AnnotationTarget.TYPE] type=kotlin.Array<out kotlin.annotation.AnnotationTarget> varargElementType=kotlin.annotation.AnnotationTarget)
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.ZComposable
+      CONSTRUCTOR visibility:public returnType:<root>.ZComposable [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:ZComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+    CLASS OBJECT name:ComposableSingletons$Module_main_composableInferredTargetConstraintsKt modality:FINAL visibility:internal superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt
+      PROPERTY name:lambda$1687092482 visibility:internal modality:FINAL [val]
+        FIELD name:lambda$1687092482 type:kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static]
+        FUN GENERATED[androidx.compose.compiler.plugins.kotlin.lower.ComposeCompilerKey] name:<get-lambda$1687092482> visibility:internal modality:FINAL returnType:kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+          VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt
+          correspondingProperty: PROPERTY name:lambda$1687092482 visibility:internal modality:FINAL [val]
+          BLOCK_BODY
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD name:lambda$1687092482 type:kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
+                    receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD name:lambda$1687092482 type:kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt origin=null
+                  value: CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
+                    ARG key: CONST Int type=kotlin.Int value=1687092482
+                    ARG tracked: CONST Boolean type=kotlin.Boolean value=false
+                    ARG block: FUN_EXPR type=kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                        VALUE_PARAMETER kind:Regular name:it index:0 type:@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+                        VALUE_PARAMETER kind:Regular name:$composer index:1 type:androidx.compose.runtime.Composer? [assignable]
+                        VALUE_PARAMETER kind:Regular name:$changed index:2 type:kotlin.Int
+                        annotations:
+                          Composable
+                          FunctionKeyMeta(key = 1687092482, startOffset = 1134, endOffset = 1136)
+                        BLOCK_BODY
+                          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG sourceInformation: CONST String type=kotlin.String value="CN(it):module_main_composableInferredTargetConstraints.kt"
+                          WHEN type=kotlin.Unit origin=IF
+                            BRANCH
+                              if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                                ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                                  ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                                    ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                      ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG other: CONST Int type=kotlin.Int value=17
+                                    ARG arg1: CONST Int type=kotlin.Int value=16
+                                ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                  ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>.<anonymous>' type=kotlin.Int origin=null
+                                  ARG other: CONST Int type=kotlin.Int value=1
+                              then: BLOCK type=kotlin.Unit origin=null
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                                      ARG key: CONST Int type=kotlin.Int value=1687092482
+                                      ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG dirty2: CONST Int type=kotlin.Int value=-1
+                                      ARG info: CONST String type=kotlin.String value="ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>.<anonymous> (module_main_composableInferredTargetConstraints.kt:46)"
+                                GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            BRANCH
+                              if: CONST Boolean type=kotlin.Boolean value=true
+                              then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+            RETURN type=kotlin.Nothing from='internal final fun <get-lambda$1687092482> (): kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt'
+              GET_FIELD 'FIELD name:lambda$1687092482 type:kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
+                receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$1687092482>' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt origin=null
+      PROPERTY name:lambda$-1940491834 visibility:internal modality:FINAL [val]
+        FIELD name:lambda$-1940491834 type:kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static]
+        FUN GENERATED[androidx.compose.compiler.plugins.kotlin.lower.ComposeCompilerKey] name:<get-lambda$-1940491834> visibility:internal modality:FINAL returnType:kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+          VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> index:0 type:<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt
+          correspondingProperty: PROPERTY name:lambda$-1940491834 visibility:internal modality:FINAL [val]
+          BLOCK_BODY
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD name:lambda$-1940491834 type:kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
+                    receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: SET_FIELD 'FIELD name:lambda$-1940491834 type:kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Unit origin=null
+                  receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt origin=null
+                  value: CALL 'public final fun composableLambdaInstance (key: kotlin.Int, tracked: kotlin.Boolean, block: kotlin.Any): androidx.compose.runtime.internal.ComposableLambda declared in androidx.compose.runtime.internal' type=androidx.compose.runtime.internal.ComposableLambda origin=null
+                    ARG key: CONST Int type=kotlin.Int value=-1940491834
+                    ARG tracked: CONST Boolean type=kotlin.Boolean value=false
+                    ARG block: FUN_EXPR type=kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                        VALUE_PARAMETER kind:Regular name:it index:0 type:@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+                        VALUE_PARAMETER kind:Regular name:$composer index:1 type:androidx.compose.runtime.Composer? [assignable]
+                        VALUE_PARAMETER kind:Regular name:$changed index:2 type:kotlin.Int
+                        annotations:
+                          Composable
+                          FunctionKeyMeta(key = -1940491834, startOffset = 1442, endOffset = 1444)
+                        BLOCK_BODY
+                          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG sourceInformation: CONST String type=kotlin.String value="CN(it):module_main_composableInferredTargetConstraints.kt"
+                          WHEN type=kotlin.Unit origin=IF
+                            BRANCH
+                              if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                                ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                                  ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                                    ARG arg0: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                      ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG other: CONST Int type=kotlin.Int value=17
+                                    ARG arg1: CONST Int type=kotlin.Int value=16
+                                ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                  ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>.<anonymous>' type=kotlin.Int origin=null
+                                  ARG other: CONST Int type=kotlin.Int value=1
+                              then: BLOCK type=kotlin.Unit origin=null
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                                      ARG key: CONST Int type=kotlin.Int value=-1940491834
+                                      ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>.<anonymous>' type=kotlin.Int origin=null
+                                      ARG dirty2: CONST Int type=kotlin.Int value=-1
+                                      ARG info: CONST String type=kotlin.String value="ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>.<anonymous> (module_main_composableInferredTargetConstraints.kt:56)"
+                                GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+                                WHEN type=kotlin.Unit origin=IF
+                                  BRANCH
+                                    if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                                    then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                            BRANCH
+                              if: CONST Boolean type=kotlin.Boolean value=true
+                              then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+                                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+            RETURN type=kotlin.Nothing from='internal final fun <get-lambda$-1940491834> (): kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt'
+              GET_FIELD 'FIELD name:lambda$-1940491834 type:kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? visibility:private [static] declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>? origin=null
+                receiver: GET_VAR '<this>: <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt.<get-lambda$-1940491834>' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:ComposableSingletons$Module_main_composableInferredTargetConstraintsKt modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN name:CallContent visibility:public modality:FINAL returnType:@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function3<@[ParameterName(name = "content")] @[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+      VALUE_PARAMETER kind:Regular name:content index:0 type:@[WComposable] @[XComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+      VALUE_PARAMETER kind:Regular name:$composer index:1 type:androidx.compose.runtime.Composer? [assignable]
+      VALUE_PARAMETER kind:Regular name:$changed index:2 type:kotlin.Int
+      annotations:
+        Composable
+        ComposableInferredTarget(scheme = "[0[0]:[1[1]]]")
+        ComposableInferredTargetConstraints(positional = "", indexed = "[{WComposable,XComposable},{YComposable,ZComposable}]")
+        FunctionKeyMeta(key = 801890196, startOffset = 1152, endOffset = 1446)
+      BLOCK_BODY
+        CALL 'public final fun sourceInformationMarkerStart (composer: androidx.compose.runtime.Composer, key: kotlin.Int, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+          ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallContent' type=androidx.compose.runtime.Composer? origin=null
+          ARG key: CONST Int type=kotlin.Int value=801890196
+          ARG sourceInformation: CONST String type=kotlin.String value="C(CallContent)N(content)55@1421L9:module_main_composableInferredTargetConstraints.kt"
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+            then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+              ARG key: CONST Int type=kotlin.Int value=801890196
+              ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.CallContent' type=kotlin.Int origin=null
+              ARG dirty2: CONST Int type=kotlin.Int value=-1
+              ARG info: CONST String type=kotlin.String value="CallContent (module_main_composableInferredTargetConstraints.kt:54)"
+        CALL 'public abstract fun invoke (p1: P1 of kotlin.Function2, p2: P2 of kotlin.Function2): R of kotlin.Function2 [operator] declared in kotlin.Function2' type=kotlin.Unit origin=null
+          ARG <this>: GET_VAR 'content: @[WComposable] @[XComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.CallContent' type=@[WComposable] @[XComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=VARIABLE_AS_FUNCTION
+          ARG p1: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallContent' type=androidx.compose.runtime.Composer? origin=null
+          ARG p2: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CONST Int type=kotlin.Int value=14
+            ARG other: GET_VAR '$changed: kotlin.Int declared in <root>.CallContent' type=kotlin.Int origin=null
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> [val]
+          CALL 'internal final fun <get-lambda$-1940491834> (): kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+            ARG <this>: GET_OBJECT 'CLASS OBJECT name:ComposableSingletons$Module_main_composableInferredTargetConstraintsKt modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+            then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+        CALL 'public final fun sourceInformationMarkerEnd (composer: androidx.compose.runtime.Composer): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+          ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallContent' type=androidx.compose.runtime.Composer? origin=null
+        RETURN type=kotlin.Nothing from='public final fun CallContent (content: @[WComposable] @[XComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, $composer: androidx.compose.runtime.Composer?, $changed: kotlin.Int): @[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function3<@[ParameterName(name = "content")] @[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>'
+          GET_VAR 'val tmp_0: kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> [val] declared in <root>.CallContent' type=kotlin.Function3<@[ComposableOpenTarget(index = 1)] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+    FUN name:CallWX visibility:public modality:FINAL returnType:@[WComposable] @[XComposable] kotlin.Function3<@[ParameterName(name = "content")] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+      VALUE_PARAMETER kind:Regular name:content index:0 type:@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>
+      VALUE_PARAMETER kind:Regular name:$composer index:1 type:androidx.compose.runtime.Composer? [assignable]
+      VALUE_PARAMETER kind:Regular name:$changed index:2 type:kotlin.Int
+      annotations:
+        Composable
+        ComposableInferredTarget(scheme = "[_[_]:[_[_]]]")
+        ComposableInferredTargetConstraints(positional = "[{WComposable,XComposable}[{YComposable,ZComposable}]:[{WComposable,XComposable}[{YComposable,ZComposable}]]]", indexed = "")
+        FunctionKeyMeta(key = -484202892, startOffset = 904, endOffset = 1138)
+      BLOCK_BODY
+        CALL 'public final fun sourceInformationMarkerStart (composer: androidx.compose.runtime.Composer, key: kotlin.Int, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+          ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+          ARG key: CONST Int type=kotlin.Int value=-484202892
+          ARG sourceInformation: CONST String type=kotlin.String value="C(CallWX)N(content)45@1118L4:module_main_composableInferredTargetConstraints.kt"
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+            then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+              ARG key: CONST Int type=kotlin.Int value=-484202892
+              ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.CallWX' type=kotlin.Int origin=null
+              ARG dirty2: CONST Int type=kotlin.Int value=-1
+              ARG info: CONST String type=kotlin.String value="CallWX (module_main_composableInferredTargetConstraints.kt:44)"
+        CALL 'public final fun WX ($composer: androidx.compose.runtime.Composer?, $changed: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+          ARG $composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+          ARG $changed: CONST Int type=kotlin.Int value=0
+        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> [val]
+          CALL 'internal final fun <get-lambda$1687092482> (): kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt' type=kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+            ARG <this>: GET_OBJECT 'CLASS OBJECT name:ComposableSingletons$Module_main_composableInferredTargetConstraintsKt modality:FINAL visibility:internal superTypes:[kotlin.Any]' type=<root>.ComposableSingletons$Module_main_composableInferredTargetConstraintsKt
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+            then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+        CALL 'public final fun sourceInformationMarkerEnd (composer: androidx.compose.runtime.Composer): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+          ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+        RETURN type=kotlin.Nothing from='public final fun CallWX (content: @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, $composer: androidx.compose.runtime.Composer?, $changed: kotlin.Int): @[WComposable] @[XComposable] kotlin.Function3<@[ParameterName(name = "content")] @[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> declared in <root>'
+          GET_VAR 'val tmp_1: kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> [val] declared in <root>.CallWX' type=kotlin.Function3<@[YComposable] @[ZComposable] kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>, androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit> origin=null
+    FUN name:WX visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer? [assignable]
+      VALUE_PARAMETER kind:Regular name:$changed index:1 type:kotlin.Int
+      annotations:
+        Composable
+        WComposable
+        XComposable
+        FunctionKeyMeta(key = -214702893, startOffset = 878, endOffset = 890)
+      BLOCK_BODY
+        BLOCK type=kotlin.Unit origin=null
+          SET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=kotlin.Unit origin=null
+            CALL 'public abstract fun startRestartGroup (key: kotlin.Int): androidx.compose.runtime.Composer declared in androidx.compose.runtime.Composer' type=androidx.compose.runtime.Composer origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+              ARG key: CONST Int type=kotlin.Int value=-214702893
+          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+            ARG sourceInformation: CONST String type=kotlin.String value="C(WX):module_main_composableInferredTargetConstraints.kt"
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+              ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                  ARG arg0: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                  ARG arg1: CONST Int type=kotlin.Int value=0
+              ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                ARG other: CONST Int type=kotlin.Int value=1
+            then: BLOCK type=kotlin.Unit origin=null
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                  then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                    ARG key: CONST Int type=kotlin.Int value=-214702893
+                    ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                    ARG dirty2: CONST Int type=kotlin.Int value=-1
+                    ARG info: CONST String type=kotlin.String value="WX (module_main_composableInferredTargetConstraints.kt:37)"
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                  then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+        BLOCK type=kotlin.Unit origin=null
+          BLOCK type=kotlin.Unit origin=SAFE_CALL
+            VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:androidx.compose.runtime.ScopeUpdateScope? [val]
+              CALL 'public abstract fun endRestartGroup (): androidx.compose.runtime.ScopeUpdateScope? declared in androidx.compose.runtime.Composer' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                  ARG arg0: GET_VAR 'val tmp_2: androidx.compose.runtime.ScopeUpdateScope? [val] declared in <root>.WX' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                  ARG arg1: CONST Null type=kotlin.Any? value=null
+                then: CONST Null type=kotlin.Any? value=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public abstract fun updateScope (block: kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>): kotlin.Unit declared in androidx.compose.runtime.ScopeUpdateScope' type=kotlin.Unit origin=null
+                  ARG <this>: GET_VAR 'val tmp_2: androidx.compose.runtime.ScopeUpdateScope? [val] declared in <root>.WX' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                  ARG block: FUN_EXPR type=kotlin.Function2<androidx.compose.runtime.Composer?, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                      VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer?
+                      VALUE_PARAMETER kind:Regular name:$force index:1 type:kotlin.Int
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> ($composer: androidx.compose.runtime.Composer?, $force: kotlin.Int): kotlin.Unit declared in <root>.WX'
+                          CALL 'public final fun WX ($composer: androidx.compose.runtime.Composer?, $changed: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+                            ARG $composer: GET_VAR '$composer: androidx.compose.runtime.Composer? declared in <root>.WX.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG $changed: CALL 'internal final fun updateChangedFlags (flags: kotlin.Int): kotlin.Int declared in androidx.compose.runtime' type=kotlin.Int origin=null
+                              ARG flags: CALL 'public final fun or (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                                ARG other: CONST Int type=kotlin.Int value=1

--- a/plugins/compose/compiler-hosted/testData/codegen/composableInferredTargetConstraints.kt
+++ b/plugins/compose/compiler-hosted/testData/codegen/composableInferredTargetConstraints.kt
@@ -1,0 +1,58 @@
+// DUMP_IR
+
+// MODULE: main
+import androidx.compose.runtime.*
+
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "A W Composable")
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPE,
+)
+annotation class WComposable
+
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "An X Composable")
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPE,
+)
+annotation class XComposable
+
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "A Y Composable")
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPE,
+)
+annotation class YComposable
+
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "A Z Composable")
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPE,
+)
+annotation class ZComposable
+
+@Composable @WComposable @XComposable fun WX() { }
+
+@Composable
+fun CallWX(content: @Composable @YComposable @ZComposable () -> Unit):
+        @Composable @WComposable @XComposable (
+            content: @Composable @YComposable @ZComposable () -> Unit,
+        ) -> Unit
+{
+    WX()
+    return {}
+}
+
+@Composable
+fun CallContent(content: @Composable @WComposable @XComposable () -> Unit):
+        @Composable @ComposableOpenTarget(1) @YComposable @ZComposable (
+            content: @Composable @ComposableOpenTarget(1) @YComposable @ZComposable () -> Unit,
+        ) -> Unit
+{
+    content()
+    return {}
+}

--- a/plugins/compose/compiler-hosted/testData/codegen/composableInferredTargetConstraints.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/composableInferredTargetConstraints.txt
@@ -1,0 +1,23 @@
+public final class Module_main_composableInferredTargetConstraintsKt {
+    // source: 'module_main_composableInferredTargetConstraints.kt'
+    public final static method CallContent(p0: kotlin.jvm.functions.Function2, p1: androidx.compose.runtime.Composer, p2: int): kotlin.jvm.functions.Function3
+    public final static method CallWX(p0: kotlin.jvm.functions.Function2, p1: androidx.compose.runtime.Composer, p2: int): kotlin.jvm.functions.Function3
+    private final static method WX$lambda$0(p0: int, p1: androidx.compose.runtime.Composer, p2: int): kotlin.Unit
+    public final static method WX(p0: androidx.compose.runtime.Composer, p1: int): void
+}
+
+public annotation class WComposable {
+    // source: 'module_main_composableInferredTargetConstraints.kt'
+}
+
+public annotation class XComposable {
+    // source: 'module_main_composableInferredTargetConstraints.kt'
+}
+
+public annotation class YComposable {
+    // source: 'module_main_composableInferredTargetConstraints.kt'
+}
+
+public annotation class ZComposable {
+    // source: 'module_main_composableInferredTargetConstraints.kt'
+}

--- a/plugins/compose/compiler-hosted/testData/codegen/repeatedComposableTarget.ir.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/repeatedComposableTarget.ir.txt
@@ -1,0 +1,195 @@
+MODULE_FRAGMENT
+  FILE fqName:<root> fileName:module_main_repeatedComposableTarget.kt
+    CLASS ANNOTATION_CLASS name:WComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+      annotations:
+        Retention(value = AnnotationRetention.BINARY)
+        ComposableTargetMarker(description = "A W Composable")
+        Target(allowedTargets = [AnnotationTarget.FUNCTION] type=kotlin.Array<out kotlin.annotation.AnnotationTarget> varargElementType=kotlin.annotation.AnnotationTarget)
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.WComposable
+      CONSTRUCTOR visibility:public returnType:<root>.WComposable [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:WComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+    CLASS ANNOTATION_CLASS name:XComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+      annotations:
+        Retention(value = AnnotationRetention.BINARY)
+        ComposableTargetMarker(description = "An X Composable")
+        Target(allowedTargets = [AnnotationTarget.FUNCTION] type=kotlin.Array<out kotlin.annotation.AnnotationTarget> varargElementType=kotlin.annotation.AnnotationTarget)
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.XComposable
+      CONSTRUCTOR visibility:public returnType:<root>.XComposable [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:XComposable modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+    FUN name:CallWX visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer? [assignable]
+      VALUE_PARAMETER kind:Regular name:$changed index:1 type:kotlin.Int
+      annotations:
+        Composable
+        ComposableTarget(applier = "WComposable")
+        ComposableTarget(applier = "XComposable")
+        FunctionKeyMeta(key = 354942892, startOffset = 448, endOffset = 473)
+      BLOCK_BODY
+        BLOCK type=kotlin.Unit origin=null
+          SET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=kotlin.Unit origin=null
+            CALL 'public abstract fun startRestartGroup (key: kotlin.Int): androidx.compose.runtime.Composer declared in androidx.compose.runtime.Composer' type=androidx.compose.runtime.Composer origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+              ARG key: CONST Int type=kotlin.Int value=354942892
+          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+            ARG sourceInformation: CONST String type=kotlin.String value="C(CallWX)19@467L4:module_main_repeatedComposableTarget.kt"
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+              ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                  ARG arg0: GET_VAR '$changed: kotlin.Int declared in <root>.CallWX' type=kotlin.Int origin=null
+                  ARG arg1: CONST Int type=kotlin.Int value=0
+              ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.CallWX' type=kotlin.Int origin=null
+                ARG other: CONST Int type=kotlin.Int value=1
+            then: BLOCK type=kotlin.Unit origin=null
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                  then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                    ARG key: CONST Int type=kotlin.Int value=354942892
+                    ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.CallWX' type=kotlin.Int origin=null
+                    ARG dirty2: CONST Int type=kotlin.Int value=-1
+                    ARG info: CONST String type=kotlin.String value="CallWX (module_main_repeatedComposableTarget.kt:18)"
+              CALL 'public final fun WX ($composer: androidx.compose.runtime.Composer?, $changed: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+                ARG $composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+                ARG $changed: CONST Int type=kotlin.Int value=0
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                  then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+        BLOCK type=kotlin.Unit origin=null
+          BLOCK type=kotlin.Unit origin=SAFE_CALL
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:androidx.compose.runtime.ScopeUpdateScope? [val]
+              CALL 'public abstract fun endRestartGroup (): androidx.compose.runtime.ScopeUpdateScope? declared in androidx.compose.runtime.Composer' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.CallWX' type=androidx.compose.runtime.Composer? origin=null
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                  ARG arg0: GET_VAR 'val tmp_0: androidx.compose.runtime.ScopeUpdateScope? [val] declared in <root>.CallWX' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                  ARG arg1: CONST Null type=kotlin.Any? value=null
+                then: CONST Null type=kotlin.Any? value=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public abstract fun updateScope (block: kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>): kotlin.Unit declared in androidx.compose.runtime.ScopeUpdateScope' type=kotlin.Unit origin=null
+                  ARG <this>: GET_VAR 'val tmp_0: androidx.compose.runtime.ScopeUpdateScope? [val] declared in <root>.CallWX' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                  ARG block: FUN_EXPR type=kotlin.Function2<androidx.compose.runtime.Composer?, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                      VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer?
+                      VALUE_PARAMETER kind:Regular name:$force index:1 type:kotlin.Int
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> ($composer: androidx.compose.runtime.Composer?, $force: kotlin.Int): kotlin.Unit declared in <root>.CallWX'
+                          CALL 'public final fun CallWX ($composer: androidx.compose.runtime.Composer?, $changed: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+                            ARG $composer: GET_VAR '$composer: androidx.compose.runtime.Composer? declared in <root>.CallWX.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG $changed: CALL 'internal final fun updateChangedFlags (flags: kotlin.Int): kotlin.Int declared in androidx.compose.runtime' type=kotlin.Int origin=null
+                              ARG flags: CALL 'public final fun or (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.CallWX' type=kotlin.Int origin=null
+                                ARG other: CONST Int type=kotlin.Int value=1
+    FUN name:WX visibility:public modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer? [assignable]
+      VALUE_PARAMETER kind:Regular name:$changed index:1 type:kotlin.Int
+      annotations:
+        Composable
+        WComposable
+        XComposable
+        FunctionKeyMeta(key = -1122830290, startOffset = 422, endOffset = 434)
+      BLOCK_BODY
+        BLOCK type=kotlin.Unit origin=null
+          SET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=kotlin.Unit origin=null
+            CALL 'public abstract fun startRestartGroup (key: kotlin.Int): androidx.compose.runtime.Composer declared in androidx.compose.runtime.Composer' type=androidx.compose.runtime.Composer origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+              ARG key: CONST Int type=kotlin.Int value=-1122830290
+          CALL 'public final fun sourceInformation (composer: androidx.compose.runtime.Composer, sourceInformation: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+            ARG composer: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+            ARG sourceInformation: CONST String type=kotlin.String value="C(WX):module_main_repeatedComposableTarget.kt"
+        WHEN type=kotlin.Unit origin=IF
+          BRANCH
+            if: CALL 'public abstract fun shouldExecute (parametersChanged: kotlin.Boolean, flags: kotlin.Int): kotlin.Boolean declared in androidx.compose.runtime.Composer' type=kotlin.Boolean origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+              ARG parametersChanged: CALL 'public final fun not (): kotlin.Boolean [operator] declared in kotlin.Boolean' type=kotlin.Boolean origin=null
+                ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                  ARG arg0: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                  ARG arg1: CONST Int type=kotlin.Int value=0
+              ARG flags: CALL 'public final fun and (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                ARG other: CONST Int type=kotlin.Int value=1
+            then: BLOCK type=kotlin.Unit origin=null
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                  then: CALL 'public final fun traceEventStart (key: kotlin.Int, dirty1: kotlin.Int, dirty2: kotlin.Int, info: kotlin.String): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+                    ARG key: CONST Int type=kotlin.Int value=-1122830290
+                    ARG dirty1: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                    ARG dirty2: CONST Int type=kotlin.Int value=-1
+                    ARG info: CONST String type=kotlin.String value="WX (module_main_repeatedComposableTarget.kt:15)"
+              WHEN type=kotlin.Unit origin=IF
+                BRANCH
+                  if: CALL 'public final fun isTraceInProgress (): kotlin.Boolean declared in androidx.compose.runtime' type=kotlin.Boolean origin=null
+                  then: CALL 'public final fun traceEventEnd (): kotlin.Unit declared in androidx.compose.runtime' type=kotlin.Unit origin=null
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: CALL 'public abstract fun skipToGroupEnd (): kotlin.Unit declared in androidx.compose.runtime.Composer' type=kotlin.Unit origin=null
+              ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+        BLOCK type=kotlin.Unit origin=null
+          BLOCK type=kotlin.Unit origin=SAFE_CALL
+            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:androidx.compose.runtime.ScopeUpdateScope? [val]
+              CALL 'public abstract fun endRestartGroup (): androidx.compose.runtime.ScopeUpdateScope? declared in androidx.compose.runtime.Composer' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                ARG <this>: GET_VAR '$composer: androidx.compose.runtime.Composer? [assignable] declared in <root>.WX' type=androidx.compose.runtime.Composer? origin=null
+            WHEN type=kotlin.Unit origin=IF
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=null
+                  ARG arg0: GET_VAR 'val tmp_1: androidx.compose.runtime.ScopeUpdateScope? [val] declared in <root>.WX' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                  ARG arg1: CONST Null type=kotlin.Any? value=null
+                then: CONST Null type=kotlin.Any? value=null
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public abstract fun updateScope (block: kotlin.Function2<androidx.compose.runtime.Composer, kotlin.Int, kotlin.Unit>): kotlin.Unit declared in androidx.compose.runtime.ScopeUpdateScope' type=kotlin.Unit origin=null
+                  ARG <this>: GET_VAR 'val tmp_1: androidx.compose.runtime.ScopeUpdateScope? [val] declared in <root>.WX' type=androidx.compose.runtime.ScopeUpdateScope? origin=null
+                  ARG block: FUN_EXPR type=kotlin.Function2<androidx.compose.runtime.Composer?, kotlin.Int, kotlin.Unit> origin=LAMBDA
+                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit
+                      VALUE_PARAMETER kind:Regular name:$composer index:0 type:androidx.compose.runtime.Composer?
+                      VALUE_PARAMETER kind:Regular name:$force index:1 type:kotlin.Int
+                      BLOCK_BODY
+                        RETURN type=kotlin.Nothing from='local final fun <anonymous> ($composer: androidx.compose.runtime.Composer?, $force: kotlin.Int): kotlin.Unit declared in <root>.WX'
+                          CALL 'public final fun WX ($composer: androidx.compose.runtime.Composer?, $changed: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+                            ARG $composer: GET_VAR '$composer: androidx.compose.runtime.Composer? declared in <root>.WX.<anonymous>' type=androidx.compose.runtime.Composer? origin=null
+                            ARG $changed: CALL 'internal final fun updateChangedFlags (flags: kotlin.Int): kotlin.Int declared in androidx.compose.runtime' type=kotlin.Int origin=null
+                              ARG flags: CALL 'public final fun or (other: kotlin.Int): kotlin.Int [infix] declared in kotlin.Int' type=kotlin.Int origin=null
+                                ARG <this>: GET_VAR '$changed: kotlin.Int declared in <root>.WX' type=kotlin.Int origin=null
+                                ARG other: CONST Int type=kotlin.Int value=1

--- a/plugins/compose/compiler-hosted/testData/codegen/repeatedComposableTarget.kt
+++ b/plugins/compose/compiler-hosted/testData/codegen/repeatedComposableTarget.kt
@@ -1,0 +1,21 @@
+// DUMP_IR
+
+// MODULE: main
+import androidx.compose.runtime.*
+
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "A W Composable")
+@Target(AnnotationTarget.FUNCTION)
+annotation class WComposable
+
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "An X Composable")
+@Target(AnnotationTarget.FUNCTION)
+annotation class XComposable
+
+@Composable @WComposable @XComposable fun WX() { }
+
+@Composable
+fun CallWX() {
+    WX()
+}

--- a/plugins/compose/compiler-hosted/testData/codegen/repeatedComposableTarget.txt
+++ b/plugins/compose/compiler-hosted/testData/codegen/repeatedComposableTarget.txt
@@ -1,0 +1,16 @@
+public final class Module_main_repeatedComposableTargetKt {
+    // source: 'module_main_repeatedComposableTarget.kt'
+    private final static method CallWX$lambda$0(p0: int, p1: androidx.compose.runtime.Composer, p2: int): kotlin.Unit
+    public final static method CallWX(p0: androidx.compose.runtime.Composer, p1: int): void
+    private final static method WX$lambda$0(p0: int, p1: androidx.compose.runtime.Composer, p2: int): kotlin.Unit
+    public final static method WX(p0: androidx.compose.runtime.Composer, p1: int): void
+    public inner class androidx/compose/runtime/ComposableTarget$Container
+}
+
+public annotation class WComposable {
+    // source: 'module_main_repeatedComposableTarget.kt'
+}
+
+public annotation class XComposable {
+    // source: 'module_main_repeatedComposableTarget.kt'
+}

--- a/plugins/compose/compiler-hosted/testData/diagnostics/targetConstraintWarnings.diag.txt
+++ b/plugins/compose/compiler-hosted/testData/diagnostics/targetConstraintWarnings.diag.txt
@@ -1,0 +1,3 @@
+/module_main_targetConstraintWarnings.kt:51:9: warning: Calling a X, Y or Z composable function where a U, V or W composable was expected
+
+/module_main_targetConstraintWarnings.kt:57:9: warning: Calling a U, V or W composable function where a X, Y or Z composable was expected

--- a/plugins/compose/compiler-hosted/testData/diagnostics/targetConstraintWarnings.kt
+++ b/plugins/compose/compiler-hosted/testData/diagnostics/targetConstraintWarnings.kt
@@ -1,0 +1,61 @@
+// RUN_PIPELINE_TILL: BACKEND
+
+// MODULE: dep2
+
+import androidx.compose.runtime.*
+
+@ComposableTargetMarker(description = "U")
+@Target(AnnotationTarget.TYPE)
+annotation class UComposable()
+
+@ComposableTargetMarker(description = "V")
+@Target(AnnotationTarget.TYPE)
+annotation class VComposable()
+
+@ComposableTargetMarker(description = "W")
+@Target(AnnotationTarget.TYPE)
+annotation class WComposable()
+
+@Composable
+fun UVWWrapper(content: @Composable @UComposable @VComposable @WComposable () -> Unit) {
+    content()
+}
+
+// MODULE: dep1
+
+import androidx.compose.runtime.*
+
+@ComposableTargetMarker(description = "X")
+@Target(AnnotationTarget.TYPE)
+annotation class XComposable()
+
+@ComposableTargetMarker(description = "Y")
+@Target(AnnotationTarget.TYPE)
+annotation class YComposable()
+
+@ComposableTargetMarker(description = "Z")
+@Target(AnnotationTarget.TYPE)
+annotation class ZComposable()
+
+@Composable
+fun XYZWrapper(content: @Composable @XComposable @YComposable @ZComposable () -> Unit) {
+    content()
+}
+
+// MODULE: main(dep1, dep2)
+
+import androidx.compose.runtime.Composable
+
+@Composable fun XYZInUVW() {
+    UVWWrapper {
+        <!COMPOSE_APPLIER_CALL_MISMATCH!>XYZWrapper<!> {}
+    }
+}
+
+@Composable fun UVWInXYZ() {
+    XYZWrapper {
+        <!COMPOSE_APPLIER_CALL_MISMATCH!>UVWWrapper<!> {}
+    }
+}
+
+/* GENERATED_FIR_TAGS: annotationDeclaration, functionDeclaration, functionalType, lambdaLiteral, stringLiteral */

--- a/plugins/compose/compiler-hosted/tests-gen/androidx/compose/compiler/plugins/kotlin/CompilerFacilityTestForComposeCompilerPluginGenerated.java
+++ b/plugins/compose/compiler-hosted/tests-gen/androidx/compose/compiler/plugins/kotlin/CompilerFacilityTestForComposeCompilerPluginGenerated.java
@@ -46,6 +46,12 @@ public class CompilerFacilityTestForComposeCompilerPluginGenerated extends Abstr
   }
 
   @Test
+  @TestMetadata("composableInferredTargetConstraints.kt")
+  public void testComposableInferredTargetConstraints() {
+    run("composableInferredTargetConstraints.kt");
+  }
+
+  @Test
   @TestMetadata("composableTypeRemappingOfExternalAccessors.kt")
   public void testComposableTypeRemappingOfExternalAccessors() {
     run("composableTypeRemappingOfExternalAccessors.kt");
@@ -157,6 +163,12 @@ public class CompilerFacilityTestForComposeCompilerPluginGenerated extends Abstr
   @TestMetadata("propertyWithDelegateBackingField.kt")
   public void testPropertyWithDelegateBackingField() {
     run("propertyWithDelegateBackingField.kt");
+  }
+
+  @Test
+  @TestMetadata("repeatedComposableTarget.kt")
+  public void testRepeatedComposableTarget() {
+    run("repeatedComposableTarget.kt");
   }
 
   @Test

--- a/plugins/compose/compiler-hosted/tests-gen/androidx/compose/compiler/plugins/kotlin/PhasedJvmDiagnosticLightTreeForComposeTestGenerated.java
+++ b/plugins/compose/compiler-hosted/tests-gen/androidx/compose/compiler/plugins/kotlin/PhasedJvmDiagnosticLightTreeForComposeTestGenerated.java
@@ -40,6 +40,12 @@ public class PhasedJvmDiagnosticLightTreeForComposeTestGenerated extends Abstrac
   }
 
   @Test
+  @TestMetadata("targetConstraintWarnings.kt")
+  public void testTargetConstraintWarnings() {
+    run("targetConstraintWarnings.kt");
+  }
+
+  @Test
   @TestMetadata("targetWarnings.kt")
   public void testTargetWarnings() {
     run("targetWarnings.kt");


### PR DESCRIPTION
... per the semantics described in the documentation of `ComposableTarget`

Relnote: "Made the applier inferencer support repeated `ComposableTarget` annotations per the semantics described in the documentation of `ComposableTarget`"

Bug: 481422057