### PR TITLE
[Gradle] Fix NpmDependencyTest - file versions use absolute normalized paths

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmDependencyTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/functionalTest/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmDependencyTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertEquals
 class NpmDependencyTest {
 
     @Test
-    fun `directoryNpmDependency - expect version uses absolute real path`(
+    fun `directoryNpmDependency - expect version uses absolute+normalized path`(
         @TempDir
         tempDir: Path,
     ) {
@@ -32,7 +32,7 @@ class NpmDependencyTest {
             )
 
         assertEquals(
-            "file:" + tempDir.toRealPath().absolutePathString(),
+            "file:" + tempDir.toAbsolutePath().normalize().absolutePathString(),
             npmDep.version,
         )
     }


### PR DESCRIPTION

The test fails on macOS
```
Expected :file:/private/var/folders/...
Actual   :file:/var/folders/...
```

NpmDependency deliberately does not resolve symlinks for file versions, because KT-69613 bans canonicalFile. So on macOS the `/var -> /private/var` symlink stays unresolved.

The test is wrong: update it to match production, which uses absolute normalized path, and no symlink resolution.