### PR TITLE
2.4.20: [Gradle] Use resolved versions for npm dependencies in shared `kotlin-npm-tooling` directory

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/WasmPackageManagerGradlePluginIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/WasmPackageManagerGradlePluginIT.kt
@@ -3,13 +3,21 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package org.jetbrains.kotlin.gradle
 
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask.Companion.KOTLIN_JS_STORE
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask.Companion.PACKAGE_LOCK
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask.Companion.YARN_LOCK
 import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.gradle.util.kgpPackageLockJsonFileContent
+import org.jetbrains.kotlin.gradle.util.kgpYarnLockFileContent
 import org.jetbrains.kotlin.gradle.util.replaceText
 import org.jetbrains.kotlin.gradle.util.setupCustomKgpNpmToolingDependenciesDir
 import org.jetbrains.kotlin.test.TestMetadata
@@ -261,20 +269,20 @@ abstract class WasmPackageManagerGradlePluginIT : KGPBaseTest() {
     fun testWasmUsePredefinedTooling(gradleVersion: GradleVersion) {
         project("kotlin-wasm-tooling-inside-project", gradleVersion) {
 
-            // extracted as val to be serializable
-            val isYarn = yarn
-
             val toolingCustomDir = projectPath.resolve(toolingCustomDirName)
 
             setupCustomKgpNpmToolingDependenciesDir(
                 toolingCustomDir = toolingCustomDir,
-                useYarn = isYarn,
+                useYarn = yarn,
             )
 
             build(":toolingInstall") {
                 assertTasksExecuted(":toolingInstall")
 
-                assertDirectoryExists(projectPath.resolve("$toolingCustomDir/node_modules"))
+                assertFileExists(toolingCustomDir.resolve("package.json"))
+                assertDirectoryExists(toolingCustomDir.resolve("node_modules"))
+
+                checkLockFiles(isYarn = yarn, toolingCustomDir = toolingCustomDir)
             }
 
             build("build") {
@@ -294,5 +302,56 @@ abstract class WasmPackageManagerGradlePluginIT : KGPBaseTest() {
                 assertTasksExecuted(":kotlinWasmToolingSetup")
             }
         }
+    }
+}
+
+private val json = Json {
+    prettyPrint = true
+    prettyPrintIndent = "  "
+}
+
+/**
+ * Verify the lockfiles exist, and they have not been modified during `npm/yarn install`
+ * (i.e. they are up-to-date and in sync with the `package.json`, so they will work in offline mode).
+ */
+private fun checkLockFiles(
+    isYarn: Boolean,
+    toolingCustomDir: Path,
+) {
+    val lockfile = toolingCustomDir.resolve(if (isYarn) "yarn.lock" else "package-lock.json")
+    assertFileExists(lockfile)
+
+    assertFileNotExists(
+        toolingCustomDir.resolve(if (!isYarn) "yarn.lock" else "package-lock.json")
+    )
+
+    // Must make sure KGP's store lockfiles are not outdated.
+    // Package managers might silently update them after an installation,
+    // which is a problem for offline installs.
+    if (isYarn) {
+        val expectedLockfile = kgpYarnLockFileContent
+        val actualLockfile = lockfile.readText()
+        assertEquals(expectedLockfile, actualLockfile)
+
+    } else {
+        // Only check the `packages` key.
+        // The root package, with key `""`, is for the current project and can be ignored.
+        fun extractPackages(packageLockJson: String) =
+            json.decodeFromString<JsonObject>(packageLockJson)
+                .getValue("packages")
+                .jsonObject
+                .filterKeys { it != "" }
+                .let { json.encodeToString(it) }
+
+        val expectedLockfilePackages =
+            extractPackages(kgpPackageLockJsonFileContent)
+
+        val actualLockfilePackages =
+            extractPackages(lockfile.readText())
+
+        assertEquals(
+            expectedLockfilePackages,
+            actualLockfilePackages,
+        )
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/kgpNpmToolingDependencies.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/kgpNpmToolingDependencies.kt
@@ -9,13 +9,15 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.withType
 import org.gradle.process.ExecOperations
-import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.NpmVersions
+import org.jetbrains.kotlin.gradle.targets.js.allDependenciesInternal
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsEnvSpec
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNpmTooling
 import org.jetbrains.kotlin.gradle.targets.wasm.npm.WasmNpmExtension
@@ -23,6 +25,7 @@ import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnRootEnvSpec
 import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnRootExtension
 import org.jetbrains.kotlin.gradle.testbase.TestProject
 import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
+import org.jetbrains.kotlin.gradle.testbase.buildScriptReturn
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Path
@@ -50,7 +53,7 @@ private fun KClass<*>.loadResource(path: String): String {
  *
  * @see [org.jetbrains.kotlin.gradle.targets.js.NpmVersions]
  */
-internal val kgpNpmToolingPackageJson: String by lazy {
+internal fun createKgpNpmToolingPackageJson(npmVersions: NpmVersions): String {
     val json = Json {
         prettyPrint = true
     }
@@ -61,13 +64,13 @@ internal val kgpNpmToolingPackageJson: String by lazy {
             put("version", "1.0.0")
             put("private", true)
             put("dependencies", buildJsonObject {
-                NpmVersions().allDependencies.forEach { [name, version] ->
-                    put(name, version)
+                npmVersions.allDependenciesInternal().forEach { dep ->
+                    put(dep.name, dep.requestedVersion)
                 }
             })
         }
 
-    json.encodeToString(JsonObject.serializer(), packageJson)
+    return json.encodeToString(JsonObject.serializer(), packageJson)
 }
 
 /**
@@ -77,9 +80,17 @@ internal fun TestProject.setupCustomKgpNpmToolingDependenciesDir(
     toolingCustomDir: Path,
     useYarn: Boolean,
 ) {
+    // Use the same NpmVersions that KGP uses (which is important, because we're also using KGP's lockfiles)
+    val defaultNpmVersions =
+        buildScriptReturn {
+            project.extensions.getByName<WasmNodeJsRootExtension>(WasmNodeJsRootExtension.EXTENSION_NAME).versions
+        }.buildAndReturn()
+    val packageJson = createKgpNpmToolingPackageJson(defaultNpmVersions)
+
     createCustomKgpNpmToolingDependenciesDir(
         toolingCustomDir = toolingCustomDir,
         useYarn = useYarn,
+        packageJson = packageJson,
     )
     setCustomKgpNpmToolingDependenciesDir(toolingCustomDir = toolingCustomDir)
     registerCustomNpmToolingInstallTask(
@@ -91,11 +102,12 @@ internal fun TestProject.setupCustomKgpNpmToolingDependenciesDir(
 private fun createCustomKgpNpmToolingDependenciesDir(
     toolingCustomDir: Path,
     useYarn: Boolean,
+    packageJson: String,
 ) {
     toolingCustomDir.createDirectories()
 
     // A `package.json` file is required for `npm install` and `yarn install` commands to work.
-    toolingCustomDir.resolve("package.json").writeText(kgpNpmToolingPackageJson)
+    toolingCustomDir.resolve("package.json").writeText(packageJson)
 
     if (useYarn) {
         toolingCustomDir.resolve("yarn.lock").writeText(kgpYarnLockFileContent)
@@ -104,7 +116,6 @@ private fun createCustomKgpNpmToolingDependenciesDir(
     }
 }
 
-@OptIn(ExperimentalWasmDsl::class)
 private fun TestProject.setCustomKgpNpmToolingDependenciesDir(
     toolingCustomDir: Path,
 ) {
@@ -124,7 +135,6 @@ private fun TestProject.setCustomKgpNpmToolingDependenciesDir(
  * Used to test if users can specify custom npm/yarn executable locations,
  * meaning KGP does not need to install them.
  */
-@OptIn(ExperimentalWasmDsl::class)
 private fun TestProject.registerCustomNpmToolingInstallTask(
     useYarn: Boolean,
     toolingCustomDir: Path,
@@ -156,7 +166,14 @@ private fun TestProject.registerCustomNpmToolingInstallTask(
             }
 
             val installArgs = if (useYarn) {
-                project.rootProject.extensions.getByType(WasmYarnRootEnvSpec::class.java).executable.map { listOf(it) }
+                project.rootProject.extensions.getByType(WasmYarnRootEnvSpec::class.java).executable.map { yarnExecutable ->
+                    listOf(
+                        yarnExecutable,
+                        "install",
+                        "--ignore-scripts",
+                        "--frozen-lockfile",
+                    )
+                }
             } else {
                 project.provider {
                     listOf("install", "--ignore-scripts")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmPackageVersion.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmPackageVersion.kt
@@ -19,3 +19,39 @@ data class NpmPackageVersion(
     override fun createDependency(objectFactory: ObjectFactory, scope: NpmDependency.Scope): Dependency =
         NpmDependency(objectFactory, scope, name, version)
 }
+
+/**
+ * Describes an npm dependency, in addition to the requested and resolved versions.
+ */
+// This class was added because it's hard to modify NpmPackageVersion.
+// See KT-88160.
+internal data class NpmPackageVersionInternal(
+    @Input
+    val name: String,
+    /**
+     * The version originally requested in a `package.json` dependencies block.
+     * Typically this will be a dynamic version, e.g. `^1.0.0`.
+     *
+     * This version is used create a `package.json` in the shared `kotlin-npm-tooling` directory.
+     */
+    @Input
+    val requestedVersion: String,
+    /**
+     * The exact resolved version, from `package-lock.json`.
+     *
+     * This is the same version exposed to users in [NpmPackageVersion.version].
+     */
+    @Input
+    val resolvedVersion: String,
+)
+
+internal fun NpmVersions.allDependenciesInternal(): List<NpmPackageVersionInternal> =
+    allDependencies.map { npv ->
+        val requestedVersion = requestedVersions[npv]
+            ?: error("NpmVersions is missing requestedVersion for ${npv.name}")
+        NpmPackageVersionInternal(
+            name = npv.name,
+            requestedVersion = requestedVersion,
+            resolvedVersion = npv.version,
+        )
+    }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinToolingSetupTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinToolingSetupTask.kt
@@ -12,7 +12,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersion
+import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersionInternal
 import org.jetbrains.kotlin.gradle.targets.js.npm.NodeJsEnvironmentTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.NpmProject
 import org.jetbrains.kotlin.gradle.targets.js.npm.PackageJson
@@ -47,7 +47,7 @@ internal constructor() :
     internal abstract val versionsHash: Property<String>
 
     @get:Nested
-    internal abstract val tools: ListProperty<NpmPackageVersion>
+    internal abstract val tools: ListProperty<NpmPackageVersionInternal>
 
     @get:OutputDirectory
     abstract val destination: DirectoryProperty
@@ -77,7 +77,7 @@ internal constructor() :
                 ).apply {
                     private = true
                     dependencies.putAll(
-                        tools.get().map { it.name to it.version }
+                        tools.get().map { it.name to it.requestedVersion }
                     )
                 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootPlugin.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.targets.wasm.nodejs
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.targets.js.allDependenciesInternal
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.TASKS_GROUP_NAME
 import org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask
@@ -72,7 +73,7 @@ abstract class WasmNodeJsRootPlugin internal constructor() : CommonNodeJsRootPlu
 
         val packageManagerName = nodeJsRoot.packageManagerExtension.map { it.name }
 
-        val allDeps = nodeJsRoot.versions.allDependencies
+        val allDeps = nodeJsRoot.versions.allDependenciesInternal()
 
         val npmTooling = target.extensions.create(
             "wasmNpmTooling",

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNpmTooling.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNpmTooling.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.gradle.targets.wasm.nodejs
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
-import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersion
+import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersionInternal
 import org.jetbrains.kotlin.gradle.targets.web.nodejs.NpmToolingEnv
 import org.jetbrains.kotlin.gradle.utils.getFile
 import org.jetbrains.kotlin.gradle.utils.toHexString
@@ -29,14 +29,15 @@ abstract class WasmNpmTooling internal constructor() {
 
     abstract val installationDir: DirectoryProperty
 
-    internal abstract val allDeps: ListProperty<NpmPackageVersion>
+    internal abstract val allDeps: ListProperty<NpmPackageVersionInternal>
 
     fun produceEnv(): Provider<NpmToolingEnv> {
         return allDeps.map { allDepsValue ->
             val md = MessageDigest.getInstance("MD5")
-            allDepsValue.forEach { (name, version) ->
-                md.update(name.toByteArray(StandardCharsets.UTF_8))
-                md.update(version.toByteArray(StandardCharsets.UTF_8))
+            allDepsValue.forEach { dep ->
+                md.update(dep.name.toByteArray(StandardCharsets.UTF_8))
+                md.update(dep.requestedVersion.toByteArray(StandardCharsets.UTF_8))
+                md.update(dep.resolvedVersion.toByteArray(StandardCharsets.UTF_8))
             }
 
             val hashVersion = md.digest().toHexString()

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmVersionsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmVersionsTest.kt
@@ -8,6 +8,8 @@ package org.jetbrains.kotlin.gradle.targets.js
 import org.jetbrains.kotlin.gradle.testing.prettyPrinted
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class NpmVersionsTest {
@@ -62,5 +64,15 @@ class NpmVersionsTest {
         val karmaVersion = NpmVersions().karma.version
         val expectedPrefix = "github:Kotlin/karma#"
         assertTrue(karmaVersion.startsWith(expectedPrefix), "Karma version should start with $expectedPrefix, but was $karmaVersion")
+    }
+
+    @Test
+    fun `verify all dependencies have a requested version`() {
+        val npmVersions = NpmVersions()
+        assertAll(
+            npmVersions.allDependencies.map {
+                { assertContains(npmVersions.requestedVersions, it) }
+            }
+        )
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/targets/web/KotlinNpmToolingLockFilesTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/targets/web/KotlinNpmToolingLockFilesTest.kt
@@ -3,11 +3,8 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-@file:OptIn(ExperimentalSerializationApi::class)
-
 package org.jetbrains.kotlin.gradle.targets.web
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import org.jetbrains.kotlin.gradle.targets.js.NpmVersions
 import org.jetbrains.kotlin.gradle.targets.web.KotlinNpmToolingLockFilesTest.Companion.packageLockJson
@@ -82,14 +79,19 @@ class KotlinNpmToolingLockFilesTest {
     /**
      * The npm `package-lock.json` file must not have a version.
      *
-     * ```json
+     * ```json5
      * {
      *   "name": "kotlin-npm-tooling",
      *   "packages": {
      *     "": {
-     *       "name": "kotlin-npm-tooling",
-     *       "version": "...", // forbidden!
-     *       "dependencies": { /* ... */ }
+     *     "name": "kotlin-npm-tooling",
+     *     "version": "...", // forbidden!
+     *     "dependencies": {
+     *         // ...
+     *       }
+     *     }
+     *   }
+     * }
      * ```
      *
      * The lockfile is used in a shared directory, which can be used by multiple projects

--- a/repo/gradle-build-conventions/kgp-npm-tooling-helper/src/main/kotlin/tasks/GenerateNpmVersionsKotlinClassTask.kt
+++ b/repo/gradle-build-conventions/kgp-npm-tooling-helper/src/main/kotlin/tasks/GenerateNpmVersionsKotlinClassTask.kt
@@ -50,21 +50,18 @@ internal constructor() : DefaultTask() {
         val dependenciesWithActualVersions = computeDependencyVersions()
 
         val npmVersions = createNpmVersionsClass(
-            dependencyVersions = dependenciesWithActualVersions
+            dependencies = dependenciesWithActualVersions
         )
 
         createNpmVersionsFile(npmVersions)
     }
 
     /**
-     * Determine the resolved versions of dependencies of the root package.
+     * Determine the requested and resolved versions of dependencies of the root package.
      *
      * ### Implementation
      *
      * First, get the names of the root package's dependencies.
-     *
-     * Ignore the versions of the root package's dependencies:
-     * they are the requested versions, which might not match the resolved versions.
      *
      * Next, determine the resolved version for each root package dependency.
      *
@@ -73,7 +70,7 @@ internal constructor() : DefaultTask() {
      * For example, the requested version of `is-even` is `^1.0.0` (note the pinned version),
      * but the resolved version is `1.0.1` (which is not pinned).
      *
-     * ```json
+     * ```json5
      * // package-lock.json
      * {
      *   "name": "kotlin-npm-tooling",
@@ -83,14 +80,15 @@ internal constructor() : DefaultTask() {
      *       "dependencies": {
      *         "is-even": "^1.0.0"
      *       }
+     *     },
      *     "node_modules/is-even": {
-     *       "version": "1.0.1"
+     *         "version": "1.0.1"
      *     }
      *   }
      * }
      * ```
      */
-    private fun computeDependencyVersions(): Map<String, String> {
+    private fun computeDependencyVersions(): SortedSet<NpmDep> {
         val npmLockFile = npmLockFile.get().asFile
 
         val packageLockJson = PackageLockJson.decodeFromString(npmLockFile.readText())
@@ -98,48 +96,54 @@ internal constructor() : DefaultTask() {
         val rootPackage = packageLockJson.packages[""]
         requireNotNull(rootPackage) { "Missing root package in ${npmLockFile.invariantSeparatorsPath}" }
 
-        return rootPackage.dependencies.mapValues { (id, _) ->
+        return rootPackage.dependencies.map { (id, requestedVersion) ->
+
             val entry = packageLockJson.packages["node_modules/$id"]
                 ?: error("Missing entry for $id in ${npmLockFile.invariantSeparatorsPath}")
 
-            when {
-                // Must use the requested version if the dep is resolved from a git url,
-                // https://docs.npmjs.com/cli/v11/configuring-npm/package-json#git-urls-as-dependencies
-                // because `version` is inaccurate for git URLs
-                // (Example: Kotlin Karma has a git tag of v6.4.5, but the package version is 6.4.4.)
-                entry.resolved != null && entry.resolved.startsWith("git+") ->
-                    packageLockJson.packages[""]?.dependencies?.get(id)
-                entry.version != null ->
-                    entry.version
-                else ->
-                    null
-            } ?: error("Could not find version for $id in ${npmLockFile.invariantSeparatorsPath}. $entry")
-        }
+            val resolvedVersion =
+                when {
+                    // Must use the requested version if the dep is resolved from a git url,
+                    // https://docs.npmjs.com/cli/v11/configuring-npm/package-json#git-urls-as-dependencies
+                    // because `version` is inaccurate for git URLs
+                    // (Example: Kotlin Karma has a git tag of v6.4.5, but the package version is 6.4.4.)
+                    entry.resolved != null && entry.resolved.startsWith("git+") ->
+                        requestedVersion
+                    entry.version != null ->
+                        entry.version
+                    else ->
+                        null
+                } ?: error("Could not find version for $id in ${npmLockFile.invariantSeparatorsPath}. $entry")
+
+            NpmDep(
+                name = id,
+                requestedVersion = requestedVersion,
+                resolvedVersion = resolvedVersion,
+            )
+        }.toSortedSet()
+    }
+
+    private class NpmDep(
+        val name: String,
+        val requestedVersion: String,
+        val resolvedVersion: String,
+    ) : Comparable<NpmDep> {
+        /**
+         * Pretty camelCased display name, for use as a Kotlin property name.
+         */
+        val displayName: String =
+            name.removePrefix("@")
+                .split("-", "/")
+                .joinToString("") { it.replaceFirstChar { c -> c.uppercase(Locale.ROOT) } }
+                .replaceFirstChar { it.lowercase(Locale.ROOT) }
+
+        override fun compareTo(other: NpmDep): Int =
+            displayName.compareTo(other.displayName)
     }
 
     private fun createNpmVersionsClass(
-        dependencyVersions: Map<String, String>,
+        dependencies: SortedSet<NpmDep>,
     ): String {
-        class NpmDep(
-            val name: String,
-            val version: String,
-        ) {
-            /**
-             * Pretty camelCased display name, for use as a Kotlin property name.
-             */
-            val displayName: String =
-                name.removePrefix("@")
-                    .split("-", "/")
-                    .joinToString("") { it.replaceFirstChar { c -> c.uppercase(Locale.ROOT) } }
-                    .replaceFirstChar { it.lowercase(Locale.ROOT) }
-        }
-
-        val dependencies = dependencyVersions
-            .map { (name, version) ->
-                NpmDep(name, version)
-            }
-            .sortedBy { it.displayName }
-
         return buildString {
             appendLine(copyrightHeader.get().asFile.readText())
             appendLine("package org.jetbrains.kotlin.gradle.targets.js")
@@ -148,16 +152,27 @@ internal constructor() : DefaultTask() {
             appendLine()
             appendLine("/**")
             appendLine(" * Versions of npm dependencies used by Kotlin Gradle plugin.")
+            appendLine(" *")
+            appendLine(" * The versions are the resolved versions, extracted from KGP's `kotlin-npm-tooling/package-lock.json`.")
             appendLine(" */")
             appendLine("// Generated class. Do not modify directly!")
             appendLine("class $npmVersionsClassName : Serializable {")
             dependencies.forEach { dep ->
-                appendLine("    val ${dep.displayName} = NpmPackageVersion(\"${dep.name}\", \"${dep.version}\")")
+                appendLine("    val ${dep.displayName} = NpmPackageVersion(\"${dep.name}\", \"${dep.resolvedVersion}\")")
             }
             appendLine()
             appendLine("    val allDependencies: List<NpmPackageVersion> = listOf(")
             dependencies.forEach { dep ->
                 appendLine("        ${dep.displayName},")
+            }
+            appendLine("    )")
+            appendLine()
+            appendLine("    /**")
+            appendLine("     * The original requested versions from KGP's `kotlin-npm-tooling/package.json`.")
+            appendLine("     */")
+            appendLine("    internal val requestedVersions: Map<NpmPackageVersion, String> = mapOf(")
+            dependencies.forEach { dep ->
+                appendLine("        ${dep.displayName} to \"${dep.requestedVersion}\",")
             }
             appendLine("    )")
             appendLine("}")


### PR DESCRIPTION
If the versions of `package.json` and `yarn.lock` don't exactly match then Yarn will re-resolve the dependency graph.
This is a problem for 'offline' users - if 'offline' is enabled then Yarn will fail.

The fix is for KGP to also track the _requested_ versions from the `package.json`.
KGP will use the requested versions to create the `package.json` in the shared `kotlin-npm-tooling` directory.

^KT-88115
