### PR TITLE
Rewrite `getDefaultValueForOverriddenBuiltinFunction`

### DIFF
--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/java/specialBuiltinMembers.kt
@@ -45,14 +45,6 @@ object BuiltinMethodsWithSpecialGenericSignature : SpecialGenericSignatures() {
         return functionDescriptor.firstOverridden { it.hasErasedValueParametersInJava } as FunctionDescriptor?
     }
 
-    @JvmStatic
-    fun getDefaultValueForOverriddenBuiltinFunction(functionDescriptor: FunctionDescriptor): TypeSafeBarrierDescription? {
-        if (functionDescriptor.name !in ERASED_VALUE_PARAMETERS_SHORT_NAMES) return null
-        return functionDescriptor.firstOverridden {
-            it.computeJvmSignature() in SIGNATURE_TO_DEFAULT_VALUES_MAP.keys
-        }?.let { SIGNATURE_TO_DEFAULT_VALUES_MAP[it.computeJvmSignature()] }
-    }
-
     val Name.sameAsBuiltinMethodWithErasedValueParameters: Boolean
         get() = this in ERASED_VALUE_PARAMETERS_SHORT_NAMES
 

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/methodSignatureMapping.kt
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/methodSignatureMapping.kt
@@ -82,7 +82,7 @@ fun forceSingleValueParameterBoxing(f: CallableDescriptor): Boolean {
 }
 
 // This method only returns not-null for class methods
-fun CallableDescriptor.computeJvmSignature(): String? = signatures {
+internal fun CallableDescriptor.computeJvmSignature(): String? = signatures {
     if (DescriptorUtils.isLocal(this@computeJvmSignature)) return null
 
     val classDescriptor = containingDeclaration as? ClassDescriptor ?: return null

--- a/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/methodSignatureMapping.kt
+++ b/core/descriptors.jvm/src/org/jetbrains/kotlin/load/kotlin/methodSignatureMapping.kt
@@ -82,7 +82,7 @@ fun forceSingleValueParameterBoxing(f: CallableDescriptor): Boolean {
 }
 
 // This method only returns not-null for class methods
-internal fun CallableDescriptor.computeJvmSignature(): String? = signatures {
+fun CallableDescriptor.computeJvmSignature(): String? = signatures {
     if (DescriptorUtils.isLocal(this@computeJvmSignature)) return null
 
     val classDescriptor = containingDeclaration as? ClassDescriptor ?: return null

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -11,22 +11,20 @@ import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlockBody
 import org.jetbrains.kotlin.backend.common.lower.irIfThen
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
-import org.jetbrains.kotlin.backend.konan.descriptors.*
+import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.*
-import org.jetbrains.kotlin.backend.konan.ir.BridgeDirection
-import org.jetbrains.kotlin.backend.konan.ir.BridgeDirectionKind
-import org.jetbrains.kotlin.backend.konan.ir.BridgeDirections
-import org.jetbrains.kotlin.backend.konan.ir.OverriddenFunctionInfo
 import org.jetbrains.kotlin.backend.konan.llvm.computeFunctionName
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrRawFunctionReference
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrRawFunctionReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
@@ -40,14 +38,22 @@ import org.jetbrains.kotlin.ir.types.isNullableAny
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
-import org.jetbrains.kotlin.load.java.BuiltinMethodsWithSpecialGenericSignature
 import org.jetbrains.kotlin.load.java.SpecialGenericSignatures
+import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.ERASED_VALUE_PARAMETERS_SHORT_NAMES
+import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.SIGNATURE_TO_DEFAULT_VALUES_MAP
+import org.jetbrains.kotlin.load.kotlin.computeJvmSignature
+import org.jetbrains.kotlin.resolve.descriptorUtil.firstOverridden
 import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 
 private var IrFunction.bridges: MutableMap<BridgeDirections, IrSimpleFunction>? by irAttribute(copyByDefault = false)
 
-@OptIn(ObsoleteDescriptorBasedAPI::class, K1Deprecation::class)
-internal fun IrFunction.getDefaultValueForOverriddenBuiltinFunction() = BuiltinMethodsWithSpecialGenericSignature.getDefaultValueForOverriddenBuiltinFunction(descriptor)
+@OptIn(ObsoleteDescriptorBasedAPI::class)
+internal fun IrFunction.getDefaultValueForOverriddenBuiltinFunction(): SpecialGenericSignatures.TypeSafeBarrierDescription? {
+    if (descriptor.name !in ERASED_VALUE_PARAMETERS_SHORT_NAMES) return null
+    return descriptor.firstOverridden {
+        it.computeJvmSignature() in SIGNATURE_TO_DEFAULT_VALUES_MAP.keys
+    }?.let { SIGNATURE_TO_DEFAULT_VALUES_MAP[it.computeJvmSignature()] }
+}
 
 internal class BridgesSupport(val irBuiltIns: IrBuiltIns, val symbols: BackendNativeSymbols, val irFactory: IrFactory) {
     fun getBridge(overriddenFunction: OverriddenFunctionInfo): IrSimpleFunction {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -50,21 +50,20 @@ internal fun IrFunction.getDefaultValueForOverriddenBuiltinFunction(): TypeSafeB
     if (this.name !in ERASED_VALUE_PARAMETERS_SHORT_NAMES) return null
     if (this !is IrSimpleFunction) return null
 
-    var result: IrSimpleFunctionSymbol? = null
+    var result: TypeSafeBarrierDescription? = null
     return DFS.dfs(listOf(this.symbol),
             { current -> current?.owner?.overriddenSymbols ?: emptyList() },
-            object : DFS.NodeHandler<IrSimpleFunctionSymbol, IrSimpleFunctionSymbol?> {
-                override fun beforeChildren(current: IrSimpleFunctionSymbol?): Boolean = result == null
+            object : DFS.NodeHandler<IrSimpleFunctionSymbol, TypeSafeBarrierDescription?> {
+                override fun beforeChildren(current: IrSimpleFunctionSymbol): Boolean = result == null
 
-                override fun afterChildren(current: IrSimpleFunctionSymbol?) {
-                    if (result == null && current?.owner?.computeJvmLikeSignature() in SIGNATURE_TO_DEFAULT_VALUES_MAP) {
-                        result = current
-                    }
+                override fun afterChildren(current: IrSimpleFunctionSymbol) {
+                    if (result != null) return
+                    SIGNATURE_TO_DEFAULT_VALUES_MAP[current.owner.computeJvmLikeSignature()]?.let { result = it }
                 }
 
-                override fun result(): IrSimpleFunctionSymbol? = result
+                override fun result(): TypeSafeBarrierDescription? = result
             }
-    )?.let { SIGNATURE_TO_DEFAULT_VALUES_MAP[it.owner.computeJvmLikeSignature()] }
+    )
 }
 
 private val SIGNATURE_TO_DEFAULT_VALUES_MAP = mapOf(
@@ -73,8 +72,6 @@ private val SIGNATURE_TO_DEFAULT_VALUES_MAP = mapOf(
 
         "${StandardClassIds.Map}.containsKey(${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
         "${StandardClassIds.Map}.containsValue(${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
-        "${StandardClassIds.MutableMap}.remove(${StandardClassIds.Any}, ${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
-        "${StandardClassIds.Map}.getOrDefault(${StandardClassIds.Any}, ${StandardClassIds.Any}): ${StandardClassIds.Any}" to TypeSafeBarrierDescription.MAP_GET_OR_DEFAULT,
         "${StandardClassIds.Map}.get(${StandardClassIds.Any}): ${StandardClassIds.Any}" to TypeSafeBarrierDescription.NULL,
         "${StandardClassIds.MutableMap}.remove(${StandardClassIds.Any}): ${StandardClassIds.Any}" to TypeSafeBarrierDescription.NULL,
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -14,11 +14,9 @@ import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.*
 import org.jetbrains.kotlin.backend.konan.llvm.computeFunctionName
-import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
@@ -41,34 +39,60 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.java.SpecialGenericSignatures
 import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.ERASED_VALUE_PARAMETERS_SHORT_NAMES
-import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.SIGNATURE_TO_DEFAULT_VALUES_MAP
-import org.jetbrains.kotlin.load.kotlin.computeJvmSignature
+import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.TypeSafeBarrierDescription
+import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.utils.DFS
-import org.jetbrains.kotlin.utils.DFS.AbstractNodeHandler
 import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 
 private var IrFunction.bridges: MutableMap<BridgeDirections, IrSimpleFunction>? by irAttribute(copyByDefault = false)
 
-@OptIn(ObsoleteDescriptorBasedAPI::class)
-internal fun IrFunction.getDefaultValueForOverriddenBuiltinFunction(): SpecialGenericSignatures.TypeSafeBarrierDescription? {
-    if (descriptor.name !in ERASED_VALUE_PARAMETERS_SHORT_NAMES) return null
-    var result: CallableMemberDescriptor? = null
-    return DFS.dfs(listOf<CallableMemberDescriptor>(descriptor),
-            { current ->
-                val descriptor = if (false) current?.original else current
-                descriptor?.overriddenDescriptors ?: emptyList()
-            },
-            object : AbstractNodeHandler<CallableMemberDescriptor, CallableMemberDescriptor?>() {
-                override fun beforeChildren(current: CallableMemberDescriptor) = result == null
-                override fun afterChildren(current: CallableMemberDescriptor) {
-                    if (result == null && current.computeJvmSignature() in SIGNATURE_TO_DEFAULT_VALUES_MAP.keys) {
+internal fun IrFunction.getDefaultValueForOverriddenBuiltinFunction(): TypeSafeBarrierDescription? {
+    if (this.name !in ERASED_VALUE_PARAMETERS_SHORT_NAMES) return null
+    if (this !is IrSimpleFunction) return null
+
+    var result: IrSimpleFunctionSymbol? = null
+    return DFS.dfs(listOf(this.symbol),
+            { current -> current?.owner?.overriddenSymbols ?: emptyList() },
+            object : DFS.NodeHandler<IrSimpleFunctionSymbol, IrSimpleFunctionSymbol?> {
+                override fun beforeChildren(current: IrSimpleFunctionSymbol?): Boolean = result == null
+
+                override fun afterChildren(current: IrSimpleFunctionSymbol?) {
+                    if (result == null && current?.owner?.computeJvmLikeSignature() in SIGNATURE_TO_DEFAULT_VALUES_MAP) {
                         result = current
                     }
                 }
 
-                override fun result(): CallableMemberDescriptor? = result
+                override fun result(): IrSimpleFunctionSymbol? = result
             }
-       )?.let { SIGNATURE_TO_DEFAULT_VALUES_MAP[it.computeJvmSignature()] }
+    )?.let { SIGNATURE_TO_DEFAULT_VALUES_MAP[it.owner.computeJvmLikeSignature()] }
+}
+
+private val SIGNATURE_TO_DEFAULT_VALUES_MAP = mapOf(
+        "${StandardClassIds.Collection}.contains(${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
+        "${StandardClassIds.MutableCollection}.remove(${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
+
+        "${StandardClassIds.Map}.containsKey(${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
+        "${StandardClassIds.Map}.containsValue(${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
+        "${StandardClassIds.MutableMap}.remove(${StandardClassIds.Any}, ${StandardClassIds.Any}): ${StandardClassIds.Boolean}" to TypeSafeBarrierDescription.FALSE,
+        "${StandardClassIds.Map}.getOrDefault(${StandardClassIds.Any}, ${StandardClassIds.Any}): ${StandardClassIds.Any}" to TypeSafeBarrierDescription.MAP_GET_OR_DEFAULT,
+        "${StandardClassIds.Map}.get(${StandardClassIds.Any}): ${StandardClassIds.Any}" to TypeSafeBarrierDescription.NULL,
+        "${StandardClassIds.MutableMap}.remove(${StandardClassIds.Any}): ${StandardClassIds.Any}" to TypeSafeBarrierDescription.NULL,
+
+        "${StandardClassIds.List}.indexOf(${StandardClassIds.Any}): ${StandardClassIds.Int}" to TypeSafeBarrierDescription.INDEX,
+        "${StandardClassIds.List}.lastIndexOf(${StandardClassIds.Any}): ${StandardClassIds.Int}" to TypeSafeBarrierDescription.INDEX,
+)
+
+private fun IrSimpleFunction.computeJvmLikeSignature(): String {
+    return buildString {
+        append(this@computeJvmLikeSignature.parentClassOrNull?.classId)
+        append(".")
+        append(this@computeJvmLikeSignature.name)
+        val params = this@computeJvmLikeSignature.nonDispatchParameters
+                .joinToString(separator = ", ", prefix = "(", postfix = ")") { it.type.erasedUpperBound.classId.toString() }
+        append(params)
+        append(": ")
+        append(this@computeJvmLikeSignature.returnType.erasedUpperBound.classId)
+    }
 }
 
 internal class BridgesSupport(val irBuiltIns: IrBuiltIns, val symbols: BackendNativeSymbols, val irFactory: IrFactory) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.*
 import org.jetbrains.kotlin.backend.konan.llvm.computeFunctionName
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
@@ -42,7 +43,8 @@ import org.jetbrains.kotlin.load.java.SpecialGenericSignatures
 import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.ERASED_VALUE_PARAMETERS_SHORT_NAMES
 import org.jetbrains.kotlin.load.java.SpecialGenericSignatures.Companion.SIGNATURE_TO_DEFAULT_VALUES_MAP
 import org.jetbrains.kotlin.load.kotlin.computeJvmSignature
-import org.jetbrains.kotlin.resolve.descriptorUtil.firstOverridden
+import org.jetbrains.kotlin.utils.DFS
+import org.jetbrains.kotlin.utils.DFS.AbstractNodeHandler
 import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 
 private var IrFunction.bridges: MutableMap<BridgeDirections, IrSimpleFunction>? by irAttribute(copyByDefault = false)
@@ -50,9 +52,23 @@ private var IrFunction.bridges: MutableMap<BridgeDirections, IrSimpleFunction>? 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
 internal fun IrFunction.getDefaultValueForOverriddenBuiltinFunction(): SpecialGenericSignatures.TypeSafeBarrierDescription? {
     if (descriptor.name !in ERASED_VALUE_PARAMETERS_SHORT_NAMES) return null
-    return descriptor.firstOverridden {
-        it.computeJvmSignature() in SIGNATURE_TO_DEFAULT_VALUES_MAP.keys
-    }?.let { SIGNATURE_TO_DEFAULT_VALUES_MAP[it.computeJvmSignature()] }
+    var result: CallableMemberDescriptor? = null
+    return DFS.dfs(listOf<CallableMemberDescriptor>(descriptor),
+            { current ->
+                val descriptor = if (false) current?.original else current
+                descriptor?.overriddenDescriptors ?: emptyList()
+            },
+            object : AbstractNodeHandler<CallableMemberDescriptor, CallableMemberDescriptor?>() {
+                override fun beforeChildren(current: CallableMemberDescriptor) = result == null
+                override fun afterChildren(current: CallableMemberDescriptor) {
+                    if (result == null && current.computeJvmSignature() in SIGNATURE_TO_DEFAULT_VALUES_MAP.keys) {
+                        result = current
+                    }
+                }
+
+                override fun result(): CallableMemberDescriptor? = result
+            }
+       )?.let { SIGNATURE_TO_DEFAULT_VALUES_MAP[it.computeJvmSignature()] }
 }
 
 internal class BridgesSupport(val irBuiltIns: IrBuiltIns, val symbols: BackendNativeSymbols, val irFactory: IrFactory) {


### PR DESCRIPTION
This PR rewrites `getDefaultValueForOverriddenBuiltinFunction` function in `BridgesBuilding`. In the new version we are not using K1 anymore.

The whole rewrite is straightforward, but I split it into four small commits to simplify the review.