### PR TITLE
[build] Test Federation: Allow domains.yaml to include directories

### DIFF
--- a/.idea/runConfigurations/Update_domains_dump_txt.xml
+++ b/.idea/runConfigurations/Update_domains_dump_txt.xml
@@ -1,0 +1,35 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Update domains.dump.txt" type="GradleRunConfiguration" factoryName="Gradle" folderName="Tools">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="UPDATE_DOMAINS_DUMP" value="true" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":gradle-build-conventions:test-federation-convention:test" />
+          <option value="--tests" />
+          <option value="&quot;org.jetbrains.kotlin.testFederation.DomainsDumpTest&quot;" />
+          <option value="--rerun" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/repo/TEST-FEDERATION.md
+++ b/repo/TEST-FEDERATION.md
@@ -44,13 +44,15 @@ e.g., the `Native` domain could be defined as:
 ```yaml
 Native:
   include:
-    - "native/**"
-    - "kotlin-native/**"
+    - "native"
+    - "kotlin-native"
   fullyAffectedBy:
     - Compiler
 ```
 
-Files belonging to this 'Native' domain are included using the `native/**` and `kotlin-native/**` globs.
+Entries under `include` and `exclude` can be directory paths or glob patterns. A directory path matches the directory and
+all its descendants, so the `Native` domain above includes everything under the `native` and `kotlin-native` directories.
+When `include` and `exclude` entries overlap, the most specific matching entry takes precedence.
 A domain is always marked as 'affected' if any file, belonging to the domain, is changed.
 
 ## '^affects' commit command

--- a/repo/domains.dump.txt
+++ b/repo/domains.dump.txt
@@ -132,16 +132,6 @@ Native:
  - native/unsafe-mem
  - native/utils
 
-Js, Wasm:
- - js/js.translator/testData
-
-Compiler, CoreLibs:
- - core/descriptors.runtime
- - core/metadata
- - core/metadata.jvm
- - core/reflection.common.jvm
- - core/reflection.jvm
-
 CoreLibs:
  - libraries/kotlin.test
  - libraries/kotlinx-metadata
@@ -200,9 +190,6 @@ CompilerPlugins:
  - plugins/power-assert
  - plugins/sam-with-receiver
  - plugins/test-plugins
-
-Js, SwiftExport:
- - libraries/tools/analysis-api-based-klib-reader
 
 Gradle:
  - libraries/tools/gradle
@@ -334,12 +321,25 @@ Unknown:
  - tests
  - third-party
 
+Js, Wasm:
+ - js/js.translator/testData
+
+Compiler, CoreLibs:
+ - core/descriptors.runtime
+ - core/metadata
+ - core/metadata.jvm
+ - core/reflection.common.jvm
+ - core/reflection.jvm
+
+Js, SwiftExport:
+ - libraries/tools/analysis-api-based-klib-reader
+
 AnalysisApi, CompilerPlugins:
  - plugins/plugin-sandbox
  - plugins/scripting
 
-BuildToolsApi, Compiler, Gradle:
- - build-common
-
 BuildToolsApi, Gradle:
  - compiler/build-tools/kotlin-build-statistics
+
+BuildToolsApi, Compiler, Gradle:
+ - build-common

--- a/repo/domains.dump.txt
+++ b/repo/domains.dump.txt
@@ -147,6 +147,7 @@ CoreLibs:
  - libraries/kotlinx-metadata
  - libraries/reflect
  - libraries/stdlib
+ - libraries/tools/jdk-api-validator
  - libraries/tools/kotlin-annotations-jvm
 
 AnalysisApi:
@@ -286,7 +287,6 @@ Unknown:
  - libraries/tools/binary-compatibility-validator
  - libraries/tools/dukat
  - libraries/tools/ide-plugin-dependencies-validator
- - libraries/tools/jdk-api-validator
  - libraries/tools/js-plain-objects
  - libraries/tools/klib-abi-reader
  - libraries/tools/kotlin-allopen

--- a/repo/domains.yaml
+++ b/repo/domains.yaml
@@ -3,125 +3,125 @@ $schema: domains.schema.json
 # CLI + Frontend + JVM backend
 Compiler:
   include:
-    - "compiler/**"
-    - "core/**"
-    - "build-common/**"
-    - "compiler/psi/parser/**"
-    - "jps/**"
+    - "compiler"
+    - "core"
+    - "build-common"
+    - "compiler/psi/parser"
+    - "jps"
   exclude:
-    - "compiler/psi/**"
-    - "compiler/build-tools/**"
-    - "compiler/incremental-compilation-*/**"
-    - "compiler/daemon/**"
-    - "compiler/compiler-runner/**"
-    - "compiler/compiler-runner-unshaded/**"
-    - "compiler/plugin-api/**"
-    - "compiler/ir/backend.wasm/**"
-    - "compiler/ir/backend.js/**"
-    - "compiler/ir/serialization.js/**"
-    - "compiler/ir/backend.native/**"
-    - "compiler/ir/ir.objcinterop/**"
-    - "compiler/ir/serialization.native/**"
+    - "compiler/psi"
+    - "compiler/build-tools"
+    - "compiler/incremental-compilation-*"
+    - "compiler/daemon"
+    - "compiler/compiler-runner"
+    - "compiler/compiler-runner-unshaded"
+    - "compiler/plugin-api"
+    - "compiler/ir/backend.wasm"
+    - "compiler/ir/backend.js"
+    - "compiler/ir/serialization.js"
+    - "compiler/ir/backend.native"
+    - "compiler/ir/ir.objcinterop"
+    - "compiler/ir/serialization.native"
   fullyAffectedBy:
     - CoreLibs
 
 Wasm:
   include:
-    - "compiler/ir/backend.wasm/**"
-    - "wasm/**"
-    - "js/js.translator/testData/**"
+    - "compiler/ir/backend.wasm"
+    - "wasm"
+    - "js/js.translator/testData"
   fullyAffectedBy:
     - Compiler
     - CoreLibs
 Js:
   include:
-    - "js/**"
-    - "compiler/ir/backend.js/**"
-    - "compiler/ir/serialization.js/**"
-    - "libraries/tools/analysis-api-based-klib-reader/**"
+    - "js"
+    - "compiler/ir/backend.js"
+    - "compiler/ir/serialization.js"
+    - "libraries/tools/analysis-api-based-klib-reader"
   fullyAffectedBy:
     - Compiler
     - CoreLibs
 
 Native:
   include:
-    - "compiler/ir/backend.native/**"
-    - "compiler/ir/ir.objcinterop/**"
-    - "compiler/ir/serialization.native/**"
-    - "native/**"
-    - "kotlin-native/**"
+    - "compiler/ir/backend.native"
+    - "compiler/ir/ir.objcinterop"
+    - "compiler/ir/serialization.native"
+    - "native"
+    - "kotlin-native"
   exclude:
-    - "native/swift/**"
+    - "native/swift"
   fullyAffectedBy:
     - Compiler
     - CoreLibs
 
 CoreLibs:
   include:
-    - "libraries/stdlib/**"
-    - "libraries/tools/kotlin-annotations-jvm/**"
-    - "core/metadata*/**"
-    - "core/reflect*/**"
+    - "libraries/stdlib"
+    - "libraries/tools/kotlin-annotations-jvm"
+    - "core/metadata*"
+    - "core/reflect*"
     # Old reflect
-    - "core/descriptors.runtime/**"
-    - "libraries/kotlinx-metadata/**"
-    - "libraries/reflect/**"
-    - "libraries/kotlin.test/**"
+    - "core/descriptors.runtime"
+    - "libraries/kotlinx-metadata"
+    - "libraries/reflect"
+    - "libraries/kotlin.test"
     - "libraries/tools/jdk-api-validator"
 
 AnalysisApi:
   include:
-    - "analysis/**"
-    - "compiler/psi/**"
-    - "prepare/analysis-api/**"
-    - "plugins/plugin-sandbox/**"
-    - "plugins/scripting/**"
+    - "analysis"
+    - "compiler/psi"
+    - "prepare/analysis-api"
+    - "plugins/plugin-sandbox"
+    - "plugins/scripting"
   exclude:
-    - "compiler/psi/parser/**"
+    - "compiler/psi/parser"
   fullyAffectedBy:
     - Compiler
     - CoreLibs
 
 BuildToolsApi:
   include:
-    - "build-common/**"
-    - "compiler/build-tools/**"
-    - "compiler/incremental-compilation-*/**"
-    - "compiler/daemon/**"
-    - "compiler/compiler-runner/**"
-    - "compiler/compiler-runner-unshaded/**"
+    - "build-common"
+    - "compiler/build-tools"
+    - "compiler/incremental-compilation-*"
+    - "compiler/daemon"
+    - "compiler/compiler-runner"
+    - "compiler/compiler-runner-unshaded"
   fullyAffectedBy:
     - Compiler
 
 SwiftExport:
   include:
-    - "native/swift/**"
-    - "libraries/tools/analysis-api-based-klib-reader/**"
+    - "native/swift"
+    - "libraries/tools/analysis-api-based-klib-reader"
   fullyAffectedBy:
     - AnalysisApi # todo: Replace this dependency with a reviewed set of @AffectedByAnalysisApi tests
 
 CompilerPlugins:
   include:
-    - "compiler/plugin-api/**"
-    - "plugins/**"
+    - "compiler/plugin-api"
+    - "plugins"
   fullyAffectedBy:
     - Compiler
 
 Gradle:
   include:
-    - "build-common/**"
-    - "libraries/tools/*gradle*/**"
-    - "compiler/build-tools/kotlin-build-statistics/**"
+    - "build-common"
+    - "libraries/tools/*gradle*"
+    - "compiler/build-tools/kotlin-build-statistics"
 
 Maven:
   include:
-    - "libraries/tools/*maven*/**"
+    - "libraries/tools/*maven*"
 
 # The IntelliJ domain has no owned files in this repository.
 # It is used to declare which domains will affect IntelliJ and to infer when to run tests against kt-master
 IntelliJ:
   include:
-    - "prepare/ide-plugin-dependencies/**"
+    - "prepare/ide-plugin-dependencies"
   fullyAffectedBy:
     - Compiler
     - AnalysisApi
@@ -131,14 +131,14 @@ IntelliJ:
 
 BuildInfrastructure:
   include:
-    - "repo/**"
-    - "gradle/**"
+    - "repo"
+    - "gradle"
     - "build.gradle.kts"
     - "settings.gradle.kts"
     - "gradle.properties"
-    - "scripts/**"
-    - ".space/**"
-    - ".idea/**"
+    - "scripts"
+    - ".space"
+    - ".idea"
 
 Unknown:
   # Files not matching other domains will be sorted into 'Unknown' by default.

--- a/repo/gradle-build-conventions/test-federation-convention/src/main/generated/domains.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/main/generated/domains.kt
@@ -24,91 +24,91 @@ enum class Domain {
 
 internal object CompilerDomainInfo : DomainInfo {
     override val domain = Domain.Compiler
-    override val include: List<String> = listOf("compiler/**", "core/**", "build-common/**", "compiler/psi/parser/**", "jps/**")
-    override val exclude: List<String> = listOf("compiler/psi/**", "compiler/build-tools/**", "compiler/incremental-compilation-*/**", "compiler/daemon/**", "compiler/compiler-runner/**", "compiler/compiler-runner-unshaded/**", "compiler/plugin-api/**", "compiler/ir/backend.wasm/**", "compiler/ir/backend.js/**", "compiler/ir/serialization.js/**", "compiler/ir/backend.native/**", "compiler/ir/ir.objcinterop/**", "compiler/ir/serialization.native/**")
+    override val include: List<String> = listOf("compiler", "core", "build-common", "compiler/psi/parser", "jps")
+    override val exclude: List<String> = listOf("compiler/psi", "compiler/build-tools", "compiler/incremental-compilation-*", "compiler/daemon", "compiler/compiler-runner", "compiler/compiler-runner-unshaded", "compiler/plugin-api", "compiler/ir/backend.wasm", "compiler/ir/backend.js", "compiler/ir/serialization.js", "compiler/ir/backend.native", "compiler/ir/ir.objcinterop", "compiler/ir/serialization.native")
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CoreLibsDomainInfo) }
 }
 
 internal object WasmDomainInfo : DomainInfo {
     override val domain = Domain.Wasm
-    override val include: List<String> = listOf("compiler/ir/backend.wasm/**", "wasm/**", "js/js.translator/testData/**")
+    override val include: List<String> = listOf("compiler/ir/backend.wasm", "wasm", "js/js.translator/testData")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, CoreLibsDomainInfo) }
 }
 
 internal object JsDomainInfo : DomainInfo {
     override val domain = Domain.Js
-    override val include: List<String> = listOf("js/**", "compiler/ir/backend.js/**", "compiler/ir/serialization.js/**", "libraries/tools/analysis-api-based-klib-reader/**")
+    override val include: List<String> = listOf("js", "compiler/ir/backend.js", "compiler/ir/serialization.js", "libraries/tools/analysis-api-based-klib-reader")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, CoreLibsDomainInfo) }
 }
 
 internal object NativeDomainInfo : DomainInfo {
     override val domain = Domain.Native
-    override val include: List<String> = listOf("compiler/ir/backend.native/**", "compiler/ir/ir.objcinterop/**", "compiler/ir/serialization.native/**", "native/**", "kotlin-native/**")
-    override val exclude: List<String> = listOf("native/swift/**")
+    override val include: List<String> = listOf("compiler/ir/backend.native", "compiler/ir/ir.objcinterop", "compiler/ir/serialization.native", "native", "kotlin-native")
+    override val exclude: List<String> = listOf("native/swift")
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, CoreLibsDomainInfo) }
 }
 
 internal object CoreLibsDomainInfo : DomainInfo {
     override val domain = Domain.CoreLibs
-    override val include: List<String> = listOf("libraries/stdlib/**", "libraries/tools/kotlin-annotations-jvm/**", "core/metadata*/**", "core/reflect*/**", "core/descriptors.runtime/**", "libraries/kotlinx-metadata/**", "libraries/reflect/**", "libraries/kotlin.test/**", "libraries/tools/jdk-api-validator")
+    override val include: List<String> = listOf("libraries/stdlib", "libraries/tools/kotlin-annotations-jvm", "core/metadata*", "core/reflect*", "core/descriptors.runtime", "libraries/kotlinx-metadata", "libraries/reflect", "libraries/kotlin.test", "libraries/tools/jdk-api-validator")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf() }
 }
 
 internal object AnalysisApiDomainInfo : DomainInfo {
     override val domain = Domain.AnalysisApi
-    override val include: List<String> = listOf("analysis/**", "compiler/psi/**", "prepare/analysis-api/**", "plugins/plugin-sandbox/**", "plugins/scripting/**")
-    override val exclude: List<String> = listOf("compiler/psi/parser/**")
+    override val include: List<String> = listOf("analysis", "compiler/psi", "prepare/analysis-api", "plugins/plugin-sandbox", "plugins/scripting")
+    override val exclude: List<String> = listOf("compiler/psi/parser")
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, CoreLibsDomainInfo) }
 }
 
 internal object BuildToolsApiDomainInfo : DomainInfo {
     override val domain = Domain.BuildToolsApi
-    override val include: List<String> = listOf("build-common/**", "compiler/build-tools/**", "compiler/incremental-compilation-*/**", "compiler/daemon/**", "compiler/compiler-runner/**", "compiler/compiler-runner-unshaded/**")
+    override val include: List<String> = listOf("build-common", "compiler/build-tools", "compiler/incremental-compilation-*", "compiler/daemon", "compiler/compiler-runner", "compiler/compiler-runner-unshaded")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo) }
 }
 
 internal object SwiftExportDomainInfo : DomainInfo {
     override val domain = Domain.SwiftExport
-    override val include: List<String> = listOf("native/swift/**", "libraries/tools/analysis-api-based-klib-reader/**")
+    override val include: List<String> = listOf("native/swift", "libraries/tools/analysis-api-based-klib-reader")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(AnalysisApiDomainInfo) }
 }
 
 internal object CompilerPluginsDomainInfo : DomainInfo {
     override val domain = Domain.CompilerPlugins
-    override val include: List<String> = listOf("compiler/plugin-api/**", "plugins/**")
+    override val include: List<String> = listOf("compiler/plugin-api", "plugins")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo) }
 }
 
 internal object GradleDomainInfo : DomainInfo {
     override val domain = Domain.Gradle
-    override val include: List<String> = listOf("build-common/**", "libraries/tools/*gradle*/**", "compiler/build-tools/kotlin-build-statistics/**")
+    override val include: List<String> = listOf("build-common", "libraries/tools/*gradle*", "compiler/build-tools/kotlin-build-statistics")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf() }
 }
 
 internal object MavenDomainInfo : DomainInfo {
     override val domain = Domain.Maven
-    override val include: List<String> = listOf("libraries/tools/*maven*/**")
+    override val include: List<String> = listOf("libraries/tools/*maven*")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf() }
 }
 
 internal object IntelliJDomainInfo : DomainInfo {
     override val domain = Domain.IntelliJ
-    override val include: List<String> = listOf("prepare/ide-plugin-dependencies/**")
+    override val include: List<String> = listOf("prepare/ide-plugin-dependencies")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, AnalysisApiDomainInfo, CoreLibsDomainInfo, BuildToolsApiDomainInfo, CompilerPluginsDomainInfo) }
 }
 
 internal object BuildInfrastructureDomainInfo : DomainInfo {
     override val domain = Domain.BuildInfrastructure
-    override val include: List<String> = listOf("repo/**", "gradle/**", "build.gradle.kts", "settings.gradle.kts", "gradle.properties", "scripts/**", ".space/**", ".idea/**")
+    override val include: List<String> = listOf("repo", "gradle", "build.gradle.kts", "settings.gradle.kts", "gradle.properties", "scripts", ".space", ".idea")
     override val exclude: List<String> = listOf()
     override val fullyAffectedBy: List<DomainInfo> by lazy { listOf() }
 }

--- a/repo/gradle-build-conventions/test-federation-convention/src/main/kotlin/org/jetbrains/kotlin/testFederation/DeclaredDomain.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/main/kotlin/org/jetbrains/kotlin/testFederation/DeclaredDomain.kt
@@ -12,23 +12,23 @@ internal data class DeclaredDomain(
     val name: String,
 
     /**
-     * Files matching these 'glob' patterns will be included in this subsystem.
-     * - e.g., 'compiler/​**' will include all files under the 'compiler' subdirectory
-     * - e.g., '**​/​*gradle* will include all files containing the word 'gradle'
+     * Files matching these patterns will be included in this subsystem. Directory paths include all their descendants.
+     * - e.g., 'compiler' will include the 'compiler' directory and all files under it
+     * - e.g., '**​/​*gradle*' will include all paths whose name contains the word 'gradle'
      */
     val includes: List<String>,
 
     /**
-     * Files matching these 'glob' patterns will be excluded from this subsystem
+     * Files matching these patterns will be excluded from this subsystem. Directory paths exclude all their descendants.
      * See [includes].
      *
-     * Note: If a file matches an 'include' and 'exclude' glob pattern, then the 'most specific' pattern will dominate.
+     * Note: If a file matches an 'include' and 'exclude' pattern, then the 'most specific' pattern will dominate.
      * e.g., a definition like
      * ```yaml
      * include:
-     *     - foo/​**
+     *     - foo
      * exclude:
-     *     - foo/​**​/bar
+     *     - foo/abc
      * ```
      *
      * Will exclude 'foo/abc/bar', as the exclude rule is considered 'more specific'.

--- a/repo/gradle-build-conventions/test-federation-convention/src/main/kotlin/org/jetbrains/kotlin/testFederation/DomainInfo.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/main/kotlin/org/jetbrains/kotlin/testFederation/DomainInfo.kt
@@ -45,6 +45,9 @@ data class RepositoryPath(private val root: Path, val value: Path) {
      */
     fun resolve(): Path = root.resolve(value)
 
+    val parentOrNull: RepositoryPath?
+        get() = value.parent?.let { parent -> RepositoryPath(root, parent) }
+
     override fun toString(): String {
         return value.toString()
     }
@@ -65,35 +68,49 @@ internal fun Project.repositoryPath(path: Path): RepositoryPath {
  */
 fun DomainInfo.Companion.resolveDomainInfosOf(path: RepositoryPath): List<DomainInfo> {
     val fileSystem = path.fileSystem
-    val value = if (path.resolve().isDirectory()) path.value.resolve(".") else path.value
 
-    val domains = mutableListOf<DomainInfo>()
+    val domains = mutableSetOf<DomainInfo>()
+    val excludes = mutableSetOf<DomainInfo>()
 
-    allDomainInfos.forEach { currentDomain ->
-        var isInclude = false
-        var matchingRule = ""
+    var currentPath: RepositoryPath? = path
+    while(currentPath != null) {
+        val value = currentPath.value
 
-        currentDomain.exclude.forEach { exclude ->
-            if (fileSystem.getPathMatcher("glob:$exclude").matches(value)) {
-                if (exclude.length > matchingRule.length) {
-                    matchingRule = exclude
-                    isInclude = false
+        allDomainInfos.minus(excludes).forEach { currentDomain ->
+            var isInclude = false
+            var isExclude = false
+            var matchingRule = ""
+
+            currentDomain.exclude.forEach { exclude ->
+                if (fileSystem.getPathMatcher("glob:$exclude").matches(value)) {
+                    if (exclude.length > matchingRule.length) {
+                        matchingRule = exclude
+                        isExclude = true
+                        isInclude = false
+                    }
                 }
+            }
+
+            currentDomain.include.forEach { include ->
+                if (fileSystem.getPathMatcher("glob:$include").matches(value)) {
+                    if (include.length > matchingRule.length) {
+                        matchingRule = include
+                        isInclude = true
+                        isExclude = false
+                    }
+                }
+            }
+
+            if (isInclude) {
+                domains += currentDomain
+            }
+
+            if(isExclude) {
+                excludes += currentDomain
             }
         }
 
-        currentDomain.include.forEach { include ->
-            if (fileSystem.getPathMatcher("glob:$include").matches(value)) {
-                if (include.length > matchingRule.length) {
-                    matchingRule = include
-                    isInclude = true
-                }
-            }
-        }
-
-        if (isInclude) {
-            domains += currentDomain
-        }
+        currentPath = currentPath.parentOrNull
     }
 
     if (domains.isEmpty()) {

--- a/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/DomainsDumpTest.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/DomainsDumpTest.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.testFederation
 
+import groovy.util.MapEntry
 import org.jetbrains.kotlin.repoTestFixtures.isGitIgnored
 import org.jetbrains.kotlin.tooling.core.withClosure
 import org.opentest4j.AssertionFailedError
@@ -36,8 +37,11 @@ class DomainsDumpTest {
             appendLine("####################################################")
             appendLine()
 
+            fun <T> sorting() = compareBy<Map.Entry<Collection<Domain>, T>> { (domains, _) -> domains.size }
+                .thenComparing { (domains, _) -> domains.sumOf { it.ordinal } }
+
             conflatedTree.withClosure { it.children }.filter { it.children.isEmpty() }
-                .groupBy { it.domains }.entries.sortedBy { it.key.sumOf { it.ordinal } }.forEach { (domains, nodes) ->
+                .groupBy { it.domains }.entries.sortedWith(sorting()).forEach { (domains, nodes) ->
                     appendLine("${domains.joinToString(", ") { it.name }}:")
                     nodes.toList().sortedBy { it.path.value.invariantSeparatorsPathString }.forEach { node ->
                         appendLine(" - ${node.path.value.invariantSeparatorsPathString}")

--- a/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/DomainsDumpTest.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/DomainsDumpTest.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.tooling.core.withClosure
 import org.opentest4j.AssertionFailedError
 import org.opentest4j.FileInfo
 import java.io.File
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
 import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.invariantSeparatorsPathString
@@ -58,6 +60,54 @@ class DomainsDumpTest {
                 actualText,
             )
         }
+
+        /* Check if any 'include' or 'exclude' rules are orphan (not matching anything) */
+
+        fun globMatchesAnyNode(glob: String): Boolean {
+            val matcher = FileSystems.getDefault().getPathMatcher("glob:$glob")
+            return conflatedTree.withClosure { it.children }.any { node ->
+                matcher.matches(node.path.value)
+            }
+        }
+
+        class UnmatchedRule(val domain: DomainInfo, val rule: String, val isInclude: Boolean)
+
+        val unmatchedRules = mutableListOf<UnmatchedRule>()
+
+        allDomainInfos.forEach { domain ->
+            domain.include.forEach forEachRule@{ include ->
+                if (!globMatchesAnyNode(include)) {
+                    unmatchedRules.add(UnmatchedRule(domain, include, isInclude = true))
+                }
+            }
+
+            domain.exclude.forEach forEachRule@{ exclude ->
+                if (!globMatchesAnyNode(exclude)) {
+                    unmatchedRules.add(UnmatchedRule(domain, exclude, isInclude = false))
+                }
+            }
+        }
+
+        if (unmatchedRules.isNotEmpty()) error(buildString {
+            appendLine("Unmatched includes/excludes found")
+            unmatchedRules.groupBy { it.domain }.forEach { (domain, nodes) ->
+                appendLine("${domain.domain.name}:")
+                val includes = nodes.filter { it.isInclude }
+                if (includes.isNotEmpty()) {
+                    appendLine("  include:")
+                    includes.forEach { include ->
+                        appendLine("    - \"${include.rule}\"")
+                    }
+                }
+                val excludes = nodes.filterNot { it.isInclude }
+                if (excludes.isNotEmpty()) {
+                    appendLine("  exclude:")
+                    excludes.forEach { exclude ->
+                        appendLine("    - \"${exclude.rule}\"")
+                    }
+                }
+            }
+        })
     }
 
     private data class Node(


### PR DESCRIPTION
Previously, files needed to match exactly, using the glob /** syntax. This change allows for including directories directly.

In scope of: KTI-3428