### PR TITLE
[K/N][build] Properly remove per-file caches during cache invalidation

### DIFF
--- a/kotlin-native/tools/compiler-cache-invalidator/src/org/jetbrains/kotlin/nativecacheinvalidator/NativeCacheInvalidator.kt
+++ b/kotlin-native/tools/compiler-cache-invalidator/src/org/jetbrains/kotlin/nativecacheinvalidator/NativeCacheInvalidator.kt
@@ -83,9 +83,34 @@ private fun FingerprintedDistribution.validateStaleCache(cache: Cache): Boolean 
 }
 
 context(logger: Logger)
+private fun FingerprintedDistribution.removeEmptyCacheDirectories() {
+    /*
+    A quick hack for per-file caches after removing stale caches.
+
+    The layout of per-file caches is different from that of regular caches.
+    Basically, a per-file cache is a directory which has regular caches inside.
+    So, after removing stale caches, this directory remains existing but empty.
+    Some parts of the compiler treat its existence that as a sign that the cache already exists and skip the building.
+    This is not right, and leads to KT-87996, for example.
+
+    Just remove empty directories within `systemCacheRoot` to make it more consistent and workaround the issue.
+    Not the best solution, but the easiest one. Considering that this code isn't used in production, this is good enough.
+    */
+    systemCacheRoot.walk()
+            .filter { it.list()?.isEmpty() == true } // Only empty directories
+            .toList() // Just in case, don't delete during the walk: convert `Sequence` to `List` to separate the steps.
+            .forEach {
+                logger.info("Removing empty cache directory ${it.toRelativeString(distributionRoot)}")
+                it.delete()
+            }
+}
+
+context(logger: Logger)
 fun Distribution.invalidateStaleCaches() = with(fingerprinted) {
     collectCaches().forEach {
         if (!validateStaleCache(it))
             it.rootDir.deleteRecursively()
     }
+
+    removeEmptyCacheDirectories()
 }


### PR DESCRIPTION
^KT-87996 Fixed

During the K/N build, the `NativeCacheInvalidator` removes stale caches: for example, if the compiler changes, it removes the caches built with the previous "version". It does that by simply searching for any directories under `dist/klib/cache` that looks like a cache, checking the fingerprints and removing on mismatch.

The layout of per-file caches is different from that of regular caches. Basically, a per-file cache is a directory which has regular caches inside. So, the cache invalidator removes those caches inside that directory, but not the directory itself.

Some parts of the compiler treat the existence of that empty directory as a sign that the cache already exists and skip the building. This is not right, and leads to KT-87996, for example.

This commit applies the easiest trick to avoid that: after removing stale caches, just remove all empty directories within `systemCacheRoot`. So the resulting `klib/cache` contents are more consistent and expected.

Not the best solution, but the easiest one. Considering that this code isn't used in production, this is good enough.