### PR TITLE
[KT-88154] [2.4.20] swift pm lock file is ignored on switching version from exact to from

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
@@ -842,7 +842,7 @@ class SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests : KGPB
                         packageResolved,
                         checkoutRepoDir = checkoutDir,
                         listOf(
-                            packageRepo to "1.0.2",
+                            packageRepo to "1.0.1",
                         )
                     )
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/apple/SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FetchSyntheticImportProjectPackages
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.GenerateSyntheticLinkageImportProject
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.PackageResolvedSynchronization
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_CHECKOUT_DIR
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SHARED_SYNTHETIC_PACKAGE_DIR
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SerializeSwiftPMDependenciesMetadataForLockFiles
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.SyncPackageResolvedTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftimport.FingerprintSyntheticPackage
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.condition.OS
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.io.path.readText
 
 @OsCondition(
     supportedOn = [OS.MAC],
@@ -785,10 +788,26 @@ class SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests : KGPB
                         }
                     }
                 }
+
+                val syntheticPackageFingerprintFile = projectPath.resolve(SYNTHETIC_PACKAGE_FINGERPRINT_BUILD_DIR_PATH)
+
                 build("fetchSyntheticImportProjectPackages", "-P${useExactVersionKey}=true") {
                     assertResolvedVersions(
                         persistedPackageResolvedSyncPath,
                         checkoutRepoDir = projectPath.resolve(".swiftpm-locks/$identifier/swiftPMCheckout/checkouts"),
+                        listOf(
+                            packageRepo to "1.0.1",
+                        )
+                    )
+
+                    val syntheticPackageFingerprint = syntheticPackageFingerprintFile.readText().trim().split("\n")[1]
+                    val packageResolved = projectPath.resolve(SHARED_SYNTHETIC_PACKAGE_DIR).resolve(syntheticPackageFingerprint).resolve("Package.resolved")
+                    val checkoutDir = projectPath.resolve(SHARED_CHECKOUT_DIR).resolve(syntheticPackageFingerprint).resolve("checkouts")
+
+
+                    assertResolvedVersions(
+                        packageResolved,
+                        checkoutRepoDir = checkoutDir,
                         listOf(
                             packageRepo to "1.0.1",
                         )
@@ -811,6 +830,19 @@ class SwiftPMImportPersistentDefaultIdentifierPackageLockIntegrationTests : KGPB
                         checkoutRepoDir = projectPath.resolve(".swiftpm-locks/$identifier/swiftPMCheckout/checkouts"),
                         listOf(
                             packageRepo to "1.0.1",
+                        )
+                    )
+
+                    val syntheticPackageFingerprint = syntheticPackageFingerprintFile.readText().trim().split("\n")[1]
+                    val packageResolved = projectPath.resolve(SHARED_SYNTHETIC_PACKAGE_DIR).resolve(syntheticPackageFingerprint).resolve("Package.resolved")
+                    val checkoutDir = projectPath.resolve(SHARED_CHECKOUT_DIR).resolve(syntheticPackageFingerprint).resolve("checkouts")
+
+
+                    assertResolvedVersions(
+                        packageResolved,
+                        checkoutRepoDir = checkoutDir,
+                        listOf(
+                            packageRepo to "1.0.2",
                         )
                     )
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
@@ -623,7 +623,7 @@ private fun Project.enableFingerprintCoordination(
         fingerprintSwiftPMDependencyGraph(
             directMetadata,
             transitiveMetadata,
-            normalizeVersions = false,
+            normalizeVersions = true,
         )
     }
 


### PR DESCRIPTION
- Add repro IT
- Fix by not including versions into fingerprinting for package generation.

^KT-88154 