### PR TITLE
Enable "Must-Use Return Values" feature in the Kotlin project

### DIFF
--- a/analysis/analysis-api-standalone/analysis-api-fir-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/services/LLStandaloneFirElementByPsiElementChooser.kt
+++ b/analysis/analysis-api-standalone/analysis-api-fir-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/services/LLStandaloneFirElementByPsiElementChooser.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.psi.psiUtil.hasActualModifier
 import org.jetbrains.kotlin.psi.psiUtil.hasExpectModifier
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.utils.addIfNotNull
+import org.jetbrains.kotlin.utils.addToStdlib.forEachZipped
 
 /**
  * In Standalone mode, deserialized elements don't have sources, so we need to implement [LLFirElementByPsiElementChooser] based on
@@ -105,7 +106,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
     private fun typeParametersMatch(psiFunction: KtCallableDeclaration, firFunction: FirCallableDeclaration): Boolean {
         if (firFunction.typeParameters.size != psiFunction.typeParameters.size) return false
         val boundsByName = psiFunction.typeConstraints.groupBy { it.subjectTypeParameterName?.getReferencedName() }
-        firFunction.typeParameters.zip(psiFunction.typeParameters).forEach { [expectedTypeParameter, candidateTypeParameter] ->
+        firFunction.typeParameters.forEachZipped(psiFunction.typeParameters) { expectedTypeParameter, candidateTypeParameter ->
             if (expectedTypeParameter.symbol.name.toString() != candidateTypeParameter.name) return false
             val candidateBounds = mutableListOf<KtTypeReference>()
             candidateBounds.addIfNotNull(candidateTypeParameter.extendsBound)
@@ -114,7 +115,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
             }
             val expectedBounds = expectedTypeParameter.symbol.resolvedBounds.filter { it !is FirImplicitNullableAnyTypeRef }
             if (candidateBounds.size != expectedBounds.size) return false
-            expectedBounds.zip(candidateBounds).forEach { [expectedBound, candidateBound] ->
+            expectedBounds.forEachZipped(candidateBounds) { expectedBound, candidateBound ->
                 if (!isTheSameTypes(
                         candidateBound,
                         expectedBound,
@@ -137,7 +138,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
             return false
         }
 
-        firParameters.zip(psiParameters).forEach { [expectedParameter, candidateParameter] ->
+        firParameters.forEachZipped(psiParameters) { expectedParameter, candidateParameter ->
             if (expectedParameter.name.toString() != candidateParameter.name) return false
             if (expectedParameter.isVararg != candidateParameter.isVarArg) return false
             val candidateParameterType = candidateParameter.typeReference ?: return false
@@ -166,7 +167,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
                     return false
                 }
 
-                firContextParameters.zip(contextReceivers).forEach { [expectedParameter, candidateParameterType] ->
+                firContextParameters.forEachZipped(contextReceivers) { expectedParameter, candidateParameterType ->
                     val typeReference = candidateParameterType.typeReference() ?: return false
                     if (!isTheSameTypes(typeReference, expectedParameter.returnTypeRef, isVararg = false)) {
                         return false

--- a/analysis/analysis-api-standalone/analysis-api-fir-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/services/LLStandaloneFirElementByPsiElementChooser.kt
+++ b/analysis/analysis-api-standalone/analysis-api-fir-standalone-base/src/org/jetbrains/kotlin/analysis/api/standalone/base/services/LLStandaloneFirElementByPsiElementChooser.kt
@@ -105,7 +105,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
     private fun typeParametersMatch(psiFunction: KtCallableDeclaration, firFunction: FirCallableDeclaration): Boolean {
         if (firFunction.typeParameters.size != psiFunction.typeParameters.size) return false
         val boundsByName = psiFunction.typeConstraints.groupBy { it.subjectTypeParameterName?.getReferencedName() }
-        firFunction.typeParameters.zip(psiFunction.typeParameters) { expectedTypeParameter, candidateTypeParameter ->
+        firFunction.typeParameters.zip(psiFunction.typeParameters).forEach { [expectedTypeParameter, candidateTypeParameter] ->
             if (expectedTypeParameter.symbol.name.toString() != candidateTypeParameter.name) return false
             val candidateBounds = mutableListOf<KtTypeReference>()
             candidateBounds.addIfNotNull(candidateTypeParameter.extendsBound)
@@ -114,7 +114,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
             }
             val expectedBounds = expectedTypeParameter.symbol.resolvedBounds.filter { it !is FirImplicitNullableAnyTypeRef }
             if (candidateBounds.size != expectedBounds.size) return false
-            expectedBounds.zip(candidateBounds) { expectedBound, candidateBound ->
+            expectedBounds.zip(candidateBounds).forEach { [expectedBound, candidateBound] ->
                 if (!isTheSameTypes(
                         candidateBound,
                         expectedBound,
@@ -137,7 +137,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
             return false
         }
 
-        firParameters.zip(psiParameters) { expectedParameter, candidateParameter ->
+        firParameters.zip(psiParameters).forEach { [expectedParameter, candidateParameter] ->
             if (expectedParameter.name.toString() != candidateParameter.name) return false
             if (expectedParameter.isVararg != candidateParameter.isVarArg) return false
             val candidateParameterType = candidateParameter.typeReference ?: return false
@@ -166,7 +166,7 @@ class LLStandaloneFirElementByPsiElementChooser : LLFirElementByPsiElementChoose
                     return false
                 }
 
-                firContextParameters.zip(contextReceivers) { expectedParameter, candidateParameterType ->
+                firContextParameters.zip(contextReceivers).forEach { [expectedParameter, candidateParameterType] ->
                     val typeReference = candidateParameterType.typeReference() ?: return false
                     if (!isTheSameTypes(typeReference, expectedParameter.returnTypeRef, isVararg = false)) {
                         return false

--- a/analysis/decompiled/light-classes-for-decompiled/src/org/jetbrains/kotlin/analysis/decompiled/light/classes/origin/KotlinDeclarationInCompiledFileSearcher.kt
+++ b/analysis/decompiled/light-classes-for-decompiled/src/org/jetbrains/kotlin/analysis/decompiled/light/classes/origin/KotlinDeclarationInCompiledFileSearcher.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isCompanion
 import org.jetbrains.kotlin.psi.stubs.impl.KotlinAnnotationEntryStubImpl
 import org.jetbrains.kotlin.utils.SmartList
 import org.jetbrains.kotlin.utils.addIfNotNull
+import org.jetbrains.kotlin.utils.addToStdlib.forEachZipped
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
@@ -338,7 +339,7 @@ class KotlinDeclarationInCompiledFileSearcher {
 
     private fun doTypeParametersMatchByName(member: PsiMethod, callableDeclaration: KtCallableDeclaration): Boolean {
         if (member.typeParameters.size != callableDeclaration.typeParameters.size) return false
-        member.typeParameters.zip(callableDeclaration.typeParameters).forEach { [psiTypeParam, ktTypeParameter] ->
+        member.typeParameters.forEachZipped(callableDeclaration.typeParameters) { psiTypeParam, ktTypeParameter ->
             if (psiTypeParam.name.toString() != ktTypeParameter.name) {
                 return false
             }
@@ -417,7 +418,7 @@ class KotlinDeclarationInCompiledFileSearcher {
     private fun doTypeParameters(member: PsiMethod, ktNamedFunction: KtFunction): Boolean {
         if (member.typeParameters.size != ktNamedFunction.typeParameters.size) return false
         val boundsByName = ktNamedFunction.typeConstraints.groupBy { it.subjectTypeParameterName?.getReferencedName() }
-        member.typeParameters.zip(ktNamedFunction.typeParameters).forEach { [psiTypeParam, ktTypeParameter] ->
+        member.typeParameters.forEachZipped(ktNamedFunction.typeParameters) { psiTypeParam, ktTypeParameter ->
             if (psiTypeParam.name.toString() != ktTypeParameter.name) return false
             val psiBounds = mutableListOf<KtTypeReference>()
             psiBounds.addIfNotNull(ktTypeParameter.extendsBound)
@@ -426,7 +427,7 @@ class KotlinDeclarationInCompiledFileSearcher {
             }
             val expectedBounds = psiTypeParam.extendsListTypes
             if (psiBounds.size != expectedBounds.size) return false
-            expectedBounds.zip(psiBounds).forEach { [expectedBound, candidateBound] ->
+            expectedBounds.forEachZipped(psiBounds) { expectedBound, candidateBound ->
                 if (!areTypesTheSame(candidateBound, expectedBound, false)) {
                     return false
                 }

--- a/analysis/decompiled/light-classes-for-decompiled/src/org/jetbrains/kotlin/analysis/decompiled/light/classes/origin/KotlinDeclarationInCompiledFileSearcher.kt
+++ b/analysis/decompiled/light-classes-for-decompiled/src/org/jetbrains/kotlin/analysis/decompiled/light/classes/origin/KotlinDeclarationInCompiledFileSearcher.kt
@@ -338,7 +338,7 @@ class KotlinDeclarationInCompiledFileSearcher {
 
     private fun doTypeParametersMatchByName(member: PsiMethod, callableDeclaration: KtCallableDeclaration): Boolean {
         if (member.typeParameters.size != callableDeclaration.typeParameters.size) return false
-        member.typeParameters.zip(callableDeclaration.typeParameters) { psiTypeParam, ktTypeParameter ->
+        member.typeParameters.zip(callableDeclaration.typeParameters).forEach { [psiTypeParam, ktTypeParameter] ->
             if (psiTypeParam.name.toString() != ktTypeParameter.name) {
                 return false
             }
@@ -417,7 +417,7 @@ class KotlinDeclarationInCompiledFileSearcher {
     private fun doTypeParameters(member: PsiMethod, ktNamedFunction: KtFunction): Boolean {
         if (member.typeParameters.size != ktNamedFunction.typeParameters.size) return false
         val boundsByName = ktNamedFunction.typeConstraints.groupBy { it.subjectTypeParameterName?.getReferencedName() }
-        member.typeParameters.zip(ktNamedFunction.typeParameters) { psiTypeParam, ktTypeParameter ->
+        member.typeParameters.zip(ktNamedFunction.typeParameters).forEach { [psiTypeParam, ktTypeParameter] ->
             if (psiTypeParam.name.toString() != ktTypeParameter.name) return false
             val psiBounds = mutableListOf<KtTypeReference>()
             psiBounds.addIfNotNull(ktTypeParameter.extendsBound)
@@ -426,7 +426,7 @@ class KotlinDeclarationInCompiledFileSearcher {
             }
             val expectedBounds = psiTypeParam.extendsListTypes
             if (psiBounds.size != expectedBounds.size) return false
-            expectedBounds.zip(psiBounds) { expectedBound, candidateBound ->
+            expectedBounds.zip(psiBounds).forEach { [expectedBound, candidateBound] ->
                 if (!areTypesTheSame(candidateBound, expectedBound, false)) {
                     return false
                 }

--- a/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/api/InvalidFirElementTypeException.kt
+++ b/analysis/low-level-api-fir/src/org/jetbrains/kotlin/analysis/low/level/api/fir/api/InvalidFirElementTypeException.kt
@@ -43,7 +43,7 @@ class InvalidFirElementTypeException(
 
     override val message: String = buildString {
         ktElement?.let {
-            "For ${ktElement::class.simpleName}, "
+            append("For ${ktElement::class.simpleName}, ")
         }
 
         val message = when (expectedFirClasses.size) {

--- a/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/AbstractFirLazyDeclarationResolveTest.kt
+++ b/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/AbstractFirLazyDeclarationResolveTest.kt
@@ -106,10 +106,10 @@ abstract class AbstractFirLazyDeclarationResolveTest : AbstractFirLazyDeclaratio
      * for lazy resolve tests with [KaDanglingFileResolutionMode.IGNORE_SELF] mode if the copy file differs from the original one.
      * That's why we need to use outer [analyzeCopy] call to manually set the dangling file resolution mode.
      */
-    private inline fun <R> wrapWithAnalyzeCopyIfNeeded(
+    private inline fun wrapWithAnalyzeCopyIfNeeded(
         file: KtFile,
         danglingFileResolutionMode: KaDanglingFileResolutionMode?,
-        crossinline action: () -> R
+        crossinline action: () -> Unit
     ) {
         if (file.copyOrigin != null && danglingFileResolutionMode != null) {
             analyzeCopy(file, danglingFileResolutionMode) {

--- a/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/AbstractGetOrBuildFirTest.kt
+++ b/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/AbstractGetOrBuildFirTest.kt
@@ -251,7 +251,7 @@ abstract class AbstractInterruptingGetOrBuildFirTest : AbstractGetOrBuildFirTest
         if (index in testModule.directives[Directives.INTERRUPT_AT]) {
             ErrorResistanceServiceRegistrar.handleInterruption {
                 try {
-                    block()
+                    val _ = block()
                     throw IllegalStateException("Analysis should be interrupted")
                 } catch (_: AnalysisInterruptedException) {
                 }

--- a/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/AbstractDiagnosticTraversalCounterTest.kt
+++ b/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/diagnostic/AbstractDiagnosticTraversalCounterTest.kt
@@ -49,8 +49,9 @@ abstract class AbstractDiagnosticTraversalCounterTest : AbstractAnalysisApiBased
 
     override fun doTestByMainFile(mainFile: KtFile, mainModule: KtTestModule, testServices: TestServices) {
         withResolutionFacade(mainFile) { resolutionFacade ->
-            // we should get diagnostics before we resolve the whole file by  ktFile.getOrBuildFir
-            mainFile.diagnostics(resolutionFacade, DiagnosticCheckerFilter.ONLY_DEFAULT_CHECKERS)
+            // we should get diagnostics before we resolve the whole file by ktFile.getOrBuildFir
+            val _ = mainFile
+                .diagnostics(resolutionFacade, DiagnosticCheckerFilter.ONLY_DEFAULT_CHECKERS)
                 .count()
 
             val firFile = mainFile.getOrBuildFirOfType<FirFile>(resolutionFacade)

--- a/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/resolve/AbstractErrorResistanceTest.kt
+++ b/analysis/low-level-api-fir/testFixtures/org/jetbrains/kotlin/analysis/low/level/api/fir/resolve/AbstractErrorResistanceTest.kt
@@ -25,7 +25,9 @@ abstract class AbstractErrorResistanceTest : AbstractAnalysisApiBasedTest() {
     override fun doTestByMainFile(mainFile: KtFile, mainModule: KtTestModule, testServices: TestServices) {
         withResolutionFacade(mainFile) { resolutionFacade ->
             ErrorResistanceServiceRegistrar.handleInterruption {
-                mainFile.diagnostics(resolutionFacade, DiagnosticCheckerFilter.ONLY_DEFAULT_CHECKERS)
+                // we should get diagnostics before we resolve the whole file by ktFile.getOrBuildFir
+                val _ = mainFile
+                    .diagnostics(resolutionFacade, DiagnosticCheckerFilter.ONLY_DEFAULT_CHECKERS)
                     .count()
             }
 

--- a/analysis/symbol-light-classes/src/org/jetbrains/kotlin/light/classes/symbol/methods/SymbolLightMethod.kt
+++ b/analysis/symbol-light-classes/src/org/jetbrains/kotlin/light/classes/symbol/methods/SymbolLightMethod.kt
@@ -85,7 +85,7 @@ internal abstract class SymbolLightMethod<FType : KaFunctionSymbol> private cons
             }
 
             withFunctionSymbol { functionSymbol ->
-                functionSymbol.valueParameters.mapIndexed { index, parameter ->
+                functionSymbol.valueParameters.forEachIndexed { index, parameter ->
                     val needToSkip = valueParameterPickMask?.get(index) == false
                     if (!needToSkip) {
                         builder.addParameter(createValueParameter(parameter, index))

--- a/build-common/test/org/jetbrains/kotlin/compilerRunner/CompilerArgumentParsingTest.kt
+++ b/build-common/test/org/jetbrains/kotlin/compilerRunner/CompilerArgumentParsingTest.kt
@@ -140,7 +140,7 @@ private fun assertEqualArguments(expected: CommonToolArguments, actual: CommonTo
     expected::class.memberProperties
         .filter { it.javaField?.getAnnotation(Argument::class.java) != null }
         .ifEmpty { fail("No members with ${Argument::class} annotation") }
-        .map { property ->
+        .forEach { property ->
             @Suppress("UNCHECKED_CAST")
             property as KProperty1<Any, Any?>
             val expectedValue = property.get(expected)

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/processUninitializedStores.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/coroutines/processUninitializedStores.kt
@@ -181,7 +181,7 @@ class UninitializedStoresProcessor(private val methodNode: MethodNode) {
         val uninitializedValuesToRemovableUsages = hashMapOf<AbstractInsnNode, MutableSet<AbstractInsnNode>>()
         override fun newOperation(insn: AbstractInsnNode): BasicValue? {
             if (insn.opcode == Opcodes.NEW) {
-                uninitializedValuesToRemovableUsages.getOrPut(insn) { mutableSetOf() }
+                uninitializedValuesToRemovableUsages.computeIfAbsent(insn) { mutableSetOf() }
                 return UninitializedNewValue(insn as TypeInsnNode, insn.desc)
             }
             return super.newOperation(insn)

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InplaceArgumentsMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InplaceArgumentsMethodTransformer.kt
@@ -121,7 +121,7 @@ class InplaceArgumentsMethodTransformer : MethodTransformer() {
                     val next = insn.next
                     return when {
                         next is VarInsnNode && next.opcode in Opcodes.ISTORE..Opcodes.ASTORE -> {
-                            iter.next()
+                            val _ = iter.next()
                             ArgContext(start, insn, calls, next)
                         }
                         insn.previous.isInplaceArgumentStartMarker() -> {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InplaceArgumentsMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/InplaceArgumentsMethodTransformer.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.codegen.InsnSequence
 import org.jetbrains.kotlin.codegen.optimization.boxing.isMethodInsnWith
 import org.jetbrains.kotlin.codegen.optimization.common.*
 import org.jetbrains.kotlin.codegen.optimization.transformer.MethodTransformer
+import org.jetbrains.kotlin.utils.addToStdlib.skipNext
 import org.jetbrains.org.objectweb.asm.Opcodes
 import org.jetbrains.org.objectweb.asm.tree.*
 
@@ -121,7 +122,7 @@ class InplaceArgumentsMethodTransformer : MethodTransformer() {
                     val next = insn.next
                     return when {
                         next is VarInsnNode && next.opcode in Opcodes.ISTORE..Opcodes.ASTORE -> {
-                            val _ = iter.next()
+                            iter.skipNext()
                             ArgContext(start, insn, calls, next)
                         }
                         insn.previous.isInplaceArgumentStartMarker() -> {

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/RedundantCheckcastsBeforeAastoreMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/RedundantCheckcastsBeforeAastoreMethodTransformer.kt
@@ -19,8 +19,8 @@ object RedundantCheckcastsBeforeAastoreMethodTransformer : MethodTransformer() {
                 val isReified = isOperationReifiedMarker(insn.previous)
                 iter.remove()
                 if (isReified) {
-                    for (i in 1..3) {
-                        iter.previous()
+                    repeat(3) {
+                        val _ = iter.previous()
                         iter.remove()
                     }
                 }

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/state/KotlinTypeMapper.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/state/KotlinTypeMapper.kt
@@ -82,7 +82,7 @@ abstract class KotlinTypeMapper {
             arguments: List<TypeArgumentMarker>,
             parameters: List<TypeParameterMarker>,
             mode: TypeMappingMode,
-            mapType: (KotlinTypeMarker, JvmSignatureWriter, TypeMappingMode) -> Type
+            mapType: (KotlinTypeMarker, JvmSignatureWriter, TypeMappingMode) -> Unit
         ) {
             processGenericArguments(
                 arguments,
@@ -135,7 +135,7 @@ abstract class KotlinTypeMapper {
         fun TypeSystemCommonBackendContext.writeFormalTypeParameter(
             typeParameter: TypeParameterMarker,
             sw: JvmSignatureWriter,
-            mapType: (KotlinTypeMarker, TypeMappingMode) -> Type
+            mapType: (KotlinTypeMarker, TypeMappingMode) -> Unit
         ) {
             sw.writeFormalTypeParameter(typeParameter.getName().asString())
 

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testDaemonOptions/kotlin/DaemonLogConfigurationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testDaemonOptions/kotlin/DaemonLogConfigurationTest.kt
@@ -23,9 +23,10 @@ class DaemonLogConfigurationTest : BaseCompilationTest() {
                 val module = module("basic-multimodule-project/module-1")
                 val logsPath = daemonPolicy[ExecutionPolicy.WithDaemon.LOGS_PATH]
                 module.compile {
-                    logsPath.useDirectoryEntries {
+                    val hasDaemonLogFile = logsPath.useDirectoryEntries {
                         it.any { entry -> entry.name.startsWith("kotlin-daemon") && entry.name.endsWith(".log") }
                     }
+                    assert(hasDaemonLogFile) { "Expected a kotlin-daemon log file in $logsPath" }
                 }
             }
         }
@@ -41,9 +42,10 @@ class DaemonLogConfigurationTest : BaseCompilationTest() {
                 val module = module("basic-multimodule-project/module-1")
                 val logsPath = daemonPolicy[ExecutionPolicy.WithDaemon.LOGS_PATH]
                 module.compile {
-                    logsPath.useDirectoryEntries {
+                    val hasDaemonLogFile = logsPath.useDirectoryEntries {
                         it.any { entry -> entry.name.startsWith("kotlin-daemon") && entry.name.endsWith(".log") }
                     }
+                    assert(hasDaemonLogFile) { "Expected a kotlin-daemon log file in $logsPath" }
                 }
             }
         }

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testRestrictedArguments/kotlin/RestrictedArgumentsTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testRestrictedArguments/kotlin/RestrictedArgumentsTest.kt
@@ -292,7 +292,7 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
                     additionalCompilationAssertions()
                 }
             }
-            val exception = assertThrows<CompilerArgumentsParseException> { compilationBody() }
+            val exception = assertThrows<CompilerArgumentsParseException> { val _ = compilationBody() }
             assertTrue(
                 restrictedArgs.flatMap { it.first }.any { alias ->
                     exception.message?.contains("'$alias' is not supported in the Build Tools API.") == true

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testDaemonOptions/kotlin/DaemonLogConfigurationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testDaemonOptions/kotlin/DaemonLogConfigurationTest.kt
@@ -23,9 +23,10 @@ class DaemonLogConfigurationTest : BaseCompilationTest() {
                 val module = module("basic-multimodule-project/module-1")
                 val logsPath = daemonPolicy[ExecutionPolicy.WithDaemon.LOGS_PATH]
                 module.compile {
-                    logsPath.useDirectoryEntries {
+                    val hasDaemonLogFile = logsPath.useDirectoryEntries {
                         it.any { entry -> entry.name.startsWith("kotlin-daemon") && entry.name.endsWith(".log") }
                     }
+                    assert(hasDaemonLogFile) { "Expected a kotlin-daemon log file in $logsPath" }
                 }
             }
         }
@@ -41,9 +42,10 @@ class DaemonLogConfigurationTest : BaseCompilationTest() {
                 val module = module("basic-multimodule-project/module-1")
                 val logsPath = daemonPolicy[ExecutionPolicy.WithDaemon.LOGS_PATH]
                 module.compile {
-                    logsPath.useDirectoryEntries {
+                    val hasDaemonLogFile = logsPath.useDirectoryEntries {
                         it.any { entry -> entry.name.startsWith("kotlin-daemon") && entry.name.endsWith(".log") }
                     }
+                    assert(hasDaemonLogFile) { "Expected a kotlin-daemon log file in $logsPath" }
                 }
             }
         }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testRestrictedArguments/kotlin/RestrictedArgumentsTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testRestrictedArguments/kotlin/RestrictedArgumentsTest.kt
@@ -304,7 +304,7 @@ class RestrictedArgumentsTest : BaseCompilationTest() {
         } else {
             // Error args require separate compilations because the first error throws an exception
 
-            val compilationBody = {
+            val compilationBody: () -> Unit = {
                 compile(compilationConfigAction = {
                     it.compilerArguments.applyArgumentStrings(configuredArgs)
                 }) {

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/KotlinToolchainsImpl.kt
@@ -113,7 +113,7 @@ internal class KotlinToolchainsImpl() : KotlinToolchains {
                 // For an operation that uses the shared application environment, pin it just before, so that it is kept
                 // alive for reuse by subsequent operations and only disposed when the session ends.
                 if (operation.usesApplicationEnvironment) {
-                    applicationEnvironmentPin.value
+                    val _ = applicationEnvironmentPin.value
                 }
                 unwrapExecutionException(executor.submit(operationBody))
             } else {

--- a/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/Properties.kt
+++ b/compiler/cli/cli-base/src/org/jetbrains/kotlin/cli/common/Properties.kt
@@ -88,7 +88,7 @@ enum class CompilerSystemProperties(val property: String, val alwaysDirectAccess
             return getProperFunction(systemPropertyGetter, System::getProperty)(property)
         }
         set(value) {
-            getProperFunction(systemPropertySetter, System::setProperty)(property, value!!)
+            val _ = getProperFunction(systemPropertySetter, System::setProperty)(property, value!!)
         }
 
     val safeValue

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/common/FirSessionConstructionUtils.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/common/FirSessionConstructionUtils.kt
@@ -287,7 +287,7 @@ object SessionConstructionUtils {
         createMetadataSessionFactoryContextForHmppCommonLibrarySession: () -> AbstractFirMetadataSessionFactory.Context,
         additionalProvidersForMetadataLibrarySessionsInHmppMode: AdditionalProvidersSupplierForHmpp? = null,
         createSharedLibrarySession: () -> FirSession,
-        createLibrarySession: (sharedLibrarySession: FirSession) -> FirSession,
+        createLibrarySession: (sharedLibrarySession: FirSession) -> Unit,
         createSourceSession: FirSessionProducer,
     ): List<SessionWithSources<F>> {
         val languageVersionSettings = configuration.languageVersionSettings

--- a/compiler/compiler-runner-unshaded/src/org/jetbrains/kotlin/compilerRunner/CompilerOutputParser.kt
+++ b/compiler/compiler-runner-unshaded/src/org/jetbrains/kotlin/compilerRunner/CompilerOutputParser.kt
@@ -66,7 +66,7 @@ object CompilerOutputParser {
             // Load all the text into the stringBuilder
             try {
                 // This will not close the reader (see the wrapper above)
-                wrappingReader.readText()
+                val _ = wrappingReader.readText()
             } catch (ioException: IOException) {
                 reportException(messageCollector, ioException)
             }

--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/BaseDaemonSessionTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/BaseDaemonSessionTest.kt
@@ -59,7 +59,7 @@ abstract class BaseDaemonSessionTest {
     @AfterEach
     fun stopDaemons() {
         for (compileService in compileServices) {
-            runCatching { compileService.shutdown() }
+            val _ = runCatching { compileService.shutdown() }
         }
         Thread.sleep(500) // wait a bit so that all the daemons are shut down
     }

--- a/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt
+++ b/compiler/daemon/daemon-tests/test/org/jetbrains/kotlin/daemon/CompilerDaemonTest.kt
@@ -548,7 +548,7 @@ class CompilerDaemonTest : KotlinIntegrationTestBase() {
             var resCode: Int? = null
             // running intermediate process (daemon command line controller) that executes the daemon
             val runnerProcess = ProcessBuilder(args).redirectErrorStream(true).start()
-            thread {
+            val _ = thread {
                 resOutput = runnerProcess.inputStream.reader().readText()
             }
             val waitThread = thread {

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/CompileServiceImpl.kt
@@ -266,7 +266,7 @@ abstract class CompileServiceImplBase(
         if (state.sessions.isEmpty()) {
             // TODO: and some goes here
         }
-        timer.schedule(0) {
+        val _ = timer.schedule(0) {
             periodicAndAfterSessionCheck()
         }
         return CompileService.CallResult.Ok()
@@ -618,17 +618,17 @@ abstract class CompileServiceImplBase(
     //    }
 
     fun startDaemonElections() {
-        timer.schedule(10) {
+        val _ = timer.schedule(10) {
             exceptionLoggingTimerThread { initiateElections() }
         }
     }
 
     fun configurePeriodicActivities() {
         log.info("Periodic liveness check activities configured")
-        timer.schedule(delay = DAEMON_PERIODIC_CHECK_INTERVAL_MS, period = DAEMON_PERIODIC_CHECK_INTERVAL_MS) {
+        val _ = timer.schedule(delay = DAEMON_PERIODIC_CHECK_INTERVAL_MS, period = DAEMON_PERIODIC_CHECK_INTERVAL_MS) {
             exceptionLoggingTimerThread { periodicAndAfterSessionCheck() }
         }
-        timer.schedule(delay = DAEMON_PERIODIC_SELDOM_CHECK_INTERVAL_MS + 100, period = DAEMON_PERIODIC_SELDOM_CHECK_INTERVAL_MS) {
+        val _ = timer.schedule(delay = DAEMON_PERIODIC_SELDOM_CHECK_INTERVAL_MS + 100, period = DAEMON_PERIODIC_SELDOM_CHECK_INTERVAL_MS) {
             exceptionLoggingTimerThread { periodicSeldomCheck() }
         }
     }
@@ -1219,7 +1219,7 @@ class CompileServiceImpl(
         val currentSessionId = state.sessions.lastSessionId
         val currentCompilationsCount = compilationsCounter.get()
         log.info("Delayed shutdown in ${daemonOptions.shutdownDelayMilliseconds}ms")
-        timer.schedule(daemonOptions.shutdownDelayMilliseconds) {
+        val _ = timer.schedule(daemonOptions.shutdownDelayMilliseconds) {
             state.delayedShutdownQueued.set(false)
             if (currentClientsCount == state.clientsCounter &&
                 currentCompilationsCount == compilationsCounter.get() &&
@@ -1259,7 +1259,7 @@ class CompileServiceImpl(
         if (!onAnotherThread) {
             shutdownIfIdle()
         } else {
-            timer.schedule(1) {
+            val _ = timer.schedule(1) {
                 shutdownIfIdle()
             }
         }

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/KotlinCompileDaemon.kt
@@ -237,8 +237,8 @@ object KotlinCompileDaemon : KotlinCompileDaemonBase() {
                                                  timer = timer,
                                                  onShutdown = {
                                                      if (daemonOptions.forceShutdownTimeoutMilliseconds != COMPILE_DAEMON_TIMEOUT_INFINITE_MS) {
-                                                         // running a watcher thread that ensures that if the daemon is not exited normally (may be due to RMI leftovers), it's forced to exit
-                                                         timer.schedule(daemonOptions.forceShutdownTimeoutMilliseconds) {
+                                                        // running a watcher thread that ensures that if the daemon is not exited normally (may be due to RMI leftovers), it's forced to exit
+                                                         val _ = timer.schedule(daemonOptions.forceShutdownTimeoutMilliseconds) {
                                                              cancel()
                                                              log.info("force JVM shutdown")
                                                              exitProcess(0)

--- a/compiler/daemon/src/org/jetbrains/kotlin/daemon/LazyClasspathWatcher.kt
+++ b/compiler/daemon/src/org/jetbrains/kotlin/daemon/LazyClasspathWatcher.kt
@@ -56,7 +56,7 @@ class LazyClasspathWatcher(classpath: Iterable<String>,
     init {
         // locking before entering thread in order to avoid racing with isChanged
         fileIdsLock.acquire()
-        thread(isDaemon = true, start = true) {
+        val _ = thread(isDaemon = true, start = true) {
             try {
                 fileIds = classpath
                         .map(::File)

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/FirInlineCheckerPlatformSpecificComponent.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/FirInlineCheckerPlatformSpecificComponent.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.fir.isEnabled
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
-import org.jetbrains.kotlin.fir.scopes.ProcessorAction
 import org.jetbrains.kotlin.utils.SmartSet
 
 abstract class FirInlineCheckerPlatformSpecificComponent : FirComposableSessionComponent<FirInlineCheckerPlatformSpecificComponent> {
@@ -54,7 +53,6 @@ abstract class FirInlineCheckerPlatformSpecificComponent : FirComposableSessionC
 
             (symbol as? FirNamedFunctionSymbol)?.processOverriddenFunctionsSafe {
                 checkDefaultParamsRecursive(it)
-                ProcessorAction.NEXT
             }
         }
 

--- a/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirFiniteBoundRestrictionChecker.kt
+++ b/compiler/fir/checkers/src/org/jetbrains/kotlin/fir/analysis/checkers/declaration/FirFiniteBoundRestrictionChecker.kt
@@ -81,7 +81,7 @@ object FirFiniteBoundRestrictionChecker : FirRegularClassChecker(MppCheckerKind.
                     if (type.typeArguments[i].kind != ProjectionKind.INVARIANT) {
                         val parameter = parameters[i].toConeType()
                         edges.getOrPut(coneType) { mutableSetOf() }.add(parameter)
-                        edges.getOrPut(parameter) { mutableSetOf() }
+                        edges.computeIfAbsent(parameter) { mutableSetOf() }
                     }
                 }
             }

--- a/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/scopes/JavaScopeUtils.kt
+++ b/compiler/fir/fir-jvm/src/org/jetbrains/kotlin/fir/java/scopes/JavaScopeUtils.kt
@@ -163,7 +163,7 @@ private fun FirNamedFunctionSymbol.firstOverriddenFunction(
 
 private inline fun <T : FirCallableSymbol<*>> T.firstOverriddenCallable(
     containingScope: FirTypeScope,
-    processFunction: FirTypeScope.(T, (T) -> ProcessorAction) -> ProcessorAction,
+    processFunction: FirTypeScope.(T, (T) -> ProcessorAction) -> Unit,
     noinline predicate: (T) -> Boolean,
 ): T? {
     var result: T? = null

--- a/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
+++ b/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
@@ -1519,7 +1519,7 @@ class FirElementSerializer private constructor(
 
     private inline fun <M : GeneratedMessageLite.ExtendableMessage<M>, B : GeneratedMessageLite.Builder<M, B>> B.serializeCompilerPluginMetadata(
         declaration: FirDeclaration,
-        addCompilerPluginData: B.(ProtoBuf.CompilerPluginData.Builder) -> B
+        addCompilerPluginData: B.(ProtoBuf.CompilerPluginData.Builder) -> Unit
     ) {
         extension.additionalMetadataProvider?.findMetadataExtensionsFor(declaration)?.forEach { [pluginId, data] ->
             val pluginData = ProtoBuf.CompilerPluginData.newBuilder().apply {

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirDefaultStarImportingScope.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirDefaultStarImportingScope.kt
@@ -43,7 +43,9 @@ class FirDefaultStarImportingScope(
         }
 
         if (!wasFoundAny) {
-            second.processClassifiersByNameWithSubstitution(name, processor::invoke)
+            second.processClassifiersByNameWithSubstitution(name) { symbol, substitutor ->
+                val _ = processor.invoke(symbol, substitutor)
+            }
         }
     }
 

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirOverrideUtils.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirOverrideUtils.kt
@@ -55,7 +55,7 @@ fun <D : FirCallableSymbol<*>> overrides(
 
     var result = false
 
-    fScope.processAllOverridden(fMember) { overridden ->
+    val _ = fScope.processAllOverridden(fMember) { overridden ->
         if (overridden == gMember) {
             result = true
             ProcessorAction.STOP

--- a/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScopeContext.kt
+++ b/compiler/fir/providers/src/org/jetbrains/kotlin/fir/scopes/impl/FirTypeIntersectionScopeContext.kt
@@ -338,7 +338,7 @@ class FirTypeIntersectionScopeContext(
             return
         }
 
-        scope.processDirectOverridden(symbol) { overridden, baseScope ->
+        val _ = scope.processDirectOverridden(symbol) { overridden, baseScope ->
             collectRealOverridden(overridden, baseScope, result, visited, processDirectOverridden)
             ProcessorAction.NEXT
         }

--- a/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/LightTreeRawFirDeclarationBuilder.kt
+++ b/compiler/fir/raw-fir/light-tree2fir/src/org/jetbrains/kotlin/fir/lightTree/converter/LightTreeRawFirDeclarationBuilder.kt
@@ -766,7 +766,7 @@ class LightTreeRawFirDeclarationBuilder(
                     val delegatedSelfType = objectDeclaration.toDelegatedSelfType(this)
                     registerSelfType(delegatedSelfType)
 
-                    superTypeRefs.ifEmpty {
+                    if (superTypeRefs.isEmpty()) {
                         superTypeRefs += implicitAnyType
                         delegatedSuperTypeRef = implicitAnyType
                     }

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirCallResolver.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/calls/FirCallResolver.kt
@@ -1114,7 +1114,7 @@ class AllCandidatesCollector(
 
         // To preserve the behavior of a HashSet which keeps the first added item, we use getOrPut instead of put.
         // Changing this behavior breaks testData/components/callResolver/resolveCandidates/singleCandidate/functionTypeVariableCall_extensionReceiver.kt
-        allCandidatesMap.getOrPut(key) { candidate }
+        val _ = allCandidatesMap.getOrPut(key) { candidate }
         return super.consumeCandidate(group, candidate, context)
     }
 

--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirTypeResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirTypeResolveTransformer.kt
@@ -288,7 +288,7 @@ open class FirTypeResolveTransformer(
 
     private fun setAccessorTypesByPropertyType(property: FirProperty) {
         property.getter?.replaceReturnTypeRef(property.returnTypeRef)
-        property.setter?.valueParameters?.map { it.replaceReturnTypeRef(property.returnTypeRef) }
+        property.setter?.valueParameters?.forEach { it.replaceReturnTypeRef(property.returnTypeRef) }
     }
 
     override fun transformField(field: FirField, data: Any?): FirField = whileAnalysing(session, field) {

--- a/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/FirLookupTrackerComponent.kt
+++ b/compiler/fir/semantics/src/org/jetbrains/kotlin/fir/FirLookupTrackerComponent.kt
@@ -93,9 +93,10 @@ fun FirLookupTrackerComponent.recordTypeResolveAsLookup(typeRef: FirTypeRef, sou
 
 fun FirLookupTrackerComponent.recordUserTypeRefLookup(typeRef: FirUserTypeRef, inScopes: Iterable<String>, fileSource: KtSourceElement?) {
     inScopes.forEach { scope ->
-        typeRef.qualifier.fold(FqName(scope)) { result, suffix ->
+        var result = FqName(scope)
+        for (suffix in typeRef.qualifier) {
             recordLookup(suffix.name.asString(), result.asString(), typeRef.source, fileSource)
-            result.child(suffix.name)
+            result = result.child(suffix.name)
         }
     }
 }

--- a/compiler/fir/tree/src/org/jetbrains/kotlin/fir/scopes/FirTypeScope.kt
+++ b/compiler/fir/tree/src/org/jetbrains/kotlin/fir/scopes/FirTypeScope.kt
@@ -108,7 +108,7 @@ inline fun <reified S : FirCallableSymbol<*>> FirTypeScope.anyOverriddenOf(
     noinline predicate: (S) -> Boolean,
 ): Boolean {
     var result = false
-    processOverridden(symbol) {
+    val _ = processOverridden(symbol) {
         if (predicate(it)) {
             result = true
             return@processOverridden ProcessorAction.STOP

--- a/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/InterfaceDefaultMethodCallChecker.kt
+++ b/compiler/frontend.java/src/org/jetbrains/kotlin/resolve/jvm/checkers/InterfaceDefaultMethodCallChecker.kt
@@ -78,7 +78,8 @@ class InterfaceDefaultMethodCallChecker(val jvmTarget: JvmTarget, project: Proje
         bindingContext: BindingContext
     ): CallableMemberDescriptor? {
         val parents = generateSequence({ startExpression.parent }) { it.parent }
-        parents.fold<PsiElement, PsiElement>(startExpression) { child, parent ->
+        var child: PsiElement = startExpression
+        for (parent in parents) {
             if (parent is KtClassBody &&
                 descriptorToSearch == bindingContext.get(BindingContext.CLASS, parent.parent)
             ) {
@@ -87,7 +88,8 @@ class InterfaceDefaultMethodCallChecker(val jvmTarget: JvmTarget, project: Proje
                     is KtProperty -> bindingContext.get(BindingContext.VARIABLE, child) as? PropertyDescriptor
                     else -> null
                 }
-            } else parent
+            }
+            child = parent
         }
 
         return null

--- a/compiler/frontend/cfg/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt
+++ b/compiler/frontend/cfg/src/org/jetbrains/kotlin/cfg/pseudocode/pseudocodeUtils.kt
@@ -150,7 +150,7 @@ fun getExpectedTypePredicate(
                             element.getStrictParentOfType<KtWhileExpression>()?.condition -> addSubtypesOf(builtIns.booleanType)
                             is KtProperty -> {
                                 val propertyDescriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, element] as? PropertyDescriptor
-                                propertyDescriptor?.accessors?.map {
+                                propertyDescriptor?.accessors?.forEach {
                                     addByExplicitReceiver(bindingContext[BindingContext.DELEGATED_PROPERTY_RESOLVED_CALL, it])
                                 }
                             }

--- a/compiler/frontend/src/org/jetbrains/kotlin/contracts/ContextInfoToDataFlowInfo.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/contracts/ContextInfoToDataFlowInfo.kt
@@ -37,7 +37,6 @@ fun MutableContextInfo.toDataFlowInfo(languageVersionSettings: LanguageVersionSe
         if (rightDfv != null) {
             resultingDataFlowInfo = resultingDataFlowInfo.equate(leftDfv, rightDfv, false, languageVersionSettings)
         }
-        IntArray(42) { it }
     }
 
     extractDataFlowStatements(notEqualValues, builtIns) { leftDfv, rightValue ->

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/QualifiedExpressionResolver.kt
@@ -712,9 +712,10 @@ class QualifiedExpressionResolver(val languageVersionSettings: LanguageVersionSe
         trace: BindingTrace,
         position: QualifierPosition
     ) {
-        path.foldRight(packageView) { qualifierPart, currentView ->
+        var currentView = packageView
+        for (qualifierPart in path.asReversed()) {
             storeResult(trace, qualifierPart.expression, currentView, shouldBeVisibleFrom = null, position = position)
-            currentView.containingDeclaration
+            currentView = currentView.containingDeclaration
                 ?: error(
                     "Containing Declaration must be not null for package with fqName: ${currentView.fqName}, " +
                             "path: ${path.joinToString()}, packageView fqName: ${packageView.fqName}"

--- a/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/ImplicitNothingAsTypeParameterCallChecker.kt
+++ b/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/checkers/ImplicitNothingAsTypeParameterCallChecker.kt
@@ -194,6 +194,8 @@ object ImplicitNothingAsTypeParameterCallChecker : CallChecker {
     }
 
     override fun check(resolvedCall: ResolvedCall<*>, reportOn: PsiElement, context: CallCheckerContext) {
-        checkByReturnPositionWithoutExpected(resolvedCall, reportOn, context) || checkAgainstNotNothingExpectedType(resolvedCall, context)
+        if (!checkByReturnPositionWithoutExpected(resolvedCall, reportOn, context)) {
+            checkAgainstNotNothingExpectedType(resolvedCall, context)
+        }
     }
 }

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
@@ -392,7 +392,12 @@ abstract class IncrementalCompilerRunner<
         outputDirs.toSet().forEach {
             when {
                 it.isDirectory -> it.deleteDirectoryContents()
-                it.isFile -> "Expected a directory but found a regular file: ${it.path}"
+
+                it.isFile -> {
+                    // KT-88538: suppressing for now to avoid potential breaking changes
+                    @Suppress("RETURN_VALUE_NOT_USED_COERCION")
+                    "Expected a directory but found a regular file: ${it.path}"
+                }
                 else -> it.createDirectory()
             }
         }

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/FinallyBlocksLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/FinallyBlocksLowering.kt
@@ -179,7 +179,6 @@ class FinallyBlocksLowering(val context: CommonBackendContext, private val throw
         val currentTryScope = tryScopes[index]
         currentTryScope.jumps.getOrPut(jump) {
             val type = (jump as? Return)?.target?.owner?.returnType(context) ?: value.type
-            jump.toString()
             val symbol = IrReturnableBlockSymbolImpl()
             with(currentTryScope) {
                 irBuilder.run {

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/BlockDecomposerLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/BlockDecomposerLowering.kt
@@ -423,13 +423,14 @@ class BlockDecomposerTransformer(
             val block = IrBlockImpl(expression.startOffset, expression.endOffset, unitType, expression.origin)
 
             // TODO: consider decomposing only when it is really required
-            results.foldIndexed(block) { i, appendBlock, [cond, res, orig] ->
+            var appendBlock: IrBlockImpl = block
+            results.forEachIndexed { i, [cond, res, orig] ->
                 val condStatements = destructureComposite(cond)
                 val condValue = condStatements.last() as IrExpression
 
                 appendBlock.statements += condStatements.run { subList(0, lastIndex) }
 
-                JsIrBuilder.buildBlock(unitType).also {
+                appendBlock = JsIrBuilder.buildBlock(unitType).also {
                     val elseBlock = it.takeIf { results.lastIndex != i }
                     val additionalStatements = when {
                         isElseBranch(orig) -> (res as? IrBlock)?.statements ?: listOf(res)

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/JsSuspendFunctionsLowering.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/lower/coroutines/JsSuspendFunctionsLowering.kt
@@ -286,10 +286,10 @@ open class JsSuspendFunctionsLowering<C : JsCommonBackendContext>(
         val localToPropertyMap = hashMapOf<IrValueSymbol, IrFieldSymbol>()
         var localCounter = 0
         // TODO: optimize by using the same property for different locals.
-        liveLocals.forEach {
-            if (it !== suspendState && it !== suspendResult && it !== stateVar) {
-                localToPropertyMap.getOrPut(it.symbol) {
-                    coroutineClass.addField(Name.identifier("${it.name}${localCounter++}"), it.type, it.isVar)
+        liveLocals.forEach { liveLocal ->
+            if (liveLocal !== suspendState && liveLocal !== suspendResult && liveLocal !== stateVar) {
+                localToPropertyMap.computeIfAbsent(liveLocal.symbol) {
+                    coroutineClass.addField(Name.identifier("${liveLocal.name}${localCounter++}"), liveLocal.type, liveLocal.isVar)
                         .symbol
                 }
             }
@@ -297,7 +297,7 @@ open class JsSuspendFunctionsLowering<C : JsCommonBackendContext>(
         val isSuspendLambda = transformingFunction.parent === coroutineClass
         val parameters = if (isSuspendLambda) simplifiedFunction.nonDispatchParameters else simplifiedFunction.parameters
         for (parameter in parameters) {
-            localToPropertyMap.getOrPut(parameter.symbol) {
+            localToPropertyMap.computeIfAbsent(parameter.symbol) {
                 argumentToPropertiesMap.getValue(parameter).symbol
             }
         }
@@ -418,4 +418,3 @@ internal fun getSuspendFunctionKind(
 @Suppress("MemberVisibilityCanBePrivate")
 internal fun IrCall.isReturnIfSuspendedCall(context: JsCommonBackendContext) =
     symbol == context.symbols.returnIfSuspended
-

--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ToArrayLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/ToArrayLowering.kt
@@ -117,7 +117,7 @@ internal class ToArrayLowering(private val context: JvmBackendContext) : ClassLo
     private fun IrClass.findOrCreate(
         indirectSubclass: Boolean,
         matcher: (IrSimpleFunction) -> Boolean,
-        fallback: (ToArrayBridge?) -> IrSimpleFunction
+        fallback: (ToArrayBridge?) -> Unit
     ) {
         val existing = functions.find(matcher)
         if (existing != null) {

--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/ExternalDependenciesGenerator.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/ExternalDependenciesGenerator.kt
@@ -36,7 +36,7 @@ class ExternalDependenciesGenerator(
             for (symbol in unbound) {
                 // Symbol could get bound as a side effect of deserializing other symbols.
                 if (!symbol.isBound) {
-                    irProviders.firstNotNullOfOrNull { provider -> provider.getDeclaration(symbol) }
+                    val _ = irProviders.firstNotNullOfOrNull { provider -> provider.getDeclaration(symbol) }
                 }
             }
             // We wait for the unbound to stabilize on fake overrides.

--- a/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/JavaTypeResolver.kt
+++ b/compiler/java-direct/src/org/jetbrains/kotlin/java/direct/resolution/JavaTypeResolver.kt
@@ -168,8 +168,10 @@ private fun resolveFromSameFile(
     simpleName: String,
     fullResolution: Boolean,
 ): ClassId? {
-    c.scopeContext.sameFileTopLevelClassProvider(Name.identifier(simpleName)) ?: return null
-    val classId = ClassId(c.packageFqName, Name.identifier(simpleName))
+    val simpleNameIdentifier = Name.identifier(simpleName)
+    if (c.scopeContext.sameFileTopLevelClassProvider(simpleNameIdentifier) == null) return null
+
+    val classId = ClassId(c.packageFqName, simpleNameIdentifier)
     return if (classExists(classId, fullResolution)) classId else null
 }
 

--- a/compiler/multiplatform-parsing/common/src/org/jetbrains/kotlin/kmp/lexer/KDocKnownTag.kt
+++ b/compiler/multiplatform-parsing/common/src/org/jetbrains/kotlin/kmp/lexer/KDocKnownTag.kt
@@ -32,7 +32,7 @@ enum class KDocKnownTag(val isReferenceRequired: Boolean, val isSectionStart: Bo
             }
             try {
                 val upperCaseAsciiOnly = buildString {
-                    name.map {
+                    name.forEach {
                         append(if (it in 'a'..'z') it.uppercaseChar() else it)
                     }
                 }

--- a/compiler/psi/psi-api/src/org/jetbrains/kotlin/psi/psiUtil/psiUtils.kt
+++ b/compiler/psi/psi-api/src/org/jetbrains/kotlin/psi/psiUtil/psiUtils.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.lexer.KtTokens.PLUS
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.utils.addToStdlib.skipNext
 import java.util.*
 import kotlin.collections.ArrayDeque
 import kotlin.contracts.ExperimentalContracts
@@ -170,7 +171,7 @@ fun PsiElement.siblings(forward: Boolean = true, withItself: Boolean = true): Se
             return object : Iterator<PsiElement> {
                 init {
                     if (!withItself) {
-                        val _ = next()
+                        skipNext()
                     }
                 }
 

--- a/compiler/psi/psi-api/src/org/jetbrains/kotlin/psi/psiUtil/psiUtils.kt
+++ b/compiler/psi/psi-api/src/org/jetbrains/kotlin/psi/psiUtil/psiUtils.kt
@@ -169,7 +169,9 @@ fun PsiElement.siblings(forward: Boolean = true, withItself: Boolean = true): Se
             var next: PsiElement? = this@siblings
             return object : Iterator<PsiElement> {
                 init {
-                    if (!withItself) next()
+                    if (!withItself) {
+                        val _ = next()
+                    }
                 }
 
                 override fun hasNext(): Boolean = next != null

--- a/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/MutableContextInfo.kt
+++ b/compiler/resolution/src/org/jetbrains/kotlin/contracts/model/MutableContextInfo.kt
@@ -132,8 +132,6 @@ class MutableContextInfo private constructor(
         equalValues.printMapEntriesWithSeparator("==")
 
         notEqualValues.printMapEntriesWithSeparator("!=")
-
-        this.toString()
     }
 
 }

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/DebugRunner.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/DebugRunner.kt
@@ -101,8 +101,8 @@ abstract class DebugRunner(testServices: TestServices) : JvmBoxRunner(testServic
                                 prepareReq.setSuspendPolicy(SUSPEND_ALL)
                                 EXCLUDED_PACKAGES.forEach { prepareReq.addClassExclusionFilter(it) }
                             }
-                            manager.stepRequests().map { it.enable() }
-                            manager.classPrepareRequests().map { it.enable() }
+                            manager.stepRequests().forEach { it.enable() }
+                            manager.classPrepareRequests().forEach { it.enable() }
                             inBoxMethod = true
                             storeStep(loggedItems, event)
                         }
@@ -113,9 +113,9 @@ abstract class DebugRunner(testServices: TestServices) : JvmBoxRunner(testServic
                             if (event.location().method().name() == "main" &&
                                 event.location().declaringType().name().contains(BOX_MAIN_FILE_CLASS_NAME)
                             ) {
-                                manager.stepRequests().map { it.disable() }
-                                manager.classPrepareRequests().map { it.disable() }
-                                manager.breakpointRequests().map { it.disable() }
+                                manager.stepRequests().forEach { it.disable() }
+                                manager.classPrepareRequests().forEach { it.disable() }
+                                manager.breakpointRequests().forEach { it.disable() }
                                 break@vmLoop
                             }
                             storeStep(loggedItems, event)
@@ -123,9 +123,9 @@ abstract class DebugRunner(testServices: TestServices) : JvmBoxRunner(testServic
                     }
                     is MethodExitEvent -> {
                         if (event.location().method().name() == "box") {
-                            manager.stepRequests().map { it.disable() }
-                            manager.classPrepareRequests().map { it.disable() }
-                            manager.breakpointRequests().map { it.disable() }
+                            manager.stepRequests().forEach { it.disable() }
+                            manager.classPrepareRequests().forEach { it.disable() }
+                            manager.breakpointRequests().forEach { it.disable() }
                             break@vmLoop
                         }
                     }

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/utils/SteppingTestUtils.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/utils/SteppingTestUtils.kt
@@ -109,7 +109,9 @@ fun checkSteppingTestResult(
     for (line in lineIterator) {
         if (line.startsWith(EXPECTATIONS_MARKER)) {
             // Rewind the iterator to the first '// EXPECTATIONS' line
-            if (lineIterator.hasPrevious()) lineIterator.previous()
+            if (lineIterator.hasPrevious()) {
+                val _ = lineIterator.previous()
+            }
             break
         }
         actual.add(line)

--- a/compiler/tests-integration/tests/org/jetbrains/kotlin/reflection/ReflectionIntegrationTest.kt
+++ b/compiler/tests-integration/tests/org/jetbrains/kotlin/reflection/ReflectionIntegrationTest.kt
@@ -80,7 +80,7 @@ class ReflectionIntegrationTest {
         val latch = CountDownLatch(1)
         val error = AtomicReference<Throwable?>()
         repeat(2) {
-            thread {
+            val _ = thread {
                 while (latch.count == 1L) {
                     try {
                         val classLoader = URLClassLoader(urls, null)

--- a/compiler/tests-java8/tests/org/jetbrains/kotlin/serialization/builtins/AdditionalBuiltInsMembersSignatureListsTest.kt
+++ b/compiler/tests-java8/tests/org/jetbrains/kotlin/serialization/builtins/AdditionalBuiltInsMembersSignatureListsTest.kt
@@ -85,9 +85,10 @@ class AdditionalBuiltInsMembersSignatureListsTest {
                     else
                         scope.getContributedFunctions(Name.identifier(stringName), NoLookupLocation.FROM_TEST)
 
-                functions.singleOrNull {
+                val matchingFunction = functions.singleOrNull {
                     it.isEffectivelyPublicApi && it.computeJvmDescriptor() == jvmDescriptor
-                } ?: fail("Expected single function with signature $jvmDescriptor in $internalName")
+                }
+                if (matchingFunction == null) fail("Expected single function with signature $jvmDescriptor in $internalName")
             }
         }
     }

--- a/compiler/tests/org/jetbrains/kotlin/serialization/JvmVersionRequirementTest.kt
+++ b/compiler/tests/org/jetbrains/kotlin/serialization/JvmVersionRequirementTest.kt
@@ -47,14 +47,15 @@ class JvmVersionRequirementTest : TestCaseWithTmpdir() {
             val requirements = extractRequirement(descriptor)
             if (requirements.isEmpty()) throw AssertionError("No VersionRequirement for $descriptor")
 
-            requirements.firstOrNull {
+            val requiredVersion = requirements.firstOrNull {
                 expectedVersionRequirement == it.version &&
                         expectedLevel == it.level &&
                         expectedMessage == it.message &&
                         expectedVersionKind == it.kind &&
                         expectedErrorCode == it.errorCode
             }
-                ?: throw AssertionError(
+            if (requiredVersion == null)
+                throw AssertionError(
                     "Version requirement not found, expected:\n" +
                             "versionRequirement=" + expectedVersionRequirement +
                             "; level=" + expectedLevel +

--- a/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibLayoutReaderTest.kt
+++ b/compiler/util-klib/test/org/jetbrains/kotlin/library/KlibLayoutReaderTest.kt
@@ -98,8 +98,11 @@ class KlibLayoutReaderTest {
 
         TestMandatoryComponentLayout(klibDir).baseDir.deleteRecursively()
 
-        with(klibDir.toTestLib().mandatoryComponent) { assertThrows<IOException> { intValue } }
-        with(klibDir.compress().toTestLib().mandatoryComponent) { assertThrows<IOException> { intValue } }
+        val mandatoryComponent = klibDir.toTestLib().mandatoryComponent
+        assertThrows<IOException> { mandatoryComponent.intValue }
+
+        val compressedMandatoryComponent = klibDir.compress().toTestLib().mandatoryComponent
+        assertThrows<IOException> { compressedMandatoryComponent.intValue }
     }
 
     @Test

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/AbstractKlibLoaderTest.kt
@@ -80,7 +80,9 @@ abstract class AbstractKlibLoaderTest {
             // Copy of a real KLIB without the "default" component. As a directory.
             val noDefaultComponentDir = tmpDir.resolve("corrupted-library3")
             Path(stdlib).copyToRecursively(noDefaultComponentDir, followLinks = false, overwrite = true)
-            with(noDefaultComponentDir.resolve("default")) { moveTo(resolveSibling("non-default")) }
+            with(noDefaultComponentDir.resolve("default")) {
+                val _ = moveTo(resolveSibling("non-default"))
+            }
             add(noDefaultComponentDir)
 
             // Copy of a real KLIB without the "default" component. As a file.
@@ -313,14 +315,14 @@ abstract class AbstractKlibLoaderTest {
         val qux = libsDir.resolve("qux").pathString
         val qux_klib = libsDir.resolve("qux.klib").pathString
 
-        with(Path(generateNewKlib(asFile = false, fileExtension = ""))) {
+        val _ = with(Path(generateNewKlib(asFile = false, fileExtension = ""))) {
             copyToRecursively(Path(foo), followLinks = false, overwrite = false)
             copyToRecursively(Path(foo_klib), followLinks = false, overwrite = false)
             copyToRecursively(Path(bar), followLinks = false, overwrite = false)
             copyToRecursively(Path(baz_klib), followLinks = false, overwrite = false)
         }
 
-        with(Path(generateNewKlib(asFile = true, fileExtension = "klib"))) {
+        val _ = with(Path(generateNewKlib(asFile = true, fileExtension = "klib"))) {
             copyToRecursively(Path(bar_klib), followLinks = false, overwrite = false)
             copyToRecursively(Path(baz), followLinks = false, overwrite = false)
             copyToRecursively(Path(qux), followLinks = false, overwrite = false)

--- a/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/KlibMockDSL.kt
+++ b/compiler/util-klib/testFixtures/org/jetbrains/kotlin/library/KlibMockDSL.kt
@@ -52,9 +52,8 @@ class KlibMockDSL(val currentDir: Path, val parent: KlibMockDSL?) {
          */
         fun mockKlib(klibDir: Path, init: KlibMockDSL.() -> Unit): Path {
             klibDir.createDirectories()
-            KlibMockDSL(currentDir = klibDir, parent = null).apply {
-                dir(KLIB_DEFAULT_COMPONENT_NAME, init)
-            }
+            KlibMockDSL(currentDir = klibDir, parent = null)
+                .dir(KLIB_DEFAULT_COMPONENT_NAME, init)
             return klibDir
         }
 

--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/AbstractAnnotationTypeQualifierResolver.kt
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/AbstractAnnotationTypeQualifierResolver.kt
@@ -261,7 +261,7 @@ abstract class AbstractAnnotationTypeQualifierResolver<TAnnotation : Any>(
     private companion object {
         val JAVA_APPLICABILITY_TYPES = mutableMapOf<String, AnnotationQualifierApplicabilityType>().apply {
             for (type in AnnotationQualifierApplicabilityType.values()) {
-                getOrPut(type.javaTarget) { type }
+                val _ = getOrPut(type.javaTarget) { type }
             }
         }
     }

--- a/core/compiler.common/src/org/jetbrains/kotlin/util/AttributeArrayOwner.kt
+++ b/core/compiler.common/src/org/jetbrains/kotlin/util/AttributeArrayOwner.kt
@@ -73,7 +73,7 @@ abstract class AttributeArrayOwner<K : Any, T : Any> protected constructor(
             val content = buildString {
                 val services = typeRegistry.allValuesThreadUnsafeForRendering()
                 appendLine("[")
-                map.mapIndexed { index, value ->
+                map.forEachIndexed { index, value ->
                     val service = services.entries.firstOrNull { it.value == index }
                     appendLine("  $service[$index]: $value")
                 }

--- a/core/descriptors/src/org/jetbrains/kotlin/builtins/functions/FunctionClassDescriptor.kt
+++ b/core/descriptors/src/org/jetbrains/kotlin/builtins/functions/FunctionClassDescriptor.kt
@@ -51,7 +51,7 @@ class FunctionClassDescriptor(
             ))
         }
 
-        (1..arity).map { i ->
+        (1..arity).forEach { i ->
             typeParameter(Variance.IN_VARIANCE, "P$i")
         }
 

--- a/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberScope.kt
+++ b/core/deserialization/src/org/jetbrains/kotlin/serialization/deserialization/descriptors/DeserializedMemberScope.kt
@@ -245,7 +245,7 @@ abstract class DeserializedMemberScope protected constructor(
         private fun Map<Name, Collection<AbstractMessageLite>>.packToByteArray(): Map<Name, ByteArray> =
             mapValues { entry ->
                 val byteArrayOutputStream = ByteArrayOutputStream()
-                entry.value.map { proto -> proto.writeDelimitedTo(byteArrayOutputStream) }
+                entry.value.forEach { proto -> proto.writeDelimitedTo(byteArrayOutputStream) }
                 byteArrayOutputStream.toByteArray()
             }
 

--- a/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt
+++ b/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt
@@ -548,3 +548,19 @@ class ChainedIterator<T>(delegates: Collection<Iterator<T>>) : Iterator<T> {
 fun <T> Iterator<T>.skipNext() {
     val _ = next()
 }
+
+inline fun <T, K> Iterable<T>.forEachZipped(other: Iterable<K>, transform: (T, K) -> Unit) {
+    val first = iterator()
+    val second = other.iterator()
+    while (first.hasNext() && second.hasNext()) {
+        transform(first.next(), second.next())
+    }
+}
+
+inline fun <T, K> Array<out T>.forEachZipped(other: Iterable<K>, transform: (T, K) -> Unit) {
+    val second = other.iterator()
+    for (first in this) {
+        if (!second.hasNext()) break
+        transform(first, second.next())
+    }
+}

--- a/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt
+++ b/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt
@@ -544,3 +544,7 @@ class ChainedIterator<T>(delegates: Collection<Iterator<T>>) : Iterator<T> {
         return currentIterator?.next() ?: throw NoSuchElementException()
     }
 }
+
+fun <T> Iterator<T>.skipNext() {
+    val _ = next()
+}

--- a/jps/jps-common/src/org/jetbrains/kotlin/config/facetSerialization.kt
+++ b/jps/jps-common/src/org/jetbrains/kotlin/config/facetSerialization.kt
@@ -318,7 +318,7 @@ private fun KotlinFacetSettings.writeConfig(element: Element) {
     if (sourceSetNames.isNotEmpty()) {
         element.addContent(
             Element("sourceSets").apply {
-                sourceSetNames.map { addContent(Element("sourceSet").apply { addContent(it) }) }
+                sourceSetNames.forEach { addContent(Element("sourceSet").apply { addContent(it) }) }
             }
         )
     }
@@ -397,7 +397,7 @@ private fun saveElementsList(element: Element, elementsList: List<String>, rootE
                 if (singleModule != null) {
                     addContent(singleModule)
                 } else {
-                    elementsList.map { addContent(Element(elementName).apply { addContent(it) }) }
+                    elementsList.forEach { addContent(Element(elementName).apply { addContent(it) }) }
                 }
             }
         )

--- a/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/ECMA426BasedSourceMapParser.kt
+++ b/js/js.parser/src/org/jetbrains/kotlin/js/parser/sourcemaps/ECMA426BasedSourceMapParser.kt
@@ -214,9 +214,10 @@ object ECMA426BasedSourceMapParser {
         // 11. Let namesField be GetOptionalListOfStrings(json, "names").
         val namesField = getOptionalListOfStrings(json, "names").ifFailure { return it }
         // 12. Let mappings be DecodeMappings(mappingsField, namesField, sources).
-        val mappings = decodeMappings(mappingsField, namesField, sources).ifFailure { return it }
         // 13. Sort mappings in ascending order, with a Decoded Mapping Record a being less than a Decoded Mapping Record b if ComparePositions(a.[[GeneratedPosition]], b.[[GeneratedPosition]]) is lesser.
-        mappings.sortedWith { record1, record2 -> comparePositions(record1.generatedPosition, record2.generatedPosition).value }
+        val mappings = decodeMappings(mappingsField, namesField, sources)
+            .ifFailure { return it }
+            .sortedWith { record1, record2 -> comparePositions(record1.generatedPosition, record2.generatedPosition).value }
         // 14. Return the Decoded Source Map Record { [[File]]: fileField, [[Sources]]: sources, [[Mappings]]: mappings }.
         return Success(DecodedSourceMapRecord(fileField, sources, mappings))
     }

--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
@@ -1034,7 +1034,7 @@ public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boole
 
             CXIdxEntity_Function -> {
                 if (isSuitableFunction(cursor)) {
-                    functionById.getOrPut(getDeclarationId(cursor)) {
+                    functionById.computeIfAbsent(getDeclarationId(cursor)) {
                         getFunction(cursor)
                     }
                 }
@@ -1048,7 +1048,7 @@ public open class NativeIndexImpl(val library: NativeLibrary, val verbose: Boole
                 val parentKind = info.semanticContainer!!.pointed.cursor.kind
                 if (parentKind == CXCursorKind.CXCursor_TranslationUnit || parentKind == CXCursorKind.CXCursor_Namespace) {
                     // Top-level or namespace member. Skip class static members - they are loaded by visitClass
-                    globalById.getOrPut(getDeclarationId(cursor)) {
+                    globalById.computeIfAbsent(getDeclarationId(cursor)) {
                         val definitionCursor = findDefinition(cursor)
                         val directAccess = when {
                             definitionCursor != null -> {

--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
@@ -744,22 +744,22 @@ fun indexTranslationUnitsForTypesDefinitions(
                 when (kind) {
                     CXIdxEntity_Union, CXIdxEntity_Struct -> {
                         if (!isStructDeclForward(cursor)) {
-                            structDefinitionBySpelling.getOrPut(getCursorSpelling(cursor)) { cursor }
+                            structDefinitionBySpelling.computeIfAbsent(getCursorSpelling(cursor)) { cursor }
                         }
                     }
                     CXIdxEntity_ObjCClass -> {
                         if (cursor.kind == CXCursorKind.CXCursor_ObjCInterfaceDecl && !isObjCInterfaceDeclForward(cursor)) {
-                            classDefinitionBySpelling.getOrPut(getCursorSpelling(cursor)) { cursor }
+                            classDefinitionBySpelling.computeIfAbsent(getCursorSpelling(cursor)) { cursor }
                         }
                     }
                     CXIdxEntity_ObjCProtocol -> {
                         if (cursor.kind == CXCursorKind.CXCursor_ObjCProtocolDecl && !isObjCProtocolDeclForward(cursor)) {
-                            protocolDefinitionBySpelling.getOrPut(getCursorSpelling(cursor)) { cursor }
+                            protocolDefinitionBySpelling.computeIfAbsent(getCursorSpelling(cursor)) { cursor }
                         }
                     }
                     CXIdxEntity_Enum -> {
                         if (!isEnumDeclForward(cursor)) {
-                            enumDefinitionBySpelling.getOrPut(getCursorSpelling(cursor)) { cursor }
+                            enumDefinitionBySpelling.computeIfAbsent(getCursorSpelling(cursor)) { cursor }
                         }
                     }
                     else -> {}

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrDriver.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/StubIrDriver.kt
@@ -214,7 +214,7 @@ class StubIrDriver(
             return
         }
 
-        val out = { it: String -> cFile.appendLine(it) }
+        val out: (String) -> Unit = { cFile.appendLine(it) }
 
         context.libraryForCStubs.preambleLines.forEach {
             out(it)

--- a/kotlin-native/Interop/StubGenerator/test/org/jetbrains/kotlin/native/interop/gen/ModularCinteropUnitTests.kt
+++ b/kotlin-native/Interop/StubGenerator/test/org/jetbrains/kotlin/native/interop/gen/ModularCinteropUnitTests.kt
@@ -584,11 +584,11 @@ class ModularCinteropUnitTests : IndexerTestsBase() {
         )
 
         val enumDecl = index.enums.single()
-        listOf(
-                listOf("one" to enumDecl, "two" to enumDecl),
+        assertEquals(
+                listOf(markerFunctionOne to enumDecl, markerFunctionTwo to enumDecl),
                 index.functions.map {
                     it.name to assertIs<EnumType>(it.parameters.single().type).def
-                }
+                },
         )
     }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
@@ -55,7 +55,7 @@ internal fun determineLinkerOutput(context: NativeBackendPhaseContext): LinkerOu
                 if (context.config.target.family == Family.ANDROID) {
                     val configuration = context.config.configuration
                     val androidProgramType = configuration.get(BinaryOptions.androidProgramType) ?: AndroidProgramType.Default
-                    when (androidProgramType) {
+                    return@run when (androidProgramType) {
                         AndroidProgramType.Standalone -> LinkerOutputKind.EXECUTABLE
                         AndroidProgramType.NativeActivity -> LinkerOutputKind.DYNAMIC_LIBRARY
                     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.library.uniqueName
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
-import kotlin.io.path.deleteExisting
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.name
 import kotlin.io.path.pathString

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -52,7 +52,7 @@ internal fun PhaseEngine<NativeGenerationState>.runLowerings(
     for (module in modules) {
         for (file in module.files) {
             context.fileLowerState = FileLowerState()
-            lowerings.fold(file) { loweredFile, lowering ->
+            val _ = lowerings.fold(file) { loweredFile, lowering ->
                 performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
                     runPhase(lowering, loweredFile)
                 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/ClassLayoutBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/ClassLayoutBuilder.kt
@@ -231,7 +231,7 @@ internal class GlobalHierarchyAnalysis(val context: NativeBackendContext, val ir
                     }
 
                     fun registerInterface(iface: IrClass) {
-                        interfaceIndices.getOrPut(iface) {
+                        interfaceIndices.computeIfAbsent(iface) {
                             forbidden.add(mutableListOf())
                             interfaces.add(iface)
                             interfaces.size - 1

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -1927,7 +1927,7 @@ private fun MethodBridge.parametersAssociated(
                 it to null
 
             MethodBridgeReceiver.Factory -> {
-                kotlinParameters.next()
+                val _ = kotlinParameters.next()
                 it to null
             }
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -42,6 +42,7 @@ import org.jetbrains.kotlin.konan.target.LinkerOutputKind
 import org.jetbrains.kotlin.library.isNativeStdlib
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.utils.DFS
+import org.jetbrains.kotlin.utils.addToStdlib.skipNext
 import kotlin.jvm.Throws
 
 internal fun TypeBridge.makeNothing(llvm: CodegenLlvmHelpers) = when (this) {
@@ -1927,7 +1928,7 @@ private fun MethodBridge.parametersAssociated(
                 it to null
 
             MethodBridgeReceiver.Factory -> {
-                val _ = kotlinParameters.next()
+                kotlinParameters.skipNext()
                 it to null
             }
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/StringTable.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/StringTable.kt
@@ -58,7 +58,7 @@ internal class StringTableBuilder {
     private var index = 0
 
     operator fun String.unaryPlus() {
-        this@StringTableBuilder.indices.getOrPut(this) { index++ }
+        this@StringTableBuilder.indices.computeIfAbsent(this) { index++ }
     }
 
     fun build() = StringTable(indices)

--- a/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/FlagDelegatesTest.kt
+++ b/libraries/kotlinx-metadata/jvm/test/kotlin/metadata/test/FlagDelegatesTest.kt
@@ -104,7 +104,7 @@ class FlagDelegatesTest {
         inline var noinlineModifierVar: () -> String
             get() = { "" }
             set(noinline param) {
-                param()
+                val _ = param()
             }
 
     }

--- a/libraries/scripting/jvm-host-test/test/kotlin/script/experimental/jvmhost/test/ScriptingHostTest.kt
+++ b/libraries/scripting/jvm-host-test/test/kotlin/script/experimental/jvmhost/test/ScriptingHostTest.kt
@@ -688,8 +688,8 @@ class ScriptingHostTest {
         }
         val res = makeScriptingHost().eval(script.toScriptSource(), compilationConfiguration1, null)
         assertTrue(res is ResultWithDiagnostics.Failure)
-        res.reports.find { it.message.startsWith("The feature \"break continue in inline lambdas\" is only available since language version 2.2") }
-            ?: fail("Error report about language version not found. Reported:\n  ${res.reports.joinToString("\n  ") { it.message }}")
+        if (res.reports.none { it.message.startsWith("The feature \"break continue in inline lambdas\" is only available since language version 2.2") })
+            fail("Error report about language version not found. Reported:\n  ${res.reports.joinToString("\n  ") { it.message }}")
     }
 
     @Test
@@ -701,8 +701,8 @@ class ScriptingHostTest {
         }) {}
         assertTrue(res1 is ResultWithDiagnostics.Failure)
         val regex = "Unresolved reference\\W+println".toRegex()
-        res1.reports.find { it.message.contains(regex) }
-            ?: fail("Expected unresolved reference report. Reported:\n  ${res1.reports.joinToString("\n  ") { it.message }}")
+        if (res1.reports.none { it.message.contains(regex) })
+            fail("Expected unresolved reference report. Reported:\n  ${res1.reports.joinToString("\n  ") { it.message }}")
 
         val res2 = evalScriptWithConfiguration(script, compilation = {
             refineConfiguration {

--- a/libraries/scripting/jvm-host-test/test/kotlin/script/experimental/jvmhost/test/commonUtil.kt
+++ b/libraries/scripting/jvm-host-test/test/kotlin/script/experimental/jvmhost/test/commonUtil.kt
@@ -10,7 +10,7 @@ import java.nio.file.Files
 
 internal const val TEST_DATA_DIR = "libraries/scripting/jvm-host-test/testData"
 
-internal fun <R> withTempDir(keyName: String = "tmp", body: (File) -> R) {
+internal fun withTempDir(keyName: String = "tmp", body: (File) -> Unit) {
     val tempDir = Files.createTempDirectory(keyName).toFile()
     try {
         body(tempDir)

--- a/libraries/stdlib/samples/test/samples/collections/grouping.kt
+++ b/libraries/stdlib/samples/test/samples/collections/grouping.kt
@@ -128,13 +128,13 @@ class Grouping {
         // grouping by first char and collect only max of contains vowels
         val compareByVowelCount = compareBy { s: String -> s.count { it in "aeiou" } }
 
-        animals.groupingBy { it.first() }.reduceTo(maxVowels) { _, a, b -> maxOf(a, b, compareByVowelCount) }
+        val reduced = animals.groupingBy { it.first() }.reduceTo(maxVowels) { _, a, b -> maxOf(a, b, compareByVowelCount) }
 
-        assertPrints(maxVowels, "{r=reindeer, c=camel, g=giraffe}")
+        assertPrints(reduced, "{r=reindeer, c=camel, g=giraffe}")
 
         val moreAnimals = listOf("capybara", "rat")
-        moreAnimals.groupingBy { it.first() }.reduceTo(maxVowels) { _, a, b -> maxOf(a, b, compareByVowelCount) }
+        val moreReduced = moreAnimals.groupingBy { it.first() }.reduceTo(maxVowels) { _, a, b -> maxOf(a, b, compareByVowelCount) }
 
-        assertPrints(maxVowels, "{r=reindeer, c=capybara, g=giraffe}")
+        assertPrints(moreReduced, "{r=reindeer, c=capybara, g=giraffe}")
     }
 }

--- a/libraries/stdlib/samples/test/samples/collections/iterators.kt
+++ b/libraries/stdlib/samples/test/samples/collections/iterators.kt
@@ -66,7 +66,7 @@ class Iterators {
         val iterator = (1..3).iterator()
         // skip an element
         if (iterator.hasNext()) {
-            iterator.next()
+            val _ = iterator.next()
         }
 
         // do something with the rest of elements

--- a/libraries/stdlib/samples/test/samples/uuid/uuid.kt
+++ b/libraries/stdlib/samples/test/samples/uuid/uuid.kt
@@ -280,7 +280,7 @@ class Uuids {
         val timestamp = Instant.fromEpochMilliseconds(1757440583000L)
 
         // Generate 5 uuids for the same timestamp, and them explicitly sort them to ensure monotonicity
-        val uuids = sequence<Uuid> { Uuid.generateV7NonMonotonicAt(timestamp) }.take(5).sorted().toList()
+        val uuids = List(5) { Uuid.generateV7NonMonotonicAt(timestamp) }.sorted()
 
         for (idx in 1..<uuids.size) {
             assertTrue(uuids[idx - 1] < uuids[idx])

--- a/libraries/tools/abi-validation/abi-tools-api/src/test/kotlin/org/jetbrains/kotlin/abi/tools/KlibTargetNameTest.kt
+++ b/libraries/tools/abi-validation/abi-tools-api/src/test/kotlin/org/jetbrains/kotlin/abi/tools/KlibTargetNameTest.kt
@@ -23,17 +23,17 @@ class KlibTargetNameTest {
         assertFailsWith<IllegalArgumentException> { KlibTarget.parse("a.") }
         assertFailsWith<IllegalArgumentException> { KlibTarget.parse(".a") }
 
-        KlibTarget.parse("a.b").also {
+        KlibTarget.parse("a.b").let {
             assertEquals("b", it.configurableName)
             assertEquals("a", it.targetName)
         }
 
-        KlibTarget.parse("a.a").also {
+        KlibTarget.parse("a.a").let {
             assertEquals("a", it.configurableName)
             assertEquals("a", it.targetName)
         }
 
-        KlibTarget.parse("a").also {
+        KlibTarget.parse("a").let {
             assertEquals("a", it.configurableName)
             assertEquals("a", it.targetName)
         }

--- a/libraries/tools/abi-validation/abi-tools/src/main/kotlin/org/jetbrains/kotlin/abi/tools/impl/klib/KlibAbiDumpFileMerger.kt
+++ b/libraries/tools/abi-validation/abi-tools/src/main/kotlin/org/jetbrains/kotlin/abi/tools/impl/klib/KlibAbiDumpFileMerger.kt
@@ -113,7 +113,7 @@ internal class KlibAbiDumpMerger {
         val aliases = mutableMapOf<String, Set<KlibTarget>>()
         val bcvTargets = mutableSetOf<KlibTarget>()
         if (isMergedFile) {
-            lines.next() // skip the heading line
+            val _ = lines.next() // skip the heading line
             bcvTargets.addAll(lines.parseTargets())
             aliases.putAll(lines.parseAliases())
         }
@@ -146,7 +146,8 @@ internal class KlibAbiDumpMerger {
         while (lines.hasNext()) {
             val line = lines.peek()!!
             if (line.isEmpty()) {
-                lines.next(); continue
+                val _ = lines.next()
+                continue
             }
             // TODO: wrap the line and cache the depth inside that wrapper?
             val lineDepth = line.depth()
@@ -183,7 +184,7 @@ internal class KlibAbiDumpMerger {
                     if (line.trim() == CLASS_DECLARATION_TERMINATOR) {
                         currentContainer.delimiter = line
                         // We processed the terminator char, so let's skip this line.
-                        lines.next()
+                        val _ = lines.next()
                     }
                     // For the top level declaration depth is -1
                     depth = if (currentContainer.parent == null) -1 else currentContainer.text.depth()
@@ -200,7 +201,7 @@ internal class KlibAbiDumpMerger {
         require(line.startsWith(TARGETS_LIST_PREFIX)) {
             "The line should starts with $TARGETS_LIST_PREFIX, but was: $line"
         }
-        next()
+        val _ = next()
         val targets = parseBcvTargetsLine(line)
         return targets
     }
@@ -241,7 +242,7 @@ internal class KlibAbiDumpMerger {
                 throw IllegalStateException("Library header has invalid format at line \"$next\"")
             }
             header.add(next)
-            next()
+            val _ = next()
             if (next.startsWith(LIBRARY_NAME_PREFIX)) {
                 break
             }
@@ -250,7 +251,7 @@ internal class KlibAbiDumpMerger {
         while (hasNext()) {
             val next = peek()!!
             if (!next.startsWith(COMMENT_PREFIX) || next.startsWith(TARGETS_LIST_PREFIX)) break
-            next()
+            val _ = next()
             // There's no manifest in merged files
             check(!isMergedFile) { "Unexpected header line: $next" }
             when {
@@ -324,7 +325,7 @@ internal class KlibAbiDumpMerger {
     ): DeclarationContainer {
         val line = peek()!!
         return if (line.startsWith(" ".repeat(depth * INDENT_WIDTH) + TARGETS_LIST_PREFIX)) {
-            next() // skip prefix
+            val _ = next() // skip prefix
             // Target list means that the declaration following it has a narrower set of targets than its parent,
             // so we must use it.
             val targets = parseBcvTargetsLine(line)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/AppleFrameworkIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/AppleFrameworkIT.kt
@@ -726,6 +726,6 @@ private val GradleProject.darwinBuildProductsDir: Path
 
 private fun GradleProject.iosBuildProductsDir(writeProtected: Boolean = false): Path = darwinBuildProductsDir.apply {
     if (writeProtected) {
-        setPosixFilePermissions(setOf(PosixFilePermission.OWNER_READ))
+        val _ = setPosixFilePermissions(setOf(PosixFilePermission.OWNER_READ))
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/CocoaPodsXcodeIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/CocoaPodsXcodeIT.kt
@@ -241,7 +241,7 @@ private fun TestProject.manualPodInstall(taskPrefix: String, iosAppPath: Path) {
     build("$taskPrefix:$DUMMY_FRAMEWORK_TASK_NAME", buildOptions = buildOptions)
 
     val environmentalVariables = environmentVariables.environmentalVariables.toMutableMap()
-    environmentalVariables.getOrPut("LC_ALL") { "en_US.UTF-8" }
+    environmentalVariables.putIfAbsent("LC_ALL", "en_US.UTF-8")
 
     runProcess(
         cmd = listOf("env", "pod", "install"),

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/KotlinNativeIsolatedClassloaderIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/KotlinNativeIsolatedClassloaderIT.kt
@@ -27,7 +27,7 @@ internal class KotlinNativeIsolatedClassloaderIT : KGPBaseTest() {
          * Ensure that the class is accessible here.
          * We try to access it in the isolated classpath and ensure that it's not accessible there.
          */
-        org.gradle.launcher.bootstrap.EntryPoint::class.java
+        val _ = org.gradle.launcher.bootstrap.EntryPoint::class.java
         nativeProject("compilerPlugins/pluginUsesJdkClass", gradleVersion, buildJdk = providedJdk.location) {
             build(":library:compileKotlinLinuxX64")
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testHelpers.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testHelpers.kt
@@ -87,7 +87,7 @@ fun TestProject.makeSnapshotTo(
         )
 
         if ("Windows" !in System.getProperty("os.name")) {
-            setPosixFilePermissions(
+            val _ = setPosixFilePermissions(
                 setOf(
                     PosixFilePermission.OWNER_EXECUTE,
                     PosixFilePermission.OWNER_READ,

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT62877ProjectMutationAfterEvaluation.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/regressionTests/KT62877ProjectMutationAfterEvaluation.kt
@@ -48,7 +48,7 @@ class KT62877ProjectMutationAfterEvaluation {
         // Now initialize tasks
         val taskNames = project.tasks.names.toMutableSet()
         taskNames.remove("init") // initializing the init task isn't possible due to Gradle reasons
-        taskNames.map { project.tasks.getByName(it) }
+        taskNames.forEach { project.tasks.getByName(it) }
 
         // And resolve IDE dependencies
         project.kotlinIdeMultiplatformImport.resolveDependencies("commonMain")

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/CInteropCommonizerTaskTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/CInteropCommonizerTaskTest.kt
@@ -323,32 +323,32 @@ class CInteropCommonizerTaskTest : MultiplatformExtensionTest() {
         val iosTargets = listOf(iosX64, iosArm64)
 
         /* Define interops */
-        nativeTargets.map { target ->
-            target.compilations.getByName("main").cinterops.create("nativeHelper").identifier
+        nativeTargets.forEach { target ->
+            target.compilations.getByName("main").cinterops.create("nativeHelper")
         }
 
-        nativeTargets.map { target ->
-            target.compilations.getByName("test").cinterops.create("nativeTestHelper").identifier
+        nativeTargets.forEach { target ->
+            target.compilations.getByName("test").cinterops.create("nativeTestHelper")
         }
 
-        windowsTargets.map { target ->
-            target.compilations.getByName("main").cinterops.create("windowsHelper").identifier
+        windowsTargets.forEach { target ->
+            target.compilations.getByName("main").cinterops.create("windowsHelper")
         }
 
-        unixLikeTargets.map { target ->
-            target.compilations.getByName("main").cinterops.create("unixHelper").identifier
+        unixLikeTargets.forEach { target ->
+            target.compilations.getByName("main").cinterops.create("unixHelper")
         }
 
-        appleTargets.map { target ->
-            target.compilations.getByName("main").cinterops.create("appleHelper").identifier
+        appleTargets.forEach { target ->
+            target.compilations.getByName("main").cinterops.create("appleHelper")
         }
 
-        appleTargets.map { target ->
-            target.compilations.getByName("test").cinterops.create("appleTestHelper").identifier
+        appleTargets.forEach { target ->
+            target.compilations.getByName("test").cinterops.create("appleTestHelper")
         }
 
-        iosTargets.map { target ->
-            target.compilations.getByName("main").cinterops.create("iosHelper").identifier
+        iosTargets.forEach { target ->
+            target.compilations.getByName("main").cinterops.create("iosHelper")
         }
 
         iosX64.compilations.getByName("main").cinterops.create("iosX64Helper").identifier

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExternalKotlinTargetApiTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/ExternalKotlinTargetApiTests.kt
@@ -205,8 +205,8 @@ class ExternalKotlinTargetApiTests {
         KotlinPluginLifecycle.Stage.AfterFinaliseCompilations.await()
         val component = target.delegate.kotlinComponents.singleOrNull() ?: fail("Expected single 'component' for external target")
 
-        component.internal.usages.find { it.dependencyConfigurationName == target.sourcesElementsPublishedConfiguration.name }
-            ?: fail("Missing sourcesElements usage")
+        if (component.internal.usages.none { it.dependencyConfigurationName == target.sourcesElementsPublishedConfiguration.name })
+            fail("Missing sourcesElements usage")
     }
 
     @Test

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/IdeMultiplatformImportPriorityTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/IdeMultiplatformImportPriorityTest.kt
@@ -43,7 +43,7 @@ class IdeMultiplatformImportPriorityTest {
         assertEquals(predefinedValues, predefinedValues.sorted())
         assertEquals(predefinedValues.reversed(), predefinedValues.sortedDescending())
 
-        predefinedValues.zipWithNext { lower, higher ->
+        for ((lower, higher) in predefinedValues.zipWithNext()) {
             assertNotEquals(lower, higher)
             assertTrue(lower < higher)
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/JvmBinariesDslTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/JvmBinariesDslTest.kt
@@ -28,6 +28,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class JvmBinariesDslTest {
 
@@ -598,7 +599,7 @@ class JvmBinariesDslTest {
         val installTask = consumerProject.assertContainsTaskInstance<Sync>("installJvmTestDist")
 
         scriptsTask.assertDependsOn(libJarTask)
-        scriptsTask.classpath!!.files.map { it.name }.contains(libJarTask.archiveFileName.get())
+        assertTrue(libJarTask.archiveFileName.get() in scriptsTask.classpath!!.files.map { it.name })
 
         installTask.assertDependsOn(libJarTask)
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinInterprocessFileLockTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinInterprocessFileLockTest.kt
@@ -103,7 +103,7 @@ class KotlinInterprocessFileLockTest {
                 arrayOf(classLoader.loadClass(Function1::class.java.name)),
                 InvocationHandler { _, _, _ -> action() })
             val withLockMethod = instance::class.declaredFunctions.first { it.name == "withLock" }
-            withLockMethod.call(instance, actionProxy)
+            val _ = withLockMethod.call(instance, actionProxy)
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJvmRunTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinJvmRunTest.kt
@@ -83,7 +83,7 @@ class KotlinJvmRunTest {
 
         configurationResult.await()
 
-        mainCompilation.output.allOutputs.files.ifEmpty { fail("Expected some file in 'allOutputs'") }
+        if (mainCompilation.output.allOutputs.files.isEmpty()) fail("Expected some file in 'allOutputs'")
         if (!mainRunTask.classpath.files.containsAll(mainCompilation.output.allOutputs.files)) {
             fail("Missing output from main compilation in '$mainRunTask'")
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPluginLifecycleTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinPluginLifecycleTest.kt
@@ -207,7 +207,7 @@ class KotlinPluginLifecycleTest {
             assertFalse(exceptionWasProvoked.getAndSet(true))
             throw thrownException
         }
-        runCatching { project.evaluate() }
+        val _ = runCatching { project.evaluate() }
         assertTrue(exceptionWasProvoked.get(), "Exception during '.evaluate()' was not provoked")
 
         /* Assert: The 'AfterEvaluate' based stage should not have been executed */
@@ -239,7 +239,7 @@ class KotlinPluginLifecycleTest {
             assertFalse(exceptionWasProvoked.getAndSet(true))
             throw thrownException
         }
-        runCatching { project.evaluate() }
+        val _ = runCatching { project.evaluate() }
         assertTrue(exceptionWasProvoked.get(), "Exception during '.evaluate()' was not provoked")
         assertTrue(executedAfterLifecycleFinished.get(), "Expected coroutine waiting for '.finished' to be executed")
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetVariantResourcesPublicationTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetVariantResourcesPublicationTests.kt
@@ -117,7 +117,7 @@ class KotlinTargetVariantResourcesPublicationTests {
         ) {
             kotlin {
                 targetsToTest.forEach { createTarget ->
-                    createTarget()
+                    val _ = createTarget()
                 }
             }
         }.evaluate()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetVariantResourcesResolutionTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/KotlinTargetVariantResourcesResolutionTests.kt
@@ -219,16 +219,16 @@ class KotlinTargetVariantResourcesResolutionTests {
         val producer = rootProject.createSubproject(
             "producer",
         ) {
-            kotlin { producerTarget() }
+            kotlin { val _ = producerTarget() }
         }
         val consumer = rootProject.createSubproject(
             "consumer",
         ) {
             kotlin {
-                consumerTarget()
+                val _ = consumerTarget()
                 sourceSets.commonMain {
                     dependencies {
-                        dependencyScope()(project(":${producer.name}"))
+                        val _ = dependencyScope()(project(":${producer.name}"))
                     }
                 }
             }
@@ -255,7 +255,7 @@ class KotlinTargetVariantResourcesResolutionTests {
                 enableMppResourcesPublication(true)
             }
         ) {
-            kotlin { targetProvider() }
+            kotlin { val _ = targetProvider() }
         }
 
         val middle = rootProject.createSubproject(
@@ -265,10 +265,10 @@ class KotlinTargetVariantResourcesResolutionTests {
             }
         ) {
             kotlin {
-                targetProvider()
+                val _ = targetProvider()
                 sourceSets.commonMain {
                     dependencies {
-                        dependencyScope()(dependencies.project(":${producer.name}"))
+                        val _ = dependencyScope()(dependencies.project(":${producer.name}"))
                     }
                 }
             }
@@ -281,10 +281,10 @@ class KotlinTargetVariantResourcesResolutionTests {
             }
         ) {
             kotlin {
-                targetProvider()
+                val _ = targetProvider()
                 sourceSets.commonMain {
                     dependencies {
-                        dependencyScope()(dependencies.project(":${middle.name}"))
+                        val _ = dependencyScope()(dependencies.project(":${middle.name}"))
                     }
                 }
             }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/PublishJvmEnvironmentAttributeTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/PublishJvmEnvironmentAttributeTest.kt
@@ -85,7 +85,7 @@ class PublishJvmEnvironmentAttributeTest {
     private fun KotlinTarget.forEachUsage(action: (usage: KotlinUsageContext) -> Unit) {
         val component = internal.kotlinComponents.singleOrNull() ?: fail("Expected a single component. Found: ${components}")
         component as KotlinVariantWithMetadataVariant
-        component.usages.ifEmpty { fail("Expected at least one 'usage'") }
+        if (component.usages.isEmpty()) fail("Expected at least one 'usage'")
         component.usages.forEach(action)
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/SwiftExportUnitTests.kt
@@ -183,7 +183,7 @@ class SwiftExportUnitTests {
     fun `test swift export missing arch`() {
         val project = swiftExportProject(archs = "arm64", multiplatform = {
             @Suppress("DEPRECATION") // fixme: KT-81704 Cleanup tests after apple x64 family deprecation
-            listOf(iosSimulatorArm64(), iosX64(), iosArm64())
+            iosSimulatorArm64(); iosX64(); iosArm64()
         })
 
         project.evaluate()
@@ -212,7 +212,7 @@ class SwiftExportUnitTests {
     fun `test swift export embed and sign inputs`() {
         val project = swiftExportProject(archs = "arm64 x86_64", multiplatform = {
             @Suppress("DEPRECATION") // fixme: KT-81704 Cleanup tests after apple x64 family deprecation
-            listOf(iosSimulatorArm64(), iosX64())
+            iosSimulatorArm64(); iosX64()
         })
 
         project.evaluate()

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/XCFrameworkCocoaPodsTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/XCFrameworkCocoaPodsTest.kt
@@ -32,11 +32,9 @@ class XCFrameworkCocoaPodsTest {
             applyCocoapodsPlugin()
             kotlin {
                 @Suppress("DEPRECATION") // fixme: KT-81704 Cleanup tests after apple x64 family deprecation
-                listOf(
-                    iosSimulatorArm64(),
-                    iosX64(),
-                    iosArm64(),
-                )
+                iosSimulatorArm64()
+                iosX64()
+                iosArm64()
 
                 cocoapods {
                     framework {

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/uklibs/UklibResolutionWithMockComponents.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/unitTests/uklibs/UklibResolutionWithMockComponents.kt
@@ -2245,7 +2245,8 @@ class UklibResolutionTestsWithMockComponents {
             val resolutionException = runCatching {
                 it()
             }.exceptionOrNull() ?: error("Expect a failure")
-            findMatchingExceptions(resolutionException, VariantSelectionByAttributesException::class.java).single()
+            val exceptions = findMatchingExceptions(resolutionException, VariantSelectionByAttributesException::class.java)
+            assert(exceptions.size == 1) { "Expected exactly one exception, but got ${exceptions.size}: $exceptions" }
         }
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/kmpTargets.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/util/kmpTargets.kt
@@ -31,6 +31,6 @@ fun KotlinMultiplatformExtension.enableAllKotlinTargets(
         .filter { it.returnType.isSubtypeOf(KotlinTarget::class.starProjectedType) }
         .filter { it.name !in excludedTargets }
         .forEach {
-            it.call(this)
+            val _ = it.call(this)
         }
 }

--- a/libraries/tools/kotlin-tooling-core/src/test/kotlin/org/jetbrains/kotlin/tooling/core/KotlinToolingVersionTest.kt
+++ b/libraries/tools/kotlin-tooling-core/src/test/kotlin/org/jetbrains/kotlin/tooling/core/KotlinToolingVersionTest.kt
@@ -317,7 +317,7 @@ class KotlinToolingVersionTest {
 
     @Test
     fun testBehaviourInEdgeCases() {
-        KotlinToolingVersion("1.6.20.1").apply {
+        KotlinToolingVersion("1.6.20.1").run {
             assertEquals(STABLE, maturity)
             assertEquals(1, major)
             assertEquals(6, minor)
@@ -327,7 +327,7 @@ class KotlinToolingVersionTest {
             assertNull(buildNumber)
         }
 
-        KotlinToolingVersion("1.6-x").apply {
+        KotlinToolingVersion("1.6-x").run {
             assertEquals(DEV, maturity)
             assertEquals(1, major)
             assertEquals(6, minor)
@@ -337,7 +337,7 @@ class KotlinToolingVersionTest {
             assertNull(buildNumber)
         }
 
-        KotlinToolingVersion("1.8.0-dev----999").apply {
+        KotlinToolingVersion("1.8.0-dev----999").run {
             assertEquals(DEV, maturity)
             assertEquals(1, major)
             assertEquals(8, minor)
@@ -347,7 +347,7 @@ class KotlinToolingVersionTest {
             assertEquals(999, buildNumber)
         }
 
-        KotlinToolingVersion("1.6.20-dev-google-pr-510").apply {
+        KotlinToolingVersion("1.6.20-dev-google-pr-510").run {
             assertEquals(DEV, maturity)
             assertEquals(1, major)
             assertEquals(6, minor)
@@ -357,7 +357,7 @@ class KotlinToolingVersionTest {
             assertEquals(510, buildNumber)
         }
 
-        KotlinToolingVersion("1.6.x-dev").apply {
+        KotlinToolingVersion("1.6.x-dev").run {
             assertEquals(DEV, maturity)
             assertEquals(1, major)
             assertEquals(6, minor)

--- a/native/commonizer/src/org/jetbrains/kotlin/commonizer/CommonizerQueue.kt
+++ b/native/commonizer/src/org/jetbrains/kotlin/commonizer/CommonizerQueue.kt
@@ -87,7 +87,7 @@ internal class CommonizerQueue(
     }
 
     fun invokeTarget(outputTarget: OutputCommonizerTarget) {
-        commonizedTargets[outputTarget]?.invoke()
+        val _ = commonizedTargets[outputTarget]?.invoke()
     }
 
     private fun enqueue(outputTarget: OutputCommonizerTarget) {

--- a/native/commonizer/src/org/jetbrains/kotlin/commonizer/core/CommonizationVisitor.kt
+++ b/native/commonizer/src/org/jetbrains/kotlin/commonizer/core/CommonizationVisitor.kt
@@ -20,7 +20,7 @@ internal class CommonizationVisitor(
     }
 
     override fun visitModuleNode(node: CirModuleNode, data: Unit) {
-        node.commonDeclaration() // commonize module
+        val _ = node.commonDeclaration() // commonize module
 
         node.packages.values.forEach { pkg ->
             pkg.accept(this, Unit)
@@ -29,7 +29,7 @@ internal class CommonizationVisitor(
 
     @Suppress("DuplicatedCode")
     override fun visitPackageNode(node: CirPackageNode, data: Unit) {
-        node.commonDeclaration() // commonize package
+        val _ = node.commonDeclaration() // commonize package
 
         node.properties.values.forEach { property ->
             property.accept(this, Unit)
@@ -49,11 +49,11 @@ internal class CommonizationVisitor(
     }
 
     override fun visitPropertyNode(node: CirPropertyNode, data: Unit) {
-        node.commonDeclaration() // commonize property
+        val _ = node.commonDeclaration() // commonize property
     }
 
     override fun visitFunctionNode(node: CirFunctionNode, data: Unit) {
-        node.commonDeclaration() // commonize function
+        val _ = node.commonDeclaration() // commonize function
     }
 
     @Suppress("DuplicatedCode")
@@ -91,10 +91,10 @@ internal class CommonizationVisitor(
     }
 
     override fun visitClassConstructorNode(node: CirClassConstructorNode, data: Unit) {
-        node.commonDeclaration() // commonize constructor
+        val _ = node.commonDeclaration() // commonize constructor
     }
 
     override fun visitTypeAliasNode(node: CirTypeAliasNode, data: Unit) {
-        node.commonDeclaration() // commonize type alias
+        val _ = node.commonDeclaration() // commonize type alias
     }
 }

--- a/native/commonizer/tests/org/jetbrains/kotlin/commonizer/tree/deserializer/CirTreeClassDeserializerTest.kt
+++ b/native/commonizer/tests/org/jetbrains/kotlin/commonizer/tree/deserializer/CirTreeClassDeserializerTest.kt
@@ -184,18 +184,18 @@ class CirTreeClassDeserializerTest : AbstractCirTreeDeserializerTest() {
         val clazz = module.assertSingleClass()
 
         fun assertContainsProperty(name: String) {
-            clazz.properties.singleOrNull { it.name.toStrippedString() == name }
-                ?: kotlin.test.fail("Missing property '$name'")
+            if (clazz.properties.singleOrNull { it.name.toStrippedString() == name } == null)
+                kotlin.test.fail("Missing property '$name'")
         }
 
         fun assertContainsFunction(name: String) {
-            clazz.functions.singleOrNull { it.name.toStrippedString() == name }
-                ?: kotlin.test.fail("Missing function '$name'")
+            if (clazz.functions.singleOrNull { it.name.toStrippedString() == name } == null)
+                kotlin.test.fail("Missing function '$name'")
         }
 
         fun assertContainsClass(name: String) {
-            clazz.classes.singleOrNull { it.clazz.name.toStrippedString() == name }
-                ?: kotlin.test.fail("Missing class '$name'")
+            if (clazz.classes.singleOrNull { it.clazz.name.toStrippedString() == name } == null)
+                kotlin.test.fail("Missing class '$name'")
         }
 
         assertContainsProperty("myInt")

--- a/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/FirebaseCloudXCTestExecutor.kt
+++ b/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/FirebaseCloudXCTestExecutor.kt
@@ -86,7 +86,7 @@ class FirebaseCloudXCTestExecutor(
                 createZip(bundle.prepareToRun(projectDir))
             }
         } catch (throwable: Throwable) {
-            rememberedFailure.compareAndSet(
+            val _ = rememberedFailure.compareAndSet(
                 null,
                 IllegalStateException(
                     "Failed to prepare a XCTest bundle with Xcode. Check Xcode or project configuration",

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBrideExtensions.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBrideExtensions.kt
@@ -27,7 +27,7 @@ fun MethodBridge.valueParametersAssociated(
          * Skip logic is bound to [this.valueParameters] array construction
          * at [org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportMapper.bridgeMethodImpl]
          */
-        kotlinParameters.next()
+        val _ = kotlinParameters.next()
     }
 
     return this.valueParameters.map {

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBrideExtensions.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBrideExtensions.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.konan.InternalKotlinNativeApi
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 import org.jetbrains.kotlin.descriptors.konan.allParameters
+import org.jetbrains.kotlin.utils.addToStdlib.skipNext
 
 
 @InternalKotlinNativeApi
@@ -27,7 +28,7 @@ fun MethodBridge.valueParametersAssociated(
          * Skip logic is bound to [this.valueParameters] array construction
          * at [org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportMapper.bridgeMethodImpl]
          */
-        val _ = kotlinParameters.next()
+        kotlinParameters.skipNext()
     }
 
     return this.valueParameters.map {

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.typeUtil.isNothing
 import org.jetbrains.kotlin.types.typeUtil.isUnit
+import org.jetbrains.kotlin.utils.addToStdlib.skipNext
 
 @InternalKotlinNativeApi
 class ObjCExportMapper(
@@ -435,12 +436,12 @@ private fun ObjCExportMapper.bridgeMethodImpl(descriptor: FunctionDescriptor): M
     val isTopLevel = isTopLevel(descriptor)
 
     val receiver = if (descriptor is ConstructorDescriptor && descriptor.constructedClass.isArray) {
-        val _ = kotlinParameters.next()
+        kotlinParameters.skipNext()
         MethodBridgeReceiver.Factory
     } else if (isTopLevel) {
         MethodBridgeReceiver.Static
     } else {
-        val _ = kotlinParameters.next()
+        kotlinParameters.skipNext()
         MethodBridgeReceiver.Instance
     }
 

--- a/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
+++ b/native/objcexport-header-generator/impl/k1/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
@@ -435,12 +435,12 @@ private fun ObjCExportMapper.bridgeMethodImpl(descriptor: FunctionDescriptor): M
     val isTopLevel = isTopLevel(descriptor)
 
     val receiver = if (descriptor is ConstructorDescriptor && descriptor.constructedClass.isArray) {
-        kotlinParameters.next()
+        val _ = kotlinParameters.next()
         MethodBridgeReceiver.Factory
     } else if (isTopLevel) {
         MethodBridgeReceiver.Static
     } else {
-        kotlinParameters.next()
+        val _ = kotlinParameters.next()
         MethodBridgeReceiver.Instance
     }
 

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/BridgeProvider/TypeBridging.kt
@@ -1239,7 +1239,8 @@ internal sealed interface Bridge {
         context(sir: SirSession)
         override fun helperBridges(typeNamer: SirTypeNamer): List<SirBridge> {
             return bridgeProxy?.createSirBridges {
-                val actualArgs = argNames.drop(1).also { if (extensionReceiverParameter != null) it.drop(1) }
+                // extensionReceiverParameter is always 'null', see bridgeProxy in the AsCovariantBlock constructor
+                val actualArgs = argNames.drop(1)
                 buildCall("(${argNames.first()} as ${typeNamer.kotlinFqName(swiftType, SirTypeNamer.KotlinNameType.PARAMETRIZED)}).invoke(${actualArgs.joinToString()})")
             } ?: emptyList()
         }

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/translation/ModuleTranslation.kt
@@ -115,7 +115,7 @@ internal fun translateCrossReferencingModulesTransitively(
     while (translationStates.any { it.unprocessedReferences.isNotEmpty() }) {
         translationStates
             .filter { it.unprocessedReferences.isNotEmpty() }
-            .map {
+            .forEach {
                 // Copy new references to avoid concurrent modification exception.
                 it.currentlyProcessing = it.unprocessedReferences.toList()
                 it.unprocessedReferences.clear()

--- a/native/utils/tests/org/jetbrains/kotlin/konan/target/DefFileConfigTest.kt
+++ b/native/utils/tests/org/jetbrains/kotlin/konan/target/DefFileConfigTest.kt
@@ -44,7 +44,7 @@ class DefFileConfigTest {
 
             for (expected: List<String>? in stringListValues) {
                 val properties = Properties()
-                expected?.let { properties.setProperty(propertyName, it.joinToString(separator = " ")) }
+                if (expected != null) properties.setProperty(propertyName, expected.joinToString(separator = " "))
 
                 val actual: List<String> = DefFileConfig(properties).readProperty()
                 assertEquals(expected.orEmpty(), actual, "Incorrect value for \"$propertyName\" property: $expected vs $actual")
@@ -69,7 +69,7 @@ class DefFileConfigTest {
 
             for (expected: String? in stringValues) {
                 val properties = Properties()
-                expected?.let { properties.setProperty(propertyName, it) }
+                if (expected != null) properties.setProperty(propertyName, expected)
 
                 val actual: String? = DefFileConfig(properties).readProperty()
                 assertEquals(expected ?: defaultValue, actual, "Incorrect value for \"$propertyName\" property: $expected vs $actual")
@@ -89,7 +89,7 @@ class DefFileConfigTest {
 
             for (expected: Boolean? in booleanValues) {
                 val properties = Properties()
-                expected?.let { properties.setProperty(propertyName, it.toString()) }
+                if (expected != null) properties.setProperty(propertyName, expected.toString())
 
                 val actual: Boolean = DefFileConfig(properties).readProperty()
                 assertEquals(expected ?: false, actual, "Incorrect value for \"$propertyName\" property: $expected vs $actual")

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/debug/AbstractDebuggerTest.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/debug/AbstractDebuggerTest.kt
@@ -224,8 +224,8 @@ abstract class AbstractDebuggerTest : AbstractCodegenTest() {
                                     prepareReq.addClassExclusionFilter("androidx.compose.runtime.*")
                                     prepareReq.addClassExclusionFilter("jdk.internal.*")
                                 }
-                                manager.stepRequests().map { it.enable() }
-                                manager.classPrepareRequests().map { it.enable() }
+                                manager.stepRequests().forEach { it.enable() }
+                                manager.classPrepareRequests().forEach { it.enable() }
                                 inContentMethod = true
                                 loggedItems.add(event)
                             }
@@ -233,9 +233,9 @@ abstract class AbstractDebuggerTest : AbstractCodegenTest() {
                         is StepEvent -> {
                             // Handle the case where an Exception causing program to exit without MethodExitEvent.
                             if (inContentMethod && event.location().method().name() == "run") {
-                                manager.stepRequests().map { it.disable() }
-                                manager.classPrepareRequests().map { it.disable() }
-                                manager.breakpointRequests().map { it.disable() }
+                                manager.stepRequests().forEach { it.disable() }
+                                manager.classPrepareRequests().forEach { it.disable() }
+                                manager.breakpointRequests().forEach { it.disable() }
                                 break@vmLoop
                             }
                             if (inContentMethod) {
@@ -244,9 +244,9 @@ abstract class AbstractDebuggerTest : AbstractCodegenTest() {
                         }
                         is MethodExitEvent -> {
                             if (event.location().method().name() == CONTENT_METHOD) {
-                                manager.stepRequests().map { it.disable() }
-                                manager.classPrepareRequests().map { it.disable() }
-                                manager.breakpointRequests().map { it.disable() }
+                                manager.stepRequests().forEach { it.disable() }
+                                manager.classPrepareRequests().forEach { it.disable() }
+                                manager.breakpointRequests().forEach { it.disable() }
                                 break@vmLoop
                             }
                         }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -43,6 +43,7 @@ import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.utils.addToStdlib.forEachZipped
 
 /**
  * This transformer walks the IR tree to infer the applier annotations such as ComposableTarget,
@@ -663,7 +664,7 @@ class InferenceFunctionDeclaration(
             transformer.addAnnotationToDeclaration(function, scheme)
         } else {
             transformer.addAnnotationToDeclaration(function, scheme.target)
-            parameters().zip(scheme.parameters).forEach { [parameter, parameterScheme] ->
+            parameters().forEachZipped(scheme.parameters) { parameter, parameterScheme ->
                 parameter.updateScheme(parameterScheme)
             }
         }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -663,7 +663,7 @@ class InferenceFunctionDeclaration(
             transformer.addAnnotationToDeclaration(function, scheme)
         } else {
             transformer.addAnnotationToDeclaration(function, scheme.target)
-            parameters().zip(scheme.parameters) { parameter, parameterScheme ->
+            parameters().zip(scheme.parameters).forEach { [parameter, parameterScheme] ->
                 parameter.updateScheme(parameterScheme)
             }
         }

--- a/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiClassInfoBuilder.kt
+++ b/plugins/jvm-abi-gen/src/org/jetbrains/kotlin/jvm/abi/JvmAbiClassInfoBuilder.kt
@@ -31,7 +31,7 @@ internal class JvmAbiClassInfoBuilder(private val removePrivateClasses: Boolean)
     fun addInnerClass(innerClass: String, outerClass: String?) {
         if (outerClass == null) return
         if (removePrivateClasses) {
-            innerClassToOuter.getOrPut(innerClass) { outerClass }
+            innerClassToOuter.computeIfAbsent(innerClass) { outerClass }
         }
     }
 

--- a/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/impl/PluginDataFrameSchemaParser.kt
+++ b/plugins/kotlin-dataframe/kotlin-dataframe.k2/src/org/jetbrains/kotlinx/dataframe/plugin/impl/PluginDataFrameSchemaParser.kt
@@ -91,7 +91,7 @@ class PluginDataFrameSchemaParser {
                 return Result.parsingError("Column name cannot be blank")
             }
 
-            parseColumn(name, value).fold(
+            val _ = parseColumn(name, value).fold(
                 onSuccess = { columns.add(it) },
                 onFailure = { return Result.failure(it) }
             )
@@ -147,7 +147,7 @@ class PluginDataFrameSchemaParser {
                 return Result.failure(IllegalArgumentException("Nested column name cannot be blank"))
             }
 
-            parseColumn(key, value).fold(
+            val _ = parseColumn(key, value).fold(
                 onSuccess = { columns.add(it) },
                 onFailure = { return Result.failure(it) }
             )

--- a/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.backend/src/org/jetbrains/kotlinx/serialization/compiler/backend/ir/BaseIrGenerator.kt
@@ -427,7 +427,7 @@ abstract class BaseIrGenerator(private val currentClass: IrClass, final override
 
     internal fun IrClass.addCachedChildSerializersProperty(cacheableSerializers: List<IrExpression?>): IrProperty? {
         // if all child serializers are null (non-cacheable) we don't need to create a property
-        cacheableSerializers.firstOrNull { it != null } ?: return null
+        if (cacheableSerializers.all { it == null }) return null
 
         val kSerializerType = kSerializerType(compilerContext.irBuiltIns.anyType)
         val elementType = lazyType(kSerializerType)

--- a/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/AbstractBuilderGenerator.kt
+++ b/plugins/lombok/lombok.k2/src/org/jetbrains/kotlin/lombok/generators/AbstractBuilderGenerator.kt
@@ -840,7 +840,7 @@ abstract class AbstractBuilderGenerator<T : AbstractBuilder>(session: FirSession
         createCallable: (name: Name) -> K
     ) {
         if (name !in existingNames) {
-            getOrPut(name) { createCallable(name) }
+            val _ = getOrPut(name) { createCallable(name) }
         }
     }
 

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/irUtils.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/irUtils.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELABLE_FQN
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.PARCELER_FQN
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.WRITE_TO_PARCEL_NAME
 import org.jetbrains.kotlin.types.Variance
+import org.jetbrains.kotlin.utils.addToStdlib.forEachZipped
 
 private val PARCELIZE_ALLOWED_CLASS_KINDS = listOf(ClassKind.CLASS, ClassKind.OBJECT, ClassKind.ENUM_CLASS)
 
@@ -217,7 +218,7 @@ fun IrTypeArgument.upperBound(builtIns: IrBuiltIns): IrType =
     upperBoundOrNull() ?: builtIns.anyNType
 
 fun IrClass.typeParameterMapping(instantiation: IrType): Map<IrTypeParameterSymbol, IrType> = buildMap {
-    (instantiation as? IrSimpleType)?.arguments?.zip(typeParameters)?.forEach { [arg, parameter] ->
+    (instantiation as? IrSimpleType)?.arguments?.forEachZipped(typeParameters) { arg, parameter ->
         put(parameter.symbol, arg.upperBoundOrNull() ?: parameter.representativeUpperBound)
     }
 }

--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/irUtils.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/irUtils.kt
@@ -217,7 +217,7 @@ fun IrTypeArgument.upperBound(builtIns: IrBuiltIns): IrType =
     upperBoundOrNull() ?: builtIns.anyNType
 
 fun IrClass.typeParameterMapping(instantiation: IrType): Map<IrTypeParameterSymbol, IrType> = buildMap {
-    (instantiation as? IrSimpleType)?.arguments?.zip(typeParameters) { arg, parameter ->
+    (instantiation as? IrSimpleType)?.arguments?.zip(typeParameters)?.forEach { [arg, parameter] ->
         put(parameter.symbol, arg.upperBoundOrNull() ?: parameter.representativeUpperBound)
     }
 }

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptingProcessSourcesBeforeCompilingExtension.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/extensions/ScriptingProcessSourcesBeforeCompilingExtension.kt
@@ -64,6 +64,7 @@ class KotlinScriptExpressionExplainTransformer(
         val symbol = currentScope!!.scope.scopeOwnerSymbol
         val builder = DeclarationIrBuilder(context, symbol, expression.startOffset, expression.endOffset)
         return builder.irExplain(expression, sourceFile) { variables ->
+            @Suppress("RETURN_VALUE_NOT_USED_COERCION") // Tracking issue: KT-88282
             variables.last()
         }
     }

--- a/repo/codebase-tests/tests/org/jetbrains/kotlin/code/TestMetadataTest.kt
+++ b/repo/codebase-tests/tests/org/jetbrains/kotlin/code/TestMetadataTest.kt
@@ -64,10 +64,10 @@ class TestMetadataTest {
 
         runBlocking(Dispatchers.IO) {
             forEachCompiledClass { file, classNode ->
-                checkedClasses.incrementAndFetch()
+                val _ = checkedClasses.incrementAndFetch()
                 classNode.visibleAnnotations?.forEach { annotation ->
                     if (annotation.desc == testMetadataAnnotationDesc) {
-                        checkedAnnotations.incrementAndFetch()
+                        val _ = checkedAnnotations.incrementAndFetch()
                         val now = Clock.System.now()
                         if ((now - lastProgressPrinted).inWholeSeconds >= 5) {
                             lastProgressPrinted = now

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/common-configuration.gradle.kts
@@ -108,6 +108,21 @@ fun Project.configureJavaCompile() {
 
 val kotlinApiVersionForProjectsDependingOnStableStdlib: Provider<String> = project.providers.gradleProperty("kotlinApiVersionForProjectsDependingOnStableStdlib")
 
+// These modules are compiled with "-Xreturn-value-checker=full" flag
+// As a result, we can end up with a mix of "full" and "check" modes, which
+// produces warnings and may result in using the wrong mode, as it currently
+// depends on the order of these flags
+val projectsWithReturnValueCheckerFull = setOf(
+    ":kotlin-stdlib",
+    ":kotlin-test",
+    ":kotlin-stdlib-js-ir-minimal-for-test",
+    ":kotlin-stdlib-jvm-minimal-for-test",
+    ":kotlin-stdlib-jklib-for-test",
+    ":kotlin-power-assert-runtime",
+    ":kotlin-native:Interop:Runtime",
+    ":kotlin-native:runtime",
+)
+
 fun Project.configureKotlinCompilationOptions() {
     plugins.withType<KotlinBasePluginWrapper> {
         val kotlinLanguageVersion: Provider<String> = project.providers.gradleProperty("kotlinLanguageVersion")
@@ -136,6 +151,7 @@ fun Project.configureKotlinCompilationOptions() {
                         "-Xwarning-level=REDUNDANT_CLI_ARG:disabled".takeIf {
                             project.kotlinExtension.compilerVersion.get() == project.kotlinToolingVersion.toString()
                         },
+                        "-Xreturn-value-checker=check".takeUnless { project.path in projectsWithReturnValueCheckerFull },
                     )
                 }
 


### PR DESCRIPTION
Note that I had to disable the feature specifically for the modules that are already compiled in "full" mode. I'm not sure if this is the best way to do it, but at least it's straightforward, and I don't mind better suggestions :) 