### PR TITLE
[KT-88107] clean task leave swiftpm checkout in root build directory

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/CleanSwiftImportFingerprintArtifactsTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/CleanSwiftImportFingerprintArtifactsTests.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.apple
+
+import kotlinx.serialization.encodeToString
+import org.gradle.kotlin.dsl.kotlin
+import org.gradle.kotlin.dsl.register
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.CleanSwiftImportFingerprintArtifacts
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_CHECKOUT_DIR
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_SYNTHETIC_PACKAGE_DIR
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_XCODE_DUMP_DIR
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportFingerprintedCoordinationService
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportFingerprint
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.fingerprintJson
+import org.jetbrains.kotlin.gradle.testbase.GradleTest
+import org.jetbrains.kotlin.gradle.testbase.GradleTestVersions
+import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
+import org.jetbrains.kotlin.gradle.testbase.OsCondition
+import org.jetbrains.kotlin.gradle.testbase.SwiftPMImportGradlePluginTests
+import org.jetbrains.kotlin.gradle.testbase.TestProject
+import org.jetbrains.kotlin.gradle.testbase.TestVersions
+import org.jetbrains.kotlin.gradle.testbase.assertDirectoryDoesNotExist
+import org.jetbrains.kotlin.gradle.testbase.assertDirectoryExists
+import org.jetbrains.kotlin.gradle.testbase.build
+import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
+import org.jetbrains.kotlin.gradle.testbase.plugins
+import org.jetbrains.kotlin.gradle.testbase.project
+import org.jetbrains.kotlin.gradle.uklibs.include
+import org.junit.jupiter.api.condition.OS
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+@OsCondition(
+    supportedOn = [OS.MAC],
+    enabledOnCI = [OS.MAC],
+)
+@SwiftPMImportGradlePluginTests
+class CleanSwiftImportFingerprintArtifactsTests : KGPBaseTest() {
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
+    fun `clean removes artifacts shared by projects with the same fingerprints`(version: GradleVersion) {
+        project("empty", version) {
+            plugins {
+                kotlin("multiplatform").apply(false)
+            }
+
+            val fingerprints = Fingerprints(packageFingerprint = "shared-package", xcodebuildFingerprint = "shared-xcodebuild")
+            val lib1 = cleanupProject(version, fingerprints)
+            val lib2 = cleanupProject(version, fingerprints)
+            include(lib1, "lib1")
+            include(lib2, "lib2")
+
+            val sharedArtifacts = createSharedArtifacts(fingerprints)
+            build(":lib1:clean")
+
+            sharedArtifacts.forEach(::assertDirectoryDoesNotExist)
+        }
+    }
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
+    fun `subproject clean removes only artifacts matching its fingerprints`(version: GradleVersion) {
+        project("empty", version) {
+            plugins {
+                kotlin("multiplatform").apply(false)
+            }
+
+            val lib1Fingerprints = Fingerprints(packageFingerprint = "lib1-package", xcodebuildFingerprint = "lib1-xcodebuild")
+            val lib2Fingerprints = Fingerprints(packageFingerprint = "lib2-package", xcodebuildFingerprint = "lib2-xcodebuild")
+            val lib1 = cleanupProject(version, lib1Fingerprints)
+            val lib2 = cleanupProject(version, lib2Fingerprints)
+            include(lib1, "lib1")
+            include(lib2, "lib2")
+
+            val lib1Artifacts = createSharedArtifacts(lib1Fingerprints)
+            val lib2Artifacts = createSharedArtifacts(lib2Fingerprints)
+            build(":lib1:clean")
+
+            lib1Artifacts.forEach(::assertDirectoryDoesNotExist)
+            lib2Artifacts.forEach(::assertDirectoryExists)
+        }
+    }
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
+    fun `root clean removes artifacts matching all subproject fingerprints`(version: GradleVersion) {
+        project("empty", version) {
+            plugins {
+                kotlin("multiplatform").apply(false)
+            }
+
+            val lib1Fingerprints = Fingerprints(packageFingerprint = "lib1-package", xcodebuildFingerprint = "lib1-xcodebuild")
+            val lib2Fingerprints = Fingerprints(packageFingerprint = "lib2-package", xcodebuildFingerprint = "lib2-xcodebuild")
+            val lib1 = cleanupProject(version, lib1Fingerprints)
+            val lib2 = cleanupProject(version, lib2Fingerprints)
+            include(lib1, "lib1")
+            include(lib2, "lib2")
+
+            val sharedArtifacts = createSharedArtifacts(lib1Fingerprints) + createSharedArtifacts(lib2Fingerprints)
+            build("clean")
+
+            sharedArtifacts.forEach(::assertDirectoryDoesNotExist)
+        }
+    }
+
+    private fun TestProject.cleanupProject(
+        version: GradleVersion,
+        fingerprints: Fingerprints,
+    ): TestProject = project("empty", version) {
+        plugins {
+            kotlin("multiplatform").apply(false)
+        }
+
+        val syntheticPackageFingerprint = projectPath.resolve("build/testFingerprints/syntheticPackage")
+        val xcodebuildFingerprint = projectPath.resolve("build/testFingerprints/xcodebuild")
+        syntheticPackageFingerprint.parent.createDirectories()
+        syntheticPackageFingerprint.writeFingerprint(fingerprints.packageFingerprint)
+        xcodebuildFingerprint.writeFingerprint(fingerprints.xcodebuildFingerprint)
+
+        buildScriptInjection {
+            project.pluginManager.apply("base")
+            val coordinationService = SwiftImportFingerprintedCoordinationService.registerIfAbsent(
+                project = project,
+                xcodeDumpsDir = project.layout.dir(project.provider { project.rootDir.resolve(SHARED_XCODE_DUMP_DIR) }),
+                checkoutDir = project.layout.dir(project.provider { project.rootDir.resolve(SHARED_CHECKOUT_DIR) }),
+                generatePackageDir = project.layout.dir(project.provider { project.rootDir.resolve(SHARED_SYNTHETIC_PACKAGE_DIR) }),
+            )
+            val cleanup = project.tasks.register<CleanSwiftImportFingerprintArtifacts>(
+                CleanSwiftImportFingerprintArtifacts.TASK_NAME,
+            ) {
+                this.syntheticPackageFingerprint.set(project.layout.projectDirectory.file("build/testFingerprints/syntheticPackage"))
+                xcodebuildFingerprints.from(project.layout.projectDirectory.file("build/testFingerprints/xcodebuild"))
+                this.coordinationService.set(coordinationService)
+            }
+            project.tasks.named("clean").configure {
+                it.dependsOn(cleanup)
+            }
+        }
+    }
+
+    private fun TestProject.createSharedArtifacts(fingerprints: Fingerprints): List<Path> = listOf(
+        projectPath.resolve(SHARED_SYNTHETIC_PACKAGE_DIR).resolve(fingerprints.packageFingerprint),
+        projectPath.resolve(SHARED_CHECKOUT_DIR).resolve(fingerprints.packageFingerprint),
+        projectPath.resolve(SHARED_XCODE_DUMP_DIR).resolve(fingerprints.xcodebuildFingerprint),
+    ).onEach { it.createDirectories() }
+
+    private data class Fingerprints(
+        val packageFingerprint: String,
+        val xcodebuildFingerprint: String,
+    )
+
+
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
 import org.jetbrains.kotlin.gradle.testbase.OsCondition
 import org.jetbrains.kotlin.gradle.testbase.SwiftPMImportGradlePluginTests
 import org.jetbrains.kotlin.gradle.testbase.TestVersions
+import org.jetbrains.kotlin.gradle.testbase.assertDirectoryExists
 import org.jetbrains.kotlin.gradle.testbase.assertFileExists
 import org.jetbrains.kotlin.gradle.testbase.assertFileNotExists
 import org.jetbrains.kotlin.gradle.testbase.assertFilesContentEquals
@@ -51,8 +52,11 @@ import org.jetbrains.kotlin.incremental.testingUtils.assertEqualDirectories
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.junit.jupiter.api.condition.OS
 import kotlin.io.path.deleteRecursively
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readText
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 @OsCondition(
     supportedOn = [OS.MAC],
@@ -235,6 +239,46 @@ class FetchSyntheticImportProjectPackagesTests : KGPBaseTest() {
                     assertTasksExecuted(fetchTask)
                     assertFileExists(workspaceStateJson)
                 }
+            }
+        }
+    }
+
+    @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
+    @GradleTest
+    fun `KT-88107 - clean does not remove shared SwiftPM checkout when Kotlin is not applied to root project`(version: GradleVersion) {
+        val libraryProjectName = "lib1"
+
+        project("empty", version) {
+            withLockFileFixture {
+                plugins {
+                    kotlin("multiplatform").apply(false)
+                }
+
+                val packageRepo = repoRef("TestPackage").also { createRepo(it.name, listOf("1.0.0")) }
+                val libraryProject = project("empty", version) {
+                    initSwiftPmProject(cacheDirFile) {
+                        swiftPMDependencies {
+                            swiftPackage(
+                                url = url(packageRepo.url),
+                                version = exact("1.0.0"),
+                                products = listOf(product(packageRepo.name)),
+                            )
+                        }
+                    }
+                }
+                include(libraryProject, libraryProjectName)
+
+                val sharedCheckoutDir = projectPath.resolve(SHARED_CHECKOUT_DIR)
+
+                build(":$libraryProjectName:${FetchSyntheticImportProjectPackages.TASK_NAME}")
+                assertDirectoryExists(sharedCheckoutDir)
+
+                build("clean")
+                assertDirectoryExists(sharedCheckoutDir)
+                assertTrue(
+                    sharedCheckoutDir.listDirectoryEntries().isNotEmpty(),
+                    "Shared SwiftPM checkout directory should be empty after clean",
+                )
             }
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/FetchSyntheticImportProjectPackagesTests.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FetchSyntheticIm
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject.Companion.SyntheticProductType
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.PackageResolvedSynchronization
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.CleanSwiftImportFingerprintArtifacts
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_CHECKOUT_DIR
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_SYNTHETIC_PACKAGE_DIR
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftPMDependency
@@ -245,7 +246,7 @@ class FetchSyntheticImportProjectPackagesTests : KGPBaseTest() {
 
     @GradleTestVersions(minVersion = TestVersions.Gradle.G_8_0)
     @GradleTest
-    fun `KT-88107 - clean does not remove shared SwiftPM checkout when Kotlin is not applied to root project`(version: GradleVersion) {
+    fun `KT-88107 - clean removes shared SwiftPM checkout when Kotlin is not applied to root project`(version: GradleVersion) {
         val libraryProjectName = "lib1"
 
         project("empty", version) {
@@ -273,10 +274,14 @@ class FetchSyntheticImportProjectPackagesTests : KGPBaseTest() {
                 build(":$libraryProjectName:${FetchSyntheticImportProjectPackages.TASK_NAME}")
                 assertDirectoryExists(sharedCheckoutDir)
 
-                build("clean")
+                build("clean"){
+                    assertTasksExecuted(
+                        ":$libraryProjectName:${CleanSwiftImportFingerprintArtifacts.TASK_NAME}"
+                    )
+                }
                 assertDirectoryExists(sharedCheckoutDir)
                 assertTrue(
-                    sharedCheckoutDir.listDirectoryEntries().isNotEmpty(),
+                    sharedCheckoutDir.listDirectoryEntries().isEmpty(),
                     "Shared SwiftPM checkout directory should be empty after clean",
                 )
             }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/spmImportTestUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/spmImportTestUtils.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportExecu
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportTestExecutionKind
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftImportTestExecutionService
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SwiftPMImportExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.fingerprintJson
 import org.jetbrains.kotlin.gradle.testbase.TestProject
 import org.jetbrains.kotlin.gradle.testbase.XCTestHelpers
 import org.jetbrains.kotlin.gradle.testbase.assertDirectoryExists
@@ -1100,6 +1101,17 @@ private object JsonHolder {
         ignoreUnknownKeys = true
 
     }
+}
+
+internal fun Path.writeFingerprint(incrementalFingerprint: String) {
+    writeText(
+        JsonHolder.fingerprintJson.encodeToString(
+            SwiftImportFingerprint(
+                taskInvalidationFingerprint = "versioned-$incrementalFingerprint",
+                incrementalFingerprint = incrementalFingerprint,
+            )
+        )
+    )
 }
 
 private inline fun <reified T> runAppleToolCommand(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/CleanSwiftImportFingerprintArtifacts.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/CleanSwiftImportFingerprintArtifacts.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import javax.inject.Inject
+
+@DisableCachingByDefault(because = "KT-84827 - SwiftPM import doesn't support caching yet")
+internal abstract class CleanSwiftImportFingerprintArtifacts : DefaultTask() {
+
+    @get:Internal
+    abstract val syntheticPackageFingerprint: RegularFileProperty
+
+    @get:Internal
+    abstract val xcodebuildFingerprints: ConfigurableFileCollection
+
+    @get:Internal
+    abstract val coordinationService: Property<SwiftImportFingerprintedCoordinationService>
+
+    @get:Inject
+    abstract val fileSystemOperations: FileSystemOperations
+
+    @TaskAction
+    fun clean() {
+        val pathsToDelete = mutableSetOf<File>()
+        val coordinationService = coordinationService.get()
+
+        readIncrementalFingerprint(syntheticPackageFingerprint.asFile.orNull)?.let { fingerprint ->
+            pathsToDelete += coordinationService.sharedPackageGenerationRoot(fingerprint)
+            pathsToDelete += coordinationService.sharedCheckoutDir(fingerprint)
+        }
+
+        xcodebuildFingerprints.files.forEach { fingerprintFile ->
+            readIncrementalFingerprint(fingerprintFile)?.let { fingerprint ->
+                pathsToDelete += coordinationService.sharedXcodeDumpBucketRoot(fingerprint)
+            }
+        }
+
+        if (pathsToDelete.isNotEmpty()) {
+            fileSystemOperations.delete {
+                it.delete(pathsToDelete)
+            }
+        }
+    }
+
+    private fun readIncrementalFingerprint(fingerprintFile: File?): String? =
+        fingerprintFile
+            ?.takeIf(File::isFile)
+            ?.readSwiftImportFingerprint()
+            ?.incrementalFingerprint
+
+    companion object {
+        const val TASK_NAME = "cleanSwiftImportFingerprintArtifacts"
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportFingerprintedCoordinationService.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportFingerprintedCoordinationService.kt
@@ -104,14 +104,14 @@ internal abstract class SwiftImportFingerprintedCoordinationService : BuildServi
     fun sharedXcodeDumpDir(
         xcodebuildExecutionHash: String,
         xcodebuildSdk: String,
-    ) = sharedDumpDir(sharedDumpBucketRoot(xcodebuildExecutionHash), xcodebuildSdk)
+    ) = sharedDumpDir(sharedXcodeDumpBucketRoot(xcodebuildExecutionHash), xcodebuildSdk)
 
     fun sharedXcodeDerivedDataDir(
         xcodebuildExecutionHash: String,
         xcodebuildSdk: String,
-    ) = sharedDerivedDataDir(sharedDumpBucketRoot(xcodebuildExecutionHash), xcodebuildSdk)
+    ) = sharedDerivedDataDir(sharedXcodeDumpBucketRoot(xcodebuildExecutionHash), xcodebuildSdk)
 
-    private fun sharedDumpBucketRoot(bucketId: String): File =
+    internal fun sharedXcodeDumpBucketRoot(bucketId: String): File =
         parameters.sharedXcodeDumpRoot.get().asFile.resolve(bucketId)
 
     private fun sharedDumpDir(bucketRoot: File, xcodebuildSdk: String): File =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
@@ -9,6 +9,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
@@ -197,6 +198,17 @@ internal val SwiftImportSetupAction = KotlinProjectSetupAction {
         when (val packageIdentifier = identifierSynchronizationOrNull()) {
             is PackageResolvedSynchronization.Identifier -> {
                 val packageResolvedSynchronizationIdentifier = packageIdentifier.identifier
+                val cleanSwiftImportFingerprintArtifacts = locateOrRegisterCleanSwiftImportFingerprintArtifactsTask()
+                cleanSwiftImportFingerprintArtifacts.configure { cleanTaskProvider ->
+                    cleanTaskProvider.syntheticPackageFingerprint.set(
+                        fingerprintSyntheticPackageTask.map { it.syntheticPackageFingerprintFile.get() }
+                    )
+                    cleanTaskProvider.coordinationService.set(fingerprintCoordinationService)
+                }
+                tasks.named(LifecycleBasePlugin.CLEAN_TASK_NAME).configure {
+                    it.dependsOn(cleanSwiftImportFingerprintArtifacts)
+                }
+
                 enableFingerprintCoordination(
                     fingerprintCoordinationService = fingerprintCoordinationService,
                     generateSyntheticPackageTask = syntheticImportProjectGenerationTaskForCinteropsAndLdDump,
@@ -344,6 +356,13 @@ internal val SwiftImportSetupAction = KotlinProjectSetupAction {
                             fingerprintSyntheticPackageTask.map { it.syntheticPackageFingerprintFile.get() }
                         )
                         it.xcodebuildFingerprint.fingerprintFile.set(fingerprintXcode.map { it.xcodebuildFingerprintFile.get() })
+                    }
+
+                    val cleanSwiftImportFingerprintArtifacts = locateOrRegisterCleanSwiftImportFingerprintArtifactsTask()
+                    cleanSwiftImportFingerprintArtifacts.configure {
+                        it.xcodebuildFingerprints.from(
+                            fingerprintXcode.map { it.xcodebuildFingerprintFile.get() }
+                        )
                     }
 
                     defFilesAndLdDumpGenerationTask.configure { defFileTask ->
@@ -597,6 +616,12 @@ private fun enableFingerprintCoordination(
         )
         it.coordinationService.set(fingerprintCoordinationService)
     }
+}
+
+private fun Project.locateOrRegisterCleanSwiftImportFingerprintArtifactsTask(): TaskProvider<CleanSwiftImportFingerprintArtifacts> {
+    return locateOrRegisterTask<CleanSwiftImportFingerprintArtifacts>(
+        CleanSwiftImportFingerprintArtifacts.TASK_NAME,
+    )
 }
 
 private fun Project.locateOrRegisterUmbrellaFetchTask(

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftPMImportUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftPMImportUnitTests.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics
 import org.jetbrains.kotlin.gradle.plugin.getExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.CleanSwiftImportFingerprintArtifacts
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.ConvertSyntheticSwiftPMImportProjectIntoDefFile
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.ComputeLocalPackageDependencyInputFiles
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.DumpXcodeBuildArgs
@@ -42,6 +43,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SwiftPMImportUnitTests {
@@ -49,6 +51,44 @@ class SwiftPMImportUnitTests {
     @BeforeTest
     fun runOnMacOSOnly() {
         Assumptions.assumeTrue(HostManager.hostIsMac, "macOS host required for this test")
+    }
+
+    @Test
+    fun `no synchronization does not register fingerprint artifacts cleanup task`() {
+        val project = swiftPMImportProject(
+            swiftPMDependencies = {
+                packageResolvedSynchronization = noSynchronization()
+            }
+        )
+        project.evaluate()
+
+        assertNull(project.tasks.findByName(CleanSwiftImportFingerprintArtifacts.TASK_NAME))
+        val cleanTask = project.tasks.getByName("clean")
+        assertFalse(
+            cleanTask.taskDependencies.getDependencies(cleanTask).any {
+                it.name == CleanSwiftImportFingerprintArtifacts.TASK_NAME
+            }
+        )
+    }
+
+    @Test
+    fun `default identifier registers fingerprint artifacts cleanup task and wires clean dependency`() {
+        val project = swiftPMImportProject()
+        project.evaluate()
+
+        project.assertFingerprintArtifactsCleanupIsRegistered()
+    }
+
+    @Test
+    fun `explicit identifier registers fingerprint artifacts cleanup task and wires clean dependency`() {
+        val project = swiftPMImportProject(
+            swiftPMDependencies = {
+                packageResolvedSynchronization = identifier("custom")
+            }
+        )
+        project.evaluate()
+
+        project.assertFingerprintArtifactsCleanupIsRegistered()
     }
 
     @Test
@@ -1066,6 +1106,18 @@ class SwiftPMImportUnitTests {
 
 
     }
+}
+
+private fun ProjectInternal.assertFingerprintArtifactsCleanupIsRegistered() {
+    val cleanupTask = tasks.findByName(CleanSwiftImportFingerprintArtifacts.TASK_NAME)
+    assertNotNull(cleanupTask, "${CleanSwiftImportFingerprintArtifacts.TASK_NAME} should be registered")
+    assertIs<CleanSwiftImportFingerprintArtifacts>(cleanupTask)
+
+    val cleanTask = tasks.getByName("clean")
+    assertTrue(
+        cleanupTask in cleanTask.taskDependencies.getDependencies(cleanTask),
+        "clean should depend on ${CleanSwiftImportFingerprintArtifacts.TASK_NAME}",
+    )
 }
 
 private fun ProjectInternal.swiftPmLocalDependencies(): List<SwiftPMDependency.Local> {


### PR DESCRIPTION
- Add an integration test reproducing the issue.
- Register a project-specific `clean` task when fingerprinted synchronization is used to clean up shared SwiftPM artifacts.

 **Note**

 The fix does **not** remove the entire root `build` directory. Only the directories created by the SwiftPM fingerprinting mechanism are cleaned up.

 Example before `clean`:

 ```text
 build/
 └── syntheticPackages/
     └── <hash>/
         ├── Package.swift
         └── Sources/
             ...
 ```

 After `clean`:

 ```text
 build/
 └── syntheticPackages/
 ```


^KT-88107