### PR TITLE
[Gradle] Fix custom npm dependency versions

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/WasmNpmToolingDependenciesIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/WasmNpmToolingDependenciesIT.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalWasmDsl::class)
+
+package org.jetbrains.kotlin.gradle.js
+
+import kotlinx.serialization.json.Json
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.kotlin
+import org.gradle.kotlin.dsl.withType
+import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.NpmVersions
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNpmTooling
+import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.gradle.testing.js.PackageLockJson
+import org.junit.jupiter.api.assertNotNull
+import kotlin.io.path.appendText
+import kotlin.io.path.createDirectories
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readText
+import kotlin.test.assertEquals
+
+@GradleTestVersions(
+    // Gradle version is irrelevant
+    minVersion = TestVersions.Gradle.MAX_SUPPORTED
+)
+sealed class WasmNpmToolingDependenciesIT(
+    private val packageManager: String,
+) : KGPBaseTest() {
+
+    class Npm : WasmNpmToolingDependenciesIT(packageManager = "npm")
+
+    class Yarn : WasmNpmToolingDependenciesIT(packageManager = "yarn")
+
+    private val useYarn: Boolean = when (packageManager) {
+        "yarn" -> true
+        "npm" -> false
+        else -> error("unknown packageManager $packageManager")
+    }
+
+    @GradleTest
+    @MppGradlePluginTests
+    fun `can override versions of Wasm npm tooling dependencies`(
+        gradleVersion: GradleVersion,
+    ) {
+        project("emptyKts", gradleVersion) {
+            plugins {
+                kotlin("multiplatform")
+            }
+
+            val wasmJsNpmToolingDir = projectPath.resolve("customWasmJsNpmToolingDir")
+                .createDirectories().toFile()
+
+            gradleProperties.appendText("\nkotlin.js.yarn=${useYarn}\n")
+            @Suppress("INVISIBLE_REFERENCE")
+            val defaultWebpackVersion = NpmVersions.defaultVersions.getValue("webpack")
+
+            // npm semver supports ranges. Spaces means 'AND'. So adding `>0.0.0` means nothing.
+            // We can just add it to check this custom version gets propagated to the `package.json`.
+            val overrideWebpackVersion = ">0.0.0 $defaultWebpackVersion"
+
+            buildScriptInjection {
+                kotlinMultiplatform.apply {
+                    wasmJs {
+                        browser()
+                        binaries.executable()
+                    }
+                }
+
+                project.plugins.withType<WasmNodeJsRootPlugin> {
+                    project.extensions.configure<WasmNodeJsRootExtension> {
+                        versions.apply {
+                            webpack.version = overrideWebpackVersion
+                        }
+                    }
+                }
+
+                // override the default shared install dir, so our tests don't corrupt the live shared dir
+                project.plugins.withType<WasmNodeJsRootPlugin>().configureEach { _ ->
+                    project.extensions.configure<WasmNpmTooling> {
+                        @Suppress("INVISIBLE_REFERENCE")
+                        defaultInstallationDir.fileValue(wasmJsNpmToolingDir)
+                    }
+                }
+            }
+
+            build("kotlinWasmToolingSetup") {
+
+                assertTasksExecuted(":kotlinWasmToolingSetup")
+
+                val kgpNpmToolingDir = wasmJsNpmToolingDir.toPath().listDirectoryEntries().singleOrNull()
+                assertNotNull(kgpNpmToolingDir) {
+                    "missing npm tooling directory in ${wasmJsNpmToolingDir}. " +
+                            "All entries: " +
+                            wasmJsNpmToolingDir.toPath().listDirectoryEntries()
+                }
+
+                val packageJsonFile = kgpNpmToolingDir.resolve("package.json")
+                assertFileExists(packageJsonFile)
+
+                val packageJson = json.decodeFromString<PackageLockJson.Package>(packageJsonFile.readText())
+                assertEquals(
+                    overrideWebpackVersion,
+                    packageJson.dependencies["webpack"],
+                )
+            }
+        }
+    }
+
+    companion object {
+        private val json = Json {
+            ignoreUnknownKeys = true
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/kgpNpmToolingDependencies.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/kgpNpmToolingDependencies.kt
@@ -13,7 +13,6 @@ import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.withType
 import org.gradle.process.ExecOperations
-import org.jetbrains.kotlin.gradle.targets.js.NpmVersions
 import org.jetbrains.kotlin.gradle.targets.js.allDependenciesInternal
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsEnvSpec
@@ -28,6 +27,7 @@ import org.jetbrains.kotlin.gradle.testbase.buildScriptInjection
 import org.jetbrains.kotlin.gradle.testbase.buildScriptReturn
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.Serializable
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
@@ -53,7 +53,9 @@ private fun KClass<*>.loadResource(path: String): String {
  *
  * @see [org.jetbrains.kotlin.gradle.targets.js.NpmVersions]
  */
-internal fun createKgpNpmToolingPackageJson(npmVersions: NpmVersions): String {
+private fun createKgpNpmToolingPackageJson(
+    defaultNpmVersions: List<NpmPackageVersionForTests>,
+): String {
     val json = Json {
         prettyPrint = true
     }
@@ -64,7 +66,7 @@ internal fun createKgpNpmToolingPackageJson(npmVersions: NpmVersions): String {
             put("version", "1.0.0")
             put("private", true)
             put("dependencies", buildJsonObject {
-                npmVersions.allDependenciesInternal().forEach { dep ->
+                defaultNpmVersions.forEach { dep ->
                     put(dep.name, dep.requestedVersion)
                 }
             })
@@ -81,10 +83,7 @@ internal fun TestProject.setupCustomKgpNpmToolingDependenciesDir(
     useYarn: Boolean,
 ) {
     // Use the same NpmVersions that KGP uses (which is important, because we're also using KGP's lockfiles)
-    val defaultNpmVersions =
-        buildScriptReturn {
-            project.extensions.getByName<WasmNodeJsRootExtension>(WasmNodeJsRootExtension.EXTENSION_NAME).versions
-        }.buildAndReturn()
+    val defaultNpmVersions = extractDefaultKgpNpmPackageVersions()
     val packageJson = createKgpNpmToolingPackageJson(defaultNpmVersions)
 
     createCustomKgpNpmToolingDependenciesDir(
@@ -98,6 +97,32 @@ internal fun TestProject.setupCustomKgpNpmToolingDependenciesDir(
         toolingCustomDir = toolingCustomDir,
     )
 }
+
+/**
+ * Extract KGP's default npm dependencies.
+ */
+private fun TestProject.extractDefaultKgpNpmPackageVersions(): List<NpmPackageVersionForTests> {
+    return buildScriptReturn {
+        val npmVersions = project.extensions.getByName<WasmNodeJsRootExtension>(WasmNodeJsRootExtension.EXTENSION_NAME).versions
+        @Suppress("INVISIBLE_REFERENCE")
+        npmVersions.allDependenciesInternal(project.objects, project.providers).map { npv ->
+            NpmPackageVersionForTests(
+                name = npv.name.get(),
+                requestedVersion = npv.requestedVersion.get(),
+            )
+        }
+    }.buildAndReturn()
+}
+
+/**
+ * Serializable copy of [org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersionInternal].
+ * (This class is required because `buildScriptReturn {}` can't serialize
+ * `NpmPackageVersionInternal` because it can't serialize [org.gradle.api.provider.Property].)
+ */
+private data class NpmPackageVersionForTests(
+    val name: String,
+    val requestedVersion: String,
+) : Serializable
 
 private fun createCustomKgpNpmToolingDependenciesDir(
     toolingCustomDir: Path,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmPackageVersion.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/NpmPackageVersion.kt
@@ -7,12 +7,22 @@ package org.jetbrains.kotlin.gradle.targets.js
 
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependency
+import org.jetbrains.kotlin.gradle.utils.newInstance
+import java.io.Serializable
 
 data class NpmPackageVersion(
     @Input
     val name: String,
+    /**
+     * The version that will be used to install this dependency.
+     *
+     */
+    // Defaults to the exact resolved version from the lockfile,
+    // not the requested version from a `package.json` (which might be a flexible, ranged version).
     @Input
     var version: String,
 ) : RequiredKotlinJsDependency {
@@ -23,35 +33,71 @@ data class NpmPackageVersion(
 /**
  * Describes an npm dependency, in addition to the requested and resolved versions.
  */
-// This class was added because it's hard to modify NpmPackageVersion.
-// See KT-88160.
-internal data class NpmPackageVersionInternal(
-    @Input
-    val name: String,
+// This class was added because it's hard to modify NpmPackageVersion, see KT-88160.
+// Also because NpmPackageVersion doesn't support the Provider API KT-77145.
+internal abstract class NpmPackageVersionInternal : Serializable {
+
+    /**
+     * npm package name.
+     *
+     * @see NpmPackageVersion.name
+     */
+    @get:Input
+    abstract val name: Property<String>
+
     /**
      * The version originally requested in a `package.json` dependencies block.
      * Typically this will be a dynamic version, e.g. `^1.0.0`.
      *
      * This version is used create a `package.json` in the shared `kotlin-npm-tooling` directory.
      */
-    @Input
-    val requestedVersion: String,
+    @get:Input
+    abstract val requestedVersion: Property<String>
+
     /**
      * The exact resolved version, from `package-lock.json`.
      *
      * This is the same version exposed to users in [NpmPackageVersion.version].
      */
-    @Input
-    val resolvedVersion: String,
-)
+    @get:Input
+    abstract val resolvedVersion: Property<String>
+}
 
-internal fun NpmVersions.allDependenciesInternal(): List<NpmPackageVersionInternal> =
+internal fun ObjectFactory.NpmPackageVersionInternal(
+    configure: (NpmPackageVersionInternal) -> Unit,
+): NpmPackageVersionInternal =
+    newInstance<NpmPackageVersionInternal>().apply(configure)
+
+internal fun NpmVersions.allDependenciesInternal(
+    objects: ObjectFactory,
+    providers: ProviderFactory,
+): List<NpmPackageVersionInternal> =
     allDependencies.map { npv ->
-        val requestedVersion = requestedVersions[npv]
-            ?: error("NpmVersions is missing requestedVersion for ${npv.name}")
-        NpmPackageVersionInternal(
-            name = npv.name,
-            requestedVersion = requestedVersion,
-            resolvedVersion = npv.version,
-        )
+        val defaultVersion = NpmVersions.defaultVersions[npv.name]
+
+        val npvVersion = providers.provider { npv.version }
+
+        // Determine the version to use in the `package.json` file.
+        val requestedVersion = npvVersion.map { version ->
+            if (version != defaultVersion) {
+                // If the version doesn't match the default version, then it's been modified by a user.
+                // In this case, the modified version should be used instead of the 'requested' version.
+                version
+            } else {
+                // If the version _does_ match the default, then instead use the _requested_ version.
+                // Using the requested version is important for Yarn:
+                // KGP's embedded `yarn.lock` file contains the _requested_ versions.
+                // Yarn will ignore the lockfile if the `package.json` doesn't have exactly the same versions.
+                requestedVersions.entries
+                    .firstOrNull { (k, _) -> k.name == npv.name }
+                    ?.value
+                    ?: error("NpmVersions is missing requestedVersion for ${npv.name}. $requestedVersions")
+            }
+        }
+
+        objects.NpmPackageVersionInternal { npvInternal ->
+            npvInternal.name.set(npv.name)
+            npvInternal.requestedVersion.set(requestedVersion)
+            npvInternal.resolvedVersion.set(npvVersion)
+        }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinToolingSetupTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinToolingSetupTask.kt
@@ -77,7 +77,7 @@ internal constructor() :
                 ).apply {
                     private = true
                     dependencies.putAll(
-                        tools.get().map { it.name to it.requestedVersion }
+                        tools.get().map { it.name.get() to it.requestedVersion.get() }
                     )
                 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootPlugin.kt
@@ -6,7 +6,9 @@
 package org.jetbrains.kotlin.gradle.targets.wasm.nodejs
 
 import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.targets.js.allDependenciesInternal
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.TASKS_GROUP_NAME
@@ -24,6 +26,7 @@ import org.jetbrains.kotlin.gradle.tasks.registerTask
 import org.jetbrains.kotlin.gradle.utils.castIsolatedKotlinPluginClassLoaderAware
 import org.jetbrains.kotlin.gradle.utils.getFile
 import org.jetbrains.kotlin.gradle.utils.userKotlinPersistentDir
+import javax.inject.Inject
 
 /**
  * Represents the root plugin class for configuring and applying Node.js-related functionality specifically tailored for WebAssembly (Wasm) projects.
@@ -38,7 +41,12 @@ import org.jetbrains.kotlin.gradle.utils.userKotlinPersistentDir
  * - Configuring dependencies and lockfile management for Wasm project setups.
  *
  */
-abstract class WasmNodeJsRootPlugin internal constructor() : CommonNodeJsRootPlugin {
+abstract class WasmNodeJsRootPlugin
+@Inject
+internal constructor(
+    private val objects: ObjectFactory,
+    private val providers: ProviderFactory,
+) : CommonNodeJsRootPlugin {
 
     override fun apply(target: Project) {
         val rootDirectoryName = WasmPlatformDisambiguator.platformDisambiguator
@@ -73,7 +81,7 @@ abstract class WasmNodeJsRootPlugin internal constructor() : CommonNodeJsRootPlu
 
         val packageManagerName = nodeJsRoot.packageManagerExtension.map { it.name }
 
-        val allDeps = nodeJsRoot.versions.allDependenciesInternal()
+        val allDeps = nodeJsRoot.versions.allDependenciesInternal(objects, providers)
 
         val npmTooling = target.extensions.create(
             "wasmNpmTooling",

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNpmTooling.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNpmTooling.kt
@@ -35,9 +35,13 @@ abstract class WasmNpmTooling internal constructor() {
         return allDeps.map { allDepsValue ->
             val md = MessageDigest.getInstance("MD5")
             allDepsValue.forEach { dep ->
-                md.update(dep.name.toByteArray(StandardCharsets.UTF_8))
-                md.update(dep.requestedVersion.toByteArray(StandardCharsets.UTF_8))
-                md.update(dep.resolvedVersion.toByteArray(StandardCharsets.UTF_8))
+                val name = dep.name.orNull.orEmpty()
+                val requestedVersion = dep.requestedVersion.orNull.orEmpty()
+                val resolvedVersion = dep.resolvedVersion.orNull.orEmpty()
+
+                md.update(name.toByteArray(StandardCharsets.UTF_8))
+                md.update(requestedVersion.toByteArray(StandardCharsets.UTF_8))
+                md.update(resolvedVersion.toByteArray(StandardCharsets.UTF_8))
             }
 
             val hashVersion = md.digest().toHexString()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootExtensionTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootExtensionTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+@file:OptIn(ExperimentalWasmDsl::class)
+
+package org.jetbrains.kotlin.gradle.targets.wasm.nodejs
+
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.multiplatformExtension
+import org.jetbrains.kotlin.gradle.targets.js.allDependenciesInternal
+import org.jetbrains.kotlin.gradle.util.buildProjectWithMPP
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class WasmNodeJsRootExtensionTest {
+
+    @Test
+    fun `verify npm dependencies versions can be overridden`() {
+        val project = buildProjectWithMPP {
+            multiplatformExtension.apply {
+                wasmJs {
+                    browser()
+                }
+            }
+        }
+
+        project.evaluate()
+
+        val wasmNodeJsRootExtension = project.extensions.getByType(WasmNodeJsRootExtension::class)
+        val allDeps = wasmNodeJsRootExtension.versions.allDependenciesInternal(project.objects, project.providers)
+
+        fun getWebpack() =
+            allDeps.firstOrNull { it.name.orNull == "webpack" }
+
+        assertNotEquals("CUSTOM-VERSION", getWebpack()?.resolvedVersion?.orNull)
+
+        // users can override the default versions _after_ KGP is evaluated
+        wasmNodeJsRootExtension.versions.apply {
+            webpack.version = "CUSTOM-VERSION"
+        }
+
+        assertEquals("CUSTOM-VERSION", getWebpack()?.resolvedVersion?.orNull, "custom version overrides resolvedVersion")
+        assertEquals("CUSTOM-VERSION", getWebpack()?.requestedVersion?.orNull, "custom version overrides requestedVersion")
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNpmToolingTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNpmToolingTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.targets.wasm.nodejs
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.targets.js.NpmPackageVersionInternal
+import org.jetbrains.kotlin.gradle.utils.newInstance
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class WasmNpmToolingTest {
+    @Test
+    fun `verify changes in npm packages update WasmNpmTooling version`(
+        @TempDir tempDir: File,
+    ) {
+        val project = ProjectBuilder.builder().build()
+        val objects = project.objects
+
+        fun NpmPackageVersionInternal.reset() {
+            name.set("name 1")
+            resolvedVersion.set("resolved 1")
+            requestedVersion.set("requested 1")
+        }
+
+        val npv = objects.NpmPackageVersionInternal {
+            it.reset()
+        }
+
+        val wasmNpmTooling = project.objects.newInstance<WasmNpmTooling>().apply {
+            allDeps.set(listOf(npv))
+            defaultInstallationDir.set(tempDir)
+        }
+
+        fun npmTooling() = wasmNpmTooling.produceEnv().get()
+
+        val initialVersion = npmTooling().version
+
+        fun testChange(mutate: (npv: NpmPackageVersionInternal) -> Unit) {
+            npv.reset()
+            mutate(npv)
+            val actualVersion = npmTooling().version
+            assertNotEquals(actualVersion, initialVersion, "Expect version has changed after NpmPackageVersionInternal is modified")
+
+            assertEquals(tempDir.resolve(actualVersion).invariantSeparatorsPath, npmTooling().dir.invariantSeparatorsPath)
+        }
+
+        testChange { npv.name.set("name2") }
+        testChange { npv.resolvedVersion.set("resolved 2") }
+        testChange { npv.requestedVersion.set("requested 2") }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/testFixtures/kotlin/org/jetbrains/kotlin/gradle/testing/js/PackageLockJson.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/testFixtures/kotlin/org/jetbrains/kotlin/gradle/testing/js/PackageLockJson.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  * to reduce the complexity and maintenance.
  */
 @Serializable
-internal data class PackageLockJson(
+data class PackageLockJson(
     val name: String,
     val version: String? = null,
     val packages: Map<String, Package>,

--- a/repo/gradle-build-conventions/kgp-npm-tooling-helper/src/main/kotlin/tasks/GenerateNpmVersionsKotlinClassTask.kt
+++ b/repo/gradle-build-conventions/kgp-npm-tooling-helper/src/main/kotlin/tasks/GenerateNpmVersionsKotlinClassTask.kt
@@ -158,7 +158,7 @@ internal constructor() : DefaultTask() {
             appendLine("// Generated class. Do not modify directly!")
             appendLine("class $npmVersionsClassName : Serializable {")
             dependencies.forEach { dep ->
-                appendLine("    val ${dep.displayName} = NpmPackageVersion(\"${dep.name}\", \"${dep.resolvedVersion}\")")
+                appendLine("    val ${dep.displayName} = NpmPackageVersion(\"${dep.name}\")")
             }
             appendLine()
             appendLine("    val allDependencies: List<NpmPackageVersion> = listOf(")
@@ -175,6 +175,29 @@ internal constructor() : DefaultTask() {
                 appendLine("        ${dep.displayName} to \"${dep.requestedVersion}\",")
             }
             appendLine("    )")
+            appendLine()
+            appendLine("    internal companion object {")
+            appendLine()
+            appendLine("        /**")
+            appendLine("         * Create a new [NpmPackageVersion], ")
+            appendLine("         * using the default version from [defaultVersions].")
+            appendLine("         */")
+            appendLine("        private fun NpmPackageVersion(name: String): NpmPackageVersion =")
+            appendLine("            NpmPackageVersion(")
+            appendLine("                name = name,")
+            appendLine("                version = defaultVersions.getValue(name),")
+            appendLine("            )")
+            appendLine()
+            appendLine("        /**")
+            appendLine("         * The default versions from KGP's `kotlin-npm-tooling/package.json`.")
+            appendLine("         * The values declared in [allDependencies] may be overwritten by users.")
+            appendLine("         */")
+            appendLine("        internal val defaultVersions: Map<String, String> = mapOf(")
+            dependencies.forEach { dep ->
+                appendLine("            \"${dep.name}\" to \"${dep.resolvedVersion}\",")
+            }
+            appendLine("        )")
+            appendLine("    }")
             appendLine("}")
         }
     }


### PR DESCRIPTION
Update `NpmPackageVersionInternal` to use the Provider API for its properties. This fixes a bug where user-provided versions (which are set after KGP has been configured) were not used in the shared npm-tooling project.

The fix is achieved by storing the original default versions in the generated NpmVersions class. If `NpmPackageVersion.version` does not match the default, then it's been modified by a user, and should be used instead of the default 'requested' version

Follow up for KT-88115.

^KT-88285