### PR TITLE
[stdlib] Delete recently introduced exceptions from common & JVM parts

### DIFF
--- a/libraries/stdlib/common-non-jvm/src/kotlin/Exceptions.kt
+++ b/libraries/stdlib/common-non-jvm/src/kotlin/Exceptions.kt
@@ -85,11 +85,17 @@ public actual open class ArithmeticException : RuntimeException {
     public actual constructor(message: String?) : super(message)
 }
 
-internal actual open class ExceptionInInitializerError : Error {
+/**
+ * Equivalent to `java.lang.ExceptionInInitializerError`.
+ */
+internal class ExceptionInInitializerError : Error {
     constructor(message: String) : super(message)
-    actual constructor(cause: Throwable) : super(null, cause)
+    constructor(cause: Throwable) : super(null, cause)
 }
 
-internal actual open class NoClassDefFoundError : Error {
-    actual constructor(message: String?) : super(message)
+/**
+ * Equivalent to `java.lang.NoClassDefFoundError`.
+ */
+internal class NoClassDefFoundError : Error {
+    constructor(message: String?) : super(message)
 }

--- a/libraries/stdlib/common/src/kotlin/ExceptionsH.kt
+++ b/libraries/stdlib/common/src/kotlin/ExceptionsH.kt
@@ -124,14 +124,6 @@ internal class KotlinNothingValueException : RuntimeException {
     public constructor(cause: Throwable?) : super(cause)
 }
 
-internal expect class ExceptionInInitializerError : Error {
-    constructor(cause: Throwable)
-}
-
-internal expect class NoClassDefFoundError : Error {
-    constructor(message: String?)
-}
-
 /**
  * Returns the detailed description of this throwable with its stack trace.
  *

--- a/libraries/stdlib/jvm/runtime/kotlin/TypeAliases.kt
+++ b/libraries/stdlib/jvm/runtime/kotlin/TypeAliases.kt
@@ -23,9 +23,6 @@ package kotlin
 @Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS")
 @SinceKotlin("1.1") public actual typealias AssertionError = java.lang.AssertionError
 
-internal actual typealias ExceptionInInitializerError = java.lang.ExceptionInInitializerError
-internal actual typealias NoClassDefFoundError = java.lang.NoClassDefFoundError
-
 @SinceKotlin("1.1") public actual typealias NoSuchElementException = java.util.NoSuchElementException
 
 @Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS")


### PR DESCRIPTION
- `ExceptionInInitializerError` was introduced in  5959617b4f9bbec18220ff94f922e6aa87410381
- `NoClassDefFoundError` was introduced in  5546a55fb1d5743a9e76fb77a6ff05409696064d

Both classes were introduced in the scope of KT-57134. We only need them on non-JVM targets. We also introduced `expect` counterparts in the common source set, and two type aliases on the JVM source set, just to be clear that they are related.

However, because Kotlin auto-imports `java.lang.*` (where both these classes reside on JVM) with lower priority than other auto-imports, a usage of `NoClassDefFoundError` in user code started being resolved to the newly introduced type alias. The problem is that this type alias has internal visibility, causing `INVISIBLE_REFERENCE` compilation errors.

For this reason, we remove the declarations from the common and JVM source sets — they weren't needed there anyway.