### PR TITLE
[Test] Mute Wasm-JS forward compatibility tests

### DIFF
--- a/compiler/testData/codegen/box/initializers/correctOrder3.kt
+++ b/compiler/testData/codegen/box/initializers/correctOrder3.kt
@@ -1,6 +1,9 @@
 // ISSUE: KT-73355
 // IGNORE_BACKEND: JS_IR, JS_IR_ES6
 
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.4
+// ^^^ KT-87742 is available in 2.5.0-Beta1
+
 // WITH_STDLIB
 import kotlin.test.*
 

--- a/compiler/testData/codegen/box/secondaryConstructors/fieldInitializerOptimization.kt
+++ b/compiler/testData/codegen/box/secondaryConstructors/fieldInitializerOptimization.kt
@@ -1,6 +1,9 @@
 // IGNORE_BACKEND: JS_IR
 // IGNORE_BACKEND: JS_IR_ES6
 
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.4
+// ^^^ KT-87742 is available in 2.5.0-Beta1
+
 open class Base {
     open fun setup() {}
     init { setup() }


### PR DESCRIPTION
Nightly CI (green): https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KlibBackwardAndForwardCompatibilityTestsNightly/1018708785