### PR TITLE
[Native] ^KT-87702: move launcher functions into main runtime module

### DIFF
--- a/kotlin-native/runtime/src/launcher/cpp/launcher.cpp
+++ b/kotlin-native/runtime/src/launcher/cpp/launcher.cpp
@@ -1,5 +1,5 @@
 /*
-  * Copyright 2010-2017 JetBrains s.r.o.
+  * Copyright 2010-2026 JetBrains s.r.o.
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.
@@ -14,65 +14,16 @@
   * limitations under the License.
   */
 
-#include <cstdlib>
-
-#include "Memory.h"
-#include "Natives.h"
-#include "Runtime.h"
-#include "KString.h"
-#include "Types.h"
-#include "Worker.h"
-
 #include "launcher.h"
 
+#include "CommonLauncher.hpp"
+
 using namespace kotlin;
-
-//--- Setup args --------------------------------------------------------------//
-
-OBJ_GETTER(setupArgs, int argc, const char** argv) {
-  if (argc > 0 && argv[0][0] != '\0') {
-    // Don't set the programName to an empty string (by checking argv[0][0] != '\0') to make all platforms behave the same:
-    // Linux would set argv[0] to "" in case no programName is passed, whereas Windows & macOS would set argc to 0.
-    kotlin::programName = argv[0];
-  }
-
-  // The count is one less, because we skip argv[0] which is the binary name.
-  ObjHeader* result = AllocArrayInstance(theArrayTypeInfo, std::max(0, argc - 1), OBJ_RESULT);
-  ArrayHeader* array = result->array();
-  for (int index = 1; index < argc; index++) {
-    ObjHolder result;
-    CreateStringFromCString(argv[index], result.slot());
-    UpdateHeapRef(ArrayAddressOfElementAt(array, index - 1), result.obj());
-  }
-  return result;
-}
-
-//--- main --------------------------------------------------------------------//
-extern "C" KInt Konan_run_start(int argc, const char** argv) {
-    ObjHolder args;
-    setupArgs(argc, argv, args.slot());
-    return Konan_start(args.obj());
-}
-
-extern "C" RUNTIME_EXPORT int Init_and_run_start(int argc, const char** argv, int memoryDeInit) {
-  Kotlin_initRuntimeIfNeeded();
-  Kotlin_mm_switchThreadStateRunnable();
-
-  KInt exitStatus = Konan_run_start(argc, argv);
-
-  if (memoryDeInit) {
-      Kotlin_shutdownRuntime();
-  }
-
-  kotlin::programName = nullptr; // argv[0] might not be valid after this point
-
-  return exitStatus;
-}
 
 #ifndef KONAN_ANDROID
 extern "C" RUNTIME_EXPORT int Konan_main(int argc, const char** argv) {
 #else
 extern "C" RUNTIME_EXPORT int Konan_main_standalone(int argc, const char** argv) {
 #endif
-    return Init_and_run_start(argc, argv, 1);
+    return kotlin::executableEntryPoint(argc, argv, Konan_start);
 }

--- a/kotlin-native/runtime/src/launcher/cpp/launcher.h
+++ b/kotlin-native/runtime/src/launcher/cpp/launcher.h
@@ -17,6 +17,8 @@
 #ifndef LAUNCHER_H
 #define LAUNCHER_H
 
+#include "Types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/kotlin-native/runtime/src/main/cpp/CommonLauncher.cpp
+++ b/kotlin-native/runtime/src/main/cpp/CommonLauncher.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+#include "CommonLauncher.hpp"
+
+#include <cstdlib>
+
+#include "Memory.h"
+#include "Natives.h"
+#include "Runtime.h"
+#include "KString.h"
+#include "Types.h"
+
+using namespace kotlin;
+
+namespace {
+
+/**
+ * Returns a Kotlin's Array of Strings parsed from the given arguments.
+ */
+OBJ_GETTER(parseArgumentsToKotlinStringArray, int argc, const char** argv) {
+    if (argc > 0 && argv[0][0] != '\0') {
+        // Don't set the programName to an empty string (by checking argv[0][0] != '\0') to make all platforms behave the same:
+        // Linux would set argv[0] to "" in case no programName is passed, whereas Windows & macOS would set argc to 0.
+        kotlin::programName = argv[0];
+    }
+
+    // The count is one less, because we skip argv[0] which is the binary name.
+    ObjHeader* result = AllocArrayInstance(theArrayTypeInfo, std::max(0, argc - 1), OBJ_RESULT);
+    ArrayHeader* array = result->array();
+    for (int index = 1; index < argc; index++) {
+        ObjHolder result;
+        CreateStringFromCString(argv[index], result.slot());
+        UpdateHeapRef(ArrayAddressOfElementAt(array, index - 1), result.obj());
+    }
+
+    return result;
+}
+} // namespace
+
+namespace kotlin {
+
+int executableEntryPoint(int argc, const char** argv, KInt (*entryPoint)(const ObjHeader*)) {
+    Kotlin_initRuntimeIfNeeded();
+    Kotlin_mm_switchThreadStateRunnable();
+
+    ObjHolder args;
+    parseArgumentsToKotlinStringArray(argc, argv, args.slot());
+
+    KInt exitStatus = entryPoint(args.obj());
+
+    Kotlin_shutdownRuntime();
+
+    kotlin::programName = nullptr; // argv[0] might not be valid after this point
+
+    return exitStatus;
+}
+
+} // namespace kotlin

--- a/kotlin-native/runtime/src/main/cpp/CommonLauncher.hpp
+++ b/kotlin-native/runtime/src/main/cpp/CommonLauncher.hpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+#ifndef COMMON_LAUNCHER_H
+#define COMMON_LAUNCHER_H
+
+#include "Types.h"
+
+namespace kotlin {
+
+int executableEntryPoint(int argc, const char** argv, KInt (*entryPoint)(const ObjHeader*));
+
+}
+
+#endif


### PR DESCRIPTION
`Init_and_run_start` has been renamed to `Kotlin_executableEntryPoint`, that takes an entry point to be run.