### PR TITLE
[KT-88104] [2.4.20] dump xcodebuild args task fails if the root build directory is removed

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.gradle.testbase.assertOutputContainsExactlyTimes
 import org.jetbrains.kotlin.gradle.testbase.assertOutputDoesNotContain
 import org.jetbrains.kotlin.gradle.testbase.assertTasksExecuted
 import org.jetbrains.kotlin.gradle.testbase.build
-import org.jetbrains.kotlin.gradle.testbase.buildAndFail
 import org.jetbrains.kotlin.gradle.testbase.findTasksByPattern
 import org.jetbrains.kotlin.gradle.testbase.project
 import org.jetbrains.kotlin.gradle.util.runProcess
@@ -487,7 +486,7 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
 
     @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
     @GradleTest
-    fun `KT-88104 - dump task fails after root build directory is removed`(version: GradleVersion) {
+    fun `KT-88104 - dump task does not fail after root build directory is removed`(version: GradleVersion) {
         val libraryProjectName = "lib1"
 
         project("empty", version) {
@@ -514,7 +513,7 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
 
                 projectPath.resolve("build").deleteRecursively()
 
-                buildAndFail(dumpTask)
+                build(dumpTask)
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/DumpXcodeBuildArgsTests.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.gradle.util.runProcess
 import org.jetbrains.kotlin.gradle.uklibs.include
 import org.junit.jupiter.api.condition.OS
 import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteRecursively
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
@@ -480,6 +481,40 @@ class DumpXcodeBuildArgsTests : KGPBaseTest() {
                     assertDumpDirectoryContainsXcodebuildArgsDump(localIphoneosDumpDir(fuzzProjectName))
                     assertDumpDirectoryContainsXcodebuildArgsDump(localIphoneosDumpDir(buzzProjectName))
                 }
+            }
+        }
+    }
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
+    fun `KT-88104 - dump task fails after root build directory is removed`(version: GradleVersion) {
+        val libraryProjectName = "lib1"
+
+        project("empty", version) {
+            withLockFileFixture {
+                val packageRepo = repoRef("TestPackage").also { createRepo(it.name, listOf("1.0.0")) }
+
+                initSwiftPmProject(cacheDirFile) {}
+
+                val libraryProject = project("empty", version) {
+                    initSwiftPmProject(cacheDirFile) {
+                        swiftPMDependencies {
+                            swiftPackage(
+                                url = url(packageRepo.url),
+                                version = exact("1.0.0"),
+                                products = listOf(product(packageRepo.name)),
+                            )
+                        }
+                    }
+                }
+                include(libraryProject, libraryProjectName)
+
+                val dumpTask = ":$libraryProjectName:dumpXcodebuildArgsIphoneos"
+                build(dumpTask)
+
+                projectPath.resolve("build").deleteRecursively()
+
+                buildAndFail(dumpTask)
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/FetchSyntheticImportProjectPackages.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/FetchSyntheticImportProjectPackages.kt
@@ -93,6 +93,18 @@ internal abstract class FetchSyntheticImportProjectPackages : DefaultTask() {
         // task must not be up-to-date so the next build retries the resolve.
         testExecutionHooks.convention(SwiftImportExecutionHooks.NONE)
         outputs.upToDateWhen { !ideImportError.get().asFile.exists() }
+        // Shared resolve outputs are @Internal to avoid overlapping outputs across coordinated tasks. The local copies can
+        // survive deletion of the root build directory, so also use the shared marker files for the up-to-date decision.
+        outputs.upToDateWhen {
+            val fingerprintFile = syntheticPackageFingerprint.asFile.orNull
+            if (fingerprintFile == null) {
+                true
+            } else {
+                fingerprintFile.isFile && coordinationService.get().sharedSwiftResolveOutputsExist(
+                        fingerprintFile.readText().trim().split("\n")[1]
+                    )
+            }
+        }
     }
 
     /**

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/GenerateSyntheticLinkageImportProject.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/GenerateSyntheticLinkageImportProject.kt
@@ -104,6 +104,21 @@ internal abstract class GenerateSyntheticLinkageImportProject : DefaultTask(), U
     @get:Inject
     abstract val fs: FileSystemOperations
 
+    init {
+        // The shared package cannot be declared as an output by every coordinated task. Its local output may still be
+        // up-to-date after the root build directory is deleted, so explicitly invalidate the task when the shared marker disappears.
+        outputs.upToDateWhen {
+            val fingerprintFile = syntheticPackageFingerprint.asFile.orNull
+            if (fingerprintFile == null) {
+                true
+            } else {
+                fingerprintFile.isFile && coordinationService.get().sharedPackageGenerationOutputsExist(
+                        fingerprintFile.readText().trim().split("\n")[1]
+                    )
+            }
+        }
+    }
+
     fun configureWithExtension(swiftPMImportExtension: SwiftPMImportExtension) {
         iosDeploymentVersion.set(swiftPMImportExtension.iosMinimumDeploymentTarget)
         macosDeploymentVersion.set(swiftPMImportExtension.macosMinimumDeploymentTarget)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportFingerprintedCoordinationService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportFingerprintedCoordinationService.kt
@@ -125,6 +125,15 @@ internal abstract class SwiftImportFingerprintedCoordinationService : BuildServi
     internal fun sharedCheckoutDir(packageHash: String): File =
         parameters.sharedCheckoutDirectoryRoot.get().asFile.resolve(packageHash)
 
+    internal fun sharedPackageGenerationOutputsExist(packageHash: String): Boolean =
+        sharedPackageGenerationRoot(packageHash).resolve("Package.swift").isFile
+
+    internal fun sharedSwiftResolveOutputsExist(packageHash: String): Boolean {
+        val packageRoot = sharedPackageGenerationRoot(packageHash)
+        val checkoutDir = sharedCheckoutDir(packageHash)
+        return sharedPackageResolved(packageRoot).isFile && sharedCheckoutWorkspaceStateJsonFile(checkoutDir).isFile
+    }
+
     private fun sharedCheckoutWorkspaceStateJsonFile(checkoutDir: File): File =
         checkoutDir.resolve("workspace-state.json")
 


### PR DESCRIPTION
- Add repro IT test.
- Fix by adding upToDate check for tasks using fingerprinting

^KT-88104