### PR TITLE
Ensure BuildMetricsService unregisters as BuildOperationListener

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
@@ -5,15 +5,25 @@
 
 package org.jetbrains.kotlin.gradle
 
+import org.gradle.api.internal.GradleInternal
 import org.gradle.api.logging.LogLevel
+import org.gradle.internal.operations.BuildOperationListener
+import org.gradle.internal.operations.BuildOperationListenerManager
+import org.gradle.internal.operations.DefaultBuildOperationListenerManager
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.build.report.metrics.*
 import org.jetbrains.kotlin.build.report.statistics.formatSize
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.internal.build.metrics.GradleBuildMetricsData
+import org.jetbrains.kotlin.gradle.internals.asFinishLogMessage
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.report.BuildReportType
+import org.jetbrains.kotlin.gradle.report.data.BuildExecutionData
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.gradle.testbase.BuildOptions.ConfigurationCacheValue
 import org.jetbrains.kotlin.gradle.testbase.BuildOptions.IsolatedProjectsMode
+import org.jetbrains.kotlin.gradle.testbase.TestVersions.ThirdPartyDependencies.GRADLE_DEVELOCITY_PLUGIN_VERSION
 import org.jetbrains.kotlin.gradle.testbase.TestVersions.ThirdPartyDependencies.GRADLE_ENTERPRISE_PLUGIN_VERSION
 import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
 import org.jetbrains.kotlin.gradle.util.BuildOperationRecordImpl
@@ -24,17 +34,14 @@ import org.junit.jupiter.api.DisplayName
 import java.io.ObjectInputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.*
 import kotlin.streams.asSequence
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import  org.jetbrains.kotlin.build.report.metrics.*
-import org.jetbrains.kotlin.gradle.internals.asFinishLogMessage
-import org.jetbrains.kotlin.gradle.report.data.BuildExecutionData
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
-import org.jetbrains.kotlin.gradle.testbase.TestVersions.ThirdPartyDependencies.GRADLE_DEVELOCITY_PLUGIN_VERSION
-import kotlin.test.assertContains
+import kotlin.test.fail
 
 @DisplayName("Build reports")
 class BuildReportsIT : KGPBaseTest() {
@@ -544,6 +551,71 @@ class BuildReportsIT : KGPBaseTest() {
                 input.readObject() as GradleBuildMetricsData
             }
         }
+    }
+
+    @Suppress("DEPRECATION")
+    @DisplayName("BuildMetricsService unsubscribes from BuildOperationListenerManager on close")
+    @GradleTestVersions(
+        additionalVersions = [TestVersions.Gradle.G_8_1],
+    )
+    @GradleTest
+    @JvmGradlePluginTests
+    fun testBuildOperationListenerUnsubscribed(gradleVersion: GradleVersion) {
+        project(
+            "simpleProject", gradleVersion,
+            buildOptions = defaultBuildOptions.copy(
+                buildReport = listOf(BuildReportType.JSON),
+                configurationCache = ConfigurationCacheValue.DISABLED
+            )
+        ) {
+            val errorMessage = "BuildMetricsService should remove itself from BuildOperationListenerManager"
+            fun assertBuildMetricServiceIsNotRegistered(buildOperationListeners: List<BuildOperationListener>) {
+                val classNames = buildOperationListeners.map { lister ->
+                    val delegateField = lister.javaClass.getDeclaredField("delegate").apply { isAccessible = true }
+                    (delegateField.get(lister)).javaClass.simpleName
+                }
+                if (classNames.firstOrNull { it.startsWith("BuildMetricsService") } != null) {
+                    fail(errorMessage)
+                }
+            }
+
+            if (gradleVersion.baseVersion >= GradleVersion.version("9.1")) {
+                buildScriptInjection {
+                    val buildOperationListenerManager =
+                        (project.gradle as GradleInternal).services.get(BuildOperationListenerManager::class.java) as DefaultBuildOperationListenerManager
+
+                    project.gradle.buildFinished {
+                        val listenersField = buildOperationListenerManager.javaClass.getDeclaredField("listeners")
+                        listenersField.isAccessible = true
+                        @Suppress("UNCHECKED_CAST")
+                        val buildOperationListeners =
+                            listenersField.get(buildOperationListenerManager) as AtomicReference<List<BuildOperationListener>>
+
+                        assertBuildMetricServiceIsNotRegistered(buildOperationListeners.get())
+                    }
+                }
+            } else {
+                buildScriptInjection {
+                    val buildOperationListenerManager =
+                        (project.gradle as GradleInternal).services.get(BuildOperationListenerManager::class.java) as DefaultBuildOperationListenerManager
+                    project.gradle.buildFinished {
+                        val listenersField = buildOperationListenerManager.javaClass.getDeclaredField("listeners")
+                        listenersField.isAccessible = true
+                        @Suppress("UNCHECKED_CAST")
+                        val buildOperationListeners = listenersField.get(buildOperationListenerManager) as List<BuildOperationListener>
+
+                        assertBuildMetricServiceIsNotRegistered(buildOperationListeners)
+                    }
+                }
+            }
+
+            build(
+                "compileKotlin",
+            ) {
+                assertOutputDoesNotContain(errorMessage)
+            }
+        }
+
     }
 
     @DisplayName("custom value limit")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/report/BuildMetricsService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/report/BuildMetricsService.kt
@@ -53,6 +53,7 @@ import org.jetbrains.kotlin.gradle.utils.SingleActionPerProject
 import java.lang.management.ManagementFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CopyOnWriteArrayList
 
 internal interface UsesBuildMetricsService : Task {
     @get:Internal
@@ -86,6 +87,10 @@ abstract class BuildMetricsService : BuildService<BuildMetricsService.Parameters
     private val taskPathToTaskClass = ConcurrentHashMap<String, String>()
 
     private val processedMessages = ConcurrentHashMap<Long, Boolean>()
+
+    private val closeActions = CopyOnWriteArrayList<() -> Unit>().also {
+        it.add(::closeBuildReportService)
+    }
 
     open fun addTask(
         taskPath: String,
@@ -151,7 +156,17 @@ abstract class BuildMetricsService : BuildService<BuildMetricsService.Parameters
         return buildOperation
     }
 
+    internal fun addOnCloseAction(action: () -> Unit) {
+        closeActions.add(action)
+    }
+
     override fun close() {
+        closeActions.forEach {
+            it()
+        }
+    }
+
+    private fun closeBuildReportService() {
         buildReportService.close(buildOperationRecords, failureMessages.toList(), parameters.toBuildReportParameters())
     }
 
@@ -220,7 +235,7 @@ abstract class BuildMetricsService : BuildService<BuildMetricsService.Parameters
         @Synchronized
         private fun registerIfAbsentImpl(
             project: Project,
-            buildOperationListenerManager: BuildOperationListenerManager
+            buildOperationListenerManager: BuildOperationListenerManager,
         ): Provider<BuildMetricsService>? {
             // Return early if the service was already registered to avoid the overhead of reading the reporting settings below
             project.gradle.sharedServices.registrations.findByName(serviceName)?.let {
@@ -263,7 +278,12 @@ abstract class BuildMetricsService : BuildService<BuildMetricsService.Parameters
                 it.parameters.buildConfigurationTags.value(setupTags(project))
             }.also {
                 subscribeForTaskEvents(project, it)
-                buildOperationListenerManager.addListener(it.get())
+
+                val buildService = it.get()
+                buildService.addOnCloseAction {
+                    buildOperationListenerManager.removeListener(buildService)
+                }
+                buildOperationListenerManager.addListener(buildService)
             }
 
         }


### PR DESCRIPTION
Each build leaves a strong reference to an instance of BuildMetricsService. BuildMetricsService removes itself as a build operation listener in BuildOperationListenerManager on close

^KT-88084