### PR TITLE
[Native] Don't create NativeSecondStageCompilationConfig twice

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -91,7 +91,7 @@ class KonanDriver(
             configuration.filesToCache = fileNames
         }
 
-        var config = NativeSecondStageCompilationConfig(project, configuration)
+        val config = NativeSecondStageCompilationConfig(project, configuration)
 
         if (configuration.listTargets) {
             config.targetManager.list()
@@ -136,8 +136,13 @@ class KonanDriver(
 
         val cacheBuilder = CacheBuilder(config, compilationSpawner)
         if (cacheBuilder.needToBuild()) {
+            // Build missing caches.
             cacheBuilder.build()
-            config = NativeSecondStageCompilationConfig(project, configuration) // TODO: Just set freshly built caches.
+
+            // Reload `CacheSupport` inside `NativeSecondStageCompilationConfig` to reflect the up-to-date state of just built caches.
+            // This is important for further correct compilation of the resulting binary.
+            config.reloadCacheSupport()
+
             // Parallel cache build might have already built our asked-to-build cache. Check for that and return early if true.
             if (!hasCompilerInput && config.libraryToCache == null)
                 return

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -615,7 +615,10 @@ class NativeSecondStageCompilationConfig(
         else -> null
     }
 
-    internal val cacheSupport = CacheSupport(
+    internal var cacheSupport: CacheSupport = createCacheSupport()
+        private set
+
+    private fun createCacheSupport() = CacheSupport(
             configuration = configuration,
             resolvedLibraries = resolvedLibraries,
             ignoreCacheReason = ignoreCacheReason,
@@ -625,6 +628,10 @@ class NativeSecondStageCompilationConfig(
             target = target,
             produce = produce
     )
+
+    internal fun reloadCacheSupport() {
+        cacheSupport = createCacheSupport()
+    }
 
     internal val cachedLibraries: CachedLibraries
         get() = cacheSupport.cachedLibraries


### PR DESCRIPTION
`NativeSecondStageCompilationConfig` is a complicated component that can hold some values which are the result of expensive computations. It's better to avoid re-creating this component from scratch after building static caches, and instead just reload the fresh state of static caches into the inner `CacheSupport` component.

This commit is a pre-requisite for KT-86840, where we are going to start storing the computed DAG of KLIB dependencies inside the config.

^KT-86840