### PR TITLE
[Tests][Wasm] Preserve package reflection names during package renaming in grouping testinfra

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/DeclarationGenerator.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/ir2wasm/codegenGenerators/DeclarationGenerator.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.backend.wasm.utils.fitsLatin1
 import org.jetbrains.kotlin.backend.wasm.utils.getFunctionalInterfaceSlot
 import org.jetbrains.kotlin.backend.wasm.utils.getJsBuiltinDescriptor
 import org.jetbrains.kotlin.backend.wasm.utils.getJsFunAnnotation
+import org.jetbrains.kotlin.backend.wasm.utils.getReflectionQualifier
 import org.jetbrains.kotlin.backend.wasm.utils.getWasmImportDescriptor
 import org.jetbrains.kotlin.backend.wasm.utils.hasUnpairedSurrogates
 import org.jetbrains.kotlin.backend.wasm.utils.isAbstractOrSealed
@@ -51,7 +52,6 @@ import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
-import org.jetbrains.kotlin.name.parentOrNull
 import org.jetbrains.kotlin.wasm.ir.WasmAnyRef
 import org.jetbrains.kotlin.wasm.ir.WasmContRefType
 import org.jetbrains.kotlin.wasm.ir.WasmExport
@@ -390,7 +390,7 @@ class DeclarationGenerator(
         val originalFqName = klass.originalFqName
         val qualifier =
             if (fqnShouldBeEmitted) {
-                (originalFqName ?: klass.kotlinFqName).parentOrNull()?.asString() ?: ""
+                klass.getReflectionQualifier(originalFqName ?: klass.kotlinFqName)
             } else {
                 ""
             }

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/BuiltInsLowering.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/lower/BuiltInsLowering.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.wasm.WasmBackendContext
 import org.jetbrains.kotlin.backend.wasm.getJsClassForExternalClass
+import org.jetbrains.kotlin.backend.wasm.utils.getReflectionQualifier
 import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.ClassKind
@@ -27,15 +28,12 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.putClassTypeArgument
-import org.jetbrains.kotlin.ir.util.toIrConst
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
-import org.jetbrains.kotlin.ir.util.erasedUpperBound
 import org.jetbrains.kotlin.ir.util.getArrayElementType
 import org.jetbrains.kotlin.ir.util.isNullable
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
-import org.jetbrains.kotlin.name.parentOrNull
 
 class BuiltInsLowering(val context: WasmBackendContext) : FileLoweringPass {
     private val irBuiltins = context.irBuiltIns
@@ -316,7 +314,7 @@ class BuiltInsLowering(val context: WasmBackendContext) : FileLoweringPass {
             val fqName = type.classFqName!!
             val fqnShouldBeEmitted =
                 context.configuration.languageVersionSettings.getFlag(AnalysisFlags.allowFullyQualifiedNameInKClass)
-            val packageName = if (fqnShouldBeEmitted) fqName.parentOrNull()?.asString() ?: "" else ""
+            val packageName = if (fqnShouldBeEmitted) klass.getReflectionQualifier(fqName) else ""
             val typeName = fqName.shortName().asString()
 
             return builder.irCallConstructor(symbols.reflectionSymbols.wasmTypeInfoData.constructors.first(), emptyList()).also {

--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/utils/Annotations.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/utils/Annotations.kt
@@ -8,15 +8,20 @@ package org.jetbrains.kotlin.backend.wasm.utils
 import org.jetbrains.kotlin.backend.wasm.jsBuiltinsModulePrefix
 import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.ir.util.getConstArgument
+import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.hasAnnotation
+import org.jetbrains.kotlin.ir.util.reflectionPackageName
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.parentOrNull
+import org.jetbrains.kotlin.name.tail
 import org.jetbrains.kotlin.wasm.ir.JsBuiltinDescriptor
 import org.jetbrains.kotlin.wasm.ir.WasmImportDescriptor
 import org.jetbrains.kotlin.wasm.ir.WasmSymbol
@@ -36,6 +41,23 @@ private val jsBuiltinFqName = FqName("kotlin.wasm.internal.JsBuiltin")
 
 fun IrAnnotationContainer.hasExcludedFromCodegenAnnotation(): Boolean =
     hasAnnotation(excludedFromCodegenFqName)
+
+/**
+ * Everything that precedes the simple name of this class in its fully qualified name: the package name,
+ * followed by the names of the outer classes, if any.
+ *
+ * Respects `@ReflectionPackageName` on the containing file, so that test infrastructure renaming packages
+ * for the sake of grouping several tests into one compilation does not affect the reflective information.
+ */
+fun IrClass.getReflectionQualifier(fqName: FqName): String {
+    val qualifier = fqName.parentOrNull() ?: FqName.ROOT
+    val reflectionPackageName = (getPackageFragment() as? IrFile)?.reflectionPackageName ?: return qualifier.asString()
+    // Keep the outer class names, replace only the package part.
+    return qualifier.tail(getPackageFragment().packageFqName)
+        .pathSegments()
+        .fold(FqName(reflectionPackageName), FqName::child)
+        .asString()
+}
 
 fun IrAnnotationContainer.getWasmCoroutineMode(): Boolean? =
     getAnnotation(wasmCoroutineModeFqName)?.getConstArgument("isStackSwitchingMode")

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/AdditionalIrUtils.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/AdditionalIrUtils.kt
@@ -418,6 +418,19 @@ inline fun <reified T> IrAnnotation.getConstArgument(name: String): T? {
     return expression?.value as? T
 }
 
+private val reflectionPackageNameFqName = StandardClassIds.Annotations.ReflectionPackageName.asSingleFqName()
+
+/**
+ * The package name that should be reported in the reflective information of the classes declared in this file
+ * instead of the real package name, or `null` if the file is not annotated with `@kotlin.internal.ReflectionPackageName`.
+ *
+ * The test infrastructure uses that annotation to compensate for the package renaming it performs when compiling
+ * several tests into one batch. Backends supporting reflective information are expected to respect it, so that
+ * the renaming does not affect the observable fully qualified names.
+ */
+val IrFile.reflectionPackageName: String?
+    get() = getAnnotation(reflectionPackageNameFqName)?.getConstArgument("name")
+
 val IrBlock.singleExpressionOrNull get() = statements.singleOrNull() as? IrExpression
 
 tailrec fun getSinglePropertyReference(expression: IrExpression?, expectedReturn: IrReturnableBlockSymbol?): IrRichPropertyReference? {

--- a/compiler/testData/codegen/box/companionBlocksAndExtensions/throwingInitializers.kt
+++ b/compiler/testData/codegen/box/companionBlocksAndExtensions/throwingInitializers.kt
@@ -2,8 +2,6 @@
 // DISABLE_IR_VISIBILITY_CHECKS: ANY
 // LANGUAGE: +CompanionBlocks
 // FULL_JDK
-// IGNORE_BACKEND: WASM
-// ^^^ KT-88074 Package renaming leads to the mismatch with the expected message
 
 package foo
 

--- a/compiler/testData/codegen/box/enum/throwingEntryInitializer.kt
+++ b/compiler/testData/codegen/box/enum/throwingEntryInitializer.kt
@@ -1,8 +1,6 @@
 // ISSUE: KT-87009
 // DISABLE_IR_VISIBILITY_CHECKS: ANY
 // FULL_JDK
-// IGNORE_BACKEND: WASM
-// ^^^ KT-88074 Package renaming leads to the mismatch with the expected message
 
 package foo
 

--- a/compiler/testData/codegen/box/reflection/classes/qualifiedNameWasm.kt
+++ b/compiler/testData/codegen/box/reflection/classes/qualifiedNameWasm.kt
@@ -1,6 +1,4 @@
 // TARGET_BACKEND: WASM
-// WASM_STANDALONE
-// ^^^ in non-standalone run, test classes will be placed in a sub-package, so `::class.qualifiedName` would give different result
 
 class NonLocal
 val nonLocalObject = object {}

--- a/compiler/testData/codegen/box/reflection/classes/toStringWasm.kt
+++ b/compiler/testData/codegen/box/reflection/classes/toStringWasm.kt
@@ -1,6 +1,4 @@
 // TARGET_BACKEND: WASM
-// WASM_STANDALONE
-// ^^^ in non-standalone run, test classes will be placed in a sub-package, so `::class.toString()` would give different result
 package foo.test
 
 class NonLocal

--- a/compiler/testData/codegen/box/when/NoWhenBranchMatchedExceptionAfterAnonymous.kt
+++ b/compiler/testData/codegen/box/when/NoWhenBranchMatchedExceptionAfterAnonymous.kt
@@ -2,8 +2,6 @@
 // ^Implementing sealed interfaces in a different module fails with IncompatibleClassChangeError starting from JVM 17
 // WITH_STDLIB
 // LANGUAGE: +NoWhenBranchMatchedExceptionWithMessage
-// IGNORE_BACKEND: WASM
-// ^^^ KT-88074 Package renaming leads to the mismatch with the expected message
 // MODULE: m1
 // FILE: m1.kt
 package pkg1

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/BatchingPackageInserter.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/BatchingPackageInserter.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.platform.konan.isNative
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
@@ -59,6 +58,10 @@ import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
  * Note that packages with fully qualified names starting with "kotlin." and "helpers." are kept unchanged.
  * Examples: package kotlin.coroutines -> package kotlin.coroutines
  *           import kotlin.test.* -> import kotlin.test.*
+ *
+ * If the platform supports it (see [ReflectionPackageNameAnnotation]), every patched file is additionally annotated
+ * with the file annotation preserving the original package name in the reflective information. Otherwise, tests
+ * asserting fully qualified names would produce different results in grouping and non-grouping modes.
  */
 class BatchingPackageInserter(testServices: TestServices) : ReversibleSourceFilePreprocessor(testServices) {
     companion object {
@@ -112,11 +115,11 @@ class BatchingPackageInserter(testServices: TestServices) : ReversibleSourceFile
             }
         }
         val patcher = PackageNamePatcher(
-            testServices.targetPlatformProvider.getTargetPlatform(module),
             psiFactory,
             packageMapping,
             additionalBasePackage,
-            transformHelpersPackage = isNative
+            transformHelpersPackage = isNative,
+            reflectionPackageNameAnnotation = testServices.reflectionPackageNameAnnotation,
         )
         ktFiles.values.forEach { it.accept(patcher, emptySet()) }
         for ([testFile, ktFile] in ktFiles) {
@@ -127,11 +130,54 @@ class BatchingPackageInserter(testServices: TestServices) : ReversibleSourceFile
     override fun revert(file: TestFile, actualContent: String): String {
         var content = actualContent
         val additionalPackage = computePackage(testServices.testInfo)
-        content = content.replace("@file:kotlin.native.internal.ReflectionPackageName(.*)\n".toRegex(), "")
+        testServices.reflectionPackageNameAnnotation?.let { annotation ->
+            content = content.replace(annotation.generatedFileAnnotationsRegex) { matchResult ->
+                if (!annotation.originalFileSuppressAnnotationWasCommented(matchResult.value)) {
+                    return@replace ""
+                }
+
+                val generatedSuppression = matchResult.groups["generatedSuppression"]?.value
+                checkTestInfrastructure(generatedSuppression != null) {
+                    "Generated file annotation block contains no generated file-level Suppress annotation: ${matchResult.value}"
+                }
+                removeGeneratedInvisibleReferenceFromFileSuppression(
+                    generatedSuppression,
+                    annotation.originalFileSuppressAnnotationHadTrailingComma(matchResult.value),
+                )
+            }
+        }
         content = content.replace("package $additionalPackage\n", "")
         content = content.replace("$additionalPackage.", "")
         content = content.stripAdditionalEmptyLines(file)
         return content
+    }
+
+    private fun removeGeneratedInvisibleReferenceFromFileSuppression(
+        annotationText: String,
+        originalHadTrailingComma: Boolean,
+    ): String {
+        val invisibleReferenceArgumentRegex = "(?:<![^>]*!>|<!>)?\"INVISIBLE_REFERENCE\"(?:<![^>]*!>|<!>)?"
+        val invisibleReferenceArgument = Regex(invisibleReferenceArgumentRegex)
+        val lineBreak = annotationText.takeLastWhile { it == '\r' || it == '\n' }
+        val annotationWithoutLineBreak = annotationText.removeSuffix(lineBreak)
+        val argumentsStart = annotationWithoutLineBreak.indexOf('(') + 1
+        val argumentsEnd = annotationWithoutLineBreak.lastIndexOf(')')
+        val arguments = annotationWithoutLineBreak.substring(argumentsStart, argumentsEnd)
+        checkTestInfrastructure(invisibleReferenceArgument.containsMatchIn(arguments)) {
+            "Generated file-level Suppress annotation contains no generated \"INVISIBLE_REFERENCE\" argument: $annotationText"
+        }
+
+        val argumentsWithoutInvisibleReference = if (originalHadTrailingComma) {
+            arguments.replace(invisibleReferenceArgument, "")
+        } else {
+            arguments
+                .replace(Regex(",\\s*$invisibleReferenceArgumentRegex\\s*"), "")
+                .replace(Regex("$invisibleReferenceArgumentRegex\\s*,\\s*"), "")
+                .replace(invisibleReferenceArgument, "")
+        }
+        return annotationWithoutLineBreak.substring(0, argumentsStart) +
+                argumentsWithoutInvisibleReference +
+                annotationWithoutLineBreak.substring(argumentsEnd) + lineBreak
     }
 
     private fun String.stripAdditionalEmptyLines(file: TestFile): String {
@@ -168,11 +214,11 @@ class BatchingPackageInserter(testServices: TestServices) : ReversibleSourceFile
     }
 
     class PackageNamePatcher(
-        val targetPlatform: TargetPlatform,
         val psiFactory: KtPsiFactory, // psiFactory
         val oldToNewPackageNameMapping: Map<FqName, FqName?>,
         val basePackageName: FqName,
-        val transformHelpersPackage: Boolean
+        val transformHelpersPackage: Boolean,
+        val reflectionPackageNameAnnotation: ReflectionPackageNameAnnotation? = null,
     ) : KtVisitor<Unit, Set<Name>>() {
         companion object {
             private val KOTLINX_PACKAGE_NAME = Name.identifier("kotlinx")
@@ -205,14 +251,102 @@ class BatchingPackageInserter(testServices: TestServices) : ReversibleSourceFile
             }
 
             if (!file.name.endsWith(".def")) { // don't process .def file contents after the package directive
-                if (targetPlatform.isNative()) {
-                    // Add @ReflectionPackageName annotation to make the compiler use the original package name in the reflective information.
-                    val annotationText =
-                        "kotlin.native.internal.ReflectionPackageName(${oldPackageName.asString().quoteAsKotlinStringLiteral()})"
-                    val fileAnnotationList = psiFactory.createFileAnnotationListWithAnnotation(annotationText)
-                    file.addAnnotations(fileAnnotationList)
+                // Make the compiler use the original package name in the reflective information.
+                reflectionPackageNameAnnotation?.let { annotation ->
+                    addGeneratedFileAnnotations(
+                        file,
+                        annotation,
+                        oldPackageName,
+                    )
                 }
                 visitKtElement(file, file.collectAccessibleDeclarationNames())
+            }
+        }
+
+        private fun addGeneratedFileAnnotations(
+            file: KtFile,
+            annotation: ReflectionPackageNameAnnotation,
+            oldPackageName: FqName,
+        ) {
+            val fileSuppressAnnotations = file.fileAnnotationList
+                ?.annotationEntries
+                ?.filter { it.shortName?.asString() == "Suppress" }
+                .orEmpty()
+            val hasInvisibleReferenceFileSuppression = fileSuppressAnnotations.any {
+                it.text.contains("\"INVISIBLE_REFERENCE\"")
+            }
+            val fileSuppressAnnotationToComment = fileSuppressAnnotations.firstOrNull()
+                ?.takeUnless { hasInvisibleReferenceFileSuppression }
+            val originalFileSuppressAnnotationText = fileSuppressAnnotationToComment?.text
+            val generatedAnnotationTexts = buildList {
+                if (originalFileSuppressAnnotationText == null && !hasInvisibleReferenceFileSuppression) {
+                    add("Suppress(\"INVISIBLE_REFERENCE\")")
+                } else if (originalFileSuppressAnnotationText != null) {
+                    val closingParenthesisIndex = originalFileSuppressAnnotationText.lastIndexOf(')')
+                    checkTestInfrastructure(closingParenthesisIndex >= 0) {
+                        "File-level Suppress annotation has no closing parenthesis: $originalFileSuppressAnnotationText"
+                    }
+                    val textBeforeClosingParenthesis = originalFileSuppressAnnotationText.substring(0, closingParenthesisIndex)
+                    val separator = if (
+                        textBeforeClosingParenthesis.trimEnd().endsWith('(') ||
+                        textBeforeClosingParenthesis.trimEnd().endsWith(',')
+                    ) {
+                        ""
+                    } else {
+                        ", "
+                    }
+                    add(
+                        (textBeforeClosingParenthesis + separator +
+                                "\"INVISIBLE_REFERENCE\"" + originalFileSuppressAnnotationText.substring(closingParenthesisIndex))
+                            .removePrefix("@file:")
+                            .removePrefix("@")
+                    )
+                }
+                add(annotation.render(oldPackageName.asString()))
+            }
+            val oldFileAnnotationList = file.fileAnnotationList
+            if (fileSuppressAnnotationToComment != null) {
+                val marker = fileSuppressAnnotationToComment.replace(
+                    psiFactory.createComment(
+                        annotation.renderGeneratedFileAnnotationsMarker(
+                            hasOriginalFileSuppressAnnotation = true,
+                            hasOriginalInvisibleReferenceFileSuppression = false,
+                            originalFileSuppressAnnotationText = originalFileSuppressAnnotationText,
+                        )
+                    )
+                )
+                marker.addGeneratedFileAnnotationsAfterMarker(generatedAnnotationTexts)
+                return
+            }
+
+            val marker = psiFactory.createComment(
+                annotation.renderGeneratedFileAnnotationsMarker(
+                    hasOriginalFileSuppressAnnotation = fileSuppressAnnotations.isNotEmpty(),
+                    hasOriginalInvisibleReferenceFileSuppression = hasInvisibleReferenceFileSuppression,
+                )
+            )
+            if (oldFileAnnotationList != null) {
+                oldFileAnnotationList.add(marker).ensureSurroundedByNewLines()
+                generatedAnnotationTexts.forEach { annotationText ->
+                    oldFileAnnotationList.add(psiFactory.createFileAnnotation(annotationText)).ensureSurroundedByNewLines()
+                }
+            } else {
+                file.addBefore(marker, file.packageDirective).ensureSurroundedByNewLines()
+                val generatedFileAnnotationList = psiFactory.createFileAnnotationListWithAnnotation(generatedAnnotationTexts.first())
+                generatedAnnotationTexts.drop(1).forEach { annotationText ->
+                    generatedFileAnnotationList.add(psiFactory.createFileAnnotation(annotationText)).ensureSurroundedByNewLines()
+                }
+                file.addBefore(generatedFileAnnotationList, file.packageDirective).ensureSurroundedByNewLines()
+            }
+        }
+
+        private fun PsiElement.addGeneratedFileAnnotationsAfterMarker(annotationTexts: List<String>) {
+            var previousElement = this
+            for (annotationText in annotationTexts) {
+                previousElement = previousElement.parent.addAfter(
+                    psiFactory.createFileAnnotation(annotationText),
+                    previousElement,
+                ).ensureSurroundedByNewLines()
             }
         }
 
@@ -447,7 +581,7 @@ private fun PsiElement.whiteSpaceAfter(): Pair<Boolean, String> {
  * Returns the expression to be parsed by Kotlin as a string literal with given contents.
  * i.e. transforms `foo$bar` to `"foo\$bar"`.
  */
-private fun String.quoteAsKotlinStringLiteral(): String = buildString {
+internal fun String.quoteAsKotlinStringLiteral(): String = buildString {
     append('"')
 
     this@quoteAsKotlinStringLiteral.forEach { c ->

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/ReflectionPackageNameAnnotation.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/ReflectionPackageNameAnnotation.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.test.services
+
+import org.jetbrains.kotlin.name.StandardClassIds
+
+/**
+ * The `kotlin.internal.ReflectionPackageName` file annotation, which makes the compiler use the given
+ * package name in the reflective information of the declarations of the annotated file, instead of the real one.
+ *
+ * [BatchingPackageInserter] adds this annotation to every file whose package it patches, so that the reflective
+ * information (`KClass.qualifiedName`, `KClass.toString()`, the default `Any.toString()`, etc.) is not affected
+ * by the package renaming, and thus is the same in grouping and non-grouping modes.
+ *
+ * Not every backend takes the annotation into account (see `IrFile.reflectionPackageName`), so this service acts as
+ * an opt-in switch: test runners of the platforms supporting the annotation are expected to register it in
+ * [TestServices] via `useAdditionalService { ReflectionPackageNameAnnotation }`, or, if they don't use [TestServices],
+ * to pass it to `BatchingPackageInserter.PackageNamePatcher` directly.
+ */
+object ReflectionPackageNameAnnotation : TestService {
+    val fqName: String = StandardClassIds.Annotations.ReflectionPackageName.asFqNameString()
+
+    fun render(packageName: String): String = "$fqName(${packageName.quoteAsKotlinStringLiteral()})"
+
+    private const val GENERATED_FILE_ANNOTATIONS_MARKER_PREFIX =
+        "/* BatchingPackageInserter: generated file annotations; "
+    private const val GENERATED_FILE_ANNOTATIONS_MARKER_SUFFIX = " */"
+    private const val ORIGINAL_FILE_SUPPRESS_ANNOTATION_COMMENTED_MARKER =
+        "original file-level @file:Suppress was commented"
+
+    private val diagnosticMarkupRegex = Regex("""<![^>]*!>|<!>""")
+
+    internal fun renderGeneratedFileAnnotationsMarker(
+        hasOriginalFileSuppressAnnotation: Boolean,
+        hasOriginalInvisibleReferenceFileSuppression: Boolean,
+        originalFileSuppressAnnotationText: String? = null,
+    ): String {
+        val originalAnnotationDescription = when {
+            originalFileSuppressAnnotationText != null ->
+                "$ORIGINAL_FILE_SUPPRESS_ANNOTATION_COMMENTED_MARKER: ${originalFileSuppressAnnotationText.asCommentText()}"
+            hasOriginalInvisibleReferenceFileSuppression ->
+                "original file-level @file:Suppress containing \"INVISIBLE_REFERENCE\" was preserved"
+            hasOriginalFileSuppressAnnotation ->
+                "original file-level @file:Suppress was preserved"
+            else ->
+                "no original file-level @file:Suppress annotation existed"
+        }
+        return GENERATED_FILE_ANNOTATIONS_MARKER_PREFIX + originalAnnotationDescription + GENERATED_FILE_ANNOTATIONS_MARKER_SUFFIX
+    }
+
+    internal fun originalFileSuppressAnnotationWasCommented(markerAndAnnotations: String): Boolean =
+        ORIGINAL_FILE_SUPPRESS_ANNOTATION_COMMENTED_MARKER in markerAndAnnotations
+
+    internal fun originalFileSuppressAnnotationHadTrailingComma(markerAndAnnotations: String): Boolean {
+        if (!originalFileSuppressAnnotationWasCommented(markerAndAnnotations)) return false
+        val originalAnnotation = markerAndAnnotations
+            .substringAfter("$ORIGINAL_FILE_SUPPRESS_ANNOTATION_COMMENTED_MARKER: ")
+            .substringBefore(GENERATED_FILE_ANNOTATIONS_MARKER_SUFFIX)
+        val argumentsStart = originalAnnotation.indexOf('(') + 1
+        val argumentsEnd = originalAnnotation.lastIndexOf(')')
+        return originalAnnotation.substring(argumentsStart, argumentsEnd).trimEnd().endsWith(',')
+    }
+
+    private val fileAnnotationPattern =
+        """(?:<![^>]*!>|<!>)*@file:(?:<![^>]*!>|<!>)*${Regex.escape(fqName)}(?:<![^>]*!>|<!>)*\([^\r\n]*\)(?:<![^>]*!>|<!>)*"""
+    private val generatedFileAnnotationsMarkerPattern =
+        """${Regex.escape(GENERATED_FILE_ANNOTATIONS_MARKER_PREFIX)}[^\r\n]*${Regex.escape(GENERATED_FILE_ANNOTATIONS_MARKER_SUFFIX)}"""
+    private const val GENERATED_FILE_SUPPRESSION_PATTERN =
+        """(?<generatedSuppression>(?:<![^>]*!>|<!>)*@file:Suppress\((?s:.*?)\)(?:<![^>]*!>|<!>)*\r?\n)?"""
+
+    /**
+     * Matches the marker and the file-level annotations inserted by [BatchingPackageInserter]. Diagnostic markup may be
+     * present when this regex is applied after metadata rendering.
+     */
+    internal val generatedFileAnnotationsRegex: Regex = Regex(
+        "$generatedFileAnnotationsMarkerPattern\r?\n$GENERATED_FILE_SUPPRESSION_PATTERN$fileAnnotationPattern(?:\r?\n)?"
+    )
+
+    private fun String.asCommentText(): String = replace(diagnosticMarkupRegex, "")
+        .replace(Regex("\\s+"), " ")
+        .replace("/*", "/ *")
+        .replace("*/", "* /")
+        .trim()
+}
+
+val TestServices.reflectionPackageNameAnnotation: ReflectionPackageNameAnnotation? by TestServices.nullableTestServiceAccessor()

--- a/core/names/api/names.api
+++ b/core/names/api/names.api
@@ -340,6 +340,7 @@ public final class org/jetbrains/kotlin/name/StandardClassIds$Annotations {
 	public final fun getOptionalExpectation ()Lorg/jetbrains/kotlin/name/ClassId;
 	public final fun getPublishedApi ()Lorg/jetbrains/kotlin/name/ClassId;
 	public final fun getRawTypeAnnotation ()Lorg/jetbrains/kotlin/name/ClassId;
+	public final fun getReflectionPackageName ()Lorg/jetbrains/kotlin/name/ClassId;
 	public final fun getRepeatable ()Lorg/jetbrains/kotlin/name/ClassId;
 	public final fun getRequireKotlin ()Lorg/jetbrains/kotlin/name/ClassId;
 	public final fun getRestrictsSuspension ()Lorg/jetbrains/kotlin/name/ClassId;

--- a/core/names/src/org/jetbrains/kotlin/name/StandardClassIds.kt
+++ b/core/names/src/org/jetbrains/kotlin/name/StandardClassIds.kt
@@ -266,6 +266,14 @@ object StandardClassIds {
 
         val UsedFromCompilerGeneratedCode = "UsedFromCompilerGeneratedCode".internalId()
 
+        /**
+         * `kotlin.internal.ReflectionPackageName`: a file annotation making the backend store the given package name
+         * in the reflective information of the classes declared in the file, instead of the real one.
+         *
+         * Used by the test infrastructure, which renames packages when compiling several tests into one batch.
+         */
+        val ReflectionPackageName = "ReflectionPackageName".internalId()
+
         object ParameterNames {
             val value = Name.identifier("value")
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
@@ -581,13 +581,8 @@ internal class RTTIGenerator(
 
     private fun getReflectionInfo(irClass: IrClass): ReflectionInfo {
         val packageFragment = irClass.getPackageFragment()
-        val reflectionPackageName = if (packageFragment is IrFile) {
-            // This annotation is used by test infrastructure.
-            packageFragment.annotations.findAnnotation(KonanFqNames.reflectionPackageName)?.getConstArgument<String>("name")
-        } else {
-            null
-        }
-
+        // `@kotlin.internal.ReflectionPackageName` is used by test infrastructure.
+        val reflectionPackageName = (packageFragment as? IrFile)?.reflectionPackageName
         val packageName: String = reflectionPackageName ?: packageFragment.packageFqName.asString() // Compute and store package name in TypeInfo anyways.
         val relativeName: String?
         val flags: Int

--- a/kotlin-native/runtime/src/main/kotlin/kotlin/native/internal/Annotations.kt
+++ b/kotlin-native/runtime/src/main/kotlin/kotlin/native/internal/Annotations.kt
@@ -147,17 +147,6 @@ internal annotation class InternalForKotlinNative
 public annotation class GCUnsafeCall(val callee: String)
 
 /**
- * Marks a declaration that is internal for Kotlin/Native tests and shouldn't be used externally.
- */
-@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
-@Retention(value = AnnotationRetention.BINARY)
-internal annotation class InternalForKotlinNativeTests
-
-@InternalForKotlinNativeTests
-@Target(AnnotationTarget.FILE)
-public annotation class ReflectionPackageName(val name: String)
-
-/**
  * Indicates that the marked function is an exported bridge between Kotlin and the platform.
  * This annotation prevents the function from being removed by DCE
  * and specifies a stable [bridgeName] for the function symbol.

--- a/libraries/stdlib/common-non-jvm/src/kotlin/internal/ReflectionPackageName.kt
+++ b/libraries/stdlib/common-non-jvm/src/kotlin/internal/ReflectionPackageName.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.internal
+
+/**
+ * Makes the compiler store [name] instead of the real package FQ name in the reflective information
+ * of the classes declared in the annotated file.
+ *
+ * This annotation is used by the compiler grouping test infrastructure, which renames packages when several tests
+ * are compiled together into one batch. Without it, `KClass.qualifiedName`, `KClass.toString()`
+ * and the default `Any.toString()` would expose the batch package prefix.
+ */
+@Target(AnnotationTarget.FILE)
+@Retention(AnnotationRetention.BINARY)
+@Suppress("unused")
+internal annotation class ReflectionPackageName(val name: String)

--- a/libraries/tools/binary-compatibility-validator/klib-public-api/kotlin-stdlib.api
+++ b/libraries/tools/binary-compatibility-validator/klib-public-api/kotlin-stdlib.api
@@ -10038,14 +10038,6 @@ open annotation class kotlin.native.internal/LeakDetectorCandidate : kotlin/Anno
 }
 
 // Targets: [native]
-open annotation class kotlin.native.internal/ReflectionPackageName : kotlin/Annotation { // kotlin.native.internal/ReflectionPackageName|null[0]
-    constructor <init>(kotlin/String) // kotlin.native.internal/ReflectionPackageName.<init>|<init>(kotlin.String){}[0]
-
-    final val name // kotlin.native.internal/ReflectionPackageName.name|{}name[0]
-        final fun <get-name>(): kotlin/String // kotlin.native.internal/ReflectionPackageName.name.<get-name>|<get-name>(){}[0]
-}
-
-// Targets: [native]
 open annotation class kotlin.native.runtime/NativeRuntimeApi : kotlin/Annotation { // kotlin.native.runtime/NativeRuntimeApi|null[0]
     constructor <init>() // kotlin.native.runtime/NativeRuntimeApi.<init>|<init>(){}[0]
 }

--- a/native/base/src/main/kotlin/org/jetbrains/kotlin/backend/konan/KonanFqNames.kt
+++ b/native/base/src/main/kotlin/org/jetbrains/kotlin/backend/konan/KonanFqNames.kt
@@ -43,7 +43,6 @@ object KonanFqNames {
     val hidesFromObjC = FqName("kotlin.native.HidesFromObjC")
     val refinesInSwift = FqName("kotlin.native.RefinesInSwift")
     val shouldRefineInSwift = FqName("kotlin.native.ShouldRefineInSwift")
-    val reflectionPackageName = FqName("kotlin.native.internal.ReflectionPackageName")
     val noInline = FqName("kotlin.native.NoInline")
     val transparentForDebugger = FqName("kotlin.native.internal.TransparentForDebugger")
 }

--- a/native/native.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/konan/test/klib/AbstractCustomNativeCompilerSecondStageTest.kt
+++ b/native/native.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/konan/test/klib/AbstractCustomNativeCompilerSecondStageTest.kt
@@ -55,7 +55,6 @@ open class AbstractCustomNativeCompilerSecondStageTest : AbstractNativeCoreTest(
 
             OPT_IN with listOf(
                 "kotlin.native.internal.InternalForKotlinNative",
-                "kotlin.native.internal.InternalForKotlinNativeTests",
                 "kotlin.experimental.ExperimentalNativeApi"
             )
         }

--- a/native/native.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/konan/test/klib/CustomNativeCompilerFirstStageFacade.kt
+++ b/native/native.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/konan/test/klib/CustomNativeCompilerFirstStageFacade.kt
@@ -60,7 +60,6 @@ class CustomNativeCompilerFirstStageFacade(testServices: TestServices) : CustomK
                     K2NativeCompilerArguments::kotlinHome.cliArgument, customNativeCompilerSettings.nativeHome.absolutePath,
                     K2NativeCompilerArguments::nodefaultlibs.cliArgument,
                     K2NativeCompilerArguments::optIn.cliArgument("kotlin.native.internal.InternalForKotlinNative"),
-                    K2NativeCompilerArguments::optIn.cliArgument("kotlin.native.internal.InternalForKotlinNativeTests"),
                 ),
                 regularAndFriendDependencies.flatMap {
                     listOf(K2NativeCompilerArguments::libraries.cliArgument, it)

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
@@ -39,7 +39,6 @@ abstract class AbstractNativeCodegenBoxCoreTest : AbstractTwoStageNativeCoreTest
             defaultDirectives {
                 OPT_IN with listOf(
                     "kotlin.native.internal.InternalForKotlinNative",
-                    "kotlin.native.internal.InternalForKotlinNativeTests",
                     "kotlin.experimental.ExperimentalNativeApi"
                 )
             }

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCoreTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCoreTest.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.builders.TwoStageTestConfigurationBuilder
 import org.jetbrains.kotlin.test.grouping.AbstractTwoStageKotlinCompilerNativeTest
 import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerNativeTest
+import org.jetbrains.kotlin.test.services.ReflectionPackageNameAnnotation
 import org.jetbrains.kotlin.test.services.TestServices
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -53,6 +54,7 @@ abstract class AbstractTwoStageNativeCoreTest : AbstractTwoStageKotlinCompilerNa
             useAdditionalService { // Register TestRunProvider into TestServices
                 extensionContext.getOrCreateTestRunProvider()
             }
+            useAdditionalService { ReflectionPackageNameAnnotation }
         }
     }
 }

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/ExtTestCaseGroupProvider.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/ExtTestCaseGroupProvider.kt
@@ -40,7 +40,6 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.util.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.platform.konan.NativePlatforms
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 import org.jetbrains.kotlin.resolve.checkers.OptInNames
@@ -218,7 +217,6 @@ private class ExtTestDataFile(
         }
 
         args += "-opt-in=kotlin.native.internal.InternalForKotlinNative" // for `Any.isPermanent()` and `Any.isStack()`
-        args += "-opt-in=kotlin.native.internal.InternalForKotlinNativeTests" // for ReflectionPackageName
         if (!settings.withPlatformLibs && !structure.directives.contains(WITH_PLATFORM_LIBS))
             args += "-no-default-libs"
         val freeCInteropArgs = structure.directives[FREE_CINTEROP_ARGS]
@@ -313,11 +311,11 @@ private class ExtTestDataFile(
 
         filesToTransform.forEach { handler ->
             val visitor = BatchingPackageInserter.PackageNamePatcher(
-                NativePlatforms.unspecifiedNativePlatform,
                 handler.psiFactory,
                 oldToNewPackageNameMapping,
                 basePackageName,
-                transformHelpersPackage = false
+                transformHelpersPackage = false,
+                reflectionPackageNameAnnotation = ReflectionPackageNameAnnotation,
             )
             handler.accept(visitor, emptySet())
         }

--- a/wasm/wasm.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/wasm/test/klib/AbstractCustomWasmJsCompilerSecondStageTest.kt
+++ b/wasm/wasm.tests/klib-compatibility/testFixtures/org/jetbrains/kotlin/wasm/test/klib/AbstractCustomWasmJsCompilerSecondStageTest.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.test.model.ArtifactKinds
 import org.jetbrains.kotlin.test.model.FrontendKinds
 import org.jetbrains.kotlin.test.services.CompilationStage
 import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.ReflectionPackageNameAnnotation
 import org.jetbrains.kotlin.test.services.StandardLibrariesPathProviderForKotlinProject
 import org.jetbrains.kotlin.test.services.configuration.UnsupportedFeaturesTestConfigurator
 import org.jetbrains.kotlin.test.services.configuration.WasmSecondStageEnvironmentConfigurator
@@ -99,6 +100,7 @@ open class AbstractCustomWasmJsCompilerSecondStageTest(val testDataRoot: String 
             }
 
             useConfigurators(::WasmSecondStageEnvironmentConfigurator.bind(WasmTarget.JS))
+            useAdditionalService { ReflectionPackageNameAnnotation }
         }
         nonGroupingStage {
             useGroupingTestIsolators(::WasmGroupingTestIsolator)

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/AbstractWasmCodegenBoxTest.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/AbstractWasmCodegenBoxTest.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.test.model.FrontendKinds
 import org.jetbrains.kotlin.test.model.GroupingStageHandler
 import org.jetbrains.kotlin.test.services.AdditionalSourceProvider
 import org.jetbrains.kotlin.test.services.CompilationStage
+import org.jetbrains.kotlin.test.services.ReflectionPackageNameAnnotation
 import org.jetbrains.kotlin.test.services.SplittingModuleTransformerForBoxTests
 import org.jetbrains.kotlin.test.services.SplittingTestConfigurator
 import org.jetbrains.kotlin.test.services.configuration.WasmSecondStageEnvironmentConfigurator
@@ -79,6 +80,7 @@ abstract class AbstractWasmCodegenBoxTest(
                 DIAGNOSTICS with listOf("-infos")
             }
             useConfigurators(::WasmSecondStageEnvironmentConfigurator.bind(wasmTarget))
+            useAdditionalService { ReflectionPackageNameAnnotation }
             configureIgnoredTestSuppressor()
             useFailureSuppressors(
                 ::FirMetaInfoDiffSuppressor,


### PR DESCRIPTION
The approach, already implemented in K/N grouping testinfra, also applied here for K/Wasm grouping infra:
In case of package renaming during grouped test run, the file-level annotation is inserted to specify original package name before renaming. This allows to use this original name in RTTI and then in reflection.

The common code for Wasm and Native is unified, 
the differences are abstracted out to `ReflectionPackageNameOptInConfigurator` and `ReflectionPackageNameAnnotation` hierarchies

^[KT-88074](https://youtrack.jetbrains.com/issue/KT-88074) Fixed