### PR TITLE
[JKlib] KT-88168: Fix Java field shadowing in KLIB linking

### DIFF
--- a/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
+++ b/compiler/cli/cli-jklib/src/org/jetbrains/kotlin/cli/jklib/pipeline/JKlibIrCompilationPhase.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.backend.common.serialization.DeserializationStrategy
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureDescriptor
 import org.jetbrains.kotlin.backend.jvm.JvmIrTypeSystemContext
 import org.jetbrains.kotlin.backend.jvm.overrides.IrJavaIncompatibilityRulesOverridabilityCondition
+import org.jetbrains.kotlin.ir.backend.jklib.JKlibFieldShadowingOverridabilityCondition
 import org.jetbrains.kotlin.builtins.jvm.JvmBuiltInClassDescriptorFactory
 import org.jetbrains.kotlin.builtins.jvm.JvmBuiltIns
 import org.jetbrains.kotlin.builtins.jvm.JvmBuiltInsPackageFragmentProvider
@@ -123,7 +124,10 @@ object JKlibIrCompilationPhase :
             symbolTable = symbolTable,
             descriptorMangler = mangler,
             typeSystemContextFactory = ::JvmIrTypeSystemContext,
-            externalOverridabilityConditions = listOf(IrJavaIncompatibilityRulesOverridabilityCondition()),
+            externalOverridabilityConditions = listOf(
+                IrJavaIncompatibilityRulesOverridabilityCondition(),
+                JKlibFieldShadowingOverridabilityCondition,
+            ),
         )
 
         // Deserialize modules

--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibFieldShadowingOverridabilityCondition.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibFieldShadowingOverridabilityCondition.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ir.backend.jklib
+
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
+import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition
+import org.jetbrains.kotlin.ir.overrides.MemberWithOriginal
+import org.jetbrains.kotlin.load.java.descriptors.JavaCallableMemberDescriptor
+import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
+import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageFragment
+
+/**
+ * Custom overridability condition for JKlib compilation. Prevents fake override generation when
+ * a Kotlin property shadows a Java superclass field of the same name by returning OVERRIDABLE.
+ * Returning OVERRIDABLE suppresses duplicate fake override property creation without symbol collisions.
+ */
+
+@OptIn(ObsoleteDescriptorBasedAPI::class)
+object JKlibFieldShadowingOverridabilityCondition : IrExternalOverridabilityCondition {
+    override val contract: IrExternalOverridabilityCondition.Contract
+        get() = IrExternalOverridabilityCondition.Contract.SUCCESS_ONLY
+
+    override fun isOverridable(
+        superMember: MemberWithOriginal,
+        subMember: MemberWithOriginal,
+    ): IrExternalOverridabilityCondition.Result {
+        val superProperty =
+            superMember.original as? IrProperty ?: return IrExternalOverridabilityCondition.Result.UNKNOWN
+        val subProperty =
+            subMember.original as? IrProperty ?: return IrExternalOverridabilityCondition.Result.UNKNOWN
+
+        // 1. Names must match
+        if (superProperty.name != subProperty.name) {
+            return IrExternalOverridabilityCondition.Result.UNKNOWN
+        }
+
+        // 2. Do not match extension properties
+        if (superProperty.getter?.parameters?.any { it.kind == IrParameterKind.ExtensionReceiver } == true ||
+            subProperty.getter?.parameters?.any { it.kind == IrParameterKind.ExtensionReceiver } == true) {
+            return IrExternalOverridabilityCondition.Result.UNKNOWN
+        }
+
+        // 3. Target field shadowing: super is Java member AND at least one member lacks accessors
+        val isFieldShadowing = superProperty.descriptor.isJavaDescriptor() &&
+            (superProperty.getter == null || subProperty.getter == null)
+
+        if (isFieldShadowing) {
+            // OVERRIDABLE suppresses fake override generation
+            return IrExternalOverridabilityCondition.Result.OVERRIDABLE
+        }
+
+        return IrExternalOverridabilityCondition.Result.UNKNOWN
+    }
+
+    private fun DeclarationDescriptor.isJavaDescriptor(): Boolean {
+        if (this is PackageFragmentDescriptor) {
+            return this is LazyJavaPackageFragment
+        }
+
+        return this is JavaClassDescriptor ||
+            this is JavaCallableMemberDescriptor ||
+            (containingDeclaration?.isJavaDescriptor() == true)
+    }
+}

--- a/compiler/testData/ir/irText/fakeOverrides/fieldmodifiers/shadowingJavaField.ir.txt
+++ b/compiler/testData/ir/irText/fakeOverrides/fieldmodifiers/shadowingJavaField.ir.txt
@@ -1,0 +1,241 @@
+FILE fqName:<root> fileName:/1.kt
+  CLASS CLASS name:KtSubCustomAccessor modality:FINAL visibility:public superTypes:[<root>.BaseJava]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.KtSubCustomAccessor
+    CONSTRUCTOR visibility:public returnType:<root>.KtSubCustomAccessor [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.BaseJava'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:KtSubCustomAccessor modality:FINAL visibility:public superTypes:[<root>.BaseJava]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:bar visibility:protected/*protected and package*/ modality:FINAL [fake_override,var]
+      overridden:
+        protected/*protected and package*/ final bar: kotlin.Int declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:foo visibility:public modality:FINAL [fake_override,var]
+      overridden:
+        public final foo: @[FlexibleNullability] kotlin.String? declared in <root>.BaseJava
+    PROPERTY name:foo visibility:public modality:FINAL [var]
+      FUN name:<get-foo> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubCustomAccessor
+        correspondingProperty: PROPERTY name:foo visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-foo> (): kotlin.String declared in <root>.KtSubCustomAccessor'
+            CONST String type=kotlin.String value="custom_getter"
+      FUN name:<set-foo> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubCustomAccessor
+        VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.String
+        correspondingProperty: PROPERTY name:foo visibility:public modality:FINAL [var]
+        BLOCK_BODY
+  CLASS CLASS name:KtSubGeneric modality:FINAL visibility:public superTypes:[<root>.BaseJavaGeneric<kotlin.String>]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.KtSubGeneric
+    PROPERTY name:genericField visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:genericField type:kotlin.String visibility:public
+        annotations:
+          JvmField
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="generic_shadow"
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-genericField> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubGeneric
+        correspondingProperty: PROPERTY name:genericField visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-genericField> (): kotlin.String declared in <root>.KtSubGeneric'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:genericField type:kotlin.String visibility:public' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.KtSubGeneric declared in <root>.KtSubGeneric.<get-genericField>' type=<root>.KtSubGeneric origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-genericField> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubGeneric
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.String
+        correspondingProperty: PROPERTY name:genericField visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:genericField type:kotlin.String visibility:public' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.KtSubGeneric declared in <root>.KtSubGeneric.<set-genericField>' type=<root>.KtSubGeneric origin=null
+            value: GET_VAR '<set-?>: kotlin.String declared in <root>.KtSubGeneric.<set-genericField>' type=kotlin.String origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.KtSubGeneric [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.BaseJavaGeneric'
+          TYPE_ARG T: kotlin.String
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:KtSubGeneric modality:FINAL visibility:public superTypes:[<root>.BaseJavaGeneric<kotlin.String>]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BaseJavaGeneric
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.BaseJavaGeneric
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.BaseJavaGeneric
+    PROPERTY FAKE_OVERRIDE name:genericField visibility:public modality:FINAL [fake_override,var]
+      overridden:
+        public final genericField: @[FlexibleNullability] T of <root>.BaseJavaGeneric? declared in <root>.BaseJavaGeneric
+  CLASS CLASS name:KtSubProtected modality:FINAL visibility:public superTypes:[<root>.BaseJava]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.KtSubProtected
+    PROPERTY name:bar visibility:protected modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:bar type:kotlin.Int visibility:protected
+        annotations:
+          JvmField
+        EXPRESSION_BODY
+          CONST Int type=kotlin.Int value=100
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-bar> visibility:protected modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubProtected
+        correspondingProperty: PROPERTY name:bar visibility:protected modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='protected final fun <get-bar> (): kotlin.Int declared in <root>.KtSubProtected'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:bar type:kotlin.Int visibility:protected' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.KtSubProtected declared in <root>.KtSubProtected.<get-bar>' type=<root>.KtSubProtected origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-bar> visibility:protected modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubProtected
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.Int
+        correspondingProperty: PROPERTY name:bar visibility:protected modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:bar type:kotlin.Int visibility:protected' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.KtSubProtected declared in <root>.KtSubProtected.<set-bar>' type=<root>.KtSubProtected origin=null
+            value: GET_VAR '<set-?>: kotlin.Int declared in <root>.KtSubProtected.<set-bar>' type=kotlin.Int origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.KtSubProtected [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.BaseJava'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:KtSubProtected modality:FINAL visibility:public superTypes:[<root>.BaseJava]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:bar visibility:protected/*protected and package*/ modality:FINAL [fake_override,var]
+      overridden:
+        protected/*protected and package*/ final bar: kotlin.Int declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:foo visibility:public modality:FINAL [fake_override,var]
+      overridden:
+        public final foo: @[FlexibleNullability] kotlin.String? declared in <root>.BaseJava
+  CLASS CLASS name:KtSubVal modality:FINAL visibility:public superTypes:[<root>.BaseJava]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.KtSubVal
+    PROPERTY name:foo visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:foo type:kotlin.String visibility:public [final]
+        annotations:
+          JvmField
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="kt_sub_val_foo"
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-foo> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubVal
+        correspondingProperty: PROPERTY name:foo visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-foo> (): kotlin.String declared in <root>.KtSubVal'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:foo type:kotlin.String visibility:public [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.KtSubVal declared in <root>.KtSubVal.<get-foo>' type=<root>.KtSubVal origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.KtSubVal [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.BaseJava'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:KtSubVal modality:FINAL visibility:public superTypes:[<root>.BaseJava]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:bar visibility:protected/*protected and package*/ modality:FINAL [fake_override,var]
+      overridden:
+        protected/*protected and package*/ final bar: kotlin.Int declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:foo visibility:public modality:FINAL [fake_override,var]
+      overridden:
+        public final foo: @[FlexibleNullability] kotlin.String? declared in <root>.BaseJava
+  CLASS CLASS name:KtSubVar modality:FINAL visibility:public superTypes:[<root>.BaseJava]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.KtSubVar
+    PROPERTY name:foo visibility:public modality:FINAL [var]
+      FIELD PROPERTY_BACKING_FIELD name:foo type:kotlin.String visibility:public
+        annotations:
+          JvmField
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="kt_sub_var_foo"
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-foo> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubVar
+        correspondingProperty: PROPERTY name:foo visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-foo> (): kotlin.String declared in <root>.KtSubVar'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:foo type:kotlin.String visibility:public' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.KtSubVar declared in <root>.KtSubVar.<get-foo>' type=<root>.KtSubVar origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<set-foo> visibility:public modality:FINAL returnType:kotlin.Unit
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.KtSubVar
+        VALUE_PARAMETER kind:Regular name:<set-?> index:1 type:kotlin.String
+        correspondingProperty: PROPERTY name:foo visibility:public modality:FINAL [var]
+        BLOCK_BODY
+          SET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:foo type:kotlin.String visibility:public' type=kotlin.Unit origin=null
+            receiver: GET_VAR '<this>: <root>.KtSubVar declared in <root>.KtSubVar.<set-foo>' type=<root>.KtSubVar origin=null
+            value: GET_VAR '<set-?>: kotlin.String declared in <root>.KtSubVar.<set-foo>' type=kotlin.String origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.KtSubVar [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.BaseJava'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:KtSubVar modality:FINAL visibility:public superTypes:[<root>.BaseJava]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.BaseJava
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:bar visibility:protected/*protected and package*/ modality:FINAL [fake_override,var]
+      overridden:
+        protected/*protected and package*/ final bar: kotlin.Int declared in <root>.BaseJava
+    PROPERTY FAKE_OVERRIDE name:foo visibility:public modality:FINAL [fake_override,var]
+      overridden:
+        public final foo: @[FlexibleNullability] kotlin.String? declared in <root>.BaseJava
+  FUN name:test visibility:public modality:FINAL returnType:kotlin.Unit
+    VALUE_PARAMETER kind:Regular name:subVar index:0 type:<root>.KtSubVar
+    VALUE_PARAMETER kind:Regular name:subVal index:1 type:<root>.KtSubVal
+    VALUE_PARAMETER kind:Regular name:subCustom index:2 type:<root>.KtSubCustomAccessor
+    VALUE_PARAMETER kind:Regular name:subGeneric index:3 type:<root>.KtSubGeneric
+    VALUE_PARAMETER kind:Regular name:base index:4 type:<root>.BaseJava
+    BLOCK_BODY
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun <get-foo> (): kotlin.String declared in <root>.KtSubVar' type=kotlin.String origin=GET_PROPERTY
+          ARG <this>: GET_VAR 'subVar: <root>.KtSubVar declared in <root>.test' type=<root>.KtSubVar origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun <get-foo> (): kotlin.String declared in <root>.KtSubVal' type=kotlin.String origin=GET_PROPERTY
+          ARG <this>: GET_VAR 'subVal: <root>.KtSubVal declared in <root>.test' type=<root>.KtSubVal origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun <get-foo> (): kotlin.String declared in <root>.KtSubCustomAccessor' type=kotlin.String origin=GET_PROPERTY
+          ARG <this>: GET_VAR 'subCustom: <root>.KtSubCustomAccessor declared in <root>.test' type=<root>.KtSubCustomAccessor origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        CALL 'public final fun <get-genericField> (): kotlin.String declared in <root>.KtSubGeneric' type=kotlin.String origin=GET_PROPERTY
+          ARG <this>: GET_VAR 'subGeneric: <root>.KtSubGeneric declared in <root>.test' type=<root>.KtSubGeneric origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:foo type:@[FlexibleNullability] kotlin.String? visibility:public declared in <root>.BaseJava' type=@[FlexibleNullability] kotlin.String? superQualifierSymbol=<root>.BaseJava origin=null
+          receiver: GET_VAR 'base: <root>.BaseJava declared in <root>.test' type=<root>.BaseJava origin=null
+  PROPERTY name:foo visibility:public modality:FINAL [val]
+    FUN name:<get-foo> visibility:public modality:FINAL returnType:kotlin.String
+      VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:<root>.BaseJava
+      correspondingProperty: PROPERTY name:foo visibility:public modality:FINAL [val]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun <get-foo> (<this>: <root>.BaseJava): kotlin.String declared in <root>'
+          CONST String type=kotlin.String value="extension_foo"

--- a/compiler/testData/ir/irText/fakeOverrides/fieldmodifiers/shadowingJavaField.kt
+++ b/compiler/testData/ir/irText/fakeOverrides/fieldmodifiers/shadowingJavaField.kt
@@ -1,0 +1,69 @@
+// TARGET_BACKEND: JVM
+// FULL_JDK
+// WITH_STDLIB
+// SKIP_IR_DESERIALIZATION_CHECKS
+// REASON: Deserialization synthesizes fake overrides for Java superclass fields during KLIB linking.
+
+// FILE: BaseJava.java
+public class BaseJava {
+    public String foo = "java_base_foo";
+    public static String staticFoo = "java_static_foo";
+    protected int bar = 42;
+}
+
+// FILE: BaseJavaGeneric.java
+public class BaseJavaGeneric<T> {
+    public T genericField;
+}
+
+// FILE: 1.kt
+import kotlin.jvm.JvmField
+
+// 1. Basic @JvmField var shadowing
+class KtSubVar : BaseJava() {
+    @JvmField
+    var foo: String = "kt_sub_var_foo"
+}
+
+// 2. @JvmField val (read-only) shadowing
+class KtSubVal : BaseJava() {
+    @JvmField
+    val foo: String = "kt_sub_val_foo"
+}
+
+// 3. Custom getter/setter (non-@JvmField) shadowing Java field
+class KtSubCustomAccessor : BaseJava() {
+    var foo: String
+        get() = "custom_getter"
+        set(value) {}
+}
+
+// 4. Protected field shadowing
+class KtSubProtected : BaseJava() {
+    @JvmField
+    protected var bar: Int = 100
+}
+
+// 5. Generic field shadowing
+class KtSubGeneric : BaseJavaGeneric<String>() {
+    @JvmField
+    var genericField: String = "generic_shadow"
+}
+
+// 6. Extension property with same name (should NOT conflict)
+val BaseJava.foo: String
+    get() = "extension_foo"
+
+fun test(
+    subVar: KtSubVar,
+    subVal: KtSubVal,
+    subCustom: KtSubCustomAccessor,
+    subGeneric: KtSubGeneric,
+    base: BaseJava
+) {
+    subVar.foo
+    subVal.foo
+    subCustom.foo
+    subGeneric.genericField
+    base.foo
+}

--- a/compiler/testData/ir/irText/fakeOverrides/fieldmodifiers/shadowingJavaField.kt.txt
+++ b/compiler/testData/ir/irText/fakeOverrides/fieldmodifiers/shadowingJavaField.kt.txt
@@ -1,0 +1,84 @@
+class KtSubCustomAccessor : BaseJava {
+  constructor() /* primary */ {
+    super/*BaseJava*/()
+    /* <init>() */
+
+  }
+
+  var foo: String
+    get(): String {
+      return "custom_getter"
+    }
+    set(value: String) {
+    }
+
+}
+
+class KtSubGeneric : BaseJavaGeneric<String> {
+  var genericField: String
+    field = "generic_shadow"
+    get
+    set
+
+  constructor() /* primary */ {
+    super/*BaseJavaGeneric*/<String>()
+    /* <init>() */
+
+  }
+
+}
+
+class KtSubProtected : BaseJava {
+  protected var bar: Int
+    field = 100
+    protected get
+    protected set
+
+  constructor() /* primary */ {
+    super/*BaseJava*/()
+    /* <init>() */
+
+  }
+
+}
+
+class KtSubVal : BaseJava {
+  val foo: String
+    field = "kt_sub_val_foo"
+    get
+
+  constructor() /* primary */ {
+    super/*BaseJava*/()
+    /* <init>() */
+
+  }
+
+}
+
+class KtSubVar : BaseJava {
+  var foo: String
+    field = "kt_sub_var_foo"
+    get
+    set
+
+  constructor() /* primary */ {
+    super/*BaseJava*/()
+    /* <init>() */
+
+  }
+
+}
+
+fun test(subVar: KtSubVar, subVal: KtSubVal, subCustom: KtSubCustomAccessor, subGeneric: KtSubGeneric, base: BaseJava) {
+  subVar.<get-foo>() /*~> Unit */
+  subVal.<get-foo>() /*~> Unit */
+  subCustom.<get-foo>() /*~> Unit */
+  subGeneric.<get-genericField>() /*~> Unit */
+  base(super<BaseJava>).#foo /*~> Unit */
+}
+
+val BaseJava.foo: String
+  get(): String {
+    return "extension_foo"
+  }
+


### PR DESCRIPTION
Fixes [KT-88168](https://youtrack.jetbrains.com/issue/KT-88168/Shadowing-a-java-field-with-a-kotlin-field-is-broken)

### What are we doing
Fixing an issue where an error IrPropertySymbol is already bound when a java field is shadowed. This happens because a fakeOverride is bound for the field in addition to the property that shadows it.

### Why are we adding new logic instead of reusing Kotlin/JVM logic

We found two places where this logic is implemented
1- At "FieldIntersectionOverridabilityCondition" and use it in both places which only uses descriptors at the Fir level and will be removed.
2- Extract logic from JavaClassUseSiteMemberScope which operates at scoping time on top of FIR. Fir separates FIRProperty FirField while IR implements IrProperties as having a backing IrField and a getter or a setter, which are set to null in the case of the java field what would be a FirField.

As fake override information doesn't survives klib serialization it must be regenerated at linking time, we must operate on top of IR and reimplement different conditions to do so