### PR TITLE
[KT-88154] swift pm lock file is ignored on switching version from exact to from

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FetchSyntheticImportProjectPackages
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.PackageResolvedSynchronization
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_CHECKOUT_DIR
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_SYNTHETIC_PACKAGE_DIR
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SerializeSwiftPMDependenciesMetadataForLockFiles
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FingerprintSyntheticPackage
 import org.jetbrains.kotlin.gradle.testbase.*
@@ -782,10 +784,26 @@ class SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests : KGPB
                         }
                     }
                 }
+
+                val syntheticPackageFingerprintFile = projectPath.resolve(SYNTHETIC_PACKAGE_FINGERPRINT_BUILD_DIR_PATH)
+
                 build("fetchSyntheticImportProjectPackages", "-P${useExactVersionKey}=true") {
                     assertResolvedVersions(
                         persistedPackageResolvedSyncPath,
                         checkoutRepoDir = projectPath.resolve(".swiftpm-locks/$identifier/swiftPMCheckout/checkouts"),
+                        listOf(
+                            packageRepo to "1.0.1",
+                        )
+                    )
+
+                    val syntheticPackageFingerprint = parseSwiftPMIncrementalFingerprint(syntheticPackageFingerprintFile)
+                    val packageResolved = projectPath.resolve(SHARED_SYNTHETIC_PACKAGE_DIR).resolve(syntheticPackageFingerprint).resolve("Package.resolved")
+                    val checkoutDir = projectPath.resolve(SHARED_CHECKOUT_DIR).resolve(syntheticPackageFingerprint).resolve("checkouts")
+
+
+                    assertResolvedVersions(
+                        packageResolved,
+                        checkoutRepoDir = checkoutDir,
                         listOf(
                             packageRepo to "1.0.1",
                         )
@@ -807,6 +825,19 @@ class SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests : KGPB
                         checkoutRepoDir = projectPath.resolve(".swiftpm-locks/$identifier/swiftPMCheckout/checkouts"),
                         listOf(
                             packageRepo to "1.0.1",
+                        )
+                    )
+
+                    val syntheticPackageFingerprint = parseSwiftPMIncrementalFingerprint(syntheticPackageFingerprintFile)
+                    val packageResolved = projectPath.resolve(SHARED_SYNTHETIC_PACKAGE_DIR).resolve(syntheticPackageFingerprint).resolve("Package.resolved")
+                    val checkoutDir = projectPath.resolve(SHARED_CHECKOUT_DIR).resolve(syntheticPackageFingerprint).resolve("checkouts")
+
+
+                    assertResolvedVersions(
+                        packageResolved,
+                        checkoutRepoDir = checkoutDir,
+                        listOf(
+                            packageRepo to "1.0.2",
                         )
                     )
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
@@ -837,7 +837,7 @@ class SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests : KGPB
                         packageResolved,
                         checkoutRepoDir = checkoutDir,
                         listOf(
-                            packageRepo to "1.0.2",
+                            packageRepo to "1.0.1",
                         )
                     )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
@@ -579,7 +579,7 @@ private fun enableFingerprintCoordination(
             fingerprintSwiftPMDependencyGraph(
                 directMetadata,
                 transitiveMetadata,
-                normalizeVersions = false,
+                normalizeVersions = true,
             )
         }
 


### PR DESCRIPTION
- Add repro IT
- Fix by not including versions into fingerprinting for package generation.

^KT-88154 