### PR TITLE
[Wasm, Tests] Test infra: extend WASM_IGNORE_FOR with runner=... and mute tests related to KT-88235

### DIFF
--- a/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClassSameJvmType.kt
+++ b/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClassSameJvmType.kt
@@ -1,3 +1,5 @@
+// WASM_IGNORE_FOR: os=windows mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+// ^^^ KT-88235
 // WITH_STDLIB
 // WITH_COROUTINES
 

--- a/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClass_NullableAny.kt
+++ b/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClass_NullableAny.kt
@@ -1,3 +1,5 @@
+// WASM_IGNORE_FOR: os=windows mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+// ^^^ KT-88235
 // WITH_STDLIB
 // WITH_COROUTINES
 

--- a/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClass_NullableAny_null.kt
+++ b/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClass_NullableAny_null.kt
@@ -1,3 +1,5 @@
+// WASM_IGNORE_FOR: os=windows mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+// ^^^ KT-88235
 // WITH_STDLIB
 // WITH_COROUTINES
 

--- a/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClass_NullableInt.kt
+++ b/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/covariantOverrideSuspendFunWithNullableInlineClass_NullableInt.kt
@@ -1,3 +1,5 @@
+// WASM_IGNORE_FOR: os=windows mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+// ^^^ KT-88235
 // WITH_STDLIB
 // WITH_COROUTINES
 

--- a/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/genericOverrideSuspendFun_Any_NullableInlineClassUpperBound.kt
+++ b/compiler/testData/codegen/box/coroutines/inlineClasses/resumeWithException/genericOverrideSuspendFun_Any_NullableInlineClassUpperBound.kt
@@ -1,3 +1,5 @@
+// WASM_IGNORE_FOR: os=windows mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+// ^^^ KT-88235
 // WITH_STDLIB
 // WITH_COROUTINES
 

--- a/compiler/testData/codegen/box/typeErasure/outerClassWithTypeParameterWithUpperBoundAndInlineFunctionWithReifiedTypeParameterWithTwoUpperBounds.kt
+++ b/compiler/testData/codegen/box/typeErasure/outerClassWithTypeParameterWithUpperBoundAndInlineFunctionWithReifiedTypeParameterWithTwoUpperBounds.kt
@@ -1,3 +1,5 @@
+// WASM_IGNORE_FOR: os=windows mode=multi-module
+// ^^^ KT-88235
 // DUMP_IR_OF_PREPROCESSED_INLINE_FUNCTIONS
 // WITH_REFLECT
 // WITH_STDLIB

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/utils/WasmDirectiveUtils.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/utils/WasmDirectiveUtils.kt
@@ -6,6 +6,9 @@
 package org.jetbrains.kotlin.test.utils
 
 import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmCompilationMode
+import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerTest
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSuperclassOf
 
 /**
  * For each of these, *null means all*, e.g., if `os` is null, the config expects the test to fail regardless of the OS
@@ -14,12 +17,14 @@ data class WasmIgnoreForConfig(
     val mode: WasmCompilationMode? = null,
     val os: String? = null,
     val vmName: String? = null,
+    val runner: KClass<*>? = null,
 ) {
     override fun toString(): String {
         val props = listOfNotNull(
             mode?.let { "mode=$it" },
             os?.let { "os=$it" },
-            vmName?.let { "vm=$it" }).joinToString(" ")
+            vmName?.let { "vm=$it" },
+            runner?.let { "runner=$it" }).joinToString(" ")
         return "WASM_IGNORE_FOR: $props"
     }
 }
@@ -46,24 +51,35 @@ fun wasmIgnoreForParser(raw: String): WasmIgnoreForConfig? {
         System.err.println("Directive $raw does not specify any properties to base the suppressor on.\nIf this is an intentional catch-all suppression, use IGNORE_BACKEND")
         return null
     }
-    if (parts.keys.any { it !in listOf("mode", "os", "vm") }) {
-        System.err.println("Invalid key specified in directive $raw, only know keys 'mode', 'os', 'vm'")
+    if (parts.keys.any { it !in listOf("mode", "os", "vm", "runner") }) {
+        System.err.println("Invalid key specified in directive $raw, only know keys 'mode', 'os', 'vm', 'runner")
         return null
     }
     if (parts["os"]?.lowercase() !in listOf(null, "linux", "windows", "mac")) {
         System.err.println("Invalid OS specified in WASM_IGNORE_FOR directive: os=${parts["os"]}. Must be linux, windows, or mac (case insensitive)")
         return null
     }
+    val runnerKClass = if (parts["runner"] != null) {
+        try {
+            val runnerKClass = Class.forName(parts["runner"]).kotlin
+            runnerKClass
+        } catch (e: ClassNotFoundException) {
+            System.err.println("Invalid runner specified in WASM_IGNORE_FOR directive: runner=${parts["runner"]}. Must be a valid ***fully-qualified*** class name")
+            return null
+        }
+    } else null
+
     // NOTE: mode mismatch will be caught by WasmCompilationMode.valueOf
     // NOTE: vm mismatches will be caught by the test itself, i.e. it will fail, or warn that it should be unmuted,
     //       if the config is wrong.
-    //       There's unfortunately no non-hardcoded way to check all WasmVMs, without kotlin-reflections,
-    //       and adding a module dependency on the testFixtures module.
+    //       There's unfortunately no non-hardcoded way to check all WasmVMs,
+    //       without adding a module dependency on the testFixtures module.
 
     return WasmIgnoreForConfig(
         mode = parts["mode"]?.let { WasmCompilationMode.valueOf(it.uppercase().replace('-', '_')) },
         os = parts["os"]?.lowercase(),
         vmName = parts["vm"],
+        runner = runnerKClass
     )
 }
 

--- a/wasm/wasm.tests/build.gradle.kts
+++ b/wasm/wasm.tests/build.gradle.kts
@@ -165,6 +165,7 @@ configurations.create("wasmtime") {
 }
 
 dependencies {
+    testFixturesImplementation(commonDependency("org.jetbrains.kotlin:kotlin-reflect")) { isTransitive = false }
     testFixturesApi(testFixtures(project(":compiler:tests-common")))
     testFixturesApi(testFixtures(project(":compiler:tests-common-new")))
     testFixturesApi(testFixtures(project(":js:js.tests")))

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/utils/DirectiveTestUtils.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/utils/DirectiveTestUtils.kt
@@ -16,13 +16,14 @@ import org.jetbrains.kotlin.test.services.*
 import org.jetbrains.kotlin.test.utils.WasmIgnoreForConfig
 import org.jetbrains.kotlin.wasm.ir.WasmModule
 import org.jetbrains.kotlin.wasm.ir.WasmOp
+import org.jetbrains.kotlin.wasm.test.AbstractFirWasmJsSteppingTest
 import org.jetbrains.kotlin.wasm.test.handlers.WasiBoxRunner
 import org.jetbrains.kotlin.wasm.test.handlers.WasmBoxRunnerBase
 import org.jetbrains.kotlin.wasm.test.handlers.WasmVMException
 import org.jetbrains.kotlin.wasm.test.tools.WasmVM
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.function.Executable
+import kotlin.reflect.full.isSuperclassOf
 
 object DirectiveTestUtils {
 
@@ -207,7 +208,8 @@ object DirectiveTestUtils {
         targetBackend: TargetBackend,
     ) {
         assertAll(
-            DIRECTIVE_HANDLERS.map { handler -> Executable {
+            DIRECTIVE_HANDLERS.map { handler ->
+                Executable {
                     handler.process(module, sourceCode, targetBackend)
                 }
             }
@@ -340,6 +342,9 @@ private class WasmIgnoredTestSuppressorGroup(
                 if (hasVmMismatchInConcreteFailure(failedAssertion))
                     return@filter true
 
+                if (hasRunnerMismatch())
+                    return@filter true
+
                 // we know that all conditions that were specified are met
                 if (inDebugMode)
                     println("------ Suppressing test failure because the test is running with $ignoreForConfig (matches current environment)")
@@ -380,6 +385,14 @@ private class WasmIgnoredTestSuppressorGroup(
             return compilerConfiguration.wasmCompilationMode() != mode
         }
 
+        private fun hasRunnerMismatch(): Boolean {
+            val expectedRunnerKClass = ignoreForConfig.runner
+                ?: return false
+
+            return !testServices.testInfo.className.contains(expectedRunnerKClass.qualifiedName!!)
+        }
+
+
         fun checkIfTestShouldBeUnmuted() {
             // This function is only called if the whole test succeeded
 
@@ -390,6 +403,7 @@ private class WasmIgnoredTestSuppressorGroup(
             if (hasModeMismatch()) return
             if (hasOsMismatch()) return
             if (hasMismatchInVMsRun()) return
+            if (hasRunnerMismatch()) return
 
             // All specified conditions match the current environment
             throw AssertionError(


### PR DESCRIPTION
Introduce `// WASM_IGNORE_FOR runner=` to ignore just one runner, and mute tests related to KT-88235 using that new runner= syntax.

See the commit message of the first commit about the design of the `x` argument in `// WASM_IGNORE_FOR runner=x`), and feel free to disagree :)

(this is based on fresh master, not green master because it needs the recently merged #7187, so might have to rebase so that the CI runs through)