### PR TITLE
BTA: add LruClassLoadersCache

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompilerPlugins/kotlin/ClassLoadersCachingTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompilerPlugins/kotlin/ClassLoadersCachingTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.compilation
+
+import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation
+import org.jetbrains.kotlin.buildtools.api.BuildOperation
+import org.jetbrains.kotlin.buildtools.api.ExecutionPolicy
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogDoesNotContainPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.DefaultStrategyAndPlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectCreator
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+
+class ClassLoadersCachingTest : BaseCompilationTest() {
+    @DefaultStrategyAndPlatformAgnosticCompilationTest
+    @DisplayName("Test that plugins loader is used to cache compiler plugins")
+    fun testPluginsLoaderCache(project: ProjectCreator) {
+        project {
+            assumeTrue(this.defaultStrategyConfig is ExecutionPolicy.InProcess)
+
+            val module = module("sandbox-plugin", moduleCompilationConfigAction = { operation: BaseCompilationOperation.Builder ->
+                operation.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS] = listOf(PLUGIN_SANDBOX_PLUGIN)
+            })
+
+            module.compile(forceOutput = LogLevel.INFO) {
+                assertLogContainsPatterns(LogLevel.INFO, "Creating new classloader for classpath.*".toRegex())
+            }
+            module.compile {
+                assertLogDoesNotContainPatterns(LogLevel.INFO, "Creating new classloader for classpath.*".toRegex())
+            }
+        }
+    }
+
+    @DefaultStrategyAndPlatformAgnosticCompilationTest
+    @DisplayName("Test that plugins loader is not used to cache compiler plugins when disabled")
+    fun testPluginsLoaderCacheDisabled(project: ProjectCreator) {
+        project {
+            assumeTrue(this.defaultStrategyConfig is ExecutionPolicy.InProcess)
+
+            val module = module("sandbox-plugin", moduleCompilationConfigAction = { operation: BaseCompilationOperation.Builder ->
+                operation.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS] = listOf(PLUGIN_SANDBOX_PLUGIN)
+                operation[BuildOperation.ENABLE_CLASSLOADER_CACHE] = false
+            })
+
+            module.compile(forceOutput = LogLevel.INFO) {
+                assertLogDoesNotContainPatterns(LogLevel.INFO, "Creating new classloader for classpath.*".toRegex())
+            }
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
+++ b/compiler/build-tools/kotlin-build-tools-api/api/kotlin-build-tools-api.api
@@ -49,6 +49,7 @@ public final class org/jetbrains/kotlin/buildtools/api/BaseIncrementalCompilatio
 
 public abstract interface class org/jetbrains/kotlin/buildtools/api/BuildOperation {
 	public static final field Companion Lorg/jetbrains/kotlin/buildtools/api/BuildOperation$Companion;
+	public static final field ENABLE_CLASSLOADER_CACHE Lorg/jetbrains/kotlin/buildtools/api/BuildOperation$Option;
 	public static final field METRICS_COLLECTOR Lorg/jetbrains/kotlin/buildtools/api/BuildOperation$Option;
 	public abstract fun get (Lorg/jetbrains/kotlin/buildtools/api/BuildOperation$Option;)Ljava/lang/Object;
 }

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/BuildOperation.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/BuildOperation.kt
@@ -71,6 +71,15 @@ public interface BuildOperation<R> {
         @JvmField
         public val METRICS_COLLECTOR: Option<BuildMetricsCollector?> = Option("METRICS_COLLECTOR", KotlinReleaseVersion(2, 3, 0))
 
+        /**
+         * Whether to enable caching of classloaders used for loading compiler plugins and annotation processors between build sessions.
+         *
+         * Additionally, the size of the classloader cache can be controlled by setting the "kotlin.buildtools.classloaders.cache.size"
+         * system property *before* calling the [KotlinToolchains.loadImplementation] method. The default number of entries in the cache is 10.
+         */
+        @JvmField
+        public val ENABLE_CLASSLOADER_CACHE: Option<Boolean> = Option("ENABLE_CLASSLOADER_CACHE", KotlinReleaseVersion(2, 5, 0))
+
         @Deprecated("Internal use only for the migration period. Will be removed soon.", level = DeprecationLevel.ERROR)
         public fun <V> createCustomOption(id: String): Option<V> = Option(id, KotlinReleaseVersion(1, 0, 0))
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/build.gradle.kts
+++ b/compiler/build-tools/kotlin-build-tools-impl/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 dependencies {
     api(project(":compiler:build-tools:kotlin-build-tools-api"))
     implementation(kotlinStdlib())
+    compileOnly(libs.guava)
     compileOnly(project(":compiler:cli"))
     compileOnly(project(":compiler:cli-jvm"))
     compileOnly(project(":compiler:cli-js"))
@@ -30,6 +31,7 @@ dependencies {
 
     runtimeOnly(project(":kotlin-compiler-embeddable"))
     runtimeOnly(project(":kotlin-compiler-runner"))
+    embedded(libs.guava)
     embedded(project(":kotlin-scripting-compiler-embeddable")) { isTransitive = false }
     embedded(project(":kotlin-scripting-compiler-impl-embeddable")) { isTransitive = false }
     embedded(project(":kotlin-scripting-common")) { isTransitive = false }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
@@ -3,14 +3,11 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-@file:OptIn(ExperimentalCompilerArgument::class)
-
 package org.jetbrains.kotlin.buildtools.internal
 
 import org.jetbrains.kotlin.build.report.metrics.*
 import org.jetbrains.kotlin.build.report.reportPerformanceData
 import org.jetbrains.kotlin.buildtools.api.*
-import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation.CompilerArgumentsLogLevel
 import org.jetbrains.kotlin.buildtools.api.trackers.CompilerLookupTracker
 import org.jetbrains.kotlin.buildtools.internal.DaemonExecutionPolicyImpl.Companion.DAEMON_RUN_DIR_PATH
@@ -31,6 +28,7 @@ import org.jetbrains.kotlin.cli.common.CLICompiler
 import org.jetbrains.kotlin.cli.common.CompilerSystemProperties
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
 import org.jetbrains.kotlin.compilerRunner.KotlinCompilerRunnerUtils
 import org.jetbrains.kotlin.compilerRunner.toArgumentStrings
 import org.jetbrains.kotlin.config.Services
@@ -295,6 +293,7 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
             get(IMPORT_TRACKER)?.let { tracker: CompilerImportTracker ->
                 register(ImportTracker::class.java, ImportTrackerAdapter(tracker))
             }
+            executionContext.classloadersCache?.let { register(PluginsLoader::class.java, it.asPluginsLoader()) }
         }.build()
         logCompilerArguments(loggerAdapter, arguments, get(COMPILER_ARGUMENTS_LOG_LEVEL))
         val metricsReporter = getMetricsReporter()

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
@@ -41,7 +41,6 @@ import org.jetbrains.kotlin.incremental.components.LookupInfo
 import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.progress.CompilationCanceledStatus
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.io.ObjectOutputStream
 import java.io.Serializable
 import java.net.URLClassLoader
@@ -79,7 +78,7 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>
+        executionContext: ExecutionContext
     ): CompilationResult {
         val compilerMessageRenderer = this[COMPILER_MESSAGE_RENDERER]
         val kotlinLogger = logger ?: DefaultKotlinLogger
@@ -92,10 +91,10 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
 
         return when (executionPolicy) {
             InProcessExecutionPolicyImpl -> {
-                compileInProcess(loggerAdapter)
+                compileInProcess(loggerAdapter, executionContext)
             }
             is DaemonExecutionPolicyImpl -> {
-                compileWithDaemon(executionPolicy, loggerAdapter, sessionIsAliveFlagFile)
+                compileWithDaemon(executionPolicy, loggerAdapter, executionContext)
             }
             else -> {
                 CompilationResult.COMPILATION_ERROR.also {
@@ -152,7 +151,7 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
     private fun compileWithDaemon(
         executionPolicy: DaemonExecutionPolicyImpl,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ): CompilationResult {
         loggerAdapter.kotlinLogger.debug("Compiling using the daemon strategy")
         val compilerId = CompilerId.makeCompilerId(getCurrentClasspath())
@@ -192,7 +191,7 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
             KotlinCompilerRunnerUtils.newDaemonConnection(
                 compilerId,
                 clientIsAliveFile,
-                sessionIsAliveFlagFile.value,
+                executionContext.sessionIsAliveFlagFile.value,
                 loggerAdapter,
                 loggerAdapter.kotlinLogger.isDebugEnabled || System.getProperty("kotlin.daemon.debug.log")?.toBooleanStrictOrNull() ?: true,
                 daemonJVMOptions = jvmOptions,
@@ -260,20 +259,21 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
 
     abstract fun shouldCompileIncrementally(): Boolean
 
-    protected open fun compileInProcess(loggerAdapter: KotlinLoggerMessageCollectorAdapter): CompilationResult {
+    protected open fun compileInProcess(loggerAdapter: KotlinLoggerMessageCollectorAdapter, executionContext: ExecutionContext): CompilationResult {
         loggerAdapter.kotlinLogger.debug("Compiling using the in-process strategy")
         val arguments = createAndPrepareCompilerArguments()
 
         return if (shouldCompileIncrementally()) {
-            compileIncrementallyInProcess(arguments, loggerAdapter)
+            compileIncrementallyInProcess(arguments, loggerAdapter, executionContext)
         } else {
-            compileInProcessWithoutIc(arguments, loggerAdapter)
+            compileInProcessWithoutIc(arguments, loggerAdapter, executionContext)
         }
     }
 
     abstract fun compileIncrementallyInProcess(
         arguments: CompilerArgs,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext,
     ): CompilationResult
 
     abstract fun createCompiler(): CLICompiler<CompilerArgs>
@@ -283,6 +283,7 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
     private fun compileInProcessWithoutIc(
         arguments: CompilerArgs,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext,
     ): CompilationResult {
         val compiler = createCompiler()
         arguments.addSources()

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.buildtools.api.ExecutionPolicy
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.trackers.BuildMetricsCollector
-import java.io.File
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -32,19 +31,19 @@ internal abstract class BuildOperationImpl<R> : BuildOperation<R>, BuildOperatio
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger? = null,
-        sessionIsAliveFlagFile: Lazy<File>
+        executionContext: ExecutionContext
     ): R {
         check(executionStarted.compareAndSet(expectedValue = false, newValue = true)) {
             "Build operation $this already started execution."
         }
-        return executeImpl(projectId, executionPolicy, logger, sessionIsAliveFlagFile)
+        return executeImpl(projectId, executionPolicy, logger, executionContext)
     }
 
     abstract fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger? = null,
-        sessionIsAliveFlagFile: Lazy<File>
+        executionContext: ExecutionContext
     ): R
 
     /**

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BuildOperationImpl.kt
@@ -67,5 +67,6 @@ internal abstract class BuildOperationImpl<R> : BuildOperation<R>, BuildOperatio
         val METRICS_COLLECTOR: Option<BuildMetricsCollector?> = Option("METRICS_COLLECTOR", default = null)
         val XX_KGP_METRICS_COLLECTOR: Option<Boolean> = Option("XX_KGP_METRICS_COLLECTOR", default = false)
         val XX_KGP_METRICS_COLLECTOR_OUT: Option<ByteArray?> = Option("XX_KGP_METRICS_COLLECTOR_OUT", default = null)
+        val ENABLE_CLASSLOADER_CACHE: Option<Boolean> = Option("ENABLE_CLASSLOADER_CACHE", true)
     }
 }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/CancellableBuildOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/CancellableBuildOperationImpl.kt
@@ -5,14 +5,9 @@
 
 package org.jetbrains.kotlin.buildtools.internal
 
-import org.jetbrains.kotlin.buildtools.api.CancellableBuildOperation
-import org.jetbrains.kotlin.buildtools.api.ExecutionPolicy
-import org.jetbrains.kotlin.buildtools.api.KotlinLogger
-import org.jetbrains.kotlin.buildtools.api.OperationCancelledException
-import org.jetbrains.kotlin.buildtools.api.ProjectId
+import org.jetbrains.kotlin.buildtools.api.*
 import org.jetbrains.kotlin.progress.CompilationCanceledException
 import org.jetbrains.kotlin.progress.CompilationCanceledStatus
-import java.io.File
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
@@ -53,16 +48,16 @@ internal abstract class CancellableBuildOperationImpl<R> : BuildOperationImpl<R>
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ): R
 
     final override fun executeImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext
     ): R {
-        val returnValue = executeCancellableImpl(projectId, executionPolicy, logger, sessionIsAliveFlagFile)
+        val returnValue = executeCancellableImpl(projectId, executionPolicy, logger, executionContext)
         return if (isCancelled.load()) {
             throw OperationCancelledException()
         } else {

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.buildtools.internal.metadata.KotlinMetadataPlatformT
 import org.jetbrains.kotlin.buildtools.internal.wasm.WasmPlatformToolchainImpl
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
+import java.io.File
 import java.util.concurrent.*
 
 internal class KotlinToolchainsImpl() : KotlinToolchains {
@@ -89,7 +90,14 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
             logger: KotlinLogger?,
         ): R {
             check(operation is BuildOperationImpl<R>) { "Unknown operation type: ${operation::class.qualifiedName}" }
-            val operationBody: Callable<R> = { operation.execute(projectId, executionPolicy, logger, sessionIsAliveFlagFile) }
+            val operationBody: Callable<R> = {
+                operation.execute(
+                    projectId,
+                    executionPolicy,
+                    logger,
+                    ExecutionContext(sessionIsAliveFlagFile)
+                )
+            }
             return if (executionPolicy is ExecutionPolicy.InProcess) {
                 // For an operation that uses the shared application environment, pin it just before, so that it is kept
                 // alive for reuse by subsequent operations and only disposed when the session ends.
@@ -140,3 +148,7 @@ internal sealed interface BtaApiVersion {
     object Before2_4_20 : BtaApiVersion
     class Exact(val version: KotlinToolingVersion) : BtaApiVersion
 }
+
+internal class ExecutionContext(
+    val sessionIsAliveFlagFile: Lazy<File>,
+)

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain
 import org.jetbrains.kotlin.buildtools.api.metadata.KotlinMetadataPlatformToolchain
 import org.jetbrains.kotlin.buildtools.api.wasm.WasmPlatformToolchain
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiValidationToolchainImpl
+import org.jetbrains.kotlin.buildtools.internal.classloading.LruClassLoadersCache
 import org.jetbrains.kotlin.buildtools.internal.cri.CriToolchainImpl
 import org.jetbrains.kotlin.buildtools.internal.js.JsPlatformToolchainImpl
 import org.jetbrains.kotlin.buildtools.internal.jvm.JvmPlatformToolchainImpl
@@ -24,8 +25,15 @@ import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import java.io.File
 import java.util.concurrent.*
 
+private const val DEFAULT_CLASSLOADERS_CACHE_SIZE = 10
+private const val PROPERTY_CLASSLOADERS_CACHE_SIZE = "kotlin.buildtools.classloaders.cache.size"
+
 internal class KotlinToolchainsImpl() : KotlinToolchains {
     val toolchains: ConcurrentHashMap<Class<*>, KotlinToolchains.Toolchain> = ConcurrentHashMap()
+    val classloadersCache = LruClassLoadersCache(
+        System.getProperty(PROPERTY_CLASSLOADERS_CACHE_SIZE)?.toIntOrNull() ?: DEFAULT_CLASSLOADERS_CACHE_SIZE,
+        this::class.java.classLoader
+    )
 
     override fun <T : KotlinToolchains.Toolchain> getToolchain(type: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
@@ -56,12 +64,13 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
     override fun getCompilerVersion(): String = KotlinCompilerVersion.VERSION
 
     override fun createBuildSession(): KotlinToolchains.BuildSession {
-        return BuildSessionImpl(this, RandomProjectUUID())
+        return BuildSessionImpl(this, RandomProjectUUID(), classloadersCache)
     }
 
     private class BuildSessionImpl(
-        override val kotlinToolchains: KotlinToolchains,
+        override val kotlinToolchains: KotlinToolchainsImpl,
         override val projectId: ProjectId,
+        val classloadersCache: LruClassLoadersCache,
     ) : KotlinToolchains.BuildSession {
         private val sessionIsAliveFlagFile = lazy { createSessionIsAliveFlagFile() }
         private val executorDelegate = lazy {
@@ -91,11 +100,13 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
         ): R {
             check(operation is BuildOperationImpl<R>) { "Unknown operation type: ${operation::class.qualifiedName}" }
             val operationBody: Callable<R> = {
+                val classloadersCacheWithLogger =
+                    classloadersCache.takeIf { operation[BuildOperationImpl.ENABLE_CLASSLOADER_CACHE] }?.withLogger(logger)
                 operation.execute(
                     projectId,
                     executionPolicy,
                     logger,
-                    ExecutionContext(sessionIsAliveFlagFile)
+                    ExecutionContext(sessionIsAliveFlagFile, classloadersCacheWithLogger)
                 )
             }
             return if (executionPolicy is ExecutionPolicy.InProcess) {
@@ -151,4 +162,5 @@ internal sealed interface BtaApiVersion {
 
 internal class ExecutionContext(
     val sessionIsAliveFlagFile: Lazy<File>,
+    val classloadersCache: LruClassLoadersCache?,
 )

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/CompareAbiTextFilesOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/CompareAbiTextFilesOperationImpl.kt
@@ -11,10 +11,10 @@ import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.abi.operations.CompareAbiTextFilesOperation
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
+import org.jetbrains.kotlin.buildtools.internal.ExecutionContext
 import org.jetbrains.kotlin.buildtools.internal.DeepCopyable
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
-import java.io.File
 import java.nio.file.Path
 
 internal class CompareAbiTextFilesOperationImpl private constructor(
@@ -43,7 +43,7 @@ internal class CompareAbiTextFilesOperationImpl private constructor(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>
+        executionContext: ExecutionContext
     ) {
         val diff = abiTools.filesDiff(
             expectedDumpFile.toFile(),

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpJvmAbiToStringOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpJvmAbiToStringOperationImpl.kt
@@ -13,13 +13,13 @@ import org.jetbrains.kotlin.buildtools.api.abi.AbiFilters
 import org.jetbrains.kotlin.buildtools.api.abi.operations.DumpJvmAbiToStringOperation
 import org.jetbrains.kotlin.buildtools.internal.BaseOptionWithDefault
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
+import org.jetbrains.kotlin.buildtools.internal.ExecutionContext
 import org.jetbrains.kotlin.buildtools.internal.DeepCopyable
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.UseFromImplModuleRestricted
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiFiltersImpl
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiValidationUtils
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
-import java.io.File
 import java.nio.file.Path
 
 internal class DumpJvmAbiToStringOperationImpl private constructor(
@@ -46,7 +46,7 @@ internal class DumpJvmAbiToStringOperationImpl private constructor(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>
+        executionContext: ExecutionContext
     ) {
         val filters = options[PATTERN_FILTERS]?.let { AbiValidationUtils.convert(it) } ?: org.jetbrains.kotlin.abi.tools.AbiFilters.EMPTY
         abiTools.printJvmDump(appendable, inputFiles.map { it.toFile() }, filters)

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpKlibAbiToStringOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/abi/operations/DumpKlibAbiToStringOperationImpl.kt
@@ -14,13 +14,13 @@ import org.jetbrains.kotlin.buildtools.api.abi.KlibTargetId
 import org.jetbrains.kotlin.buildtools.api.abi.operations.DumpKlibAbiToStringOperation
 import org.jetbrains.kotlin.buildtools.internal.BaseOptionWithDefault
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
+import org.jetbrains.kotlin.buildtools.internal.ExecutionContext
 import org.jetbrains.kotlin.buildtools.internal.DeepCopyable
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.UseFromImplModuleRestricted
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiFiltersImpl
 import org.jetbrains.kotlin.buildtools.internal.abi.AbiValidationUtils
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
-import java.io.File
 import java.nio.file.Path
 
 internal class DumpKlibAbiToStringOperationImpl private constructor(
@@ -47,7 +47,7 @@ internal class DumpKlibAbiToStringOperationImpl private constructor(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>
+        executionContext: ExecutionContext
     ) {
         val filters = options[PATTERN_FILTERS]?.let { AbiValidationUtils.convert(it) } ?: org.jetbrains.kotlin.abi.tools.AbiFilters.EMPTY
 

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/classloading/LruClassLoadersCache.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/classloading/LruClassLoadersCache.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.internal.classloading
+
+import com.google.common.cache.Cache
+import com.google.common.cache.CacheBuilder
+import com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.buildtools.api.KotlinLogger
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.components.ClassLoadersCache
+import org.jetbrains.kotlin.util.ServiceLoaderLite
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+import java.time.Duration
+
+/**
+ * LRU cache for [ClassLoader]s by class path.
+ */
+internal class LruClassLoadersCache private constructor(
+    private val parentClassLoader: ClassLoader = ClassLoader.getSystemClassLoader(),
+    private val logger: KotlinLogger? = null,
+    private val cache: Cache<CacheKey, URLClassLoader>,
+) : ClassLoadersCache, AutoCloseable {
+
+    constructor(
+        size: Int,
+        parentClassLoader: ClassLoader,
+        ttl: Duration = Duration.ofHours(1),
+        logger: KotlinLogger? = null,
+    ) : this(
+        parentClassLoader,
+        logger,
+        cache = CacheBuilder.newBuilder().maximumSize(size.toLong()).expireAfterAccess(ttl)
+            .removalListener<CacheKey, URLClassLoader> { [key, cl] ->
+                check(key != null && cl != null)
+                logger?.info("Removing classloader from cache: ${key.entries.map { it.path }}")
+                cl.close()
+            }.build()
+    )
+
+    fun withLogger(logger: KotlinLogger?): LruClassLoadersCache = LruClassLoadersCache(parentClassLoader, logger, cache)
+
+    override fun getForClassPath(files: List<File>): URLClassLoader = getForClassPath(files, parentClassLoader)
+
+    private fun getForClassPath(files: List<File>, parent: ClassLoader): URLClassLoader {
+        val key = makeKey(files)
+        return cache.get(key) {
+            makeClassLoader(key, parent)
+        }
+    }
+
+    /**
+     * Gets or creates [ClassLoader] from [bottom] + [top] files.
+     * When creating new [ClassLoader] it tries to get [top] from cache first and then create new ClassLoader from [bottom] files,
+     * providing [top] [ClassLoader] as parent.
+     * Useful when you have internal and external artifacts and internal ones can be references from other internal artefacts only.
+     * So you can safely cache [ClassLoader] from external artifacts and use it for internal ones.
+     */
+    fun getForSplitPaths(bottom: List<File>, top: List<File>): ClassLoader {
+        return if (bottom.isEmpty() || top.isEmpty()) {
+            getForClassPath(bottom + top)
+        } else {
+            val key = makeKey(bottom + top)
+            cache.get(key) {
+                val parent = getForClassPath(top)
+                makeClassLoader(makeKey(bottom), parent)
+            }
+        }
+    }
+
+    override fun close() {
+        cache.invalidateAll()
+    }
+
+    private fun makeClassLoader(key: CacheKey, parent: ClassLoader): URLClassLoader {
+        val cp = key.entries.map { it.path }
+        logger?.info("Creating new classloader for classpath: $cp")
+        return URLClassLoader(cp.toTypedArray(), parent)
+    }
+
+    private fun makeKey(files: List<File>): CacheKey {
+        //probably should walk dirs content for actual last modified
+        val entries = files.map { f -> ClasspathEntry(f.toURI().toURL(), f.lastModified()) }
+        return CacheKey(entries)
+    }
+
+    private data class ClasspathEntry(val path: URL, val modificationTimestamp: Long)
+
+    private data class CacheKey(val entries: List<ClasspathEntry>)
+
+    @OptIn(ExperimentalCompilerApi::class)
+    fun asPluginsLoader(): PluginsLoader = object : PluginsLoader {
+        override fun loadCompilerPluginRegistrars(
+            pluginClasspath: Collection<String>,
+            parentDisposable: Disposable,
+        ): List<CompilerPluginRegistrar> {
+            return ServiceLoaderLite.loadImplementations(
+                CompilerPluginRegistrar::class.java, getForClassPath(pluginClasspath.map { File(it) })
+            )
+        }
+
+        override fun loadCommandLineProcessors(
+            pluginClasspath: Collection<String>,
+            parentDisposable: Disposable,
+        ): List<CommandLineProcessor> {
+            return ServiceLoaderLite.loadImplementations(
+                CommandLineProcessor::class.java, getForClassPath(pluginClasspath.map { File(it) })
+            )
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriFileIdToPathDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriFileIdToPathDataDeserializationOperationImpl.kt
@@ -11,9 +11,9 @@ import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.cri.CriFileIdToPathDataDeserializationOperation
 import org.jetbrains.kotlin.buildtools.api.cri.FileIdToPathEntry
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
+import org.jetbrains.kotlin.buildtools.internal.ExecutionContext
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
-import java.io.File
 
 internal class CriFileIdToPathDataDeserializationOperationImpl(
     private val deserializer: CriDataDeserializerImpl,
@@ -32,7 +32,7 @@ internal class CriFileIdToPathDataDeserializationOperationImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ): Iterable<FileIdToPathEntry> {
         return deserializer.deserializeFileIdToPathData(data)
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriLookupDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriLookupDataDeserializationOperationImpl.kt
@@ -11,9 +11,9 @@ import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.cri.CriLookupDataDeserializationOperation
 import org.jetbrains.kotlin.buildtools.api.cri.LookupEntry
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
+import org.jetbrains.kotlin.buildtools.internal.ExecutionContext
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
-import java.io.File
 
 internal class CriLookupDataDeserializationOperationImpl(
     private val deserializer: CriDataDeserializerImpl,
@@ -32,7 +32,7 @@ internal class CriLookupDataDeserializationOperationImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ): Iterable<LookupEntry> {
         return deserializer.deserializeLookupData(data)
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriSubtypeDataDeserializationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/cri/CriSubtypeDataDeserializationOperationImpl.kt
@@ -11,9 +11,9 @@ import org.jetbrains.kotlin.buildtools.api.ProjectId
 import org.jetbrains.kotlin.buildtools.api.cri.CriSubtypeDataDeserializationOperation
 import org.jetbrains.kotlin.buildtools.api.cri.SubtypeEntry
 import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
+import org.jetbrains.kotlin.buildtools.internal.ExecutionContext
 import org.jetbrains.kotlin.buildtools.internal.Options
 import org.jetbrains.kotlin.buildtools.internal.initializeOptions
-import java.io.File
 
 internal class CriSubtypeDataDeserializationOperationImpl(
     private val deserializer: CriDataDeserializerImpl,
@@ -32,7 +32,7 @@ internal class CriSubtypeDataDeserializationOperationImpl(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ): Iterable<SubtypeEntry> {
         return deserializer.deserializeSubtypeData(data)
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.js.tsexport.createTypeScriptExportInputModule
 import org.jetbrains.kotlin.js.tsexport.runTypeScriptExport
 import org.jetbrains.kotlin.library.metadata.KlibInputModule
 import org.jetbrains.kotlin.platform.js.JsPlatforms
-import java.io.File
 import java.nio.file.Path
 
 internal class JsDtsGenerationOperationImpl private constructor(
@@ -48,7 +47,7 @@ internal class JsDtsGenerationOperationImpl private constructor(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ): CompilationResult {
         val inputModules = transformKlibsIntoKlibInputModule(klibs, logger)
         // The main KLIB is the last one in the list; its manifest drives the merged artifact naming.

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsKlibCompilationOperationImpl.kt
@@ -212,6 +212,7 @@ internal class JsKlibCompilationOperationImpl private constructor(
     override fun compileIncrementallyInProcess(
         arguments: K2JSCompilerArguments,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext
     ): CompilationResult {
         val icConfiguration = get(INCREMENTAL_COMPILATION)
         requireNotNull(icConfiguration) { "Missing INCREMENTAL_COMPILATION option." }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsLinkingOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsLinkingOperationImpl.kt
@@ -107,6 +107,7 @@ internal class JsLinkingOperationImpl private constructor(
     override fun compileIncrementallyInProcess(
         arguments: K2JSCompilerArguments,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext
     ): CompilationResult {
         error("Linking doesn't support incremental compilation")
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/DiscoverScriptExtensionsOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/DiscoverScriptExtensionsOperationImpl.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.buildtools.api.jvm.operations.DiscoverScriptExtensio
 import org.jetbrains.kotlin.buildtools.internal.*
 import org.jetbrains.kotlin.scripting.compiler.plugin.impl.reporter
 import org.jetbrains.kotlin.scripting.definitions.ScriptDefinitionsFromClasspathDiscoverySource
-import java.io.File
 import java.nio.file.Path
 import kotlin.script.experimental.jvm.defaultJvmScriptingHostConfiguration
 
@@ -34,7 +33,7 @@ internal class DiscoverScriptExtensionsOperationImpl private constructor(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ): Collection<String> {
         // KT-84096 BTA: support daemon execution for script discovery operation
         check(executionPolicy is ExecutionPolicy.InProcess) { "Only in-process execution policy is supported for this operation." }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmClasspathSnapshottingOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmClasspathSnapshottingOperationImpl.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshotti
 import org.jetbrains.kotlin.buildtools.internal.*
 import org.jetbrains.kotlin.buildtools.internal.trackers.getMetricsReporter
 import org.jetbrains.kotlin.incremental.classpathDiff.ClasspathEntrySnapshotter
-import java.io.File
 import java.nio.file.Path
 
 internal class JvmClasspathSnapshottingOperationImpl private constructor(
@@ -53,7 +52,7 @@ internal class JvmClasspathSnapshottingOperationImpl private constructor(
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>
+        executionContext: ExecutionContext
     ): ClasspathEntrySnapshot {
         val granularity: ClassSnapshotGranularity = get(GRANULARITY)
         val parseInlinedLocalClasses: Boolean = get(PARSE_INLINED_LOCAL_CLASSES)

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
@@ -208,9 +208,12 @@ internal class JvmCompilationOperationImpl private constructor(
         return getIcOptionsAccessorOrNull()?.let { true } ?: false
     }
 
-    override fun compileInProcess(loggerAdapter: KotlinLoggerMessageCollectorAdapter): CompilationResult {
+    override fun compileInProcess(
+        loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext
+    ): CompilationResult {
         setupIdeaStandaloneExecution()
-        return super.compileInProcess(loggerAdapter)
+        return super.compileInProcess(loggerAdapter, executionContext)
     }
 
     override fun createCompiler(): CLICompiler<K2JVMCompilerArguments> {
@@ -224,6 +227,7 @@ internal class JvmCompilationOperationImpl private constructor(
     override fun compileIncrementallyInProcess(
         arguments: K2JVMCompilerArguments,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext
     ): CompilationResult {
         val snapshotBasedIcOptionsAccessor = getIcOptionsAccessorOrNull() ?: error("Missing INCREMENTAL_COMPILATION option.")
         arguments.freeArgs += sources.filter { it.toFile().isJavaFile() }.map { it.absolutePathStringOrThrow() }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/metadata/operations/KotlinMetadataKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/metadata/operations/KotlinMetadataKlibCompilationOperationImpl.kt
@@ -110,6 +110,7 @@ internal class KotlinMetadataKlibCompilationOperationImpl private constructor(
     override fun compileIncrementallyInProcess(
         arguments: K2MetadataCompilerArguments,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext
     ): CompilationResult {
         error("Metadata compiler doesn't support incremental compilation")
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmKlibCompilationOperationImpl.kt
@@ -211,6 +211,7 @@ internal class WasmKlibCompilationOperationImpl private constructor(
     override fun compileIncrementallyInProcess(
         arguments: KotlinWasmCompilerArguments,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext
     ): CompilationResult {
         val icConfiguration = get(INCREMENTAL_COMPILATION)
         requireNotNull(icConfiguration) { "Missing INCREMENTAL_COMPILATION option." }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmLinkingOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmLinkingOperationImpl.kt
@@ -104,6 +104,7 @@ internal class WasmLinkingOperationImpl private constructor(
     override fun compileIncrementallyInProcess(
         arguments: KotlinWasmCompilerArguments,
         loggerAdapter: KotlinLoggerMessageCollectorAdapter,
+        executionContext: ExecutionContext
     ): CompilationResult {
         error("Linking doesn't support incremental compilation")
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/CancellableOperationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/test/kotlin/CancellableOperationTest.kt
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.buildtools.api.ExecutionPolicy
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.ProjectId
+import org.jetbrains.kotlin.buildtools.internal.ExecutionContext
 import org.jetbrains.kotlin.buildtools.internal.CancellableBuildOperationImpl
 import org.jetbrains.kotlin.buildtools.internal.KotlinToolchainsImpl
 import org.jetbrains.kotlin.buildtools.internal.Options
@@ -25,7 +26,7 @@ private class ExampleCancellableOperation(override val options: Options = Option
         projectId: ProjectId,
         executionPolicy: ExecutionPolicy,
         logger: KotlinLogger?,
-        sessionIsAliveFlagFile: Lazy<File>,
+        executionContext: ExecutionContext,
     ) {
         repeat(10) {
             Thread.sleep(100)
@@ -54,7 +55,7 @@ class CancellableOperationTest {
                         operation.execute(
                             ProjectId.RandomProjectUUID(),
                             KotlinToolchainsImpl().createInProcessExecutionPolicy(),
-                            sessionIsAliveFlagFile = lazy { File.createTempFile("session", "alive").apply { deleteOnExit() } }
+                            executionContext = ExecutionContext(lazy { File(".") }, null),
                         )
                     )
                 } catch (_: CompilationCanceledException) {


### PR DESCRIPTION
In preparation for adding Kapt support to BTA, we're introducing classloader caching to BTA. More details: [KT-88275](https://youtrack.jetbrains.com/issue/KT-88275) BTA: implement classloader cache that can be used by operations