### PR TITLE
[stdlib] Add `boundContextArguments` to `CallableReference`

### DIFF
--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/AdaptedFunctionReference.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/AdaptedFunctionReference.java
@@ -5,10 +5,12 @@
 
 package kotlin.jvm.internal;
 
+import kotlin.ExperimentalContextParameters;
 import kotlin.SinceKotlin;
 import kotlin.reflect.KDeclarationContainer;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 import static kotlin.jvm.internal.CallableReference.NO_RECEIVER;
 
@@ -28,6 +30,9 @@ import static kotlin.jvm.internal.CallableReference.NO_RECEIVER;
 @SinceKotlin(version = "1.4")
 public class AdaptedFunctionReference implements FunctionBase, Serializable {
     protected final Object receiver;
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    protected Object[] boundContextArguments;
     private final Class owner;
     private final String name;
     private final String signature;
@@ -89,6 +94,7 @@ public class AdaptedFunctionReference implements FunctionBase, Serializable {
                arity == other.arity &&
                flags == other.flags &&
                Intrinsics.areEqual(receiver, other.receiver) &&
+               Arrays.equals(boundContextArguments, other.boundContextArguments) &&
                Intrinsics.areEqual(owner, other.owner) &&
                name.equals(other.name) &&
                signature.equals(other.signature);
@@ -97,6 +103,7 @@ public class AdaptedFunctionReference implements FunctionBase, Serializable {
     @Override
     public int hashCode() {
         int result = receiver != null ? receiver.hashCode() : 0;
+        result = result * 31 + Arrays.hashCode(boundContextArguments);
         result = result * 31 + (owner != null ? owner.hashCode() : 0);
         result = result * 31 + name.hashCode();
         result = result * 31 + signature.hashCode();

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CallableReference.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/CallableReference.java
@@ -5,6 +5,7 @@
 
 package kotlin.jvm.internal;
 
+import kotlin.ExperimentalContextParameters;
 import kotlin.SinceKotlin;
 import kotlin.jvm.KotlinReflectionNotSupportedError;
 import kotlin.reflect.*;
@@ -33,6 +34,10 @@ public abstract class CallableReference implements KCallable, Serializable, Kotl
 
     @SinceKotlin(version = "1.1")
     protected final Object receiver;
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    protected Object[] boundContextArguments;
 
     @SinceKotlin(version = "1.4")
     private final Class owner;
@@ -81,6 +86,12 @@ public abstract class CallableReference implements KCallable, Serializable, Kotl
     @SinceKotlin(version = "1.1")
     public Object getBoundReceiver() {
         return receiver;
+    }
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    public Object[] getBoundContextArguments() {
+        return boundContextArguments;
     }
 
     @SinceKotlin(version = "1.1")

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/FunctionReference.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/FunctionReference.java
@@ -9,6 +9,8 @@ import kotlin.SinceKotlin;
 import kotlin.reflect.KCallable;
 import kotlin.reflect.KFunction;
 
+import java.util.Arrays;
+
 @SuppressWarnings({"rawtypes", "unused"})
 public class FunctionReference extends CallableReference implements FunctionBase, KFunction {
     private final int arity;
@@ -84,6 +86,7 @@ public class FunctionReference extends CallableReference implements FunctionBase
             return getName().equals(other.getName()) &&
                    getSignature().equals(other.getSignature()) &&
                    Intrinsics.areEqual(getBoundReceiver(), other.getBoundReceiver()) &&
+                   Arrays.equals(getBoundContextArguments(), other.getBoundContextArguments()) &&
                    Intrinsics.areEqual(getOwner(), other.getOwner());
         }
         if (obj instanceof KFunction) {

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/MutablePropertyReference0Impl.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/MutablePropertyReference0Impl.java
@@ -5,6 +5,7 @@
 
 package kotlin.jvm.internal;
 
+import kotlin.ExperimentalContextParameters;
 import kotlin.SinceKotlin;
 import kotlin.reflect.KClass;
 import kotlin.reflect.KDeclarationContainer;
@@ -27,6 +28,20 @@ public class MutablePropertyReference0Impl extends MutablePropertyReference0 {
     @SinceKotlin(version = "1.4")
     public MutablePropertyReference0Impl(Object receiver, Class owner, String name, String signature, int flags) {
         super(receiver, owner, name, signature, flags);
+    }
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    public MutablePropertyReference0Impl(Object[] contextArguments, Class owner, String name, String signature, int flags) {
+        this(owner, name, signature, flags);
+        this.boundContextArguments = contextArguments;
+    }
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    public MutablePropertyReference0Impl(Object[] contextArguments, Object receiver, Class owner, String name, String signature, int flags) {
+        this(receiver, owner, name, signature, flags);
+        this.boundContextArguments = contextArguments;
     }
 
     @Override

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/MutablePropertyReference1Impl.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/MutablePropertyReference1Impl.java
@@ -5,6 +5,7 @@
 
 package kotlin.jvm.internal;
 
+import kotlin.ExperimentalContextParameters;
 import kotlin.SinceKotlin;
 import kotlin.reflect.KClass;
 import kotlin.reflect.KDeclarationContainer;
@@ -27,6 +28,13 @@ public class MutablePropertyReference1Impl extends MutablePropertyReference1 {
     @SinceKotlin(version = "1.4")
     public MutablePropertyReference1Impl(Object receiver, Class owner, String name, String signature, int flags) {
         super(receiver, owner, name, signature, flags);
+    }
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    public MutablePropertyReference1Impl(Object[] contextArguments, Class owner, String name, String signature, int flags) {
+        this(owner, name, signature, flags);
+        this.boundContextArguments = contextArguments;
     }
 
     @Override

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/PropertyReference.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/PropertyReference.java
@@ -9,6 +9,8 @@ import kotlin.SinceKotlin;
 import kotlin.reflect.KCallable;
 import kotlin.reflect.KProperty;
 
+import java.util.Arrays;
+
 @SuppressWarnings("rawtypes")
 public abstract class PropertyReference extends CallableReference implements KProperty {
     private final boolean syntheticJavaProperty;
@@ -68,7 +70,8 @@ public abstract class PropertyReference extends CallableReference implements KPr
             return getOwner().equals(other.getOwner()) &&
                    getName().equals(other.getName()) &&
                    getSignature().equals(other.getSignature()) &&
-                   Intrinsics.areEqual(getBoundReceiver(), other.getBoundReceiver());
+                   Intrinsics.areEqual(getBoundReceiver(), other.getBoundReceiver()) &&
+                   Arrays.equals(getBoundContextArguments(), other.getBoundContextArguments());
         }
         if (obj instanceof KProperty) {
             return obj.equals(compute());

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/PropertyReference0Impl.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/PropertyReference0Impl.java
@@ -5,6 +5,7 @@
 
 package kotlin.jvm.internal;
 
+import kotlin.ExperimentalContextParameters;
 import kotlin.SinceKotlin;
 import kotlin.reflect.KClass;
 import kotlin.reflect.KDeclarationContainer;
@@ -27,6 +28,20 @@ public class PropertyReference0Impl extends PropertyReference0 {
     @SinceKotlin(version = "1.4")
     public PropertyReference0Impl(Object receiver, Class owner, String name, String signature, int flags) {
         super(receiver, owner, name, signature, flags);
+    }
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    public PropertyReference0Impl(Object[] contextArguments, Class owner, String name, String signature, int flags) {
+        this(owner, name, signature, flags);
+        this.boundContextArguments = contextArguments;
+    }
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    public PropertyReference0Impl(Object[] contextArguments, Object receiver, Class owner, String name, String signature, int flags) {
+        this(receiver, owner, name, signature, flags);
+        this.boundContextArguments = contextArguments;
     }
 
     @Override

--- a/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/PropertyReference1Impl.java
+++ b/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/PropertyReference1Impl.java
@@ -5,6 +5,7 @@
 
 package kotlin.jvm.internal;
 
+import kotlin.ExperimentalContextParameters;
 import kotlin.SinceKotlin;
 import kotlin.reflect.KClass;
 import kotlin.reflect.KDeclarationContainer;
@@ -27,6 +28,13 @@ public class PropertyReference1Impl extends PropertyReference1 {
     @SinceKotlin(version = "1.4")
     public PropertyReference1Impl(Object receiver, Class owner, String name, String signature, int flags) {
         super(receiver, owner, name, signature, flags);
+    }
+
+    @SinceKotlin(version = "2.5")
+    @ExperimentalContextParameters
+    public PropertyReference1Impl(Object[] contextArguments, Class owner, String name, String signature, int flags) {
+        this(owner, name, signature, flags);
+        this.boundContextArguments = contextArguments;
     }
 
     @Override

--- a/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
+++ b/libraries/tools/binary-compatibility-validator/reference-public-api/kotlin-stdlib-runtime-merged.txt
@@ -3900,6 +3900,7 @@ public abstract interface class kotlin/jvm/functions/FunctionN : kotlin/Function
 }
 
 public class kotlin/jvm/internal/AdaptedFunctionReference : java/io/Serializable, kotlin/jvm/internal/FunctionBase {
+	protected field boundContextArguments [Ljava/lang/Object;
 	protected final field receiver Ljava/lang/Object;
 	public fun <init> (ILjava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (ILjava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
@@ -3956,6 +3957,7 @@ public final class kotlin/jvm/internal/ByteSpreadBuilder : kotlin/jvm/internal/P
 
 public abstract class kotlin/jvm/internal/CallableReference : java/io/Serializable, kotlin/jvm/internal/KotlinGenericDeclaration, kotlin/reflect/KCallable {
 	public static final field NO_RECEIVER Ljava/lang/Object;
+	protected field boundContextArguments [Ljava/lang/Object;
 	protected final field receiver Ljava/lang/Object;
 	public fun <init> ()V
 	protected fun <init> (Ljava/lang/Object;)V
@@ -3966,6 +3968,7 @@ public abstract class kotlin/jvm/internal/CallableReference : java/io/Serializab
 	protected abstract fun computeReflected ()Lkotlin/reflect/KCallable;
 	public fun findJavaDeclaration ()Ljava/lang/reflect/GenericDeclaration;
 	public fun getAnnotations ()Ljava/util/List;
+	public fun getBoundContextArguments ()[Ljava/lang/Object;
 	public fun getBoundReceiver ()Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun getOwner ()Lkotlin/reflect/KDeclarationContainer;
@@ -4338,6 +4341,8 @@ public class kotlin/jvm/internal/MutablePropertyReference0Impl : kotlin/jvm/inte
 	public fun <init> (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Lkotlin/reflect/KDeclarationContainer;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> ([Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
+	public fun <init> ([Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun get ()Ljava/lang/Object;
 	public fun set (Ljava/lang/Object;)V
 }
@@ -4359,6 +4364,7 @@ public class kotlin/jvm/internal/MutablePropertyReference1Impl : kotlin/jvm/inte
 	public fun <init> (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Lkotlin/reflect/KDeclarationContainer;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> ([Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun set (Ljava/lang/Object;Ljava/lang/Object;)V
 }
@@ -4430,6 +4436,8 @@ public class kotlin/jvm/internal/PropertyReference0Impl : kotlin/jvm/internal/Pr
 	public fun <init> (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Lkotlin/reflect/KDeclarationContainer;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> ([Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
+	public fun <init> ([Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun get ()Ljava/lang/Object;
 }
 
@@ -4448,6 +4456,7 @@ public class kotlin/jvm/internal/PropertyReference1Impl : kotlin/jvm/internal/Pr
 	public fun <init> (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun <init> (Lkotlin/reflect/KDeclarationContainer;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> ([Ljava/lang/Object;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
 	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
 }
 


### PR DESCRIPTION
A reference to a declaration with context parameters has to capture its context arguments at the creation site in addition to an optional bound receiver. Add runtime support for storing them.

^KT-86452