### PR TITLE
KT-86736: Kotlin/Native: stabilize performance microbenchmarks

### DIFF
--- a/kotlin-native/performance/buildSrc/build.gradle.kts
+++ b/kotlin-native/performance/buildSrc/build.gradle.kts
@@ -8,9 +8,12 @@ sourceSets["main"].kotlin {
     srcDir("../benchmarksReports/src/commonMain/kotlin")
 }
 
+val Project.kotlinxBenchmarkVersion: String
+    get() = property("kotlinx.benchmark.version") as String
+
 dependencies {
     val kotlinVersion = project.bootstrapKotlinVersion
-    val kotlinxBenchmarkVersion = "0.4.17"
+    val kotlinxBenchmarkVersion = project.kotlinxBenchmarkVersion
 
     compileOnly(gradleApi())
 

--- a/kotlin-native/performance/buildSrc/gradle.properties
+++ b/kotlin-native/performance/buildSrc/gradle.properties
@@ -1,0 +1,1 @@
+kotlinx.benchmark.version=0.4.17

--- a/kotlin-native/performance/buildSrc/settings.gradle.kts
+++ b/kotlin-native/performance/buildSrc/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
     includeBuild("../../../repo/gradle-settings-conventions")
 
     repositories {
+        mavenLocal()
         maven("https://redirector.kotlinlang.org/maven/kotlin-dependencies")
         mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         gradlePluginPortal()
@@ -11,6 +12,7 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal()
         maven("https://redirector.kotlinlang.org/maven/kotlin-dependencies")
         mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         gradlePluginPortal()

--- a/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/KotlinxBenchmarkingPlugin.kt
+++ b/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/KotlinxBenchmarkingPlugin.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.kotlin.benchmark
 
+import kotlinx.benchmark.gradle.CustomEngine
+import kotlinx.benchmark.gradle.KotlinxBenchmarkPluginExperimentalApi
 import kotlinx.benchmark.gradle.NativeBenchmarkExec
 import kotlinx.benchmark.gradle.NativeBenchmarkTarget
 import org.gradle.api.Project
@@ -25,6 +27,8 @@ import org.jetbrains.kotlin.hostTarget
 import org.jetbrains.kotlin.kotlin
 import org.jetbrains.kotlin.kotlinxBenchmark
 import org.jetbrains.kotlin.nativeWarmup
+import org.jetbrains.kotlin.useCSet
+import java.io.File
 import javax.inject.Inject
 
 private val EXTENSION_NAME = "kotlinxBenchmark"
@@ -62,6 +66,7 @@ open class KotlinxBenchmarkingPlugin : BenchmarkingPlugin() {
 
     override fun Project.createExtension() = extensions.create<KotlinxBenchmarkExtension>(EXTENSION_NAME, this)
 
+    @OptIn(KotlinxBenchmarkPluginExperimentalApi::class)
     override fun Project.configureTasks() {
         pluginManager.apply("org.jetbrains.kotlinx.benchmark")
         kotlin.apply {
@@ -88,6 +93,19 @@ open class KotlinxBenchmarkingPlugin : BenchmarkingPlugin() {
                     BenchmarkRepeatingType.EXTERNAL -> "perIteration"
                     BenchmarkRepeatingType.INTERNAL -> "perBenchmark"
                 })
+                if (project.useCSet) {
+                    customEngine = CustomEngine(
+                            name = "Taskset",
+                            enginePath = project.layout.file(
+                                    project.provider { File("/usr/bin/taskset") }
+                            ),
+                            engineArguments = providers.provider {
+                                // FIXME: Host specific biniding, see KTI-886
+                                //  shold be set dynamically
+                                listOf("--cpu-list", "0-11")
+                            }
+                    )
+                }
                 if (project.dryRun) {
                     exclude(".*")
                 } else {

--- a/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/KotlinxBenchmarkingPlugin.kt
+++ b/kotlin-native/performance/buildSrc/src/main/kotlin/benchmark/KotlinxBenchmarkingPlugin.kt
@@ -101,7 +101,8 @@ open class KotlinxBenchmarkingPlugin : BenchmarkingPlugin() {
                             ),
                             engineArguments = providers.provider {
                                 // FIXME: Host specific biniding, see KTI-886
-                                //  shold be set dynamically
+                                //  It should be set dynamically according to the host
+                                //  available CPUs and their types.
                                 listOf("--cpu-list", "0-11")
                             }
                     )

--- a/kotlin-native/performance/gradle.properties
+++ b/kotlin-native/performance/gradle.properties
@@ -13,3 +13,5 @@ kotlin.mpp.enableCInteropCommonization=true
 # klib cross-compilation is not required and produces warnings on Linux
 kotlin.native.enableKlibsCrossCompilation=false
 kotlin.native.ignoreDisabledTargets=true
+
+kotlinx.benchmark.version=0.4.17

--- a/kotlin-native/performance/settings.gradle.kts
+++ b/kotlin-native/performance/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
     includeBuild("../../repo/gradle-settings-conventions")
 
     repositories {
+        mavenLocal()
         maven("https://redirector.kotlinlang.org/maven/kotlin-dependencies")
         mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
         gradlePluginPortal()
@@ -35,6 +36,7 @@ val knownGroups = buildList {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal()
         mavenCentral { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
     }
 }


### PR DESCRIPTION
Update Kotlinx Benchmark Plugin and integrate custom engine support

* Introduce `kotlinx.benchmark.version` to override it for experimental purposes.
* Add support for a custom benchmark engine with `taskset` for CPU affinity on Linux. 
   It should make execution less volatile because it is possible to use 
   only performant cores for benchmarks.
* Configure the project to use `mavenLocal` repository for experimental dependencies
   like custom kotlinx-benchmark.