### PR TITLE
[Wasm, Tests] Mute stepping tests in single-/multi-module (^KT-88234)

### DIFF
--- a/compiler/testData/debug/stepping/kt82044.kt
+++ b/compiler/testData/debug/stepping/kt82044.kt
@@ -1,5 +1,7 @@
 // DONT_TARGET_EXACT_BACKEND: JS_IR
 // ^^^ Test hangs while executing the debugger.
+// WASM_IGNORE_FOR: mode=single-module
+// ^^^ KT-88234
 
 // MODULE: a
 // FILE: a.kt
@@ -19,21 +21,21 @@ fun box(): String {
 }
 
 // EXPECTATIONS JVM_IR
-// test.kt:15 box
-// a.kt:8 box
-// test.kt:16 box
 // test.kt:17 box
-
-// EXPECTATIONS NATIVE
-// test.kt:15 box
-// a.kt:8 box
-// test.kt:16 box
-// test.kt:16 box
-// test.kt:17 box
+// a.kt:10 box
+// test.kt:18 box
 // test.kt:19 box
 
+// EXPECTATIONS NATIVE
+// test.kt:17 box
+// a.kt:10 box
+// test.kt:18 box
+// test.kt:18 box
+// test.kt:19 box
+// test.kt:21 box
+
 // EXPECTATIONS WASM
-// test.kt:15 $box (4, 8)
-// a.kt:8 $box (17, 11)
-// test.kt:16 $box (21, 26, 21)
-// test.kt:17 $box (15, 8)
+// test.kt:17 $box (4, 8)
+// a.kt:10 $box (17, 11)
+// test.kt:18 $box (21, 26, 21)
+// test.kt:19 $box (15, 8)

--- a/compiler/testData/debug/stepping/multiModule.kt
+++ b/compiler/testData/debug/stepping/multiModule.kt
@@ -1,3 +1,6 @@
+// WASM_IGNORE_FOR: mode=single-module
+// WASM_IGNORE_FOR: mode=multi-module
+// ^^^ Both of these: KT-88234
 // MODULE: lib
 // FILE: a.kt
 
@@ -16,34 +19,34 @@ fun box() {
 }
 
 // EXPECTATIONS JVM_IR
-// test.kt:14 box
-// a.kt:4 a
-// test.kt:14 box
-// test.kt:15 box
-// b.kt:8 b
-// test.kt:15 box
-// test.kt:16 box
+// test.kt:17 box
+// a.kt:7 a
+// test.kt:17 box
+// test.kt:18 box
+// b.kt:11 b
+// test.kt:18 box
+// test.kt:19 box
 
 // EXPECTATIONS NATIVE
-// test.kt:14 box
-// a.kt:4 a
-// test.kt:14 box
-// test.kt:15 box
-// b.kt:8 b
-// test.kt:16 box
+// test.kt:17 box
+// a.kt:7 a
+// test.kt:17 box
+// test.kt:18 box
+// b.kt:11 b
+// test.kt:19 box
 
 // EXPECTATIONS JS_IR
-// test.kt:14 box
-// a.kt:4 a
-// test.kt:15 box
-// b.kt:8 b
-// test.kt:16 box
+// test.kt:17 box
+// a.kt:7 a
+// test.kt:18 box
+// b.kt:11 b
+// test.kt:19 box
 
 // EXPECTATIONS WASM
-// test.kt:14 $box (4)
-// a.kt:4 $a (10, 13)
-// test.kt:14 $box (4)
-// test.kt:15 $box (4)
-// b.kt:8 $b (10, 13)
-// test.kt:15 $box (4)
-// test.kt:16 $box (1)
+// test.kt:17 $box (4)
+// a.kt:7 $a (10, 13)
+// test.kt:17 $box (4)
+// test.kt:18 $box (4)
+// b.kt:11 $b (10, 13)
+// test.kt:18 $box (4)
+// test.kt:19 $box (1)


### PR DESCRIPTION
These have been failing since the grouped tets infra for Wasm was introduced (#6231).

Mute [half of them](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_WasmTestAggregate/1018011026), the other half isn't precisely targettable because they only fail in a single runner ([KT-88235](https://youtrack.jetbrains.com/issue/KT-88235)).