### PR TITLE
[JS] Introduce CFG and concrete value/type dataflow for JS IR

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteAnalysis.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteAnalysis.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.backend.js.JsIrBackendContext
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.ir.visitors.acceptVoid
+
+/**
+ * Sparse concrete type/value analysis over [JsControlFlowGraph] with IPA-lite parameter
+ * refinement from known call sites in the linked program.
+ *
+ * Unknown / unsupported IR evaluates to [JsFact.Top]. Exported / external / open functions
+ * keep parameter seeds at Top (or declared upper bound only — never caller-refined).
+ */
+
+private const val MAX_IPA_ROUNDS = 16
+
+/**
+ * Per-function analysis facts.
+ */
+class JsFunctionFacts(
+    val function: IrFunction,
+    val cfg: JsControlFlowGraph,
+    private val summaries: Map<IrValueDeclaration, JsFact>,
+) {
+    /**
+     * Whole-function summary: join of facts across block exits (and entry params).
+     * Used for IPA-lite call-site argument evaluation and dump queries.
+     */
+    fun summary(value: IrValueDeclaration): JsFact =
+        summaries[value] ?: JsFact.Top
+
+    fun allSummaries(): Map<IrValueDeclaration, JsFact> = summaries
+}
+
+/**
+ * Analysis result for the linked program.
+ */
+class JsConcreteAnalysisResult(
+    val index: JsProgramIndex,
+    val functionFacts: Map<IrFunction, JsFunctionFacts>,
+) {
+    fun summary(function: IrFunction, value: IrValueDeclaration): JsFact =
+        functionFacts[function]?.summary(value) ?: JsFact.Top
+
+    fun value(function: IrFunction, value: IrValueDeclaration): JsValueLattice =
+        summary(function, value).value
+
+    fun type(function: IrFunction, value: IrValueDeclaration): JsTypeLattice =
+        summary(function, value).type
+}
+
+private fun JsProgramIndex.analyze(): JsConcreteAnalysisResult {
+    var paramSeeds = emptyMap<IrFunction, Map<IrValueDeclaration, JsFact>>()
+    var functionFacts = emptyMap<IrFunction, JsFunctionFacts>()
+
+    repeat(MAX_IPA_ROUNDS) {
+        functionFacts = functions.mapValues { entry ->
+            entry.value.analyze(paramSeeds[entry.value.ir].orEmpty())
+        }
+        val nextSeeds = computeParamSeeds(functionFacts)
+        if (nextSeeds == paramSeeds) {
+            return JsConcreteAnalysisResult(this, functionFacts)
+        }
+        paramSeeds = nextSeeds
+    }
+
+    return JsConcreteAnalysisResult(this, functionFacts)
+}
+
+private fun JsProgramIndex.computeParamSeeds(
+    functionFacts: Map<IrFunction, JsFunctionFacts>,
+): Map<IrFunction, Map<IrValueDeclaration, JsFact>> {
+    val seeds = mutableMapOf<IrFunction, MutableMap<IrValueDeclaration, JsFact>>()
+    val transfer = JsConcreteTransfer()
+
+    for (function in functions.values) {
+        if (function.hasUnknownCallers) {
+            continue
+        }
+        val calls = callsTo(function.ir)
+        if (calls.isEmpty()) {
+            continue
+        }
+        val params = function.ir.parameters
+        val joined = MutableList(params.size) { JsFact.Bottom }
+        for (site in calls) {
+            val env = site.enclosingFunction?.let { functionFacts[it]?.toSummaryEnv() } ?: FactEnv()
+            for (index in params.indices) {
+                val arg = site.call.getArgumentOrNull(index) ?: continue
+                val argFact = with(transfer) { arg.evaluateWith(env) }
+                joined[index] = joined[index].join(argFact)
+            }
+        }
+        val funFacts = mutableMapOf<IrValueDeclaration, JsFact>()
+        for (indexedParam in params.withIndex()) {
+            val fact = joined[indexedParam.index]
+            if (fact != JsFact.Bottom) funFacts[indexedParam.value] = fact
+        }
+        if (funFacts.isNotEmpty()) {
+            seeds[function.ir] = funFacts
+        }
+    }
+    return seeds
+}
+
+private fun JsFunctionFacts.toSummaryEnv(): FactEnv {
+    val env = FactEnv()
+    val keys = linkedSetOf<IrValueDeclaration>()
+    keys.addAll(function.parameters)
+    for (block in cfg.blocks) {
+        for (statement in block.statements) {
+            collectValueDecls(statement, keys)
+        }
+    }
+    for (key in keys) {
+        env[key] = summary(key)
+    }
+    // Also include any keys present only in summaries.
+    for (entry in allSummaries().entries) {
+        env[entry.key] = entry.value
+    }
+    return env
+}
+
+private fun collectValueDecls(element: IrElement, into: MutableSet<IrValueDeclaration>) {
+    element.acceptVoid(object : IrVisitorVoid() {
+        override fun visitElement(element: IrElement) {
+            element.acceptChildrenVoid(this)
+        }
+
+        override fun visitVariable(declaration: IrVariable) {
+            into += declaration
+            declaration.acceptChildrenVoid(this)
+        }
+    })
+}
+
+private fun JsIndexedFunction.analyze(
+    paramSeeds: Map<IrValueDeclaration, JsFact>,
+): JsFunctionFacts {
+    val transfer = JsConcreteTransfer()
+    val entryEnv = FactEnv()
+    for (param in ir.parameters) {
+        entryEnv[param] = paramSeeds[param] ?: param.type.toFact()
+    }
+
+    if (cfg.unsupportedConstruct != null) {
+        val summaries = mutableMapOf<IrValueDeclaration, JsFact>()
+        for (param in ir.parameters) {
+            summaries[param] = JsFact.Top
+        }
+        return JsFunctionFacts(ir, cfg, summaries)
+    }
+
+    val inStates = ForwardDataflowSolver().solve(
+        cfg = cfg,
+        entryState = entryEnv,
+        lattice = FactEnv.lattice,
+        transfer = transfer,
+    )
+
+    val summary = FactEnv()
+    for (entry in inStates.entries) {
+        val block = entry.key
+        val inn = entry.value
+        val outs = transfer.transfer(block, inn)
+        if (outs.isEmpty()) {
+            summary.joinInPlace(transfer.transferUntil(block, inn, stopAt = null))
+        } else {
+            for (out in outs.values) summary.joinInPlace(out)
+        }
+    }
+    for (entry in entryEnv.map) {
+        if (entry.key !in summary.map) summary[entry.key] = entry.value
+    }
+
+    return JsFunctionFacts(function = ir, cfg, summaries = summary.map.toMap())
+}
+
+private fun IrFunctionAccessExpression.getArgumentOrNull(index: Int): IrExpression? =
+    arguments.getOrNull(index)
+
+/**
+ * Entry point: build program index and run concrete analysis over the linked program.
+ */
+context(context: JsIrBackendContext)
+fun analyzeJsProgram(modules: Iterable<IrModuleFragment>): JsConcreteAnalysisResult =
+    buildJsProgramIndex(modules).analyze()

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteLattice.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteLattice.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
+import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
+import org.jetbrains.kotlin.ir.expressions.IrConstKind
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.isUnit
+import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.ir.util.isSubclassOf
+import org.jetbrains.kotlin.ir.util.parentAsClass
+
+/**
+ * Concrete value lattice for JS IR dataflow.
+ *
+ * Invariant: [join] is commutative, associative, and idempotent; [Bottom] is identity,
+ * [Top] is annihilator.
+ */
+sealed interface JsValueLattice {
+    object Top : JsValueLattice
+    object Bottom : JsValueLattice
+
+    data class Const(val kind: IrConstKind, val value: Any?) : JsValueLattice
+
+    data class Enum(val entry: IrEnumEntry) : JsValueLattice {
+        override fun toString(): String {
+            val parentName = (entry.parent as? IrClass)?.name?.asString() ?: "?"
+            return "$parentName.${entry.name.asString()}"
+        }
+    }
+
+    object Unit : JsValueLattice
+
+    fun isNull(): Boolean = this === Null
+
+    fun asBooleanOrNull(): Boolean? =
+        (this as? Const)?.takeIf { it.kind == IrConstKind.Boolean }?.value as? Boolean
+
+    fun join(other: JsValueLattice): JsValueLattice = when {
+        this is Bottom -> other
+        other is Bottom -> this
+        this is Top || other is Top -> Top
+        this == other -> this
+        else -> Top
+    }
+
+    companion object {
+        val Null = Const(kind = IrConstKind.Null, value = null)
+    }
+}
+
+/**
+ * Concrete type lattice.
+ *
+ * - [Exact]: runtime class is known precisely; [Exact.nullable] tracks nullability.
+ * - [UpperBound]: value is a subtype of [UpperBound.irClass] (can be an interface / open class).
+ */
+sealed interface JsTypeLattice {
+    data object Top : JsTypeLattice
+    data object Bottom : JsTypeLattice
+
+    data class Exact(val irClass: IrClass, val nullable: Boolean) : JsTypeLattice {
+        val isFinal: Boolean get() = irClass.modality == Modality.FINAL
+    }
+
+    data class UpperBound(val irClass: IrClass, val nullable: Boolean) : JsTypeLattice {
+        val isFinal: Boolean get() = irClass.modality == Modality.FINAL
+    }
+
+    fun join(other: JsTypeLattice): JsTypeLattice = when {
+        this is Bottom -> other
+        other is Bottom -> this
+        this is Top || other is Top -> Top
+        this is Exact && other is Exact -> when {
+            this.irClass == other.irClass -> Exact(irClass, nullable || other.nullable)
+            else -> Top
+        }
+        this is Exact && other is UpperBound -> when {
+            this.irClass == other.irClass || this.irClass.isSubclassOf(other.irClass) ->
+                UpperBound(other.irClass, nullable || other.nullable)
+            else -> Top
+        }
+        this is UpperBound && other is Exact -> other.join(this)
+        this is UpperBound && other is UpperBound -> when {
+            this.irClass == other.irClass -> UpperBound(irClass, nullable || other.nullable)
+            this.irClass.isSubclassOf(other.irClass) -> UpperBound(other.irClass, nullable || other.nullable)
+            other.irClass.isSubclassOf(this.irClass) -> UpperBound(this.irClass, nullable || other.nullable)
+            else -> Top
+        }
+        else -> Top
+    }
+
+    companion object {
+        fun exactOf(irClass: IrClass, nullable: Boolean = false): Exact = Exact(irClass, nullable)
+
+        fun upperBoundOf(irClass: IrClass, nullable: Boolean = false): UpperBound =
+            UpperBound(irClass, nullable)
+    }
+}
+
+/**
+ * Pair of value/type facts for a single IR value declaration.
+ */
+data class JsFact(
+    val value: JsValueLattice = JsValueLattice.Bottom,
+    val type: JsTypeLattice = JsTypeLattice.Bottom,
+) {
+    fun join(other: JsFact): JsFact = JsFact(value.join(other.value), type.join(other.type))
+
+    companion object {
+        val Top: JsFact = JsFact(JsValueLattice.Top, JsTypeLattice.Top)
+        val Bottom: JsFact = JsFact(JsValueLattice.Bottom, JsTypeLattice.Bottom)
+    }
+}
+
+/**
+ * Sparse environment of facts for locals / parameters.
+ */
+class FactEnv(val map: MutableMap<IrValueDeclaration, JsFact> = mutableMapOf()) {
+    operator fun get(value: IrValueDeclaration): JsFact? = map[value]
+    operator fun set(value: IrValueDeclaration, fact: JsFact) {
+        map[value] = fact
+    }
+
+    fun copy(): FactEnv = FactEnv(map.toMutableMap())
+
+    fun join(other: FactEnv): FactEnv {
+        val keys = map.keys + other.map.keys
+        val result = FactEnv()
+        for (key in keys) {
+            val a = map[key] ?: JsFact.Bottom
+            val b = other.map[key] ?: JsFact.Bottom
+            result[key] = a.join(b)
+        }
+        return result
+    }
+
+    fun joinInPlace(other: FactEnv) {
+        for (entry in other.map) {
+            map[entry.key] = (map[entry.key] ?: JsFact.Bottom).join(entry.value)
+        }
+    }
+
+    fun equivalentTo(other: FactEnv): Boolean {
+        if (map.size != other.map.size) return false
+        for (entry in map) {
+            if (other.map[entry.key] != entry.value) return false
+        }
+        return true
+    }
+
+    companion object {
+        val lattice: Lattice<FactEnv> = object : Lattice<FactEnv> {
+            override fun bottom(): FactEnv = FactEnv()
+            override fun join(a: FactEnv, b: FactEnv): FactEnv = a.join(b)
+            override fun equivalent(a: FactEnv, b: FactEnv): Boolean = a.equivalentTo(b)
+        }
+    }
+}
+
+fun IrType.toFact(): JsFact {
+    if (isUnit()) {
+        return JsFact(value = JsValueLattice.Unit, type = JsTypeLattice.Top)
+    }
+    val irClass = classOrNull?.owner ?: return JsFact.Top
+    val nullable = isNullable()
+    val lattice = when {
+        irClass.modality == Modality.FINAL && irClass.kind == ClassKind.CLASS ->
+            JsTypeLattice.exactOf(irClass, nullable)
+        else -> JsTypeLattice.upperBoundOf(irClass, nullable)
+    }
+    return JsFact(JsValueLattice.Top, lattice)
+}
+
+fun IrEnumEntry.toEnumFact(): JsFact =
+    JsFact(
+        value = JsValueLattice.Enum(entry = this),
+        type = JsTypeLattice.exactOf(irClass = parentAsClass, nullable = false),
+    )

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteTransfer.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteTransfer.kt
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.isUnit
+import org.jetbrains.kotlin.ir.util.constructedClass
+import org.jetbrains.kotlin.ir.util.isFalseConst
+import org.jetbrains.kotlin.ir.util.isTrueConst
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.ir.visitors.acceptVoid
+
+/**
+ * Concrete value/type transfer over a [JsBasicBlock].
+ *
+ * Modeled IR nodes update [FactEnv] precisely. Every unmodelled statement goes through
+ * [killWritesIn] so assignments are never silently ignored.
+ *
+ * [TransferFunction.transfer] returns a (possibly narrowed) OUT state per successor for
+ * `is` / `==` / `!=` / null checks and `when` subjects.
+ */
+class JsConcreteTransfer : TransferFunction<FactEnv> {
+
+    override fun transfer(block: JsBasicBlock, inn: FactEnv): Map<JsBasicBlock, FactEnv> {
+        val env = inn.copy()
+        for (statement in block.statements) {
+            transferStatement(statement, env)
+        }
+        return when (val t = block.terminator) {
+            is JsTerminator.Goto -> mapOf(t.target to env)
+            is JsTerminator.Cond -> {
+                t.condition.evaluateWith(env)
+                val thenEnv = env.copy()
+                val elseEnv = env.copy()
+                narrowCondition(t.condition, thenEnv, elseEnv)
+                mapOf(t.thenTarget to thenEnv, t.elseTarget to elseEnv)
+            }
+            is JsTerminator.MultiCond -> {
+                val result = mutableMapOf<JsBasicBlock, FactEnv>()
+                for (branch in t.branches) {
+                    val armEnv = env.copy()
+                    branch.condition?.let { cond ->
+                        cond.evaluateWith(armEnv)
+                        // Taken arm: condition held; remaining arms treated independently.
+                        narrowCondition(cond, thenEnv = armEnv, elseEnv = FactEnv())
+                    }
+                    val previous = result[branch.target]
+                    result[branch.target] = previous?.join(armEnv) ?: armEnv
+                }
+                result
+            }
+            is JsTerminator.Return -> {
+                t.value?.evaluateWith(env)
+                emptyMap()
+            }
+            is JsTerminator.Throw -> {
+                t.value.evaluateWith(env)
+                emptyMap()
+            }
+            JsTerminator.Unreachable -> emptyMap()
+        }
+    }
+
+    /**
+     * Transfer statements of [block] from [inn] up to (but not including) [stopAt],
+     * or through the whole block when [stopAt] is null.
+     */
+    fun transferUntil(block: JsBasicBlock, inn: FactEnv, stopAt: IrElement?): FactEnv {
+        val env = inn.copy()
+        for (statement in block.statements) {
+            if (stopAt != null && statement === stopAt) break
+            transferStatement(statement, env)
+            if (stopAt != null && containsElement(statement, stopAt)) break
+        }
+        return env
+    }
+
+    fun transferStatement(statement: IrStatement, env: FactEnv) {
+        when (statement) {
+            is IrVariable -> {
+                val init = statement.initializer
+                env[statement] = init?.evaluateWith(env) ?: JsFact.Top
+            }
+            is IrSetValue -> {
+                val target = statement.symbol.owner
+                env[target] = statement.value.evaluateWith(env)
+            }
+            is IrExpression -> statement.evaluateWith(env)
+            else -> killWritesIn(statement, env)
+        }
+    }
+
+    /**
+     * Strong-kill every local write inside [element] to [JsFact.Top].
+     * Mandatory route for unmodelled IR — never a silent no-op on writes.
+     */
+    fun killWritesIn(element: IrElement, env: FactEnv) {
+        element.acceptVoid(object : IrVisitorVoid() {
+            override fun visitElement(element: IrElement) {
+                element.acceptChildrenVoid(this)
+            }
+
+            override fun visitVariable(declaration: IrVariable) {
+                env[declaration] = JsFact.Top
+                declaration.acceptChildrenVoid(this)
+            }
+
+            override fun visitSetValue(expression: IrSetValue) {
+                env[expression.symbol.owner] = JsFact.Top
+                expression.acceptChildrenVoid(this)
+            }
+        })
+    }
+
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    fun IrExpression.evaluateWith(env: FactEnv): JsFact {
+        return when (this) {
+            is IrConst -> toConstFact()
+            is IrGetValue -> env[symbol.owner] ?: symbol.owner.type.toFact()
+            is IrGetObjectValue -> {
+                val irClass = symbol.owner
+                if (type.isUnit()) {
+                    JsFact(value = JsValueLattice.Unit, type = JsTypeLattice.exactOf(irClass))
+                } else {
+                    JsFact(value = JsValueLattice.Top, type = JsTypeLattice.exactOf(irClass))
+                }
+            }
+            is IrGetEnumValue -> symbol.owner.toEnumFact()
+            is IrConstructorCall -> {
+                arguments.forEach { it?.evaluateWith(env) }
+                val irClass = symbol.owner.constructedClass
+                JsFact(value = JsValueLattice.Top, type = JsTypeLattice.exactOf(irClass))
+            }
+            is IrCall -> {
+                arguments.forEach { it?.evaluateWith(env) }
+                when {
+                    type.isUnit() -> JsFact(value = JsValueLattice.Unit, type = JsTypeLattice.Top)
+                    else -> type.toFact()
+                }
+            }
+            is IrTypeOperatorCall -> {
+                val argFact = argument.evaluateWith(env)
+                when (operator) {
+                    IrTypeOperator.CAST, IrTypeOperator.IMPLICIT_CAST -> {
+                        val castType = typeOperand.toFact().type
+                        val joined = argFact.type.join(castType)
+                        val type = when {
+                            argFact.type is JsTypeLattice.Exact && joined !is JsTypeLattice.Top -> argFact.type
+                            else -> castType
+                        }
+                        JsFact(argFact.value, type)
+                    }
+                    IrTypeOperator.IMPLICIT_NOTNULL -> {
+                        val value = when {
+                            argFact.value.isNull() -> JsValueLattice.Top
+                            else -> argFact.value
+                        }
+                        val type = when (val t = argFact.type) {
+                            is JsTypeLattice.Exact -> t.copy(nullable = false)
+                            is JsTypeLattice.UpperBound -> t.copy(nullable = false)
+                            else -> t
+                        }
+                        JsFact(value, type)
+                    }
+                    IrTypeOperator.SAFE_CAST -> {
+                        val bound = typeOperand.toFact()
+                        JsFact(JsValueLattice.Top, bound.type)
+                    }
+                    IrTypeOperator.INSTANCEOF -> {
+                        // Condition expression: value is Boolean Top; narrowing happens on edges.
+                        JsFact(JsValueLattice.Top, JsTypeLattice.Top)
+                    }
+                    else -> argFact
+                }
+            }
+            is IrWhen -> evaluateWhen(env)
+            is IrBlock -> {
+                var last: JsFact = JsFact.Top
+                for (s in statements) {
+                    last = when (s) {
+                        is IrExpression -> s.evaluateWith(env)
+                        else -> {
+                            transferStatement(s, env)
+                            JsFact.Top
+                        }
+                    }
+                }
+                last
+            }
+            is IrStringConcatenation -> {
+                arguments.forEach { it.evaluateWith(env) }
+                JsFact.Top
+            }
+            is IrVararg -> {
+                elements.forEach { el -> if (el is IrExpression) el.evaluateWith(env) }
+                JsFact.Top
+            }
+            is IrFunctionExpression, is IrRawFunctionReference, is IrFunctionReference -> JsFact.Top
+            is IrClassReference -> JsFact.Top
+            is IrGetField, is IrSetField -> {
+                killWritesIn(element = this, env)
+                JsFact.Top
+            }
+            is IrTry -> {
+                killWritesIn(element = this, env)
+                JsFact.Top
+            }
+            else -> {
+                killWritesIn(element = this, env)
+                JsFact.Top
+            }
+        }
+    }
+
+    private fun IrWhen.evaluateWhen(env: FactEnv): JsFact {
+        val trueBranches = mutableListOf<IrBranch>()
+        var sawNonConst = false
+        for (branch in branches) {
+            val condFact = branch.condition.evaluateWith(env)
+            val constBool = condFact.value.asBooleanOrNull()
+            when {
+                branch.condition.isTrueConst() || constBool == true -> {
+                    trueBranches += branch
+                    break
+                }
+                branch.condition.isFalseConst() || constBool == false -> continue
+                else -> {
+                    sawNonConst = true
+                    trueBranches += branch
+                }
+            }
+        }
+        if (!sawNonConst && trueBranches.size == 1) {
+            return trueBranches[0].result.evaluateWith(env)
+        }
+        var joined = JsFact.Bottom
+        for (branch in trueBranches) {
+            joined = joined.join(branch.result.evaluateWith(env))
+        }
+        return if (joined == JsFact.Bottom) JsFact.Top else joined
+    }
+
+    /**
+     * Refine [thenEnv] / [elseEnv] for a boolean condition (is / == / != / null).
+     */
+    fun narrowCondition(condition: IrExpression, thenEnv: FactEnv, elseEnv: FactEnv) {
+        when (condition) {
+            is IrTypeOperatorCall -> when (condition.operator) {
+                IrTypeOperator.INSTANCEOF -> {
+                    refineInstanceOf(condition.argument, condition.typeOperand, thenEnv, positive = true)
+                    refineInstanceOf(condition.argument, condition.typeOperand, elseEnv, positive = false)
+                }
+                IrTypeOperator.NOT_INSTANCEOF -> {
+                    refineInstanceOf(condition.argument, condition.typeOperand, thenEnv, positive = false)
+                    refineInstanceOf(condition.argument, condition.typeOperand, elseEnv, positive = true)
+                }
+                else -> Unit
+            }
+            is IrCall -> narrowEqualityCall(condition, thenEnv, elseEnv)
+            is IrGetValue -> {
+                // Boolean local used as condition: then ⇒ true, else ⇒ false when Exact Bool possible.
+                val irValue = condition.symbol.owner
+                thenEnv[irValue] = JsFact(
+                    value = JsValueLattice.Const(IrConstKind.Boolean, true),
+                    type = thenEnv[irValue]?.type ?: JsTypeLattice.Top,
+                )
+                elseEnv[irValue] = JsFact(
+                    value = JsValueLattice.Const(IrConstKind.Boolean, false),
+                    type = elseEnv[irValue]?.type ?: JsTypeLattice.Top,
+                )
+            }
+            else -> Unit
+        }
+    }
+
+    private fun narrowEqualityCall(call: IrCall, thenEnv: FactEnv, elseEnv: FactEnv) {
+        val name = call.symbol.owner.name.asString()
+        if (name != "EQEQ" && name != "equals" && name != "ieee754equals") return
+        val left = call.arguments.getOrNull(0) ?: return
+        val right = call.arguments.getOrNull(1) ?: return
+        narrowEquality(left, right, thenEnv, elseEnv)
+    }
+
+    private fun narrowEquality(
+        left: IrExpression,
+        right: IrExpression,
+        thenEnv: FactEnv,
+        elseEnv: FactEnv,
+    ) {
+        val (value, other = comparedTo) = when {
+            left is IrGetValue -> EqualityOperands(left, right)
+            right is IrGetValue -> EqualityOperands(right, left)
+            else -> return
+        }
+        val target = value.symbol.owner
+        when (other) {
+            is IrConst if other.kind == IrConstKind.Null -> {
+                val nullFact = JsFact(JsValueLattice.Null, JsTypeLattice.Top)
+                thenEnv[target] = nullFact
+                // else: not null — clear null const, mark non-nullable if Exact
+                val old = elseEnv[target]
+                if (old != null) {
+                    elseEnv[target] = stripNullability(old)
+                }
+            }
+            is IrConst -> {
+                val constFact = other.toConstFact()
+                thenEnv[target] = constFact
+            }
+            is IrGetEnumValue -> {
+                val fact = other.symbol.owner.toEnumFact()
+                thenEnv[target] = fact
+            }
+        }
+    }
+
+    private fun refineInstanceOf(
+        argument: IrExpression,
+        typeOperand: org.jetbrains.kotlin.ir.types.IrType,
+        env: FactEnv,
+        positive: Boolean,
+    ) {
+        val get = argument as? IrGetValue ?: return
+        val irClass = typeOperand.classOrNull?.owner ?: return
+        if (!positive) return // negative instanceof: leave as-is (conservative)
+        val old = env[get.symbol.owner]
+        env[get.symbol.owner] = JsFact(
+            value = old?.value ?: JsValueLattice.Top,
+            type = JsTypeLattice.exactOf(irClass, nullable = false),
+        )
+    }
+
+    private fun stripNullability(fact: JsFact): JsFact {
+        val type = when (val t = fact.type) {
+            is JsTypeLattice.Exact -> t.copy(nullable = false)
+            is JsTypeLattice.UpperBound -> t.copy(nullable = false)
+            else -> t
+        }
+        val value = if (fact.value.isNull()) JsValueLattice.Top else fact.value
+        return JsFact(value, type)
+    }
+
+    private fun containsElement(root: IrElement, target: IrElement): Boolean {
+        var found = false
+        root.acceptVoid(object : IrVisitorVoid() {
+            override fun visitElement(element: IrElement) {
+                if (element === target) {
+                    found = true
+                    return
+                }
+                if (!found) element.acceptChildrenVoid(this)
+            }
+        })
+        return found
+    }
+}
+
+private class EqualityOperands(
+    val value: IrGetValue,
+    val comparedTo: IrExpression,
+)
+
+fun IrConst.toConstFact(): JsFact {
+    val latticeValue = when (kind) {
+        IrConstKind.Null -> JsValueLattice.Null
+        IrConstKind.Boolean -> JsValueLattice.Const(IrConstKind.Boolean, value)
+        IrConstKind.Int -> JsValueLattice.Const(IrConstKind.Int, value)
+        IrConstKind.Long -> JsValueLattice.Const(IrConstKind.Long, value)
+        IrConstKind.String -> JsValueLattice.Const(IrConstKind.String, value)
+        IrConstKind.Byte -> JsValueLattice.Const(IrConstKind.Byte, value)
+        IrConstKind.Short -> JsValueLattice.Const(IrConstKind.Short, value)
+        IrConstKind.Char -> JsValueLattice.Const(IrConstKind.Char, value)
+        IrConstKind.Float, IrConstKind.Double -> return JsFact.Top
+    }
+    val type = when (kind) {
+        IrConstKind.Null -> JsTypeLattice.Top
+        else -> type.toFact().type
+    }
+    return JsFact(latticeValue, type)
+}

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsControlFlowGraph.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsControlFlowGraph.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+
+/**
+ * Control-flow graph over existing IR statements (blocks hold references, not clones).
+ *
+ * Suitable substrate for sparse type/value dataflow, call-graph construction, and inlining
+ * legality checks. Nested expression control flow that is not statement-level is left inside
+ * the containing [IrStatement]; analyses may inspect those expressions directly.
+ *
+ * If [unsupportedConstruct] is non-null (e.g. [org.jetbrains.kotlin.ir.expressions.IrTry]),
+ * the graph is incomplete for exception edges; analyses must treat the function conservatively.
+ */
+class JsControlFlowGraph(
+    val function: IrFunction,
+    val entry: JsBasicBlock,
+    val blocks: List<JsBasicBlock>,
+    val unsupportedConstruct: IrElement? = null,
+)
+
+/**
+ * A straight-line sequence of IR statements ending in a single [terminator].
+ */
+class JsBasicBlock(
+    var id: Int,
+    val statements: MutableList<IrStatement> = mutableListOf(),
+    var terminator: JsTerminator = JsTerminator.Unreachable,
+) {
+    val predecessors: MutableList<JsBasicBlock> = mutableListOf()
+    val successors: MutableList<JsBasicBlock> = mutableListOf()
+
+    override fun toString(): String = "BB$id"
+}
+
+/**
+ * One arm of a [JsTerminator.MultiCond].
+ *
+ * @param condition branch predicate, or `null` for the else / fallthrough arm.
+ * @param target block entered when this arm is taken.
+ */
+class MultiCondBranch(
+    val condition: IrExpression?,
+    val target: JsBasicBlock,
+)
+
+/**
+ * Control transfer out of a [JsBasicBlock].
+ */
+sealed interface JsTerminator {
+    /** Unconditional jump. */
+    class Goto(val target: JsBasicBlock) : JsTerminator
+
+    /** Two-way branch on [condition]. */
+    class Cond(
+        val condition: IrExpression,
+        val thenTarget: JsBasicBlock,
+        val elseTarget: JsBasicBlock,
+    ) : JsTerminator
+
+    /**
+     * Multi-way branch (statement-level `when`).
+     *
+     * [branches] are in IR order. A [MultiCondBranch.condition] of `null` is the else /
+     * fallthrough arm (appended by the builder when the `when` has no else). The first
+     * matching arm is taken at runtime; analyses should treat arms as mutually exclusive
+     * for narrowing and join the fallthrough with non-matching prefixes.
+     */
+    class MultiCond(val branches: List<MultiCondBranch>) : JsTerminator
+
+    class Return(val value: IrExpression?) : JsTerminator
+
+    class Throw(val value: IrExpression) : JsTerminator
+
+    object Unreachable : JsTerminator
+}
+
+fun JsTerminator.successors(): List<JsBasicBlock> = when (this) {
+    is JsTerminator.Goto -> listOf(target)
+    is JsTerminator.Cond -> listOf(thenTarget, elseTarget)
+    is JsTerminator.MultiCond -> branches.map { it.target }.distinct()
+    is JsTerminator.Return, is JsTerminator.Throw, JsTerminator.Unreachable -> emptyList()
+}

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsControlFlowGraphBuilder.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsControlFlowGraphBuilder.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.util.isElseBranch
+import org.jetbrains.kotlin.ir.util.isTrueConst
+
+/**
+ * Builds a [JsControlFlowGraph] for a lowered [IrFunction].
+ *
+ * Statement-level `when` / loops / return / throw become terminators. Expression-nested
+ * control flow stays inside the enclosing statement for analysis to inspect.
+ */
+fun buildJsFunctionCfg(function: IrFunction): JsControlFlowGraph {
+    val body = function.body ?: return emptyGraph(function)
+    val builder = JsControlFlowGraphBuilder()
+    val entry = builder.newBlock()
+    var current: JsBasicBlock? = entry
+    when (body) {
+        is IrBlockBody -> {
+            for (statement in body.statements) {
+                current = builder.emitStatement(statement, current) ?: break
+            }
+            current?.let { builder.finishWithReturn(it, value = null) }
+        }
+        is IrExpressionBody -> {
+            current = builder.emitStatement(body.expression, current)
+            current?.let { builder.finishWithReturn(it, body.expression) }
+        }
+        else -> builder.finishWithReturn(entry, value = null)
+    }
+    return builder.finish(function, entry)
+}
+
+private fun emptyGraph(function: IrFunction): JsControlFlowGraph {
+    val entry = JsBasicBlock(id = 0, terminator = JsTerminator.Return(null))
+    return JsControlFlowGraph(function, entry, listOf(entry))
+}
+
+private class JsControlFlowGraphBuilder {
+    private val blocks = mutableListOf<JsBasicBlock>()
+    private val loopStack = ArrayDeque<LoopContext>()
+    private var unsupportedConstruct: IrElement? = null
+
+    fun newBlock(): JsBasicBlock = JsBasicBlock(id = blocks.size).also { blocks += it }
+
+    /**
+     * Sets [from]'s terminator and wires predecessor/successor edges immediately.
+     */
+    fun link(from: JsBasicBlock, terminator: JsTerminator) {
+        if (from.terminator !is JsTerminator.Unreachable) {
+            return
+        }
+        from.terminator = terminator
+        for (succ in terminator.successors()) {
+            if (succ !in from.successors) from.successors += succ
+            if (from !in succ.predecessors) succ.predecessors += from
+        }
+    }
+
+    fun emitStatement(statement: IrStatement, current: JsBasicBlock?): JsBasicBlock? {
+        if (current == null) return null
+        return when (statement) {
+            is IrWhen -> emitWhen(statement, current)
+            is IrWhileLoop -> emitWhile(statement, current)
+            is IrDoWhileLoop -> emitDoWhile(statement, current)
+            is IrBreak -> {
+                val target = loopStack.firstOrNull { it.loop == statement.loop }?.breakTarget
+                if (target == null) {
+                    // Non-enclosing loop: do not leave IrBreak as a statement.
+                    if (unsupportedConstruct == null) unsupportedConstruct = statement
+                    link(current, JsTerminator.Unreachable)
+                    return null
+                }
+                link(current, JsTerminator.Goto(target))
+                null
+            }
+            is IrContinue -> {
+                val target = loopStack.firstOrNull { it.loop == statement.loop }?.continueTarget
+                if (target == null) {
+                    if (unsupportedConstruct == null) unsupportedConstruct = statement
+                    link(current, JsTerminator.Unreachable)
+                    return null
+                }
+                link(current, JsTerminator.Goto(target))
+                null
+            }
+            is IrReturn -> {
+                // Value lives only on the terminator, not also in statements.
+                link(current, JsTerminator.Return(statement.value))
+                null
+            }
+            is IrThrow -> {
+                link(current, JsTerminator.Throw(statement.value))
+                null
+            }
+            is IrBlock -> {
+                var cur: JsBasicBlock? = current
+                for (nested in statement.statements) {
+                    cur = emitStatement(nested, cur) ?: return null
+                }
+                cur
+            }
+            is IrTry -> {
+                if (unsupportedConstruct == null) unsupportedConstruct = statement
+                current.statements += statement
+                current
+            }
+            else -> {
+                current.statements += statement
+                current
+            }
+        }
+    }
+
+    private fun emitWhen(expression: IrWhen, current: JsBasicBlock): JsBasicBlock? {
+        if (expression.branches.isEmpty()) {
+            current.statements += expression
+            return current
+        }
+        val only = expression.branches.singleOrNull()
+        if (only != null && only.condition.isTrueConst()) {
+            return emitStatement(only.result, current)
+        }
+
+        val merge = newBlock()
+        val branchTargets = mutableListOf<MultiCondBranch>()
+        for (branch in expression.branches) {
+            val target = newBlock()
+            branchTargets += MultiCondBranch(branch.condition, target)
+            val after = emitStatement(branch.result, target)
+            after?.let { link(it, JsTerminator.Goto(merge)) }
+        }
+        if (expression.branches.none { isElseBranch(it) }) {
+            branchTargets += MultiCondBranch(condition = null, target = merge)
+        }
+        link(current, JsTerminator.MultiCond(branchTargets))
+        return merge
+    }
+
+    private fun emitWhile(loop: IrWhileLoop, current: JsBasicBlock): JsBasicBlock {
+        val header = newBlock()
+        val body = newBlock()
+        val exit = newBlock()
+        link(current, JsTerminator.Goto(header))
+        link(header, JsTerminator.Cond(loop.condition, thenTarget = body, elseTarget = exit))
+        loopStack.addFirst(LoopContext(loop, breakTarget = exit, continueTarget = header))
+        val loopBody = loop.body
+        val afterBody = if (loopBody != null) emitStatement(loopBody, body) else body
+        afterBody?.let { link(it, JsTerminator.Goto(header)) }
+        loopStack.removeFirst()
+        return exit
+    }
+
+    private fun emitDoWhile(loop: IrDoWhileLoop, current: JsBasicBlock): JsBasicBlock {
+        val body = newBlock()
+        val header = newBlock()
+        val exit = newBlock()
+        link(current, JsTerminator.Goto(body))
+        loopStack.addFirst(LoopContext(loop, breakTarget = exit, continueTarget = header))
+        val loopBody = loop.body
+        val afterBody = if (loopBody != null) emitStatement(loopBody, body) else body
+        afterBody?.let { link(it, JsTerminator.Goto(header)) }
+        loopStack.removeFirst()
+        link(header, JsTerminator.Cond(loop.condition, thenTarget = body, elseTarget = exit))
+        return exit
+    }
+
+    fun finishWithReturn(block: JsBasicBlock, value: IrExpression?) {
+        if (block.terminator is JsTerminator.Unreachable) {
+            link(block, JsTerminator.Return(value))
+        }
+    }
+
+    fun finish(function: IrFunction, entry: JsBasicBlock): JsControlFlowGraph {
+        val reachable = pruneUnreachable(entry)
+        return JsControlFlowGraph(function, entry, reachable, unsupportedConstruct)
+    }
+
+    private fun pruneUnreachable(entry: JsBasicBlock): List<JsBasicBlock> {
+        val reachable = linkedSetOf<JsBasicBlock>()
+        val queue = ArrayDeque<JsBasicBlock>()
+        queue.add(entry)
+        while (queue.isNotEmpty()) {
+            val block = queue.removeFirst()
+            if (!reachable.add(block)) continue
+            for (succ in block.successors) queue.add(succ)
+        }
+        // Drop pred/succ edges that point outside the reachable set.
+        for (block in reachable) {
+            block.predecessors.retainAll(reachable)
+            block.successors.retainAll(reachable)
+        }
+        val ordered = reachable.toList()
+        for (indexedBlock in ordered.withIndex()) {
+            indexedBlock.value.id = indexedBlock.index
+        }
+        return ordered
+    }
+}
+
+private class LoopContext(
+    val loop: IrLoop,
+    val breakTarget: JsBasicBlock,
+    val continueTarget: JsBasicBlock,
+)

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsDataflowSolver.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsDataflowSolver.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+/**
+ * Join-semilattice used by [ForwardDataflowSolver].
+ *
+ * Implementations must provide a finite-height lattice: ascending chains under [join]
+ * are finite, so the worklist algorithm terminates without an artificial iteration cap.
+ */
+interface Lattice<T> {
+    fun bottom(): T
+    fun join(a: T, b: T): T
+    fun equivalent(a: T, b: T): Boolean
+}
+
+/**
+ * Forward transfer: maps a block and its IN state to a (possibly distinct) OUT state
+ * for each successor. Branch narrowing is expressed by returning different states per edge.
+ */
+fun interface TransferFunction<S> {
+    fun transfer(block: JsBasicBlock, inn: S): Map<JsBasicBlock, S>
+}
+
+/**
+ * Classic forward dataflow fixed-point over a [JsControlFlowGraph].
+ *
+ * Returns the IN state of every reachable block. Because [Lattice] has finite height,
+ * the fixed point is reached in finitely many joins; iterationBudget is only an
+ * assertion-guarded bug detector and must never be used to silently truncate results.
+ */
+class ForwardDataflowSolver {
+    fun <S> solve(
+        cfg: JsControlFlowGraph,
+        entryState: S,
+        lattice: Lattice<S>,
+        transfer: TransferFunction<S>,
+        iterationBudget: Int = cfg.blocks.size * 64 + 256,
+    ): Map<JsBasicBlock, S> = solve(
+        entry = cfg.entry,
+        entryState = entryState,
+        lattice = lattice,
+        transfer = transfer,
+        iterationBudget = iterationBudget,
+        debugName = cfg.function.name.asString(),
+    )
+
+    fun <S> solve(
+        entry: JsBasicBlock,
+        entryState: S,
+        lattice: Lattice<S>,
+        transfer: TransferFunction<S>,
+        iterationBudget: Int,
+        debugName: String = "cfg",
+    ): Map<JsBasicBlock, S> {
+        val inStates = mutableMapOf<JsBasicBlock, S>()
+        val worklist = ArrayDeque<JsBasicBlock>()
+        inStates[entry] = entryState
+        worklist.add(entry)
+
+        var iterations = 0
+        while (worklist.isNotEmpty()) {
+            check(iterations++ < iterationBudget) {
+                "Dataflow solver exceeded iteration budget ($iterationBudget) on $debugName; " +
+                        "finite-height lattices must converge — this indicates a lattice/transfer bug"
+            }
+            val block = worklist.removeFirst()
+            val inn = inStates[block] ?: lattice.bottom()
+            val outs = transfer.transfer(block, inn)
+            for (entry in outs.entries) {
+                val succ = entry.key
+                val outState = entry.value
+                val previous = inStates[succ]
+                val joined = if (previous == null) outState else lattice.join(previous, outState)
+                if (previous == null || !lattice.equivalent(previous, joined)) {
+                    inStates[succ] = joined
+                    worklist.add(succ)
+                }
+            }
+        }
+        return inStates
+    }
+}

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsProgramIndex.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsProgramIndex.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.backend.js.JsIrBackendContext
+import org.jetbrains.kotlin.ir.backend.js.ir.isExported
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrFunctionAccessExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionReference
+import org.jetbrains.kotlin.ir.util.isEffectivelyExternal
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.ir.visitors.acceptVoid
+
+/**
+ * Thin linked-program index: functions, CFGs, and call sites.
+ *
+ * Not a per-expression data-flow graph. Intended as the shared substrate for concrete
+ * type/value analysis, call-graph construction, and later inlining / devirtualization.
+ */
+class JsProgramIndex(
+    val context: JsIrBackendContext,
+    val modules: List<IrModuleFragment>,
+    val functions: Map<IrFunction, JsIndexedFunction>,
+    val callSites: List<JsCallSite>,
+) {
+    fun function(ir: IrFunction): JsIndexedFunction? = functions[ir]
+
+    fun callsTo(callee: IrFunction): List<JsCallSite> =
+        callSites.filter { it.directCallee == callee }
+}
+
+/**
+ * Per-function view in the program index.
+ *
+ * @param hasUnknownCallers is true when parameters must not be refined from visible call sites
+ * (exported, external, referenced as a function value, or open virtual target).
+ */
+class JsIndexedFunction(
+    val ir: IrFunction,
+    val cfg: JsControlFlowGraph,
+    val hasUnknownCallers: Boolean,
+)
+
+/**
+ * A direct call / constructor call with a resolved [directCallee] when statically known.
+ */
+class JsCallSite(
+    val call: IrFunctionAccessExpression,
+    val enclosingFunction: IrFunction?,
+    val directCallee: IrFunction?,
+)
+
+/**
+ * Builds [JsProgramIndex] for all functions with bodies in [modules].
+ */
+context(context: JsIrBackendContext)
+fun buildJsProgramIndex(modules: Iterable<IrModuleFragment>): JsProgramIndex {
+    // Skip stdlib / platform modules — analyses run on the linked *user* program.
+    val moduleList = modules.filterNot { it.isKotlinLibraryModule() }
+    val functionsWithBody = linkedMapOf<IrFunction, JsIndexedFunction>()
+    val callSites = mutableListOf<JsCallSite>()
+    val referencedAsValue = mutableSetOf<IrFunction>()
+    val openCallees = mutableSetOf<IrFunction>()
+
+    val callCollector = object : IrVisitorVoid() {
+        private var currentFunction: IrFunction? = null
+
+        override fun visitElement(element: IrElement) =
+            element.acceptChildrenVoid(visitor = this)
+
+        override fun visitFunction(declaration: IrFunction) {
+            val previous = currentFunction
+            currentFunction = declaration
+            declaration.acceptChildrenVoid(visitor = this)
+            currentFunction = previous
+        }
+
+        override fun visitCall(expression: IrCall) {
+            recordCall(expression)
+            expression.acceptChildrenVoid(visitor = this)
+        }
+
+        override fun visitConstructorCall(expression: IrConstructorCall) {
+            recordCall(expression)
+            expression.acceptChildrenVoid(visitor = this)
+        }
+
+        override fun visitFunctionReference(expression: IrFunctionReference) {
+            referencedAsValue += expression.symbol.owner
+            expression.acceptChildrenVoid(visitor = this)
+        }
+
+        private fun recordCall(expression: IrFunctionAccessExpression) {
+            val directCallee = resolveDirectCallee(expression)
+            if (directCallee == null) {
+                openCallees += expression.symbol.owner
+            }
+            callSites += JsCallSite(expression, currentFunction, directCallee)
+        }
+    }
+
+    for (module in moduleList) {
+        for (file in module.files) {
+            file.acceptVoid(callCollector)
+        }
+    }
+
+    val functionIndexer = object : IrVisitorVoid() {
+        override fun visitElement(element: IrElement) {
+            element.acceptChildrenVoid(visitor = this)
+        }
+
+        override fun visitFunction(declaration: IrFunction) {
+            if (declaration.body != null) {
+                val hasUnknownCallers = declaration.isEffectivelyExternal() ||
+                        declaration.isExported(context) ||
+                        declaration in referencedAsValue ||
+                        declaration in openCallees ||
+                        declaration.isOpenLike()
+                functionsWithBody[declaration] = JsIndexedFunction(
+                    ir = declaration,
+                    cfg = buildJsFunctionCfg(declaration),
+                    hasUnknownCallers = hasUnknownCallers,
+                )
+            }
+            declaration.acceptChildrenVoid(visitor = this)
+        }
+    }
+
+    for (module in moduleList) {
+        module.acceptVoid(visitor = functionIndexer)
+    }
+
+    return JsProgramIndex(context, moduleList, functionsWithBody, callSites)
+}
+
+private fun resolveDirectCallee(expression: IrFunctionAccessExpression): IrFunction? {
+    val callee = expression.symbol.owner
+    return when (expression) {
+        is IrConstructorCall -> callee
+        is IrCall -> {
+            if (expression.superQualifierSymbol != null) return callee
+            val simple = callee as? IrSimpleFunction ?: return callee
+            if (simple.isFakeOverride || simple.modality.isOpenLike()) null else simple
+        }
+        else -> callee
+    }
+}
+
+private fun IrFunction.isOpenLike(): Boolean {
+    val simple = this as? IrSimpleFunction ?: return false
+    return simple.modality.isOpenLike()
+}
+
+private fun Modality.isOpenLike(): Boolean =
+    this == Modality.OPEN || this == Modality.ABSTRACT || this == Modality.SEALED
+
+private fun IrModuleFragment.isKotlinLibraryModule(): Boolean {
+    val raw = name.asString().removeSurrounding("<", ">")
+    return raw.startsWith("kotlin") || raw == "JS-all" || raw.contains("kotlin-stdlib")
+}

--- a/js/js.tests/build.gradle.kts
+++ b/js/js.tests/build.gradle.kts
@@ -186,6 +186,7 @@ projectTests {
     testData(project(":js:js.translator").isolated, "testData/typescript-export/js/")
     testData(project(":compiler").isolated, "testData/debug/stepping")
     testData(project(":compiler").isolated, "testData/debug/localVariables")
+    testData(isolated, "testData/dataflow")
 
     testGenerator(
         "org.jetbrains.kotlin.generators.tests.GenerateJsTestsKt",

--- a/js/js.tests/testData/dataflow/breakContinueCfg.cfg.txt
+++ b/js/js.tests/testData/dataflow/breakContinueCfg.cfg.txt
@@ -1,0 +1,29 @@
+// FUNCTION: box
+// blocks=8 entry=BB0
+BB0:
+  var i: Int = 0
+  terminator: Goto(BB1)
+  succs: BB1
+BB1:
+  terminator: Cond(jsLt(a = i, b = 3), then=BB2, else=BB3)
+  succs: BB2, BB3
+BB2:
+  val <unary>: Int = i
+  i = jsBitOr(a = jsPlus(a = <unary>, b = 1), b = 0)
+  Unit_getInstance()
+  terminator: MultiCond(jsEqeqeq(a = i, b = 2) -> BB4, else -> BB5)
+  succs: BB4, BB5
+BB3:
+  terminator: Return(when { jsGtEq(a = i, b = 2) -> "OK" else -> "FAIL" })
+BB4:
+  terminator: Goto(BB3)
+  succs: BB3
+BB5:
+  terminator: MultiCond(jsEqeqeq(a = i, b = 1) -> BB6, else -> BB7)
+  succs: BB6, BB7
+BB6:
+  terminator: Goto(BB1)
+  succs: BB1
+BB7:
+  terminator: Goto(BB1)
+  succs: BB1

--- a/js/js.tests/testData/dataflow/breakContinueCfg.facts.txt
+++ b/js/js.tests/testData/dataflow/breakContinueCfg.facts.txt
@@ -1,0 +1,3 @@
+// FUNCTION: box
+local <unary>: value=Top type=Exact(Int) final
+local i: value=Top type=Exact(Int) final

--- a/js/js.tests/testData/dataflow/breakContinueCfg.kt
+++ b/js/js.tests/testData/dataflow/breakContinueCfg.kt
@@ -1,0 +1,11 @@
+// Soundness: break/continue target enclosing loops; unreachable blocks pruned.
+
+fun box(): String {
+    var i = 0
+    while (i < 3) {
+        i++
+        if (i == 2) break
+        if (i == 1) continue
+    }
+    return if (i >= 2) "OK" else "FAIL"
+}

--- a/js/js.tests/testData/dataflow/crossModuleParamRefined.cfg.txt
+++ b/js/js.tests/testData/dataflow/crossModuleParamRefined.cfg.txt
@@ -1,0 +1,27 @@
+// FUNCTION: take
+// blocks=4 entry=BB0
+BB0:
+  var tmp: String
+  terminator: MultiCond(jsInstanceOfIntrinsic(a = p, b = jsClassIntrinsic<Child>()) -> BB1, true -> BB2)
+  succs: BB1, BB2
+BB1:
+  tmp = "OK"
+  terminator: Goto(BB3)
+  succs: BB3
+BB2:
+  tmp = "FAIL"
+  terminator: Goto(BB3)
+  succs: BB3
+BB3:
+  terminator: Return(tmp)
+
+// FUNCTION: <init>
+// blocks=1 entry=BB0
+BB0:
+  Any()
+  terminator: Return(Unit)
+
+// FUNCTION: box
+// blocks=1 entry=BB0
+BB0:
+  terminator: Return(take(p = Child()))

--- a/js/js.tests/testData/dataflow/crossModuleParamRefined.facts.txt
+++ b/js/js.tests/testData/dataflow/crossModuleParamRefined.facts.txt
@@ -1,0 +1,7 @@
+// FUNCTION: take
+param p: value=Top type=Exact(Child) final
+local tmp: value=Top type=Top
+
+// FUNCTION: <init>
+
+// FUNCTION: box

--- a/js/js.tests/testData/dataflow/crossModuleParamRefined.kt
+++ b/js/js.tests/testData/dataflow/crossModuleParamRefined.kt
@@ -1,0 +1,12 @@
+// MODULE: lib
+// FILE: lib.kt
+interface Base
+class Child : Base
+
+fun take(p: Base): String = if (p is Child) "OK" else "FAIL"
+
+// MODULE: main(lib)
+// FILE: main.kt
+// Precision: cross-module monomorphic call refines lib.take parameter.
+
+fun box(): String = take(Child())

--- a/js/js.tests/testData/dataflow/exportedParamNotRefined.cfg.txt
+++ b/js/js.tests/testData/dataflow/exportedParamNotRefined.cfg.txt
@@ -1,0 +1,15 @@
+// FUNCTION: take
+// blocks=1 entry=BB0
+BB0:
+  terminator: Return("OK")
+
+// FUNCTION: <init>
+// blocks=1 entry=BB0
+BB0:
+  Any()
+  terminator: Return(Unit)
+
+// FUNCTION: box
+// blocks=1 entry=BB0
+BB0:
+  terminator: Return(take(p = Child(), n = 7))

--- a/js/js.tests/testData/dataflow/exportedParamNotRefined.facts.txt
+++ b/js/js.tests/testData/dataflow/exportedParamNotRefined.facts.txt
@@ -1,0 +1,7 @@
+// FUNCTION: take
+param n: value=Top type=Exact(Int) final
+param p: value=Top type=UpperBound(Base)
+
+// FUNCTION: <init>
+
+// FUNCTION: box

--- a/js/js.tests/testData/dataflow/exportedParamNotRefined.kt
+++ b/js/js.tests/testData/dataflow/exportedParamNotRefined.kt
@@ -1,0 +1,9 @@
+// Soundness: exported function parameters must not be refined from call sites.
+
+interface Base
+class Child : Base
+
+@JsExport
+fun take(p: Base, n: Int): String = "OK"
+
+fun box(): String = take(Child(), 7)

--- a/js/js.tests/testData/dataflow/localConsts.cfg.txt
+++ b/js/js.tests/testData/dataflow/localConsts.cfg.txt
@@ -1,0 +1,40 @@
+// FUNCTION: box
+// blocks=13 entry=BB0
+BB0:
+  val flag: Boolean = true
+  val n: Int = 42
+  val c: Char = <Char__<init>-impl>(value = 65)
+  val s: String = "OK"
+  val z: String? = null
+  val u: Unit = Unit_getInstance()
+  terminator: MultiCond(jsNot(a = flag) -> BB1, else -> BB2)
+  succs: BB1, BB2
+BB1:
+  terminator: Return("FAIL")
+BB2:
+  terminator: MultiCond(jsNot(a = jsEqeqeq(a = n, b = 42)) -> BB3, else -> BB4)
+  succs: BB3, BB4
+BB3:
+  terminator: Return("FAIL")
+BB4:
+  terminator: MultiCond(jsNot(a = jsEqeqeq(a = c, b = <Char__<init>-impl>(value = 65))) -> BB5, else -> BB6)
+  succs: BB5, BB6
+BB5:
+  terminator: Return("FAIL")
+BB6:
+  terminator: MultiCond(jsNot(a = jsEqeqeq(a = s, b = "OK")) -> BB7, else -> BB8)
+  succs: BB7, BB8
+BB7:
+  terminator: Return("FAIL")
+BB8:
+  terminator: MultiCond(jsNot(a = jsEqeq(a = z, b = null)) -> BB9, else -> BB10)
+  succs: BB9, BB10
+BB9:
+  terminator: Return("FAIL")
+BB10:
+  terminator: MultiCond(jsNot(a = equals(obj1 = Unit_getInstance(), obj2 = Unit_getInstance())) -> BB11, else -> BB12)
+  succs: BB11, BB12
+BB11:
+  terminator: Return("FAIL")
+BB12:
+  terminator: Return("OK")

--- a/js/js.tests/testData/dataflow/localConsts.facts.txt
+++ b/js/js.tests/testData/dataflow/localConsts.facts.txt
@@ -1,0 +1,7 @@
+// FUNCTION: box
+local c: value=Top type=Exact(Char) final
+local flag: value=true type=Exact(Boolean) final
+local n: value=42:Int type=Exact(Int) final
+local s: value="OK" type=Exact(String) final
+local u: value=Unit type=Top
+local z: value=null type=Top

--- a/js/js.tests/testData/dataflow/localConsts.kt
+++ b/js/js.tests/testData/dataflow/localConsts.kt
@@ -1,0 +1,17 @@
+// Precision: local constants including Char vs Int distinction.
+
+fun box(): String {
+    val flag = true
+    val n = 42
+    val c = 'A'
+    val s = "OK"
+    val z: String? = null
+    val u = Unit
+    if (!flag) return "FAIL"
+    if (n != 42) return "FAIL"
+    if (c != 'A') return "FAIL"
+    if (s != "OK") return "FAIL"
+    if (z != null) return "FAIL"
+    if (u != Unit) return "FAIL"
+    return "OK"
+}

--- a/js/js.tests/testData/dataflow/localEnumAndExactType.cfg.txt
+++ b/js/js.tests/testData/dataflow/localEnumAndExactType.cfg.txt
@@ -1,0 +1,89 @@
+// FUNCTION: static_init
+// blocks=3 entry=BB0
+BB0:
+  terminator: MultiCond(#static_init_called -> BB1, else -> BB2)
+  succs: BB1, BB2
+BB1:
+  terminator: Return(Unit_getInstance())
+BB2:
+  #static_init_called = true
+  #Color_RED_instance = Color(name = "RED", ordinal = 0)
+  #Color_GREEN_instance = Color(name = "GREEN", ordinal = 1)
+  terminator: Return(Unit)
+
+// FUNCTION: <init>
+// blocks=1 entry=BB0
+BB0:
+  Enum<Color>(name = name, ordinal = ordinal)
+  terminator: Return(Unit)
+
+// FUNCTION: values
+// blocks=1 entry=BB0
+BB0:
+  static_init()
+  terminator: Return(arrayLiteral(a = [Color_RED_getInstance(), Color_GREEN_getInstance()]))
+
+// FUNCTION: valueOf
+// blocks=5 entry=BB0
+BB0:
+  static_init()
+  terminator: MultiCond(jsEqeqeq(a = value, b = "RED") -> BB1, jsEqeqeq(a = value, b = "GREEN") -> BB2, true -> BB3)
+  succs: BB1, BB2, BB3
+BB1:
+  terminator: Return(Color_RED_getInstance())
+BB2:
+  terminator: Return(Color_GREEN_getInstance())
+BB3:
+  THROW_IAE(msg = "No enum constant Color." + value)
+  terminator: Goto(BB4)
+  succs: BB4
+BB4:
+  terminator: Return(Unit)
+
+// FUNCTION: <get-entries>
+// blocks=3 entry=BB0
+BB0:
+  static_init()
+  terminator: MultiCond(jsEqeq(a = #$ENTRIES, b = null) -> BB1, else -> BB2)
+  succs: BB1, BB2
+BB1:
+  #$ENTRIES = enumEntries</* null */>(entries = values())
+  terminator: Goto(BB2)
+  succs: BB2
+BB2:
+  terminator: Return(#$ENTRIES)
+
+// FUNCTION: <init>
+// blocks=1 entry=BB0
+BB0:
+  Any()
+  terminator: Return(Unit)
+
+// FUNCTION: box
+// blocks=5 entry=BB0
+BB0:
+  val e: Color = Color_RED_getInstance()
+  val x: Base = Child()
+  terminator: MultiCond(jsNot(a = e.equals(other = Color_RED_getInstance())) -> BB1, else -> BB2)
+  succs: BB1, BB2
+BB1:
+  terminator: Return("FAIL")
+BB2:
+  terminator: MultiCond(jsNot(a = jsInstanceOfIntrinsic(a = x, b = jsClassIntrinsic<Child>())) -> BB3, else -> BB4)
+  succs: BB3, BB4
+BB3:
+  terminator: Return("FAIL")
+BB4:
+  terminator: Return("OK")
+
+// FUNCTION: Color_RED_getInstance
+// blocks=1 entry=BB0
+BB0:
+  static_init()
+  terminator: Return(#Color_RED_instance)
+
+// FUNCTION: Color_GREEN_getInstance
+// blocks=1 entry=BB0
+BB0:
+  static_init()
+  terminator: Return(#Color_GREEN_instance)

--- a/js/js.tests/testData/dataflow/localEnumAndExactType.facts.txt
+++ b/js/js.tests/testData/dataflow/localEnumAndExactType.facts.txt
@@ -1,0 +1,22 @@
+// FUNCTION: static_init
+
+// FUNCTION: <init>
+param name: value=Top type=Exact(String) final
+param ordinal: value=Top type=Exact(Int) final
+
+// FUNCTION: values
+
+// FUNCTION: valueOf
+param value: value=Top type=Exact(String) final
+
+// FUNCTION: <get-entries>
+
+// FUNCTION: <init>
+
+// FUNCTION: box
+local e: value=Top type=UpperBound(Color)
+local x: value=Top type=Exact(Child) final
+
+// FUNCTION: Color_RED_getInstance
+
+// FUNCTION: Color_GREEN_getInstance

--- a/js/js.tests/testData/dataflow/localEnumAndExactType.kt
+++ b/js/js.tests/testData/dataflow/localEnumAndExactType.kt
@@ -1,0 +1,14 @@
+// Precision: enum const + exact final type.
+
+enum class Color { RED, GREEN }
+
+interface Base
+class Child : Base
+
+fun box(): String {
+    val e = Color.RED
+    val x: Base = Child()
+    if (e != Color.RED) return "FAIL"
+    if (x !is Child) return "FAIL"
+    return "OK"
+}

--- a/js/js.tests/testData/dataflow/mergeJoinsToTop.cfg.txt
+++ b/js/js.tests/testData/dataflow/mergeJoinsToTop.cfg.txt
@@ -1,0 +1,63 @@
+// FUNCTION: <init>
+// blocks=1 entry=BB0
+BB0:
+  Any()
+  terminator: Return(Unit)
+
+// FUNCTION: <init>
+// blocks=1 entry=BB0
+BB0:
+  Any()
+  terminator: Return(Unit)
+
+// FUNCTION: box
+// blocks=12 entry=BB0
+BB0:
+  var x: Int = 1
+  val tmp: dynamic = js(code = "true")
+  terminator: MultiCond(when { when { jsNot(a = jsEqeq(a = tmp, b = null)) -> jsEqeqeq(a = jsTypeOf(a = tmp), b = "boolean") else -> false } ->  -> BB1, else -> BB2)
+  succs: BB1, BB2
+BB1:
+  x = 2
+  terminator: Goto(BB2)
+  succs: BB2
+BB2:
+  var tmp: Base
+  val tmp: dynamic = js(code = "true")
+  terminator: MultiCond(when { when { jsNot(a = jsEqeq(a = tmp, b = null)) -> jsEqeqeq(a = jsTypeOf(a = tmp), b = "boolean") else -> false } ->  -> BB3, true -> BB4)
+  succs: BB3, BB4
+BB3:
+  tmp = A()
+  terminator: Goto(BB5)
+  succs: BB5
+BB4:
+  tmp = B()
+  terminator: Goto(BB5)
+  succs: BB5
+BB5:
+  val y: Base = tmp
+  var tmp: String
+  var tmp: Boolean
+  terminator: MultiCond(jsGt(a = x, b = 0) -> BB6, true -> BB7)
+  succs: BB6, BB7
+BB6:
+  tmp = isInterface(obj = y, iface = jsClassIntrinsic<Base>())
+  terminator: Goto(BB8)
+  succs: BB8
+BB7:
+  tmp = false
+  terminator: Goto(BB8)
+  succs: BB8
+BB8:
+  terminator: MultiCond(tmp -> BB9, true -> BB10)
+  succs: BB9, BB10
+BB9:
+  tmp = "OK"
+  terminator: Goto(BB11)
+  succs: BB11
+BB10:
+  tmp = "FAIL"
+  terminator: Goto(BB11)
+  succs: BB11
+BB11:
+  terminator: Return(tmp)

--- a/js/js.tests/testData/dataflow/mergeJoinsToTop.facts.txt
+++ b/js/js.tests/testData/dataflow/mergeJoinsToTop.facts.txt
@@ -1,0 +1,12 @@
+// FUNCTION: <init>
+
+// FUNCTION: <init>
+
+// FUNCTION: box
+local tmp: value=Top type=Top
+local tmp: value=Top type=Top
+local tmp: value=Top type=Top
+local tmp: value=Top type=Top
+local tmp: value=Top type=Top
+local x: value=Top type=Exact(Int) final
+local y: value=Top type=Top

--- a/js/js.tests/testData/dataflow/mergeJoinsToTop.kt
+++ b/js/js.tests/testData/dataflow/mergeJoinsToTop.kt
@@ -1,0 +1,14 @@
+// Soundness: joining divergent concrete facts yields Top.
+
+interface Base
+class A : Base
+class B : Base
+
+fun box(): String {
+    var x = 1
+    if (js("true") as Boolean) {
+        x = 2
+    }
+    val y: Base = if (js("true") as Boolean) A() else B()
+    return if (x > 0 && y is Base) "OK" else "FAIL"
+}

--- a/js/js.tests/testData/dataflow/paramRefinedMonomorphic.cfg.txt
+++ b/js/js.tests/testData/dataflow/paramRefinedMonomorphic.cfg.txt
@@ -1,0 +1,39 @@
+// FUNCTION: <init>
+// blocks=1 entry=BB0
+BB0:
+  Any()
+  terminator: Return(Unit)
+
+// FUNCTION: take
+// blocks=7 entry=BB0
+BB0:
+  var tmp: String
+  var tmp: Boolean
+  terminator: MultiCond(jsInstanceOfIntrinsic(a = p, b = jsClassIntrinsic<Child>()) -> BB1, true -> BB2)
+  succs: BB1, BB2
+BB1:
+  tmp = jsEqeqeq(a = n, b = 7)
+  terminator: Goto(BB3)
+  succs: BB3
+BB2:
+  tmp = false
+  terminator: Goto(BB3)
+  succs: BB3
+BB3:
+  terminator: MultiCond(tmp -> BB4, true -> BB5)
+  succs: BB4, BB5
+BB4:
+  tmp = "OK"
+  terminator: Goto(BB6)
+  succs: BB6
+BB5:
+  tmp = "FAIL"
+  terminator: Goto(BB6)
+  succs: BB6
+BB6:
+  terminator: Return(tmp)
+
+// FUNCTION: box
+// blocks=1 entry=BB0
+BB0:
+  terminator: Return(take(p = Child(), n = 7))

--- a/js/js.tests/testData/dataflow/paramRefinedMonomorphic.facts.txt
+++ b/js/js.tests/testData/dataflow/paramRefinedMonomorphic.facts.txt
@@ -1,0 +1,9 @@
+// FUNCTION: <init>
+
+// FUNCTION: take
+param n: value=7:Int type=Exact(Int) final
+param p: value=Top type=Exact(Child) final
+local tmp: value=Top type=Top
+local tmp: value=Top type=Top
+
+// FUNCTION: box

--- a/js/js.tests/testData/dataflow/paramRefinedMonomorphic.kt
+++ b/js/js.tests/testData/dataflow/paramRefinedMonomorphic.kt
@@ -1,0 +1,10 @@
+// Precision: monomorphic call-site refines private callee parameters.
+
+interface Base
+class Child : Base
+
+private fun take(p: Base, n: Int): String {
+    return if (p is Child && n == 7) "OK" else "FAIL"
+}
+
+fun box(): String = take(Child(), 7)

--- a/js/js.tests/testData/dataflow/tryUnsupported.cfg.txt
+++ b/js/js.tests/testData/dataflow/tryUnsupported.cfg.txt
@@ -1,0 +1,7 @@
+// FUNCTION: box
+// unsupportedConstruct: IrTryImpl
+// blocks=1 entry=BB0
+BB0:
+  var tmp: String
+  try { // BLOCK\ntmp = "OK"\n}\ncatch ($p: dynamic){ // BLOCK\nvar tmp: String\nwhen {\njsInstanceOfIntrinsic(a = $p, b = jsClassIntrinsic<Throwable>()) -> { // BLOCK\nval e: Throwable = $p /*=> Throwable */\ntmp = "FAIL"\n}\nelse -> { // BLOCK\nthrow $p\n}\n}\ntmp = tmp\n}\n
+  terminator: Return(tmp)

--- a/js/js.tests/testData/dataflow/tryUnsupported.facts.txt
+++ b/js/js.tests/testData/dataflow/tryUnsupported.facts.txt
@@ -1,0 +1,2 @@
+// FUNCTION: box
+// unsupportedConstruct: IrTryImpl

--- a/js/js.tests/testData/dataflow/tryUnsupported.kt
+++ b/js/js.tests/testData/dataflow/tryUnsupported.kt
@@ -1,0 +1,9 @@
+// Soundness: try/catch is unsupported — CFG marks unsupportedConstruct.
+
+fun box(): String {
+    return try {
+        "OK"
+    } catch (e: Throwable) {
+        "FAIL"
+    }
+}

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateJsTests.kt
@@ -9,6 +9,8 @@ import org.jetbrains.kotlin.generators.dsl.junit5.generateTestGroupSuiteWithJUni
 import org.jetbrains.kotlin.generators.model.annotation
 import org.jetbrains.kotlin.generators.util.TestGeneratorUtil
 import org.jetbrains.kotlin.incremental.*
+import org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow.AbstractJsConcreteAnalysisTest
+import org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow.AbstractJsControlFlowGraphTest
 import org.jetbrains.kotlin.js.test.runners.*
 import org.jetbrains.kotlin.js.test.runners.tsexport.*
 import org.jetbrains.kotlin.test.utils.CUSTOM_TEST_DATA_EXTENSION_PATTERN
@@ -317,6 +319,15 @@ fun main(args: Array<String>) {
                 model(
                     excludeDirs = listOf("declarations/multiplatform/k1")
                 )
+            }
+        }
+
+        testGroup(testsRoot, "js/js.tests/testData/dataflow", testRunnerMethodName = "runTest0") {
+            testClass<AbstractJsControlFlowGraphTest> {
+                model()
+            }
+            testClass<AbstractJsConcreteAnalysisTest> {
+                model()
             }
         }
 

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/JsOptimizationIrTestBase.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/JsOptimizationIrTestBase.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations
+
+import org.jetbrains.kotlin.js.test.converters.*
+import org.jetbrains.kotlin.platform.js.JsPlatforms
+import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.TargetBackend
+import org.jetbrains.kotlin.test.backend.handlers.AbstractIrHandler
+import org.jetbrains.kotlin.test.builders.*
+import org.jetbrains.kotlin.test.directives.ConfigurationDirectives
+import org.jetbrains.kotlin.test.directives.configureFirParser
+import org.jetbrains.kotlin.test.model.ArtifactKind
+import org.jetbrains.kotlin.test.model.DependencyKind
+import org.jetbrains.kotlin.test.model.FrontendKinds
+import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerWithTargetBackendTest
+import org.jetbrains.kotlin.test.services.LibraryProvider
+import org.jetbrains.kotlin.test.services.TestServices
+import org.jetbrains.kotlin.test.services.configuration.CommonEnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.configuration.JsFirstStageEnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.configuration.JsSecondStageEnvironmentConfigurator
+
+/**
+ * Shared pipeline: FIR -> klib -> deserialize -> full JS IR lowering via [JsIrOptimizationLoweringFacade].
+ * Used by JS IR dataflow / optimization tests that need late lowered IR.
+ */
+abstract class JsOptimizationIrTestBase(
+    private val handler: (TestServices) -> AbstractIrHandler,
+) : AbstractKotlinCompilerWithTargetBackendTest(TargetBackend.JS_IR) {
+
+    override fun configure(builder: TestConfigurationBuilder) = with(builder) {
+        globalDefaults {
+            frontend = FrontendKinds.FIR
+            targetPlatform = JsPlatforms.defaultJsPlatform
+            targetBackend = TargetBackend.JS_IR
+            artifactKind = ArtifactKind.NoArtifact
+            dependencyKind = DependencyKind.Binary
+        }
+
+        defaultDirectives {
+            +ConfigurationDirectives.WITH_STDLIB
+        }
+
+        useAdditionalService(::LibraryProvider)
+
+        facadeStep(::FirCliWebFacade)
+        firHandlersStep()
+        facadeStep(::Fir2IrCliWebFacade)
+        irHandlersStep()
+        facadeStep(::JsIrPreSerializationLoweringFacade)
+        loweredIrHandlersStep()
+        facadeStep(::FirKlibSerializerCliJsFacade)
+        facadeStep(::JsIrDeserializerFacade)
+        facadeStep(::JsIrOptimizationLoweringFacade)
+        deserializedIrHandlersStep {
+            useHandlers(handler)
+        }
+
+        configureFirParser(FirParser.LightTree)
+
+        useConfigurators(
+            ::CommonEnvironmentConfigurator,
+            ::JsFirstStageEnvironmentConfigurator,
+            ::JsSecondStageEnvironmentConfigurator,
+        )
+    }
+}

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/AbstractJsConcreteAnalysisTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/AbstractJsConcreteAnalysisTest.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.backend.js.optimizations.JsOptimizationIrTestBase
+
+/**
+ * Base for on-disk JS concrete type/value analysis dump tests under `js/js.tests/testData/dataflow`.
+ */
+abstract class AbstractJsConcreteAnalysisTest : JsOptimizationIrTestBase(::JsConcreteAnalysisHandler)

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/AbstractJsControlFlowGraphTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/AbstractJsControlFlowGraphTest.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.backend.js.optimizations.JsOptimizationIrTestBase
+
+/**
+ * Base for on-disk JS CFG dump tests under `js/js.tests/testData/dataflow`.
+ */
+abstract class AbstractJsControlFlowGraphTest : JsOptimizationIrTestBase(::JsControlFlowGraphHandler)

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteAnalysisHandler.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsConcreteAnalysisHandler.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrConstKind
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.js.test.converters.LoweredJsIrBackendInput
+import org.jetbrains.kotlin.test.backend.handlers.AbstractIrHandler
+import org.jetbrains.kotlin.test.backend.ir.IrBackendInput
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.TestServices
+import org.jetbrains.kotlin.test.services.assertions
+import org.jetbrains.kotlin.test.services.moduleStructure
+
+/**
+ * Runs [analyzeJsProgram] and dumps per-function summaries to a golden `.facts.txt`.
+ */
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+class JsConcreteAnalysisHandler(testServices: TestServices) : AbstractIrHandler(testServices) {
+    private val builder = StringBuilder()
+
+    override fun processModule(module: TestModule, info: IrBackendInput) {
+        if (module != testServices.moduleStructure.modules.last()) return
+        check(info is LoweredJsIrBackendInput) {
+            "Expected LoweredJsIrBackendInput, got ${info::class.simpleName}"
+        }
+        val result = with(info.context) { analyzeJsProgram(info.allModules) }
+        for (entry in result.functionFacts.entries) {
+            dumpFunction(entry.key, entry.value)
+        }
+    }
+
+    override fun processAfterAllModules(someAssertionWasFailed: Boolean) {
+        val testFile = testServices.moduleStructure.originalTestDataFiles.first()
+        val dumpFile = testFile.resolveSibling("${testFile.nameWithoutExtension}.facts.txt")
+        testServices.assertions.assertEqualsToFile(dumpFile, builder.toString())
+    }
+
+    private fun dumpFunction(function: IrFunction, facts: JsFunctionFacts) {
+        builder.appendLine("// FUNCTION: ${function.name.asString()}")
+        val unsupportedConstruct = facts.cfg.unsupportedConstruct
+        if (unsupportedConstruct != null) {
+            builder.appendLine("// unsupportedConstruct: ${unsupportedConstruct::class.simpleName}")
+        }
+        val values = linkedSetOf<IrValueDeclaration>()
+        values.addAll(function.parameters)
+        values.addAll(facts.allSummaries().keys)
+        val named = values.sortedBy { it.name.asString() }
+        for (value in named) {
+            val fact = facts.summary(value)
+            if (fact == JsFact.Bottom) continue
+            val label = valueLabel(value)
+            builder.appendLine("$label: value=${formatValue(fact.value)} type=${formatType(fact.type)}")
+        }
+        builder.appendLine()
+    }
+
+    private fun valueLabel(value: IrValueDeclaration): String = when (value) {
+        is IrVariable -> "local ${value.name.asString()}"
+        else -> "param ${value.name.asString()}"
+    }
+
+    private fun formatValue(value: JsValueLattice): String = when (value) {
+        JsValueLattice.Top -> "Top"
+        JsValueLattice.Bottom -> "Bottom"
+        JsValueLattice.Unit -> "Unit"
+        is JsValueLattice.Enum -> value.toString()
+        is JsValueLattice.Const -> when (value.kind) {
+            IrConstKind.Null -> "null"
+            IrConstKind.Boolean -> value.value.toString()
+            IrConstKind.Char -> "'${value.value}'"
+            IrConstKind.String -> "\"${value.value}\""
+            IrConstKind.Byte, IrConstKind.Short, IrConstKind.Int, IrConstKind.Long ->
+                "${value.value}:${value.kind.asString}"
+            else -> "${value.value}:${value.kind.asString}"
+        }
+    }
+
+    private fun formatType(type: JsTypeLattice): String = when (type) {
+        JsTypeLattice.Top -> "Top"
+        JsTypeLattice.Bottom -> "Bottom"
+        is JsTypeLattice.Exact -> {
+            val nullability = if (type.nullable) "?" else ""
+            val final = if (type.isFinal) " final" else ""
+            "Exact(${type.irClass.name.asString()}$nullability)$final"
+        }
+        is JsTypeLattice.UpperBound -> {
+            val nullability = if (type.nullable) "?" else ""
+            "UpperBound(${type.irClass.name.asString()}$nullability)"
+        }
+    }
+}

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsControlFlowGraphHandler.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsControlFlowGraphHandler.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.util.dumpKotlinLike
+import org.jetbrains.kotlin.js.test.converters.LoweredJsIrBackendInput
+import org.jetbrains.kotlin.test.backend.handlers.AbstractIrHandler
+import org.jetbrains.kotlin.test.backend.ir.IrBackendInput
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.TestServices
+import org.jetbrains.kotlin.test.services.assertions
+import org.jetbrains.kotlin.test.services.moduleStructure
+
+/**
+ * Dumps [JsControlFlowGraph] for each function with a body to a golden `.cfg.txt`.
+ */
+class JsControlFlowGraphHandler(testServices: TestServices) : AbstractIrHandler(testServices) {
+    private val builder = StringBuilder()
+
+    override fun processModule(module: TestModule, info: IrBackendInput) {
+        if (module != testServices.moduleStructure.modules.last()) return
+        check(info is LoweredJsIrBackendInput) {
+            "Expected LoweredJsIrBackendInput, got ${info::class.simpleName}"
+        }
+        val index = with(info.context) { buildJsProgramIndex(info.allModules) }
+        for (entry in index.functions.entries) {
+            dumpFunction(entry.key, entry.value.cfg)
+        }
+    }
+
+    override fun processAfterAllModules(someAssertionWasFailed: Boolean) {
+        val testFile = testServices.moduleStructure.originalTestDataFiles.first()
+        val dumpFile = testFile.resolveSibling("${testFile.nameWithoutExtension}.cfg.txt")
+        testServices.assertions.assertEqualsToFile(dumpFile, builder.toString())
+    }
+
+    private fun dumpFunction(function: IrFunction, cfg: JsControlFlowGraph) {
+        builder.appendLine("// FUNCTION: ${function.name.asString()}")
+        val unsupportedConstruct = cfg.unsupportedConstruct
+        if (unsupportedConstruct != null) {
+            builder.appendLine("// unsupportedConstruct: ${unsupportedConstruct::class.simpleName}")
+        }
+        builder.appendLine("// blocks=${cfg.blocks.size} entry=BB${cfg.entry.id}")
+        for (block in cfg.blocks) {
+            builder.appendLine("BB${block.id}:")
+            for (statement in block.statements) {
+                builder.appendLine("  ${renderStatement(statement)}")
+            }
+            builder.appendLine("  terminator: ${renderTerminator(block.terminator)}")
+            if (block.successors.isNotEmpty()) {
+                builder.appendLine("  succs: ${block.successors.joinToString { "BB${it.id}" }}")
+            }
+        }
+        builder.appendLine()
+    }
+
+    private fun renderStatement(statement: IrStatement): String =
+        statement.dumpKotlinLike().lines().joinToString("\\n") { it.trim() }
+
+    private fun renderTerminator(terminator: JsTerminator): String = when (terminator) {
+        is JsTerminator.Goto -> "Goto(BB${terminator.target.id})"
+        is JsTerminator.Cond ->
+            "Cond(${renderExpr(terminator.condition)}, then=BB${terminator.thenTarget.id}, else=BB${terminator.elseTarget.id})"
+        is JsTerminator.MultiCond -> {
+            val arms = terminator.branches.joinToString {
+                val cond = it.condition?.let(::renderExpr) ?: "else"
+                "$cond -> BB${it.target.id}"
+            }
+            "MultiCond($arms)"
+        }
+        is JsTerminator.Return -> "Return(${terminator.value?.let(::renderExpr) ?: "Unit"})"
+        is JsTerminator.Throw -> "Throw(${renderExpr(terminator.value)})"
+        JsTerminator.Unreachable -> "Unreachable"
+    }
+
+    private fun renderExpr(expression: IrExpression): String =
+        expression.dumpKotlinLike().lines().joinToString(" ") { it.trim() }.take(120)
+}

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/JsIrOptimizationLoweringFacade.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/JsIrOptimizationLoweringFacade.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.js.test.converters
+
+import org.jetbrains.kotlin.cli.pipeline.web.WebLoadedIrPipelineArtifact
+import org.jetbrains.kotlin.cli.pipeline.web.js.JsIrLoweringPipelinePhase
+import org.jetbrains.kotlin.ir.backend.js.JsIrBackendContext
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.util.KotlinMangler
+import org.jetbrains.kotlin.test.backend.ir.DeserializedFromKlibBackendInput
+import org.jetbrains.kotlin.test.backend.ir.IrBackendInput
+import org.jetbrains.kotlin.test.checkTestInfrastructure
+import org.jetbrains.kotlin.test.diagnostics.DiagnosticsCollectorStub
+import org.jetbrains.kotlin.test.model.BackendKinds
+import org.jetbrains.kotlin.test.model.IrPreSerializationLoweringFacade
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.TestServices
+import org.jetbrains.kotlin.test.services.configuration.JsEnvironmentConfigurator
+
+/**
+ * Runs full [JsIrLoweringPipelinePhase] and exposes lowered IR for optimization / dataflow tests.
+ * Does not continue to JS codegen (unlike [JsIrLoweringFacade]).
+ */
+class JsIrOptimizationLoweringFacade(
+    testServices: TestServices,
+) : IrPreSerializationLoweringFacade<IrBackendInput>(testServices, BackendKinds.IrBackend, BackendKinds.IrBackend) {
+
+    override fun shouldTransform(module: TestModule): Boolean =
+        JsEnvironmentConfigurator.isMainModule(module, testServices)
+
+    override fun transform(module: TestModule, inputArtifact: IrBackendInput): IrBackendInput {
+        checkTestInfrastructure(inputArtifact is DeserializedFromKlibBackendInput<*>) {
+            "JsIrOptimizationLoweringFacade expects DeserializedFromKlibBackendInput, got ${inputArtifact::class.simpleName}"
+        }
+        val cliArtifact = inputArtifact.cliArtifact
+        checkTestInfrastructure(cliArtifact is WebLoadedIrPipelineArtifact) {
+            "Expected WebLoadedIrPipelineArtifact, got ${cliArtifact::class.simpleName}"
+        }
+        val lowered = JsIrLoweringPipelinePhase.executePhase(cliArtifact)
+            ?: error("JS IR lowering failed")
+        return LoweredJsIrBackendInput(
+            program = LoweredJsProgram(lowered.context, lowered.mainModule, lowered.allModules),
+            irMangler = inputArtifact.irMangler,
+        )
+    }
+}
+
+/**
+ * Fully lowered linked JS IR program for dataflow / optimization handlers.
+ */
+class LoweredJsIrBackendInput(
+    val program: LoweredJsProgram,
+    override val irMangler: KotlinMangler.IrMangler,
+) : IrBackendInput() {
+    val context: JsIrBackendContext get() = program.context
+    val allModules: List<IrModuleFragment> get() = program.allModules
+
+    override val irModuleFragment: IrModuleFragment get() = program.mainModule
+    override val irBuiltIns get() = program.context.irBuiltIns
+    override val diagnosticReporter = DiagnosticsCollectorStub()
+}
+
+/**
+ * Fully lowered JS IR for the linked program under test.
+ */
+class LoweredJsProgram(
+    val context: JsIrBackendContext,
+    val mainModule: IrModuleFragment,
+    val allModules: List<IrModuleFragment>,
+)

--- a/js/js.tests/tests/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsDataflowUnitTest.kt
+++ b/js/js.tests/tests/org/jetbrains/kotlin/ir/backend/js/optimizations/dataflow/JsDataflowUnitTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.js.optimizations.dataflow
+
+import org.jetbrains.kotlin.ir.expressions.IrConstKind
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Lattice algebra and solver termination unit tests (no IR pipeline).
+ */
+class JsDataflowUnitTest {
+
+    @Test
+    fun constKindDistinguishesCharFromInt() {
+        val charA = JsValueLattice.Const(IrConstKind.Char, 'A')
+        val int65 = JsValueLattice.Const(IrConstKind.Int, 65)
+        assertNotEquals(charA, int65)
+        assertEquals(JsValueLattice.Top, charA.join(int65))
+    }
+
+    @Test
+    fun valueJoinIsIdempotentAndCommutative() {
+        val a = JsValueLattice.Const(IrConstKind.Int, 1)
+        val b = JsValueLattice.Const(IrConstKind.Int, 2)
+        assertEquals(a, a.join(a))
+        assertEquals(a.join(b), b.join(a))
+        assertEquals(a, JsValueLattice.Bottom.join(a))
+        assertEquals(JsValueLattice.Top, a.join(JsValueLattice.Top))
+    }
+
+    @Test
+    fun factEnvLatticeJoin() {
+        val env1 = FactEnv()
+        val env2 = FactEnv()
+        assertTrue(FactEnv.lattice.equivalent(env1, env2))
+        assertTrue(FactEnv.lattice.equivalent(FactEnv.lattice.join(env1, env2), env1))
+    }
+
+    @Test
+    fun solverConvergesOnFiniteLattice() {
+        val a = JsBasicBlock(0)
+        val b = JsBasicBlock(1)
+        a.terminator = JsTerminator.Goto(b)
+        a.successors += b
+        b.predecessors += a
+        b.terminator = JsTerminator.Return(null)
+
+        val lattice = object : Lattice<Int> {
+            override fun bottom(): Int = 0
+            override fun join(a: Int, b: Int): Int = maxOf(a, b)
+            override fun equivalent(a: Int, b: Int): Boolean = a == b
+        }
+        val result = ForwardDataflowSolver().solve(
+            entry = a,
+            entryState = 1,
+            lattice = lattice,
+            transfer = { block, inn -> block.successors.associateWith { inn + 1 } },
+            iterationBudget = 32,
+        )
+        assertEquals(1, result[a])
+        assertEquals(2, result[b])
+    }
+
+    @Test
+    fun solverBudgetIsAssertionNotSilentCap() {
+        val a = JsBasicBlock(0)
+        val b = JsBasicBlock(1)
+        a.terminator = JsTerminator.Goto(b)
+        a.successors += b
+        b.predecessors += a
+        b.terminator = JsTerminator.Goto(a)
+        b.successors += a
+        a.predecessors += b
+
+        val lattice = object : Lattice<Int> {
+            override fun bottom(): Int = 0
+            override fun join(a: Int, b: Int): Int = a + b + 1
+            override fun equivalent(a: Int, b: Int): Boolean = false
+        }
+
+        assertThrows<IllegalStateException> {
+            ForwardDataflowSolver().solve(
+                entry = a,
+                entryState = 0,
+                lattice = lattice,
+                transfer = { block, inn -> block.successors.associateWith { inn + 1 } },
+                iterationBudget = 8,
+                debugName = "cycle",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a statement-level CFG over fully lowered JS IR (`JsControlFlowGraph` / builder), with unsupported `try` marked explicitly and unreachable blocks pruned.
- Add a finite-height forward dataflow solver plus sparse concrete value/type analysis (consts, exact types, enums); exported/open/external params stay unrefined.
- Wire golden dump tests (`.cfg.txt` / `.facts.txt`) and lattice/solver unit tests so soundness and precision are locked before optimisation passes consume the facts.

## Why
Bundle-size opts need path-sensitive facts (constants, exact types, refined params). 
This commit introduces the analysis foundation only — no consumer lowerings yet.

## Analysis flow
`lowered JS IR (linked program)` 
→ `JsProgramIndex (functions, call sites, export/open)` 
→ `CFG per function` 
→ `ForwardDataflowSolver + JsConcreteTransfer`
→ `JsFunctionFacts (factAt / summary) + IPA-lite param seed rounds`

Clients query `factAt(use)` for program points, or `summary(value)` for whole-function / IPA facts. 
Unknown or unsupported IR is `Top`.

## Test flow
`.kt under js/js.tests/testData/dataflow` → `FIR` → `klib` → `deserialize` → `full JS IR lowering` → `JsControlFlowGraphHandler` → `.cfg.txt` → `JsConcreteAnalysisHandler` → `.facts.txt`

Suites are generated via `GenerateJsTests` (`JsControlFlowGraphTestGenerated`, `JsConcreteAnalysisTestGenerated`). `JsDataflowUnitTest` covers lattice algebra and solver termination (including budget-as-assertion).