### PR TITLE
[PowerAssert] Do not include object literals in the explanation

### DIFF
--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/ExpressionTree.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/ExpressionTree.kt
@@ -206,6 +206,7 @@ fun <T> buildTree(
                         variable.acceptChildren(this, chainNode)
                         chainNode.addChild(ExpressionNode(expression))
                     }
+
                     IrStatementOrigin.ELVIS -> {
                         // Elvis operators are handled with a special node
                         val statements = expression.statements
@@ -245,6 +246,7 @@ fun <T> buildTree(
                             "Expected the when of the elvis expression to consist of exactly two branches.\n${expression.dump()}"
                         }
                     }
+
                     IrStatementOrigin.WHEN -> {
                         // When-with-subject expressions are handled with a special node.
                         val statements = expression.statements
@@ -260,8 +262,17 @@ fun <T> buildTree(
                         variable.acceptChildren(this, chainNode)
                         processWhen(conditional, chainNode, variable)
                     }
+
+                    IrStatementOrigin.OBJECT_LITERAL -> {
+                        // Object literals should not be included in the diagram.
+                        // The source code for the literal will be visible in the diagram,
+                        // and that is likely more useful than a 'toString()' result.
+                        data.addChild(HiddenNode(expression))
+                    }
+
                     else -> {
-                        // Everything else is considered unsafe and terminates the expression tree
+                        // Everything else is considered unsafe and terminates the expression tree,
+                        // but should be included in the diagram to be safe.
                         data.addChild(ExpressionNode(expression))
                     }
                 }

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/lambda/AnonymousObject.box.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/lambda/AnonymousObject.box.txt
@@ -1,18 +1,14 @@
 test1: ---
 assert(object { override fun toString() = "ANONYMOUS" }.toString() == "toString()")
-       |                                                |          |
-       ANONYMOUS                                        |          false
+                                                        |          |
+                                                        |          false
                                                         "ANONYMOUS"
 ---
 test2: ---
 assert(object : A() {
-       |
-       ANONYMOUS
-
     fun foo(): Boolean {
         return a > b
     }
-    override fun toString() = "ANONYMOUS"
 }.foo())
   |
   false

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/lambda/AnonymousObject.kt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/lambda/AnonymousObject.kt
@@ -15,7 +15,6 @@ fun test2(a: Int, b: Int) {
         fun foo(): Boolean {
             return a > b
         }
-        override fun toString() = "ANONYMOUS"
     }.foo())
 }
 


### PR DESCRIPTION
The source code for object literals is already included in the explanation. A `toString()` value for the object will just be noise, since it is likely the function is the default implementation for the platform, and doesn't carry any useful information.

^KT-75877 Fixed