### PR TITLE
[K/N][tests] Mark objcexport-header-generator:testAnalysisApi as smoke

### DIFF
--- a/native/objcexport-header-generator/build.gradle.kts
+++ b/native/objcexport-header-generator/build.gradle.kts
@@ -1,5 +1,9 @@
 @file:Suppress("HasPlatformType")
 
+import org.jetbrains.kotlin.testFederation.SmokeTestConfig
+import org.jetbrains.kotlin.testFederation.smokeTestConfig
+
+
 plugins {
     id("common-configuration")
     id("test-federation-convention")
@@ -80,6 +84,10 @@ projectTests {
     ) {
         classpath += analysisApiRuntimeClasspath
         exclude("**/ObjCExportIntegrationTest.class")
+
+        // Ideally, it should be marked as affected by AnalysisApi instead.
+        // But this would be cumbersome and the tests are very fast, so let's keep things simple:
+        smokeTestConfig = SmokeTestConfig.RunAllTests
     }
 }
 

--- a/native/objcexport-header-generator/impl/analysis-api/build.gradle.kts
+++ b/native/objcexport-header-generator/impl/analysis-api/build.gradle.kts
@@ -46,6 +46,8 @@ projectTests {
         "test",
         allowUnsafe = true, // KT-85212
     ) {
+        // Ideally, it should be marked as affected by AnalysisApi instead.
+        // But this would be cumbersome and the tests are very fast, so let's keep things simple:
         smokeTestConfig = SmokeTestConfig.RunAllTests
     }
 }


### PR DESCRIPTION
See KT-87618 for the context.

Add `smokeTestConfig = SmokeTestConfig.RunAllTests` to that test task, so that all tests included in it are considered smoke.

Motivation: the tests don't really need to be smoke, but all of them are affected by the "AnalysisApi" domain. So, ideally, they should be marked with `@AffectedByAnalysisApi`, and then they would run only if "Native" or "AnalysisApi" are affected. The problem is that the tests reuse the classes used in other test tasks (e.g., `testK1`), and there the same classes are not affected by "AnalysisApi". So, this approach would require a refactoring and some boilerplate.

Marking the test task as smoke instead achieves the similar effect (if "AnalysisApi" is affected, the tests are run). There is a downside -- the tests run always, but it is negligible, as they take less than 30 seconds.
Moreover, the same approach is already used in a similar test task -- `:native:objcexport-header-generator-analysis-api`.