### PR TITLE
JVM/Reflection: fix underlying field search for inline classes

### DIFF
--- a/compiler/testData/codegen/boxJvm/reflection/call/inlineClasses/contextPropertyWithSameNameAsPrimary.kt
+++ b/compiler/testData/codegen/boxJvm/reflection/call/inlineClasses/contextPropertyWithSameNameAsPrimary.kt
@@ -15,7 +15,13 @@ value class Z(val value: String) {
     }
 }
 
+fun boxZ(z: Z): Z? = z
+fun unboxZ(z: Z?): Z = z!!
+
 fun box(): String {
+    if ((::boxZ).call(Z("ok")) != Z("ok")) return "fail: boxZ"
+    if ((::unboxZ).call(Z("ok")) != Z("ok")) return "fail: unboxZ"
+
     val withContext = Z::class.members.single { p ->
         p.name == "value" && p.parameters.any { it.kind == KParameter.Kind.CONTEXT }
     }

--- a/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt
+++ b/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt
@@ -419,6 +419,7 @@ internal class KClassImpl<T : Any>(
             result as List<KClass<out T>>
         }
 
+        @OptIn(ExperimentalCompanionBlocksAndExtensions::class)
         internal val inlineClassUnderlyingType: KType? by lazy(PUBLICATION) {
             val kmClass = kmClass
             when {
@@ -429,7 +430,8 @@ internal class KClassImpl<T : Any>(
                 else -> {
                     val underlyingProperty = kmClass.properties.single {
                         it.name == kmClass.inlineClassUnderlyingPropertyName &&
-                                it.contextParameters.isEmpty() && it.receiverParameterType == null
+                                it.contextParameters.isEmpty() && it.receiverParameterType == null &&
+                                !it.isStatic
                     }
                     underlyingProperty.returnType.toKType(jClass.safeClassLoader, typeParameterTable)
                 }


### PR DESCRIPTION
Handle the case when inline class has a companion property with the same name as the underlying property name.

^KT-88145 Fixed