### PR TITLE
[Gradle] Make kotlin.project.persistent.dir support external dirs

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
@@ -15,13 +15,11 @@ import org.jetbrains.kotlin.gradle.testbase.buildScriptBuildscriptBlockInjection
 import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
 import org.jetbrains.kotlin.gradle.testbase.project
 import org.jetbrains.kotlin.gradle.testbase.projectPersistentCache
-import org.jetbrains.kotlin.gradle.testbase.settingsBuildScriptInjection
 import org.jetbrains.kotlin.gradle.testbase.source
 import org.jetbrains.kotlin.gradle.testbase.transferPluginRepositoriesIntoBuildScript
 import org.junit.jupiter.api.DisplayName
 import java.io.File
 import java.nio.file.Path
-import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.pathString
@@ -38,7 +36,6 @@ class PersistentCacheDirIT : KGPBaseTest() {
         project("empty", gradleVersion) {
             configureMultiModuleJvmProject(
                 kotlinProjectPersistentDir = null,
-                kotlinVersion = defaultBuildOptions.kotlinVersion,
             )
 
             build(":app:compileKotlin")
@@ -54,7 +51,6 @@ class PersistentCacheDirIT : KGPBaseTest() {
             val persistentDir = "custom-kotlin-persistent-dir"
             configureMultiModuleJvmProject(
                 kotlinProjectPersistentDir = persistentDir,
-                kotlinVersion = defaultBuildOptions.kotlinVersion,
             )
 
             build(":app:compileKotlin")
@@ -70,7 +66,6 @@ class PersistentCacheDirIT : KGPBaseTest() {
             val persistentDir = projectPath.parent.resolve("absolute-kotlin-persistent-dir")
             configureMultiModuleJvmProject(
                 kotlinProjectPersistentDir = persistentDir.pathString,
-                kotlinVersion = defaultBuildOptions.kotlinVersion,
             )
 
             build(":app:compileKotlin")
@@ -86,7 +81,6 @@ class PersistentCacheDirIT : KGPBaseTest() {
             val persistentDir = "../relative-outside-kotlin-persistent-dir"
             configureMultiModuleJvmProject(
                 kotlinProjectPersistentDir = persistentDir,
-                kotlinVersion = defaultBuildOptions.kotlinVersion,
             )
 
             build(":app:compileKotlin")
@@ -101,7 +95,6 @@ class PersistentCacheDirIT : KGPBaseTest() {
         project("empty", gradleVersion) {
             configureMultiModuleJvmProject(
                 kotlinProjectPersistentDir = "~/.kotlin-project-persistent-dir",
-                kotlinVersion = defaultBuildOptions.kotlinVersion,
             )
 
             build(":app:compileKotlin")
@@ -112,7 +105,6 @@ class PersistentCacheDirIT : KGPBaseTest() {
 
     private fun TestProject.configureMultiModuleJvmProject(
         kotlinProjectPersistentDir: String?,
-        kotlinVersion: String,
     ) {
         if (kotlinProjectPersistentDir != null) {
             gradleProperties.writeText(
@@ -123,44 +115,29 @@ class PersistentCacheDirIT : KGPBaseTest() {
             )
         }
 
-        settingsBuildScriptInjection {
-            settings.include(":lib", ":app")
-        }
-
         transferPluginRepositoriesIntoBuildScript()
+
+        val kotlinVersion = buildOptions.kotlinVersion
         buildScriptBuildscriptBlockInjection {
             buildscript.configurations.getByName("classpath").dependencies.add(
                 buildscript.dependencies.create("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
             )
         }
 
-        listOf("lib", "app").forEach { subprojectName ->
-            val subproject = projectPath.resolve(subprojectName)
-            subproject.source("build.gradle") { "" }
-            subproject.createDirectories()
-            subproject.resolve("src/main/kotlin").createDirectories()
-
-            subProject(subprojectName).buildScriptInjection {
+        includeOtherProjectAsSubmodule("empty", newSubmoduleName = "lib") {
+            buildScriptInjection {
                 project.plugins.apply("org.jetbrains.kotlin.jvm")
-                if (subprojectName == "app") {
-                    project.dependencies.add("implementation", project.dependencies.project(mapOf("path" to ":lib")))
-                }
             }
+            kotlinSourcesDir().source("Lib.kt") { """fun lib(): String = "lib"""" }
         }
 
-        projectPath.resolve("lib/src/main/kotlin/Lib.kt").writeText(
-            """
-            fun lib(): String = "lib"
-            
-            """.trimIndent()
-        )
-
-        projectPath.resolve("app/src/main/kotlin/App.kt").writeText(
-            """
-            fun app(): String = lib()
-            
-            """.trimIndent()
-        )
+        includeOtherProjectAsSubmodule("empty", newSubmoduleName = "app") {
+            buildScriptInjection {
+                project.plugins.apply("org.jetbrains.kotlin.jvm")
+                project.dependencies.add("implementation", project.dependencies.project(mapOf("path" to ":lib")))
+            }
+            kotlinSourcesDir().source("App.kt") { """fun app(): String = lib()""" }
+        }
     }
 
     private fun assertKotlinPersistentDirCreated(persistentDir: Path) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
@@ -10,13 +10,12 @@ import org.jetbrains.kotlin.gradle.testbase.GradleTest
 import org.jetbrains.kotlin.gradle.testbase.JvmGradlePluginTests
 import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
 import org.jetbrains.kotlin.gradle.testbase.TestProject
+import org.jetbrains.kotlin.gradle.testbase.addKgpToBuildScriptCompilationClasspath
 import org.jetbrains.kotlin.gradle.testbase.build
-import org.jetbrains.kotlin.gradle.testbase.buildScriptBuildscriptBlockInjection
 import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
 import org.jetbrains.kotlin.gradle.testbase.project
 import org.jetbrains.kotlin.gradle.testbase.projectPersistentCache
 import org.jetbrains.kotlin.gradle.testbase.source
-import org.jetbrains.kotlin.gradle.testbase.transferPluginRepositoriesIntoBuildScript
 import org.junit.jupiter.api.DisplayName
 import java.io.File
 import java.nio.file.Path
@@ -115,14 +114,7 @@ class PersistentCacheDirIT : KGPBaseTest() {
             )
         }
 
-        transferPluginRepositoriesIntoBuildScript()
-
-        val kotlinVersion = buildOptions.kotlinVersion
-        buildScriptBuildscriptBlockInjection {
-            buildscript.configurations.getByName("classpath").dependencies.add(
-                buildscript.dependencies.create("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-            )
-        }
+        addKgpToBuildScriptCompilationClasspath()
 
         includeOtherProjectAsSubmodule("empty", newSubmoduleName = "lib") {
             buildScriptInjection {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle
+
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.testbase.GradleTest
+import org.jetbrains.kotlin.gradle.testbase.JvmGradlePluginTests
+import org.jetbrains.kotlin.gradle.testbase.KGPBaseTest
+import org.jetbrains.kotlin.gradle.testbase.TestProject
+import org.jetbrains.kotlin.gradle.testbase.build
+import org.jetbrains.kotlin.gradle.testbase.buildScriptBuildscriptBlockInjection
+import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
+import org.jetbrains.kotlin.gradle.testbase.project
+import org.jetbrains.kotlin.gradle.testbase.projectPersistentCache
+import org.jetbrains.kotlin.gradle.testbase.settingsBuildScriptInjection
+import org.jetbrains.kotlin.gradle.testbase.source
+import org.jetbrains.kotlin.gradle.testbase.transferPluginRepositoriesIntoBuildScript
+import org.junit.jupiter.api.DisplayName
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.pathString
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+
+@DisplayName("Kotlin project persistent cache directory")
+@JvmGradlePluginTests
+class PersistentCacheDirIT : KGPBaseTest() {
+
+    @GradleTest
+    @DisplayName("default .kotlin directory is created")
+    fun testDefaultPersistentDir(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion) {
+            configureMultiModuleJvmProject(
+                kotlinProjectPersistentDir = null,
+                kotlinVersion = defaultBuildOptions.kotlinVersion,
+            )
+
+            build(":app:compileKotlin")
+
+            assertKotlinPersistentDirCreated(projectPersistentCache)
+        }
+    }
+
+    @GradleTest
+    @DisplayName("project-local kotlin.project.persistent.dir is resolved relative to the root project")
+    fun testProjectLocalPersistentDir(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion) {
+            val persistentDir = "custom-kotlin-persistent-dir"
+            configureMultiModuleJvmProject(
+                kotlinProjectPersistentDir = persistentDir,
+                kotlinVersion = defaultBuildOptions.kotlinVersion,
+            )
+
+            build(":app:compileKotlin")
+
+            assertKotlinPersistentDirCreated(projectPath.resolve(persistentDir))
+        }
+    }
+
+    @GradleTest
+    @DisplayName("absolute kotlin.project.persistent.dir is used as is")
+    fun testAbsolutePersistentDir(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion) {
+            val persistentDir = projectPath.parent.resolve("absolute-kotlin-persistent-dir")
+            configureMultiModuleJvmProject(
+                kotlinProjectPersistentDir = persistentDir.pathString,
+                kotlinVersion = defaultBuildOptions.kotlinVersion,
+            )
+
+            build(":app:compileKotlin")
+
+            assertKotlinPersistentDirCreated(persistentDir)
+        }
+    }
+
+    @GradleTest
+    @DisplayName("relative kotlin.project.persistent.dir outside the project is resolved relative to the root project")
+    fun testRelativeOutsideProjectPersistentDir(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion) {
+            val persistentDir = "../relative-outside-kotlin-persistent-dir"
+            configureMultiModuleJvmProject(
+                kotlinProjectPersistentDir = persistentDir,
+                kotlinVersion = defaultBuildOptions.kotlinVersion,
+            )
+
+            build(":app:compileKotlin")
+
+            assertKotlinPersistentDirCreated(projectPath.resolve(persistentDir).normalize())
+        }
+    }
+
+    @GradleTest
+    @DisplayName("tilde in kotlin.project.persistent.dir is not expanded to user home")
+    fun testTildePersistentDirIsTreatedAsProjectRelativePath(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion) {
+            configureMultiModuleJvmProject(
+                kotlinProjectPersistentDir = "~/.kotlin-project-persistent-dir",
+                kotlinVersion = defaultBuildOptions.kotlinVersion,
+            )
+
+            build(":app:compileKotlin")
+
+            assertKotlinPersistentDirCreated(projectPath.resolve("~/.kotlin-project-persistent-dir"))
+        }
+    }
+
+    private fun TestProject.configureMultiModuleJvmProject(
+        kotlinProjectPersistentDir: String?,
+        kotlinVersion: String,
+    ) {
+        if (kotlinProjectPersistentDir != null) {
+            gradleProperties.writeText(
+                """
+            kotlin.project.persistent.dir=${kotlinProjectPersistentDir.replace(File.separatorChar, '/')}
+            
+            """.trimIndent()
+            )
+        }
+
+        settingsBuildScriptInjection {
+            settings.include(":lib", ":app")
+        }
+
+        transferPluginRepositoriesIntoBuildScript()
+        buildScriptBuildscriptBlockInjection {
+            buildscript.configurations.getByName("classpath").dependencies.add(
+                buildscript.dependencies.create("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+            )
+        }
+
+        listOf("lib", "app").forEach { subprojectName ->
+            val subproject = projectPath.resolve(subprojectName)
+            subproject.source("build.gradle") { "" }
+            subproject.createDirectories()
+            subproject.resolve("src/main/kotlin").createDirectories()
+
+            subProject(subprojectName).buildScriptInjection {
+                project.plugins.apply("org.jetbrains.kotlin.jvm")
+                if (subprojectName == "app") {
+                    project.dependencies.add("implementation", project.dependencies.project(mapOf("path" to ":lib")))
+                }
+            }
+        }
+
+        projectPath.resolve("lib/src/main/kotlin/Lib.kt").writeText(
+            """
+            fun lib(): String = "lib"
+            
+            """.trimIndent()
+        )
+
+        projectPath.resolve("app/src/main/kotlin/App.kt").writeText(
+            """
+            fun app(): String = lib()
+            
+            """.trimIndent()
+        )
+    }
+
+    private fun assertKotlinPersistentDirCreated(persistentDir: Path) {
+        assertTrue(
+            persistentDir.exists() && persistentDir.isDirectory(),
+            "Expected Kotlin project persistent directory to be created: $persistentDir"
+        )
+        assertTrue(
+            persistentDir.resolve("sessions").exists() && persistentDir.resolve("sessions").isDirectory(),
+            "Expected Kotlin sessions directory to be created under: $persistentDir"
+        )
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/PersistentCacheDirIT.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.gradle.testbase.project
 import org.jetbrains.kotlin.gradle.testbase.projectPersistentCache
 import org.jetbrains.kotlin.gradle.testbase.source
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.exists
@@ -28,6 +29,8 @@ import kotlin.test.assertTrue
 @DisplayName("Kotlin project persistent cache directory")
 @JvmGradlePluginTests
 class PersistentCacheDirIT : KGPBaseTest() {
+    @TempDir
+    lateinit var tempDir: Path
 
     @GradleTest
     @DisplayName("default .kotlin directory is created")
@@ -62,7 +65,7 @@ class PersistentCacheDirIT : KGPBaseTest() {
     @DisplayName("absolute kotlin.project.persistent.dir is used as is")
     fun testAbsolutePersistentDir(gradleVersion: GradleVersion) {
         project("empty", gradleVersion) {
-            val persistentDir = projectPath.parent.resolve("absolute-kotlin-persistent-dir")
+            val persistentDir = tempDir.resolve("absolute-kotlin-persistent-dir")
             configureMultiModuleJvmProject(
                 kotlinProjectPersistentDir = persistentDir.pathString,
             )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/fileUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/fileUtils.kt
@@ -65,18 +65,14 @@ internal fun Iterable<File>.toPathsArray(): Array<String> =
     map { it.normalize().absolutePath }.toTypedArray()
 
 internal fun newTmpFile(prefix: String, suffix: String? = null, directory: File? = null, deleteOnExit: Boolean = true): File {
-    return try {
-        (if (directory == null) Files.createTempFile(prefix, suffix) else Files.createTempFile(directory.toPath(), prefix, suffix))
-    } catch (e: NoSuchFileException) {
-        val parentDir = e.file.parentFile
-
-        if (parentDir.isFile) throw IOException("Temp folder $parentDir is not a directory")
-        if (!parentDir.isDirectory) {
-            if (!parentDir.mkdirs()) throw IOException("Could not create temp directory $parentDir")
-        }
-
-        Files.createTempFile(parentDir.toPath(), prefix, suffix)
-    }.toFile().apply { if (deleteOnExit) deleteOnExit() }
+    val tempFile = if (directory == null) {
+        Files.createTempFile(prefix, suffix)
+    } else {
+        val tempDir = directory.toPath()
+        Files.createDirectories(tempDir)
+        Files.createTempFile(tempDir, prefix, suffix)
+    }
+    return tempFile.toFile().apply { if (deleteOnExit) deleteOnExit() }
 }
 
 internal fun File.isParentOf(childCandidate: File, strict: Boolean = false): Boolean {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/persistentCaches.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/persistentCaches.kt
@@ -18,9 +18,11 @@ internal val Project.userKotlinPersistentDir
     get() = kotlinPropertiesProvider.kotlinUserHomeDir?.let { File(it) }
         ?: File(System.getProperty("user.home")).resolve(".kotlin")
 
-internal fun Project.projectKotlinPersistentDir(compositeRootProject: Project? = null) =
-    kotlinPropertiesProvider.kotlinProjectPersistentDir?.let { File(it) }
-        ?: (compositeRootProject ?: this).rootDir.resolve(".kotlin")
+internal fun Project.projectKotlinPersistentDir(compositeRootProject: Project? = null): File {
+    val rootProject = compositeRootProject ?: rootProject
+    val persistentDir = kotlinPropertiesProvider.kotlinProjectPersistentDir ?: ".kotlin"
+    return rootProject.projectDir.resolve(persistentDir)
+}
 
 internal val Project.kotlinSessionsDir
     get() = projectKotlinPersistentDir().resolve(SESSIONS_DIR_NAME)


### PR DESCRIPTION
Prior to this change, the directory for the
kotlin.project.persistent.dir path was being created using the File() constructor, which would resolve relative paths against the directory where JVM was invoked. The change uses a combination of Gradle and kotlin.io APIs to make sure relative paths are resolved against the root (or composite root) project directory.

This change also fixes a number of issues with the utility used to create temporary files, to make sure it works correctly when a shared parent directory is created by multiple tasks simultaneously.

^KT-69336 Verification Pending