### PR TITLE
Build: Reduce maxParallelForks for :kotlin-gradle-plugin:functionalTest

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -680,7 +680,8 @@ testing {
                         provideToThisTaskAsSystemProperty(ProvisioningType.SDK)
                         dependsOn(acceptLicensesTask)
                     }
-                    maxParallelForks = 8
+
+                    maxParallelForks = if (kotlinBuildProperties.isTeamcityBuild.get()) 2 else 8
                     maxHeapSize = "4G" // KT-72460 to investigate why we need to change heap size
 
                     testLogging {


### PR DESCRIPTION
Reduce maxParallelForks on CI because it is not possible to have 8 forks 4gb each on a 16gb machine.

 #KTI-3350