### PR TITLE
[build] Test Federation: Do not set JUnit category includes

### DIFF
--- a/repo/gradle-build-conventions/test-federation-convention/src/main/kotlin/test-federation-convention.gradle.kts
+++ b/repo/gradle-build-conventions/test-federation-convention/src/main/kotlin/test-federation-convention.gradle.kts
@@ -110,23 +110,6 @@ tasks.withType<Test>().configureEach {
             println("##teamcity[addBuildTag 'Mode: Full']")
         }
 
-        /* Configuring JUnit includes */
-        if (testFederationMode.get() == TestFederationMode.Smoke) {
-            smokeTestConfig as SmokeTestConfig.Enabled
-
-            /*
-            If we only execute tagged smoke/contract tests, then we can already add those tags as includes.
-            The 'SmokeTestExecutionCondition' would also filter relevant tests, however adding a filter here can lead to
-            a better rendering of the executed tests.
-            */
-            if (smokeTestConfig.autoSmokeTestPercentage == 0) {
-                testFramework.options.includeTags("smoke")
-                affectedDomains.get().forEach { domain ->
-                    testFramework.options.includeTags("affectedBy:${domain.name}")
-                }
-            }
-        }
-
         /* Exclude nightly tests if not specifically running in 'nightly' mode */
         if (!areNightlyTestsEnabled.get()) {
             testFramework.options.excludeTags("nightly", "org.jetbrains.kotlin.testFederation.NightlyTest")

--- a/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/TestFederationFunctionalTest.kt
+++ b/repo/gradle-build-conventions/test-federation-convention/src/test/kotlin/org/jetbrains/kotlin/testFederation/TestFederationFunctionalTest.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.testFederation.TestBuildResult.TestResult
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
+import kotlin.collections.filterNot
 import kotlin.io.path.Path
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.name
@@ -383,9 +384,15 @@ private fun runTestBuild(
     val tests = output.mapNotNull { line ->
         val match = testResultRegex.matchEntire(line) ?: return@mapNotNull null
         TestResult(match.groupValues[1], match.groupValues[2], match.groupValues[3])
-    }
 
-    return TestBuildResult(buildResult, tests.toSet())
+    }
+        /**
+         * Can be removed again after:
+         * https://youtrack.jetbrains.com/issue/KT-88303
+         */
+        .filterNot { it.status == "SKIPPED" }.toSet()
+
+    return TestBuildResult(buildResult, tests)
 }
 
 private fun cleanTest(): BuildResult {


### PR DESCRIPTION
As this will mess with the user configuration:
If we have a test that only supports 'foo' tagged tests,

```kotlin
testFramework.options.includeTags("foo")
```

then adding *additonal tests* which are mared as 'Smoke' or 'AffectedBy' will not run the intersection of 'foo' tests which are also marked as Smoke or affected but the composite.

Therefore, we rely only on the ExecutionCondition to filter for Smoke and AffectedBy tests.