### PR TITLE
[ObjCExport] Mangle `@ObjCName` and `@ObjCEnum.EntryName` names for enum members

### DIFF
--- a/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToNSEnum.kt
+++ b/native/objcexport-header-generator/impl/analysis-api/src/org/jetbrains/kotlin/objcexport/translateToNSEnum.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.objcexport
 
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaEnumEntrySymbol
+import org.jetbrains.kotlin.backend.konan.mangleIfStdMacro
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportNSEnumTypeName
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCNSClosedEnum
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCProperty
@@ -37,8 +38,15 @@ private fun ObjCExportContext.getNSEnumEntries(symbol: KaClassSymbol, objCTypeNa
     // Map the enum entries in declaration order, preserving the ordinal
     return staticMembers.filterIsInstance<KaEnumEntrySymbol>().mapIndexed { ordinal, entry ->
         ObjCNSClosedEnum.Entry(
-            getNSEnumEntryName(entry, true),
-            objCTypeName + getNSEnumEntryName(entry, false).replaceFirstChar { it.uppercaseChar() },
+            // Swift names that are passed to swift_name() don't need to be mangled as they're passed
+            // as string literals. However, NS_SWIFT_NAME() is a macro, that does not receive names this
+            // way. If they're not mangled, the generated header file could cause compilation warnings.
+            getNSEnumEntryName(entry, true).mangleIfStdMacro(),
+            // The NSEnumEntryName is obtained through getObjCPropertyName() which mangles the
+            // name by default should it be macro-like name, primarily for translateToObjCProperty.
+            // Since we're appending the name here to objCTypeName, there's no need of that mangling.
+            // Hence, the suffix drop op.
+            objCTypeName + getNSEnumEntryName(entry, false).dropLastWhile { it == '_' }.replaceFirstChar { it.uppercaseChar() },
             ordinal
         )
     }

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportTranslator.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportTranslator.kt
@@ -301,7 +301,11 @@ class ObjCExportTranslatorImpl(
                                 entries = descriptor.enumEntries.mapIndexed { ordinal, entry ->
                                     val objcEnumEntryName = entry.getObjCEnumEntryName()
                                     val objCName = objcEnumEntryName.getName(forSwift = false) ?: namer.getEnumEntrySelector(entry)
-                                    val swiftName = objcEnumEntryName.getName(forSwift = true) ?: namer.getEnumEntrySwiftName(entry)
+                                    // Swift names that are passed to swift_name() don't need to be mangled as they're passed
+                                    // as string literals. However, NS_SWIFT_NAME() is a macro, that does not receive names this
+                                    // way. If they're not mangled, the generated header file could cause compilation warnings.
+                                    val swiftName = (objcEnumEntryName.getName(forSwift = true)
+                                        ?: namer.getEnumEntrySwiftName(entry)).mangleIfStdMacro()
                                     ObjCNSClosedEnum.Entry(
                                         objCName = nsEnumTypeName.objCName + objCName.replaceFirstChar { it.uppercaseChar() },
                                         swiftName = swiftName,
@@ -325,7 +329,9 @@ class ObjCExportTranslatorImpl(
                     }
 
                     descriptor.enumEntries.forEach {
-                        val entryName = namer.getEnumEntrySelector(it)
+                        // Ideally, buildProperty() mangles the property name appropriately. Since we're
+                        // directly constructing an ObjCProperty, we need to mangle the name ourselves here.
+                        val entryName = namer.getEnumEntrySelector(it).mangleIfStdMacro()
                         val swiftName = namer.getEnumEntrySwiftName(it)
                         add {
                             ObjCProperty(

--- a/native/objcexport-header-generator/testData/headers/enumClassWithObjCEnumAndRenamedLiterals/!enumClassWithObjCEnumAndRenamedLiterals.h
+++ b/native/objcexport-header-generator/testData/headers/enumClassWithObjCEnumAndRenamedLiterals/!enumClassWithObjCEnumAndRenamedLiterals.h
@@ -49,6 +49,8 @@ typedef NS_CLOSED_ENUM(int32_t, FooNSEnum) {
   FooNSEnumCombination1Renamed NS_SWIFT_NAME(combination1Renamed) = 7,
   FooNSEnumCombination2Renamed NS_SWIFT_NAME(combination2Renamed) = 8,
   FooNSEnumCombination3Renamed NS_SWIFT_NAME(combination3Swift) = 9,
+  FooNSEnumNULL NS_SWIFT_NAME(DEBUG_) = 10,
+  FooNSEnumYES NS_SWIFT_NAME(NO_) = 11,
 } NS_SWIFT_NAME(FooNSEnum);
 
 
@@ -68,6 +70,8 @@ __attribute__((objc_subclassing_restricted))
 @property (class, readonly) Foo *combination1Bad __attribute__((swift_name("combination1Bad")));
 @property (class, readonly) Foo *combination2BadObjC __attribute__((swift_name("combination2BadSwift")));
 @property (class, readonly) Foo *combination3BadObjC __attribute__((swift_name("combination3BadSwift")));
+@property (class, readonly) Foo *NULL_ __attribute__((swift_name("DEBUG")));
+@property (class, readonly) Foo *entryName3Swift __attribute__((swift_name("entryName3Swift")));
 + (KotlinArray<Foo *> *)values __attribute__((swift_name("values()")));
 @property (class, readonly) NSArray<Foo *> *entries __attribute__((swift_name("entries")));
 @end

--- a/native/objcexport-header-generator/testData/headers/enumClassWithObjCEnumAndRenamedLiterals/Foo.kt
+++ b/native/objcexport-header-generator/testData/headers/enumClassWithObjCEnumAndRenamedLiterals/Foo.kt
@@ -16,5 +16,12 @@ enum class Foo {
     @ObjCEnum.EntryName(name="entryName2Renamed", swiftName="entryName2Swift") ENTRY_NAME_2_SWIFT,
     @ObjCEnum.EntryName(name="combination1Renamed") @ObjCName(name="combination1Bad") COMBINATION_1,
     @ObjCEnum.EntryName(name="combination2Renamed") @ObjCName(name="combination2BadObjC", swiftName="combination2BadSwift") COMBINATION_2,
-    @ObjCEnum.EntryName(name="combination3Renamed", swiftName = "combination3Swift") @ObjCName(name="combination3BadObjC", swiftName="combination3BadSwift") COMBINATION_3
+    @ObjCEnum.EntryName(name="combination3Renamed", swiftName = "combination3Swift") @ObjCName(name="combination3BadObjC", swiftName="combination3BadSwift") COMBINATION_3,
+
+    // Entry's name should be type + NULL and its corresponding Swift name should be DEBUG_.
+    // Property's name should be NULL_ and its corresponding Swift name should be DEBUG.
+    @ObjCName(name = "NULL", swiftName = "DEBUG") OBJC_NAME_3_ORIGINAL,
+    // Entry's name should be type + YES and corresponding Swift name should be NO_.
+    // Property's name and its corresponding Swift name should be entryName3Swift.
+    @ObjCEnum.EntryName(name = "YES", swiftName = "NO") ENTRY_NAME_3_SWIFT
 }


### PR DESCRIPTION
Both the said annotations allow us to specify what names the properties and entries should carry in the enum class' corresponding `interface` and `typedef` declarations in the generated header file.

Specifying names that clash with macros can result in compilation warnings and errors. To prevent this, this change ensures that such names are mangled appropriately.

^KT-88059 fixed