### PR TITLE
A lightweight utility to compute dependency DAG for Native KLIBs

### DIFF
--- a/native/cinterop.deserialization/src/main/kotlin/org/jetbrains/kotlin/backend/konan/library/KlibDAGBuilder.kt
+++ b/native/cinterop.deserialization/src/main/kotlin/org/jetbrains/kotlin/backend/konan/library/KlibDAGBuilder.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.library
+
+import org.jetbrains.kotlin.backend.common.IdSignaturesExtractor
+import org.jetbrains.kotlin.backend.common.IdSignaturesExtractorFromRegularKlib
+import org.jetbrains.kotlin.backend.konan.serialization.IdSignaturesExtractorFromCInteropKlib
+import org.jetbrains.kotlin.io.canonicalPathString
+import org.jetbrains.kotlin.ir.util.IdSignature
+import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.components.ir
+import org.jetbrains.kotlin.library.isNativeStdlib
+import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
+import org.jetbrains.kotlin.storage.LockBasedStorageManager
+import org.jetbrains.kotlin.storage.getValue
+import kotlin.io.path.pathString
+
+interface KlibDAGNode {
+    val library: KotlinLibrary
+    val directDependencies: Set<KlibDAGNode>
+    val allDependencies: Set<KlibDAGNode>
+}
+
+typealias KlibDAG = Map<KotlinLibrary, KlibDAGNode>
+
+class KlibDAGCyclicDependencyException : Exception("Recursive dependency detected while computing DAG of KLIB dependencies")
+
+object KlibDAGBuilder {
+    fun build(libraries: Collection<KotlinLibrary>): KlibDAG {
+        checkNoDuplicatedLibraries(libraries)
+
+        val dag: Map<KotlinLibrary, KlibDAGNodeImpl> = libraries.associateWith(::KlibDAGNodeImpl)
+
+        // Index: declared signature -> KLIB.
+        val declaredSignatureToNode: MutableMap<IdSignature, KlibDAGNodeImpl> = hashMapOf()
+
+        // Index: KLIB -> imported signatures.
+        val nodeToImportedSignatures: MutableMap<KlibDAGNodeImpl, Set<IdSignature>> = hashMapOf()
+
+        val [stdlib: List<KlibDAGNodeImpl>, others: List<KlibDAGNodeImpl>] = dag.values.partition { it.library.isNativeStdlib }
+
+        // Fill in indices.
+        for (node in others) {
+            // Optimization: Stdlib is a dependency for each library.
+            node.directDependencies.addAll(stdlib)
+
+            val [declaredSignatures, importedSignatures] = node.library.getSignatureExtractor().extractOnlyTopLevelPublicSignatures()
+
+            for (signature in declaredSignatures) {
+                declaredSignatureToNode[signature] = node
+            }
+
+            nodeToImportedSignatures[node] = importedSignatures
+        }
+
+        // Build the DAG.
+        for ([node, importedSignatures] in nodeToImportedSignatures) {
+            for (importedSignature in importedSignatures) {
+                val dependency: KlibDAGNodeImpl? = declaredSignatureToNode[importedSignature]
+                if (dependency != null) {
+                    node.directDependencies.add(dependency)
+                }
+            }
+        }
+
+        return dag
+    }
+
+    private fun checkNoDuplicatedLibraries(libraries: Collection<KotlinLibrary>) {
+        val duplicatedLibraries: Map<String, List<KotlinLibrary>> = libraries.groupBy { it.path.canonicalPathString() }.filterValues { it.size > 1 }
+        if (duplicatedLibraries.isEmpty()) return
+
+        val errorMessage = buildString {
+            duplicatedLibraries.values.forEach { duplicates ->
+                append("Duplicated libraries found: ")
+                duplicates.joinTo(this, postfix = "\n") { it.path.pathString }
+            }
+        }
+
+        error(errorMessage)
+    }
+
+    private fun KotlinLibrary.getSignatureExtractor(): IdSignaturesExtractor = when {
+        isCInteropLibrary() -> IdSignaturesExtractorFromCInteropKlib(this)
+        ir != null -> IdSignaturesExtractorFromRegularKlib(this)
+        else -> error("This library does not have IR and is not a C-interop library: $path")
+    }
+}
+
+private class KlibDAGNodeImpl(override val library: KotlinLibrary) : KlibDAGNode {
+    override val directDependencies = hashSetOf<KlibDAGNodeImpl>()
+
+    override val allDependencies: Set<KlibDAGNode> by LockBasedStorageManager.NO_LOCKS.createLazyValue(
+        computable = {
+            buildSet {
+                addAll(directDependencies)
+                directDependencies.flatMapTo(this, KlibDAGNode::allDependencies)
+            }
+        },
+        onRecursiveCall = {
+            throw KlibDAGCyclicDependencyException()
+        }
+    )
+}

--- a/native/native.tests/klib-ir-inliner/build.gradle.kts
+++ b/native/native.tests/klib-ir-inliner/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     testFixturesApi(testFixtures(project(":native:native.tests")))
     testFixturesApi(testFixtures(project(":kotlin-util-klib-abi")))
     testImplementation(project(":kotlin-util-klib-metadata"))
+    testImplementation(project(":native:cinterop.deserialization"))
 
     if (project.kotlinBuildProperties.isKotlinNativeEnabled.get()) {
         llvmDevBinaryDataUsage(project(":kotlin-native:dependencies", configuration = "llvmDevBinaryData"))

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.collections.set
+import kotlin.io.path.absolutePathString
 import kotlin.text.contains
 
 @Tag("klib")
@@ -103,8 +104,8 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
             "non-existent-klib.klib",
             "non-existent-dir/non-existent-klib",
             "non-existent-dir/non-existent-klib.klib",
-            modules.modules[0].sourceFile.parentFile.resolve("non-existent-klib").absolutePath,
-            modules.modules[0].sourceFile.parentFile.resolve("non-existent-klib.klib").absolutePath,
+            (modules.modules[0] as RegularKlibTestSourceModule).sourceFile.parent.resolve("non-existent-klib").absolutePathString(),
+            (modules.modules[0] as RegularKlibTestSourceModule).sourceFile.parent.resolve("non-existent-klib.klib").absolutePathString(),
         ).forEach { libraryPath ->
             modules.compileToKlibsViaCli(
                 extraCliArgs = listOf(

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliTestUtils.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliTestUtils.kt
@@ -116,8 +116,11 @@ internal fun newSourceModules(init: KlibTestSourceModulesBuilder.() -> Unit): Kl
                     appendLine("fun ${module.name}(indent: Int) {")
                     appendLine("    repeat(indent) { print(\"  \") }")
                     appendLine("    println(\"${module.name}\")")
-                    module.dependencyNames.forEach { dependencyName ->
-                        appendLine("    $dependencyName.$dependencyName(indent + 1)")
+                    module.dependencies.forEach { dependency ->
+                        if (dependency.kind == KlibTestSourceModule.Kind.CINTEROP) {
+                            appendLine("    @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)")
+                        }
+                        appendLine("    ${dependency.name}.${dependency.name}(indent + 1)")
                     }
                     appendLine("}")
 

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliTestUtils.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliTestUtils.kt
@@ -14,18 +14,29 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.LibraryCompi
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact.KLIB
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationResult
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationResult.Companion.assertSuccess
-import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.name
+import kotlin.io.path.writeText
 
 interface KlibTestSourceModule {
     val name: String
     val kind: Kind
     val dependencies: List<KlibTestSourceModule>
-    val sourceFile: File
 
     enum class Kind {
         REGULAR,
         CINTEROP,
     }
+}
+
+interface RegularKlibTestSourceModule : KlibTestSourceModule {
+    val sourceFile: Path
+}
+
+interface CInteropKlibTestSourceModule : KlibTestSourceModule {
+    val defFile: Path
+    val headerFile: Path
 }
 
 class KlibTestSourceModules(
@@ -34,60 +45,101 @@ class KlibTestSourceModules(
 
 internal interface KlibTestSourceModuleBuilder {
     fun dependsOn(dependencyName: String, vararg otherDependencyNames: String)
+}
+
+internal interface RegularKlibTestSourceModuleBuilder : KlibTestSourceModuleBuilder {
     fun sourceFileAddend(sourceFileAddend: String)
 }
 
+internal interface CInteropKlibTestSourceModuleBuilder : KlibTestSourceModuleBuilder {
+    fun defFileAddend(defFileAddend: String)
+    fun headerFileAddend(headerFileAddend: String)
+}
+
 internal interface KlibTestSourceModulesBuilder {
-    fun addRegularModule(name: String, init: KlibTestSourceModuleBuilder.() -> Unit = {})
-    fun addCInteropModule(name: String, init: KlibTestSourceModuleBuilder.() -> Unit = {})
+    fun addRegularModule(name: String, init: RegularKlibTestSourceModuleBuilder.() -> Unit = {})
+    fun addCInteropModule(name: String, init: CInteropKlibTestSourceModuleBuilder.() -> Unit = {})
 }
 
 context(testRunner: AbstractNativeSimpleTest)
 internal fun newSourceModules(init: KlibTestSourceModulesBuilder.() -> Unit): KlibTestSourceModules {
     // Private module implementation.
-    class ModuleImpl(
+    abstract class BaseModuleImpl(
         override val name: String,
-        override val kind: KlibTestSourceModule.Kind,
-        val sourceFileAddend: String,
         val dependencyNames: List<String>,
     ) : KlibTestSourceModule {
         override lateinit var dependencies: List<KlibTestSourceModule>
-        override lateinit var sourceFile: File
 
-        override fun toString(): String = "Module \"$name\""
-        override fun hashCode() = name.hashCode()
-        override fun equals(other: Any?) = (other as? ModuleImpl)?.name == name
+        final override fun toString(): String = "Module \"$name\""
+        final override fun hashCode() = name.hashCode()
+        final override fun equals(other: Any?) = (other as? BaseModuleImpl)?.name == name
+    }
+
+    class RegularModuleImpl(
+        name: String,
+        val sourceFileAddend: String,
+        dependencyNames: List<String>,
+    ) : RegularKlibTestSourceModule, BaseModuleImpl(name, dependencyNames) {
+        override lateinit var sourceFile: Path
+        override val kind get() = KlibTestSourceModule.Kind.REGULAR
+    }
+
+    class CInteropModuleImpl(
+        name: String,
+        val defFileAddend: String,
+        val headerFileAddend: String,
+        dependencyNames: List<String>,
+    ) : CInteropKlibTestSourceModule, BaseModuleImpl(name, dependencyNames) {
+        override lateinit var defFile: Path
+        override lateinit var headerFile: Path
+        override val kind get() = KlibTestSourceModule.Kind.CINTEROP
     }
 
     // The list of source modules being built.
-    val modules = mutableListOf<ModuleImpl>()
+    val modules = mutableListOf<BaseModuleImpl>()
 
     // The builder for a single source module.
-    class ModuleBuilderImpl : KlibTestSourceModuleBuilder {
+    abstract class ModuleBuilderImpl : KlibTestSourceModuleBuilder {
         var dependencyNames = emptyList<String>()
-        var sourceFileAddend = ""
 
         override fun dependsOn(dependencyName: String, vararg otherDependencyNames: String) {
             dependencyNames = listOf(dependencyName) + otherDependencyNames.toList()
         }
+    }
+
+    class RegularModuleBuilderImpl : RegularKlibTestSourceModuleBuilder, ModuleBuilderImpl() {
+        var sourceFileAddend = ""
 
         override fun sourceFileAddend(sourceFileAddend: String) {
             this.sourceFileAddend = sourceFileAddend
         }
     }
 
+    class CInteropModuleBuilderImpl : CInteropKlibTestSourceModuleBuilder, ModuleBuilderImpl() {
+        var defFileAddend = ""
+        var headerFileAddend = ""
+
+        override fun defFileAddend(defFileAddend: String) {
+            this.defFileAddend = defFileAddend
+        }
+
+        override fun headerFileAddend(headerFileAddend: String) {
+            this.headerFileAddend = headerFileAddend
+        }
+    }
+
     // The builder for all source modules.
     class ModulesBuilderImpl : KlibTestSourceModulesBuilder {
-        override fun addRegularModule(name: String, init: KlibTestSourceModuleBuilder.() -> Unit) =
-            addModule(name, KlibTestSourceModule.Kind.REGULAR, init)
-
-        override fun addCInteropModule(name: String, init: KlibTestSourceModuleBuilder.() -> Unit): Unit =
-            addModule(name, KlibTestSourceModule.Kind.CINTEROP, init)
-
-        fun addModule(name: String, kind: KlibTestSourceModule.Kind, init: KlibTestSourceModuleBuilder.() -> Unit) {
-            val builder = ModuleBuilderImpl()
+        override fun addRegularModule(name: String, init: RegularKlibTestSourceModuleBuilder.() -> Unit) {
+            val builder = RegularModuleBuilderImpl()
             builder.init()
-            modules += ModuleImpl(name, kind, builder.sourceFileAddend, builder.dependencyNames)
+            modules += RegularModuleImpl(name, builder.sourceFileAddend, builder.dependencyNames)
+        }
+
+        override fun addCInteropModule(name: String, init: CInteropKlibTestSourceModuleBuilder.() -> Unit) {
+            val builder = CInteropModuleBuilderImpl()
+            builder.init()
+            modules += CInteropModuleImpl(name, builder.defFileAddend, builder.headerFileAddend, builder.dependencyNames)
         }
     }
 
@@ -95,58 +147,90 @@ internal fun newSourceModules(init: KlibTestSourceModulesBuilder.() -> Unit): Kl
     val builder = ModulesBuilderImpl()
     builder.init()
 
-    val nameToModuleMapping: Map<String, ModuleImpl> = modules.groupBy(KlibTestSourceModule::name).mapValues {
+    val nameToModuleMapping: Map<String, BaseModuleImpl> = modules.groupBy(KlibTestSourceModule::name).mapValues {
         it.value.singleOrNull() ?: error("Duplicated modules: ${it.value}")
     }
 
     // Initialize dependencies.
     modules.forEach { it.dependencies = it.dependencyNames.map(nameToModuleMapping::getValue) }
 
-    val generatedSourcesDir = testRunner.buildDir.resolve("generated-sources")
-    generatedSourcesDir.mkdirs()
+    val generatedSourcesDir = testRunner.buildDir.resolve("generated-sources").toPath()
+    generatedSourcesDir.createDirectories()
 
     // Generate sources.
     modules.forEach { module ->
-        when (module.kind) {
-            KlibTestSourceModule.Kind.REGULAR -> {
+        when (module) {
+            is RegularModuleImpl -> {
                 module.sourceFile = generatedSourcesDir.resolve(module.name + ".kt")
-                module.sourceFile.writeText(buildString {
-                    appendLine("package ${module.name}")
-                    appendLine()
-                    appendLine("fun ${module.name}(indent: Int) {")
-                    appendLine("    repeat(indent) { print(\"  \") }")
-                    appendLine("    println(\"${module.name}\")")
-                    module.dependencies.forEach { dependency ->
-                        if (dependency.kind == KlibTestSourceModule.Kind.CINTEROP) {
-                            appendLine("    @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)")
+                module.sourceFile.writeText(
+                    buildString {
+                        appendLine("package ${module.name}")
+                        appendLine()
+                        appendLine("fun ${module.name}(indent: Int) {")
+                        appendLine("    repeat(indent) { print(\"  \") }")
+                        appendLine("    println(\"${module.name}\")")
+                        module.dependencies.forEach { dependency ->
+                            if (dependency.kind == KlibTestSourceModule.Kind.CINTEROP) {
+                                appendLine("    @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)")
+                            }
+                            appendLine("    ${dependency.name}.${dependency.name}(indent + 1)")
                         }
-                        appendLine("    ${dependency.name}.${dependency.name}(indent + 1)")
-                    }
-                    appendLine("}")
+                        appendLine("}")
 
-                    if (module.sourceFileAddend.isNotBlank()) {
-                        appendLine()
-                        appendLine(module.sourceFileAddend)
+                        if (module.sourceFileAddend.isNotBlank()) {
+                            appendLine()
+                            appendLine(module.sourceFileAddend)
+                        }
                     }
-                })
+                )
             }
 
-            KlibTestSourceModule.Kind.CINTEROP -> {
-                module.sourceFile = generatedSourcesDir.resolve(module.name + ".def")
-                module.sourceFile.writeText(buildString {
-                    appendLine("---")
-                    appendLine("#include <stdio.h>")
-                    appendLine("static void ${module.name}(int indent) {")
-                    appendLine("    for (int i = 0; i < indent; i++) printf(\" \");")
-                    appendLine("    printf(\"%s\\n\", \"${module.name}\");")
-                    appendLine("}")
+            is CInteropModuleImpl -> {
+                val onlyCInteropDependencies = module.dependencies.filterIsInstance<CInteropKlibTestSourceModule>()
 
-                    if (module.sourceFileAddend.isNotBlank()) {
+                module.headerFile = generatedSourcesDir.resolve(module.name + ".h")
+                module.headerFile.writeText(
+                    buildString {
+                        appendLine("#ifndef __${module.name}__")
+                        appendLine("#define __${module.name}__")
                         appendLine()
-                        appendLine(module.sourceFileAddend)
+                        if (onlyCInteropDependencies.isNotEmpty()) {
+                            for (dependency in onlyCInteropDependencies) {
+                                appendLine("#include \"${dependency.headerFile.name}\"")
+                            }
+                            appendLine()
+                        }
+                        appendLine("typedef struct ${module.name}_type { int x; int y; } ${module.name}_type;")
+                        appendLine()
+                        appendLine("void ${module.name}(int indent) {}")
+                        appendLine()
+                        if (onlyCInteropDependencies.isNotEmpty()) {
+                            for (dependency in onlyCInteropDependencies) {
+                                appendLine("void use_${dependency.name}_type_from_${module.name}(${dependency.name}_type* value) {}")
+                            }
+                            appendLine()
+                        }
+                        if (module.headerFileAddend.isNotBlank()) {
+                            appendLine()
+                            appendLine(module.headerFileAddend)
+                        }
+                        appendLine("#endif")
                     }
-                })
+                )
+
+                module.defFile = generatedSourcesDir.resolve(module.name + ".def")
+                module.defFile.writeText(
+                    buildString {
+                        appendLine("headers=" + module.headerFile.name)
+                        appendLine("depends=" + module.dependencies.map { it.name }.sorted().joinToString(" "))
+                        if (module.defFileAddend.isNotBlank()) {
+                            appendLine(module.defFileAddend)
+                        }
+                    }
+                )
             }
+
+            else -> error("Unknown module type: $module, ${module::class.java}")
         }
     }
 
@@ -174,25 +258,28 @@ internal fun KlibTestSourceModules.compileToKlibsViaCli(
     }
 
     modules.forEach { module ->
-        val commonCompilerAndCInteropArgs = buildList {
+        val commonCompilerAndCInteropArgs: List<String> = buildList {
             if (produceUnpackedKlibs) add("-nopack")
             module.dependencies.forEach { dependency ->
                 add("-l")
                 add(dependency.computeArtifactPath())
             }
         }
-        val testCase = testRunner.generateTestCaseWithSingleFile(
-            sourceFile = module.sourceFile,
-            moduleName = module.name,
-            TestCompilerArgs(
-                commonCompilerAndCInteropArgs + extraCliArgs,
-                cinteropArgs = commonCompilerAndCInteropArgs,
-            )
+        val compilerArgs = TestCompilerArgs(
+            commonCompilerAndCInteropArgs + extraCliArgs,
+            cinteropArgs = commonCompilerAndCInteropArgs,
         )
 
         val expectedArtifact = KLIB(klibFilesDir.resolve(module.computeArtifactPath()))
-        val compilation = when (module.kind) {
-            KlibTestSourceModule.Kind.REGULAR -> {
+
+        val compilation = when (module) {
+            is RegularKlibTestSourceModule -> {
+                val testCase = testRunner.generateTestCaseWithSingleFile(
+                    sourceFile = module.sourceFile.toFile(),
+                    moduleName = module.name,
+                    compilerArgs
+                )
+
                 LibraryCompilation(
                     settings = testRunner.testRunSettings,
                     freeCompilerArgs = testCase.freeCompilerArgs,
@@ -202,17 +289,26 @@ internal fun KlibTestSourceModules.compileToKlibsViaCli(
                 )
             }
 
-            KlibTestSourceModule.Kind.CINTEROP -> {
+            is CInteropKlibTestSourceModule -> {
                 check(extraCliArgs.isEmpty()) { "extraCmdLineParams are not allowed for cinterop modules" }
+
+                val testCase = testRunner.generateTestCaseWithSingleFile(
+                    sourceFile = module.defFile.toFile(),
+                    moduleName = module.name,
+                    compilerArgs
+                )
+
                 CInteropCompilation(
                     settings = testRunner.testRunSettings,
                     freeCompilerArgs = testCase.freeCompilerArgs,
-                    defFile = module.sourceFile,
+                    defFile = module.defFile.toFile(),
                     sources = emptyList(),
                     dependencies = emptySet(),
                     expectedArtifact = expectedArtifact
                 )
             }
+
+            else -> error("Unknown module type: $module, ${module::class.java}")
         }
 
         val success = compilation.result.assertSuccess()

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderBenchmarkTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderBenchmarkTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.konan.test.klib
+
+import org.jetbrains.kotlin.backend.konan.library.KlibDAGBuilder
+import org.jetbrains.kotlin.konan.library.KlibNativeDistributionLibraryProvider
+import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeSimpleTest
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeHome
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
+import java.nio.file.Path
+import kotlin.io.path.pathString
+import kotlin.time.Duration
+import kotlin.time.measureTime
+
+@Disabled // The test is disabled by default because it's not intended to be executed on every CI run.
+@Tag("klib")
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class KlibDAGBuilderBenchmarkTest : AbstractNativeSimpleTest() {
+
+    /**
+     * Benchmarking results (Apple M2 Max):
+     * - target: macos_arm64
+     * - number of libraries: 177 (stdlib + platform libs)
+     * - average duration is 2.97s
+     * - median duration is 2.97s
+     */
+    @Test
+    fun `stdlib and platform libraries only`(testInfo: TestInfo) {
+        benchmark(
+            testName = testInfo.testMethod.get().name,
+            extraLibraryPaths = emptyList(),
+        )
+    }
+
+    /**
+     * Benchmarking results (Apple M2 Max):
+     * - target: macos_arm64
+     * - number of libraries: 197 (stdlib + platform libs + 20 user libs)
+     * - average duration is 3.17s
+     * - median duration is 3.17s
+     */
+    @Test
+    fun `stdlib and platform libraries with 20 user libraries`(testInfo: TestInfo) {
+        benchmark(
+            testName = testInfo.testMethod.get().name,
+            extraLibraryPaths = generateUserLibraries(regularLibsNumber = 15, cInteropLibsNumber = 5),
+        )
+    }
+
+    /**
+     * Benchmarking results (Apple M2 Max):
+     * - target: macos_arm64
+     * - number of libraries: 277 (stdlib + platform libs + 100 user libs)
+     * - average duration is 6.48s
+     * - median duration is 6.49s
+     */
+    @Test
+    fun `stdlib and platform libraries with 100 user libraries`(testInfo: TestInfo) {
+        benchmark(
+            testName = testInfo.testMethod.get().name,
+            extraLibraryPaths = generateUserLibraries(regularLibsNumber = 75, cInteropLibsNumber = 25),
+        )
+    }
+
+    private fun generateUserLibraries(regularLibsNumber: Int, cInteropLibsNumber: Int): List<Path> {
+        require(regularLibsNumber > 0)
+        require(cInteropLibsNumber > 0)
+
+        val generatedLibraries = mutableListOf<Path>()
+
+        /*
+         * Build `regularLibsNumber` regular modules and `cInteropLibsNumber` C-interop modules in the following way:
+         * - C-Interop module "I0"
+         * - C-Interop module "I1", depends on "I0"
+         * - C-Interop module "I2", depends on "I1" and "I0"
+         * - C-Interop module "I3", depends on "I2" and "I1"
+         * ...
+         * - C-interop module "I<cInteropLibsNumber-1>", depends on "I<cInteropLibsNumber-2>" and "I<cInteropLibsNumber-3>"
+         * - Regular module "R0", depends on "I<cInteropLibsNumber-1>" and "I<cInteropLibsNumber-2>"
+         * - Regular module "R1", depends on "R0" and "I<cInteropLibsNumber-1>"
+         * - Regular module "R2", depends on "R1" and "R0"
+         * ...
+         * - Regular module "R<regularLibsNumber-1>", depends on "R<regularLibsNumber-2>" and "R<regularLibsNumber-3>"
+         */
+        newSourceModules {
+            val interopModuleNames = mutableListOf<String>()
+
+            for (moduleIndex in 0 until cInteropLibsNumber) {
+                val thisModuleName = "I$moduleIndex"
+                val dependencyModuleNames = interopModuleNames.takeLast(2) // just take last 2 c-interop modules
+
+                addCInteropModule(thisModuleName) {
+                    for (dependency in dependencyModuleNames) dependsOn(dependency)
+
+                    // add 2k declarations to add "weight" to the library
+                    headerFileAddend(
+                        List(2000) { index -> "void ${thisModuleName}_$index() {}" }.joinToString("\n")
+                    )
+                }
+
+                interopModuleNames += thisModuleName
+            }
+
+            val regularModuleNames = mutableListOf<String>()
+
+            for (moduleIndex in 0 until regularLibsNumber) {
+                val thisModuleName = "R$moduleIndex"
+                val dependencyModuleNames = buildList {
+                    addAll(regularModuleNames.takeLast(2)) // just take last 2 regular modules
+                    addAll(interopModuleNames.takeLast(2 - size)) // for the first 2 modules also add deps on C-interop modules
+                }
+
+                addRegularModule(thisModuleName) {
+                    for (dependency in dependencyModuleNames) dependsOn(dependency)
+
+                    // add 2k declarations to add "weight" to the library
+                    // (it's approx. the number of declarations in the coroutines-core library)
+                    sourceFileAddend(
+                        List(2000) { index -> "fun ${thisModuleName}_$index() {}" }.joinToString("\n")
+                    )
+                }
+
+                regularModuleNames += thisModuleName
+            }
+        }.compileToKlibsViaCli { _, successKlib -> generatedLibraries.add(successKlib.resultingArtifact.klibFile.toPath()) }
+
+        assertEquals(regularLibsNumber + cInteropLibsNumber, generatedLibraries.size)
+
+        return generatedLibraries
+    }
+
+    private fun benchmark(testName: String, extraLibraryPaths: List<Path>) {
+        // Load libraries.
+        val target = testRunSettings.get<KotlinNativeTargets>().testTarget
+
+        val loadingResult = KlibLoader {
+            libraryProviders(
+                KlibNativeDistributionLibraryProvider(nativeHome = testRunSettings.get<KotlinNativeHome>().dir) {
+                    withStdlib()
+                    withPlatformLibs(target)
+                }
+            )
+            libraryPaths(extraLibraryPaths.map { it.pathString })
+        }.load()
+
+        loadingResult.reportLoadingProblemsIfAny { _, message -> fail { message } }
+        assertFalse(loadingResult.hasProblems)
+
+        val libraries = loadingResult.librariesStdlibFirst
+
+        // Run the benchmark.
+        runBenchWithWarmup(
+            name = "$testName ($target, ${libraries.size} libraries)",
+            warmupRounds = 10,
+            benchmarkRounds = 5,
+            pre = System::gc,
+            post = {},
+        ) {
+            KlibDAGBuilder.build(libraries)
+        }
+    }
+
+    @Suppress("SameParameterValue")
+    private fun runBenchWithWarmup(
+        name: String,
+        warmupRounds: Int,
+        benchmarkRounds: Int,
+        pre: () -> Unit,
+        post: () -> Unit,
+        bench: () -> Unit,
+    ) {
+        println("Run [$name] benchmark")
+        println("Warmup: $warmupRounds times...")
+
+        repeat(warmupRounds) {
+            println("W: ${it + 1} out of $warmupRounds")
+            pre()
+            bench()
+            post()
+        }
+
+        val measurements = ArrayList<Duration>(benchmarkRounds)
+
+        println("Run bench: $benchmarkRounds times...")
+
+        repeat(benchmarkRounds) {
+            print("B: ${it + 1} out of $benchmarkRounds ")
+            pre()
+            val duration = measureTime { bench() }
+            println("takes $duration")
+            post()
+            measurements += duration
+        }
+
+        val averageDuration = measurements.fold(Duration.ZERO) { a, b -> a + b } / benchmarkRounds
+        val medianDuration = measurements.sorted()[benchmarkRounds / 2]
+
+        println("[$name] average duration is $averageDuration")
+        println("[$name] median duration is $medianDuration")
+    }
+}

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibDAGBuilderTest.kt
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.konan.test.klib
+
+import org.jetbrains.kotlin.backend.common.LegacyKlibDependencies
+import org.jetbrains.kotlin.backend.konan.library.KlibDAGBuilder
+import org.jetbrains.kotlin.backend.konan.library.KlibDAGCyclicDependencyException
+import org.jetbrains.kotlin.backend.konan.library.KlibDAGNode
+import org.jetbrains.kotlin.io.readProperties
+import org.jetbrains.kotlin.io.writeProperties
+import org.jetbrains.kotlin.konan.library.KlibNativeDistributionLibraryProvider
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeSimpleTest
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeHome
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeTargets
+import org.jetbrains.kotlin.konan.test.blackbox.support.util.mapToSet
+import org.jetbrains.kotlin.library.KLIB_PROPERTY_DEPENDS
+import org.jetbrains.kotlin.library.KLIB_PROPERTY_UNIQUE_NAME
+import org.jetbrains.kotlin.library.KlibMockDSL.Companion.generateRandomName
+import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.isNativeStdlib
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
+import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
+import org.jetbrains.kotlin.utils.addToStdlib.runIf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import java.io.File
+import java.nio.file.Path
+import kotlin.collections.set
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.pathString
+
+@Tag("klib")
+class KlibDAGBuilderTest : AbstractNativeSimpleTest() {
+    @Test
+    fun `stdlib does not depend on anything`() {
+        val libraries = loadLibraries()
+        assertEquals(1, libraries.size)
+
+        val stdlib = libraries[0]
+        assertTrue(stdlib.isNativeStdlib)
+
+        val dag = KlibDAGBuilder.build(libraries)
+        assertEquals(1, dag.size)
+        assertEquals(stdlib, dag.keys.single())
+        assertEquals(stdlib, dag.values.single().library)
+        assertTrue(dag.values.single().directDependencies.isEmpty())
+        assertTrue(dag.values.single().allDependencies.isEmpty())
+    }
+
+    @Test
+    fun `dependencies of platform libs correlate to what is written in their manifest (unique_name, depends)`() {
+        val libraries = loadLibraries(platformLibs = true)
+        assertTrue(libraries.size > 1)
+
+        val stdlib = libraries[0]
+        assertTrue(stdlib.isNativeStdlib)
+        libraries.drop(1).forEach { platformLib -> assertTrue(platformLib.isCInteropLibrary()) }
+
+        // Compute direct dependencies set using the data from manifest (unique_name, depends).
+        val directDependenciesByManifest: Map<KotlinLibrary, Set<KotlinLibrary>> = computeDirectDependenciesSetByManifest(libraries)
+
+        // Compute all dependencies set using the data from manifest (unique_name, depends).
+        val allDependenciesByManifest: Map<KotlinLibrary, Set<KotlinLibrary>> = computeFullDependenciesSet(directDependenciesByManifest)
+
+        // Sanity check:
+        assertDependenciesCorrelate(
+            denseDependenciesSet = allDependenciesByManifest,
+            looseDependenciesSet = directDependenciesByManifest
+        )
+
+        // Now, compute the DAG of dependencies by signatures.
+        val dag = KlibDAGBuilder.build(libraries)
+
+        // Direct dependencies computed by signatures.
+        val directDependenciesByDAGBuilder: Map<KotlinLibrary, Set<KotlinLibrary>> = dag.values.associate { node ->
+            node.library to node.directDependencies.map { it.library }.toSet()
+        }
+
+        // All dependencies computed by signatures.
+        val allDependenciesByDAGBuilder: Map<KotlinLibrary, Set<KotlinLibrary>> = dag.values.associate { node ->
+            node.library to node.allDependencies.map { it.library }.toSet()
+        }
+
+        // Sanity check:
+        assertDependenciesCorrelate(
+            denseDependenciesSet = allDependenciesByDAGBuilder,
+            looseDependenciesSet = directDependenciesByDAGBuilder
+        )
+
+        // Main checks (yes, it is expected that DAG computed by signatures shows a looser graph of depenencies):
+        assertDependenciesCorrelate(
+            denseDependenciesSet = directDependenciesByManifest,
+            looseDependenciesSet = directDependenciesByDAGBuilder
+        )
+        assertDependenciesCorrelate(
+            denseDependenciesSet = allDependenciesByManifest,
+            looseDependenciesSet = allDependenciesByDAGBuilder
+        )
+    }
+
+    @Test
+    fun `dependencies of user libraries are computed correctly`() {
+        // Define the user's project structure.
+        // Note: stdlib & platform libraries are not reflected in this structure.
+        val userProjectModules = newSourceModules {
+            // Some regular (prefix 'R') modules:
+            addRegularModule("RA")
+            addRegularModule("RB") { dependsOn("RA") }
+            addRegularModule("RC") { dependsOn("RB") }
+            addRegularModule("RD") { dependsOn("RA") }
+            addRegularModule("RE") { dependsOn("RC", "RD") }
+
+            // Some C-interop (prefix 'I') modules:
+            addCInteropModule("IA")
+            addCInteropModule("IB") { dependsOn("IA") }
+            addCInteropModule("IC") { dependsOn("IB") }
+            addCInteropModule("ID") { dependsOn("IA") }
+            addCInteropModule("IE") { dependsOn("IC", "ID") }
+
+            // Few more modules:
+            addRegularModule("Main") { dependsOn("RE", "IE") }
+            addRegularModule("Test") { dependsOn("Main") }
+        }
+
+        // Compile all the KLIBs:
+        val userLibraryPathToModuleName: MutableMap</* path of KLIB */ Path, /* name of test module */ String> = mutableMapOf()
+        userProjectModules.compileToKlibsViaCli { module, successKlib ->
+            userLibraryPathToModuleName[successKlib.resultingArtifact.klibFile.toPath()] = module.name
+        }
+        assertEquals(userProjectModules.modules.size, userLibraryPathToModuleName.size)
+
+        // Spoil `depends` and `unique_name` in manifests to make this data unreliable:
+        for (userLibraryPath in userLibraryPathToModuleName.keys) {
+            val manifestPath = userLibraryPath.resolve("default/manifest")
+
+            val manifest = manifestPath.readProperties()
+            manifest[KLIB_PROPERTY_UNIQUE_NAME] = generateRandomName(20)
+            manifest[KLIB_PROPERTY_DEPENDS] = (0..2).joinToString(separator = " ") { generateRandomName(20) }
+            manifestPath.writeProperties(manifest)
+        }
+
+        // Load all libraries, including platform libraries:
+        val allLibraries: List<KotlinLibrary> = loadLibraries(platformLibs = true, others = userLibraryPathToModuleName.keys)
+
+        // Compute the DAG of dependencies by signatures.
+        val dag = KlibDAGBuilder.build(allLibraries)
+
+        val userLibraries: Map</* name of test module */ String, /* use library */ KotlinLibrary> = allLibraries.mapNotNull { library ->
+            val moduleName = userLibraryPathToModuleName[library.path] ?: return@mapNotNull null
+            moduleName to library
+        }.toMap()
+        assertEquals(userProjectModules.modules.size, userLibraries.size)
+
+        fun assertUserLibraryDependencies(
+            moduleName: String,
+            expectedDirectDependencies: /* set of module names */ Set<String> = emptySet(),
+            expectedAllDependencies: /* set of module names */ Set<String> = expectedDirectDependencies,
+        ) {
+            fun Set<KlibDAGNode>.excludeStdlib(): Set<KotlinLibrary> =
+                mapNotNullTo(hashSetOf()) { node -> node.library.takeUnless { it.isNativeStdlib } }
+
+            fun Set<KotlinLibrary>.toUserModuleNames(): Set<String> =
+                mapToSet { userLibraryPathToModuleName.getValue(it.path) }
+
+            val userLibrary = userLibraries.getValue(moduleName)
+            val dagNode: KlibDAGNode = dag.getValue(userLibrary)
+
+            val actualDirectDependencies = dagNode.directDependencies.excludeStdlib().toUserModuleNames()
+            assertEquals(expectedDirectDependencies, actualDirectDependencies)
+
+            val actualAllDependencies = dagNode.allDependencies.excludeStdlib().toUserModuleNames()
+            assertEquals(expectedAllDependencies, actualAllDependencies)
+        }
+
+        assertUserLibraryDependencies(moduleName = "RA")
+
+        assertUserLibraryDependencies(
+            moduleName = "RB",
+            expectedDirectDependencies = setOf("RA"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "RC",
+            expectedDirectDependencies = setOf("RB"),
+            expectedAllDependencies = setOf("RA", "RB"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "RD",
+            expectedDirectDependencies = setOf("RA"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "RE",
+            expectedDirectDependencies = setOf("RC", "RD"),
+            expectedAllDependencies = setOf("RA", "RB", "RC", "RD"),
+        )
+
+        assertUserLibraryDependencies(moduleName = "IA")
+
+        assertUserLibraryDependencies(
+            moduleName = "IB",
+            expectedDirectDependencies = setOf("IA"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "IC",
+            expectedDirectDependencies = setOf("IB"),
+            expectedAllDependencies = setOf("IB", "IA"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "ID",
+            expectedDirectDependencies = setOf("IA"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "IE",
+            expectedDirectDependencies = setOf("IC", "ID"),
+            expectedAllDependencies = setOf("IA", "IB", "IC", "ID"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "Main",
+            expectedDirectDependencies = setOf("RE", "IE"),
+            expectedAllDependencies = setOf("RA", "RB", "RC", "RD", "RE", "IA", "IB", "IC", "ID", "IE"),
+        )
+
+        assertUserLibraryDependencies(
+            moduleName = "Test",
+            expectedDirectDependencies = setOf("Main"),
+            expectedAllDependencies = setOf("Main", "RA", "RB", "RC", "RD", "RE", "IA", "IB", "IC", "ID", "IE"),
+        )
+    }
+
+    @Test
+    fun `cycling dependency is an error`() {
+        val moduleNameToLibraryPath: MutableMap</* name of test module */ String, /* path of KLIB */ Path> = mutableMapOf()
+
+        /*
+         * A <-- B <-- C
+         */
+        newSourceModules {
+            addRegularModule("A")
+            addRegularModule("B") { dependsOn("A") }
+            addRegularModule("C") { dependsOn("B") }
+        }.compileToKlibsViaCli { module, successKlib ->
+            moduleNameToLibraryPath[module.name] = successKlib.resultingArtifact.klibFile.toPath()
+        }
+        assertEquals(3, moduleNameToLibraryPath.size)
+
+        /*
+         * Now adding one more edge between A and C:
+         * +-- A <-- B <-- C <--+
+         * |                    |
+         * +--------------------+
+         */
+        newSourceModules {
+            addRegularModule("A") {
+                sourceFileAddend("fun A2() { C.C(0) }")
+            }
+        }.compileToKlibsViaCli(
+            extraCliArgs = listOf("-l", moduleNameToLibraryPath["C"]!!.absolutePathString())
+        ) { module, successKlib ->
+            assertEquals("A", module.name)
+            moduleNameToLibraryPath["A"] = successKlib.resultingArtifact.klibFile.toPath()
+        }
+        assertEquals(3, moduleNameToLibraryPath.size)
+
+        val libraries = loadLibraries(stdlib = false, others = moduleNameToLibraryPath.values)
+
+        val anyLibraryNode: KlibDAGNode = KlibDAGBuilder.build(libraries).values.first()
+        anyLibraryNode.directDependencies // that should be successful
+
+        try {
+            anyLibraryNode.allDependencies // that should fail
+            fail("DAG dependencies should have failed because of the cycle")
+        } catch (_: KlibDAGCyclicDependencyException) {
+            // OK
+        }
+    }
+
+    /**
+     * A helper to avoid boilerplate code for loading KLIBs.
+     */
+    private fun loadLibraries(
+        stdlib: Boolean = true,
+        platformLibs: Boolean = false,
+        others: Collection<Path> = emptyList(),
+    ): List<KotlinLibrary> {
+        val loadingResult = KlibLoader {
+            libraryProviders(
+                KlibNativeDistributionLibraryProvider(nativeHome) {
+                    runIf(stdlib) { withStdlib() }
+                    runIf(platformLibs) { withPlatformLibs(currentTarget) }
+                }
+            )
+            libraryPaths(others.map { it.pathString })
+        }.load()
+
+        loadingResult.reportLoadingProblemsIfAny { _, message -> fail { message } }
+        assertFalse(loadingResult.hasProblems)
+
+        return loadingResult.librariesStdlibFirst
+    }
+
+    private val nativeHome: File
+        get() = testRunSettings.get<KotlinNativeHome>().dir
+
+    private val currentTarget: KonanTarget
+        get() = testRunSettings.get<KotlinNativeTargets>().testTarget
+
+    /**
+     * Note: This is suitable only for the libraries from the Kotlin/Native distribution,
+     * where we can guarantee that `depends` in manifest of one library points exactly to `unique_name` in
+     * manifest of another library (and such library exists), and this dependency is valid.
+     *
+     * We cannot guarantee this for user libraries.
+     */
+    private fun computeDirectDependenciesSetByManifest(libraries: Collection<KotlinLibrary>): Map<KotlinLibrary, Set<KotlinLibrary>> {
+        val resolver = LegacyKlibDependencies(libraries)
+
+        return buildMap {
+            for (library in libraries) {
+                this[library] = resolver.getDependenciesFor(library).toSet()
+            }
+        }
+    }
+
+    private fun computeFullDependenciesSet(directDependenciesSet: Map<KotlinLibrary, Set<KotlinLibrary>>): Map<KotlinLibrary, Set<KotlinLibrary>> {
+        val result = hashMapOf<KotlinLibrary, Set<KotlinLibrary>>()
+
+        fun recurse(library: KotlinLibrary): Set<KotlinLibrary> {
+            result[library]?.let { return it }
+
+            val directDependencies = directDependenciesSet.getValue(library)
+
+            return buildSet {
+                addAll(directDependencies)
+                directDependencies.forEach { directDependency -> addAll(recurse(directDependency)) }
+            }
+        }
+
+        for (library in directDependenciesSet.keys) {
+            result[library] = recurse(library)
+        }
+
+        return result
+    }
+
+    /**
+     * Check that the two sets of dependencies correlate between each other.
+     *
+     * @param denseDependenciesSet The set of dependencies computed in a more dense way. I.e. there may be excessive dependencies because,
+     *   for example, of excessive/unnecessary edges specified in `depends` in manifest files if this set of dependencies was computed
+     *   by the manifest data. Or because this set of dependencies includes all transitive dependencies, while [looseDependenciesSet] does not.
+     * @param looseDependenciesSet The set of dependencies computed in a more loose way. Normally, there are less dependency libraries for
+     *   a library than in [denseDependenciesSet]. However, this set of dependencies should agree (= not contradict) with [denseDependenciesSet].
+     */
+    private fun assertDependenciesCorrelate(
+        denseDependenciesSet: Map<KotlinLibrary, Set<KotlinLibrary>>,
+        looseDependenciesSet: Map<KotlinLibrary, Set<KotlinLibrary>>,
+    ) {
+        assertEquals(denseDependenciesSet.keys, looseDependenciesSet.keys)
+
+        for (library in denseDependenciesSet.keys) {
+            val denseDependencies: Set<KotlinLibrary> = denseDependenciesSet.getValue(library)
+            val looseDependencies: Set<KotlinLibrary> = looseDependenciesSet.getValue(library)
+
+            assertTrue(denseDependencies.containsAll(looseDependencies)) {
+                buildString {
+                    appendLine("Uncorrelated dependencies for library ${library.path}:")
+                    appendLine()
+                    appendLine("Dense dependencies: (${denseDependencies.size}):")
+                    denseDependencies.map { it.path.pathString }.sorted().forEach { append("- ").appendLine(it) }
+                    appendLine()
+                    appendLine("Loose dependencies: (${looseDependencies.size}):")
+                    looseDependencies.map { it.path.pathString }.sorted().forEach { append("- ").appendLine(it) }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The entry point is `KlibDAGBuilder.build(List<KotlinLibrary>)`.
It accepts a list of KLIBs and returns a dependency DAG built purely
based on IR signatures extracted from those KLIBs.

This is a lightweight tools that does not require IR linker and does
not run IR linkage in any form.

There are a few limitations:
- Only regular (source-based) or C-interop libraries can be processed.
  An attempt to supply a metadata-only or a commonized library will
  result in an error.
- A cycle detected while builing a DAG results in an immediate error.

KT-86840

Pending the merge of https://github.com/JetBrains/kotlin/pull/7102