### PR TITLE
[ObjCExport] K2: Bring property building logic in line with K1

### DIFF
--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyGetter.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyGetter.kt
@@ -6,21 +6,11 @@
 package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
-import org.jetbrains.kotlin.backend.konan.objCMacroDefinitions
 import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
 
-/**
- * Getter needs to be defined only for properties with [reservedPropertyNames]
- * ```c
- * @interface Foo
- * @property (getter=bool, setter=setBool) BOOL bool_
- * @end
- * ```
- */
 internal fun ObjCExportContext.getObjCPropertyGetter(symbol: KaPropertySymbol, objCName: String): String? {
-
-    // `init`-like properties will always need prefixing.
-    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions && !objCName.isSpecialFamilyOrInit(exportSession.configuration.explicitMethodFamilyName))
+    // See KaPropertySymbol.requiresAccessor() to know when an explicit setter is required.
+    if (!symbol.needsAccessor(objCName, exportSession.configuration.explicitMethodFamilyName))
         return null
 
     val symbolGetter = symbol.getter

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyName.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertyName.kt
@@ -16,7 +16,7 @@ fun ObjCExportContext.getObjCPropertyName(symbol: KaVariableSymbol): ObjCExportP
 fun ObjCExportContext.getObjCPropertyName(symbol: KaVariableSymbol, transform: (String) -> String): ObjCExportPropertyName {
     val resolveObjCNameAnnotation = symbol.resolveObjCNameAnnotation()
     val stringName = exportSession.overrideObjCNameOrSymbolName(symbol)
-    val propertyName = transform(stringName.mangleIfReservedObjCName())
+    val propertyName = transform(stringName.mangleIfReservedPropertyName())
 
     return ObjCExportPropertyName(
         objCName = (resolveObjCNameAnnotation?.objCName ?: propertyName).mangleIfStdMacro(),

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertySetter.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/getObjCPropertySetter.kt
@@ -6,21 +6,11 @@
 package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
-import org.jetbrains.kotlin.backend.konan.objCMacroDefinitions
 import org.jetbrains.kotlin.objcexport.analysisApiUtils.getFunctionMethodBridge
 
-/**
- * Setter needs to be defined only for properties with [reservedPropertyNames]
- * ```c
- * @interface Foo
- * @property (getter=bool, setter=setBool) BOOL bool_
- * @end
- * ```
- */
 internal fun ObjCExportContext.getObjCPropertySetter(symbol: KaPropertySymbol, objCName: String): String? {
-
-    // `init`-like properties will always need prefixing.
-    if (!symbol.hasReservedName && symbol.name.asString() !in objCMacroDefinitions && !objCName.isSpecialFamilyOrInit(exportSession.configuration.explicitMethodFamilyName))
+    // See KaPropertySymbol.requiresAccessor() to know when an explicit setter is required.
+    if (!symbol.needsAccessor(objCName, exportSession.configuration.explicitMethodFamilyName))
         return null
 
     val setterName = symbol.setter?.let {

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/isObjCReservedName.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/isObjCReservedName.kt
@@ -24,7 +24,7 @@ private val reservedClassOrObjectNames = setOf(
 internal val String.isReservedPropertyName: Boolean
     get() = this in reservedPropertyNames
 
-private val String.isReservedClassOrObjectName: Boolean
+internal val String.isReservedClassOrObjectName: Boolean
     get() = this in reservedClassOrObjectNames
 
 /**
@@ -37,3 +37,5 @@ private val String.isReservedClassOrObjectName: Boolean
  * See [reservedClassOrObjectNames], [reservedPropertyNames] and [reservedPropertyNames]
  */
 internal fun String.mangleIfReservedObjCName(): String = if (this.isReservedClassOrObjectName) this + "_" else this
+
+internal fun String.mangleIfReservedPropertyName(): String = if (this.isReservedPropertyName) this + "_" else this

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCMethod.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCMethod.kt
@@ -231,8 +231,12 @@ fun ObjCExportContext.getSelector(symbol: KaFunctionSymbol, methodBridge: Method
     val parameters = valueParametersAssociated(methodBridge, symbol)
     val method = symbol
     val sb = StringBuilder()
+
+    // ObjCExportNamerImpl.getSelector() queries Predefined.anyMethodSelector through the `.name` property
+    // but queries reserved methodSelectors based on getMangledName()'s value. We do the same here.
     val anyMethodSelector = anyMethodSelectors[symbol.name]
-    val reservedNameSelector = objCReservedNameMethodSelectors[symbol.name]
+    val methodName = getMangledName(symbol, forSwift = false)
+    val reservedNameSelector = objCReservedNameMethodSelectors[Name.identifier(methodName)]
 
     if (reservedNameSelector != null && parameters.isEmpty()) {
         /**
@@ -249,8 +253,6 @@ fun ObjCExportContext.getSelector(symbol: KaFunctionSymbol, methodBridge: Method
     if (anyMethodSelector != null && analysisSession.overridesAnyMethod(symbol)) {
         return anyMethodSelector
     }
-
-    val methodName = getMangledName(symbol, forSwift = false)
 
     parameters.forEachIndexed { index, [bridge, parameter] ->
         val name = when (bridge) {

--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCProperty.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToObjCProperty.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.backend.konan.objCMacroDefinitions
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCProperty
 import org.jetbrains.kotlin.backend.konan.objcexport.isInstance
 import org.jetbrains.kotlin.backend.konan.objcexport.swiftNameAttribute
@@ -55,5 +56,14 @@ fun ObjCExportContext.buildProperty(symbol: KaPropertySymbol): ObjCProperty {
 internal val String.asSetterSelector: String
     get() = "set" + replaceFirstChar(Char::uppercase) + ":"
 
-internal val KaPropertySymbol.hasReservedName: Boolean
-    get() = name.asString().isReservedPropertyName
+/**
+ * A getter or setter is defined only when it differs from the property's name. This can happen in 4 scenarios:
+ * 1. Property name is a reserved keyword such as bool: (getter=bool, setter=setBool:) BOOL bool_;
+ * 2. Accessor clashes with a method (an NSObject method, for e.g.): (getter=autorelease_) int32_t autorelease;
+ * 3. Property name clashes with a macro: (setter=setNULL:) int32_t NULL_;
+ * 4. Accessor has to be prefixed with "do": (getter=doInit) int32_t init;
+ */
+internal fun KaPropertySymbol.needsAccessor(objCName: String, explicitMethodFamilyName: Boolean): Boolean {
+    val name = this.name.asString()
+    return name.isReservedClassOrObjectName || name in objCMacroDefinitions || objCName.isSpecialFamilyOrInit(explicitMethodFamilyName)
+}

--- a/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/!propertiesWithReservedNames.h
+++ b/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/!propertiesWithReservedNames.h
@@ -29,10 +29,13 @@ __attribute__((objc_subclassing_restricted))
 @property (readonly) NSString *NO_ __attribute__((swift_name("NO")));
 @property (setter=setDEBUG:) BOOL DEBUG_ __attribute__((swift_name("DEBUG")));
 @property (readonly) NSString *NULL_ __attribute__((swift_name("NULL")));
+@property (readonly) NSString *load __attribute__((swift_name("load")));
+@property (getter=release_) NSString *release __attribute__((swift_name("release")));
 @end
 
 __attribute__((objc_subclassing_restricted))
 @interface FooKt : Base
++ (void)f __attribute__((swift_name("f()")));
 @property (class, readonly) NSString *YES_ __attribute__((swift_name("YES")));
 @end
 

--- a/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/propertiesWithReservedNames/Foo.kt
@@ -4,6 +4,17 @@ object Foo {
 
     @ObjCName("NO")
     val Bar = "no_as_string"
+
+    // Acceptable as a property name. Neither it, nor its selector should be mangled.
+    val load = "load_as_string"
+
+    // Needs a mangled getter as the property's name violates the naming rules.
+    // Its setter, however, should not be exposed as it'd be in the form of `set<propertyName>:`.
+    var release = "release_as_string"
 }
 
 val YES = Foo.NULL
+
+fun f() {
+    Foo.release = "release"
+}


### PR DESCRIPTION
Consider this declaration:
```kotlin
val release = "release"
```

The resultant property generated by K1 is:
```
@property (readonly, getter=release_) NSString *release __attribute__((swift_name("release")));
```

However, K2 produces:
```
@property (readonly) NSString *release_ __attribute__((swift_name("release_")));
```

In K1, `cKeywords` + `description` are considered to be reserved names for property names. However, K2 uses a set of names that's a superset of what K1 uses. As a result, names such as `release` end up getting mangled. Because `swift_name` values are generated from property names, the resultant Swift name is also mangled and differs from that of K1's.

The additional names included when validating the property names are actually supposed to be used when building the selector for the accessors.

This change brings K2's logic in line with K1.

^KT-88052 fixed