### PR TITLE
Configure BTA domain to run kt-master & mark 'CompilerReferenceIndexIT' as @AffectedByBuildToolsApi

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerReferenceIndexIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerReferenceIndexIT.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.testFederation.AffectedByBuildToolsApi
 import org.junit.jupiter.api.DisplayName
 import kotlin.io.path.div
 import kotlin.io.path.invariantSeparatorsPathString
@@ -29,6 +30,7 @@ import kotlin.test.*
 
 @OptIn(ExperimentalBuildToolsApi::class)
 @DisplayName("Gradle / Compiler Reference Index")
+@AffectedByBuildToolsApi
 class CompilerReferenceIndexIT : KGPDaemonsBaseTest() {
 
     override val defaultBuildOptions: BuildOptions = super.defaultBuildOptions.copy(

--- a/repo/domains.yaml
+++ b/repo/domains.yaml
@@ -109,6 +109,7 @@ IntelliJ:
     - Compiler
     - AnalysisApi
     - CoreLibs
+    - BuildToolsApi # small set of BTA tests, opportunity for optimizations.
 
 BuildInfrastructure:
   include:

--- a/repo/gradle-build-conventions/test-federation-convention/src/main/generated/domains.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/main/generated/domains.kt
@@ -103,7 +103,7 @@ internal object IntelliJDomainInfo : DomainInfo {
     override val domain = Domain.IntelliJ
     override val include: List<String> = listOf("prepare/ide-plugin-dependencies/**")
     override val exclude: List<String> = listOf()
-    override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, AnalysisApiDomainInfo, CoreLibsDomainInfo) }
+    override val fullyAffectedBy: List<DomainInfo> by lazy { listOf(CompilerDomainInfo, AnalysisApiDomainInfo, CoreLibsDomainInfo, BuildToolsApiDomainInfo) }
 }
 
 internal object BuildInfrastructureDomainInfo : DomainInfo {


### PR DESCRIPTION
Context: 
https://youtrack.jetbrains.com/issue/KT-88123/Fix-stable-test-federation-coverage-for-BTA-runtime-classpath-failures