### PR TITLE
Fix duplicated words in comments and messages

### DIFF
--- a/analysis/light-classes-base/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt
+++ b/analysis/light-classes-base/src/org/jetbrains/kotlin/asJava/LightClassUtil.kt
@@ -58,7 +58,7 @@ object LightClassUtil {
             val wrapperName = wrapper.name
             if (customNameAnnoProvided) {
                 // cls with loaded text doesn't preserve annotation arguments thus we can't rely on the name
-                // accept everything but the the opposite accessors
+                // accept everything but the opposite accessors
                 if (accessor.isGetter) !JvmAbi.isSetterName(wrapperName) else !JvmAbi.isGetterName(wrapperName)
             } else if (accessor.isGetter) {
                 val getterName = JvmAbi.getterName(propertyName)

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/fir/FirDiagnosticsCompilerResultsReporter.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/fir/FirDiagnosticsCompilerResultsReporter.kt
@@ -108,7 +108,7 @@ object FirDiagnosticsCompilerResultsReporter {
                             else -> {
                                 // TODO: bring KtSourceFile and KtSourceFileLinesMapping here and rewrite reporting via it to avoid code duplication
                                 // NOTE: SequentialPositionFinder relies on the ascending order of the input offsets, so the code relies
-                                // on the the appropriate sorting above
+                                // on the appropriate sorting above
                                 offsetsToPositions?.let {
                                     val range = diagnostic.firstRange
                                     val start = offsetsToPositions[range.startOffset]!!

--- a/compiler/resolution.common/src/org/jetbrains/kotlin/types/AbstractTypeApproximator.kt
+++ b/compiler/resolution.common/src/org/jetbrains/kotlin/types/AbstractTypeApproximator.kt
@@ -512,7 +512,7 @@ abstract class AbstractTypeApproximator(
 
             // Important note that from the point of type system first type is more specific:
             // Here, approximation of KClass<Cap<out A!>> is a type KClass<T> such that KClass<Cap<out A!>> <: KClass<out T> =>
-            // So, the the more specific type for T would be "some non-null (because of declared upper bound type) subtype of A", which is `out A`
+            // So, the more specific type for T would be "some non-null (because of declared upper bound type) subtype of A", which is `out A`
 
             // But for now, to reduce differences in behaviour of old and new inference, we'll approximate such types to `KClass<out A!>`
 

--- a/kotlin-native/runtime/src/alloc/custom/README.md
+++ b/kotlin-native/runtime/src/alloc/custom/README.md
@@ -189,7 +189,7 @@ struct alignas(8) FixedCellRange {
 
 Consecutive unallocated cells are represented by a `FixedCellRange`, with
 `.first` and `.last` being the inclusive end points of the range of unallocated
-cells. The `FixedBlockCell` at the the `.last` index contains a
+cells. The `FixedBlockCell` at the `.last` index contains a
 `FixedCellRange` with the next range of unallocated cells. The `FixedCellRange`
 of unallocated ranges thus form a linked list.
 

--- a/kotlin-native/runtime/src/main/cpp/Memory.h
+++ b/kotlin-native/runtime/src/main/cpp/Memory.h
@@ -353,7 +353,7 @@ ThreadState SwitchThreadState(MemoryState* thread, ThreadState newState, bool re
 void AssertThreadState(MemoryState* thread, ThreadState expected) noexcept;
 void AssertThreadState(MemoryState* thread, std::initializer_list<ThreadState> expected) noexcept;
 
-// Asserts that the current thread is in the the given state.
+// Asserts that the current thread is in the given state.
 ALWAYS_INLINE inline void AssertThreadState(ThreadState expected) noexcept {
     // Avoid redundant TLS access in GetMemoryState if runtime asserts are disabled.
     if (compiler::runtimeAssertsMode() != compiler::RuntimeAssertsMode::kIgnore) {

--- a/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/MavenResolverTest.kt
+++ b/libraries/scripting/dependencies-maven/test/kotlin/script/experimental/test/MavenResolverTest.kt
@@ -328,7 +328,7 @@ class MavenResolverTest : ResolversTestBase() {
             filesWithDependsOnFirst.any { it.name.startsWith("kotlin-shell-core-") && it.extension == "jar" }
         )
 
-        // Test that the the same files are resolved regardless of annotation order
+        // Test that the same files are resolved regardless of annotation order
         assertEquals(filesWithReposFirst.map { it.name }.sorted(), filesWithDependsOnFirst.map { it.name }.sorted())
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
@@ -1110,7 +1110,7 @@ class BuildReportsIT : KGPBaseTest() {
         }
     }
 
-    @DisplayName("Verify metrics for for 2nd phase native in-process compilation")
+    @DisplayName("Verify metrics for 2nd phase native in-process compilation")
     @NativeGradlePluginTests
     @GradleTest
     @GradleTestVersions(

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/TestProcessSettings.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/settings/TestProcessSettings.kt
@@ -84,7 +84,7 @@ enum class TestMode(private val description: String) {
 }
 
 /**
- * Kotlin compiler plugins to be used together with the the Kotlin/Native compiler.
+ * Kotlin compiler plugins to be used together with the Kotlin/Native compiler.
  */
 @JvmInline
 value class CompilerPlugins(val compilerPluginJars: Set<File>) {

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/jvm/JvmAtomicfuIrBuilder.kt
@@ -203,5 +203,5 @@ class JvmAtomicfuIrBuilder(
         valueType: IrType,
         dispatchReceiver: IrExpression?
     ) = callArraySizeConstructor(atomicArrayClass, size)
-        ?: error("Failed to find a constructor for the the given atomic array type ${atomicArrayClass.defaultType.render()}.")
+        ?: error("Failed to find a constructor for the given atomic array type ${atomicArrayClass.defaultType.render()}.")
 }

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/native/NativeAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/native/NativeAtomicfuIrBuilder.kt
@@ -194,7 +194,7 @@ class NativeAtomicfuIrBuilder(
         } else {
             callArraySizeAndInitConstructor(atomicArrayClass, size, valueType, dispatchReceiver)
         }?.let { return it }
-        error("Failed to find a constructor for the the given atomic array type ${atomicArrayClass.defaultType.render()}.")
+        error("Failed to find a constructor for the given atomic array type ${atomicArrayClass.defaultType.render()}.")
     }
 
 }

--- a/plugins/scripting/scripting-tests/tests/org/jetbrains/kotlin/scripting/test/host/ScriptTemplateTest.kt
+++ b/plugins/scripting/scripting-tests/tests/org/jetbrains/kotlin/scripting/test/host/ScriptTemplateTest.kt
@@ -68,7 +68,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 // TODO: the contents of this file should go into ScriptTest.kt and replace appropriate xml-based functionality,
-// as soon as the the latter is removed from the codebase
+// as soon as the latter is removed from the codebase
 
 class ScriptTemplateTest {
     @Test


### PR DESCRIPTION
Removes accidentally duplicated words ("the the", "for for") in comments, KDoc, one Markdown document and two error messages.

Intentional occurrences such as "for for-loop", the vendored `sqlite3.h` test fixtures and historical changelog entries are left untouched.