### PR TITLE
[Wasm] use qualified name for JsException and fix Throwable stackTrace KT-78998, KT-78707

### DIFF
--- a/compiler/testData/codegen/box/exceptions/stacktraceWasm.kt
+++ b/compiler/testData/codegen/box/exceptions/stacktraceWasm.kt
@@ -1,0 +1,127 @@
+// KT-78707, KT-78998
+// WITH_STDLIB
+
+// TARGET_BACKEND: WASM
+// WASM_STANDALONE
+// ^^^ in non-standalone run, test classes will be placed in a sub-package, so `Throwable.toString()` would give different result
+
+package a
+
+class MyException(message: String) : RuntimeException(message)
+
+// "    ... and 3 more common stack frames skipped" - replaces the frames a throwable shares with the trace it is
+// printed inside of. How many are shared is engine-specific, so only the presence of the line is comparable.
+private fun isCommonFramesLine(line: String): Boolean = line.trimStart().startsWith("... and ")
+
+// Frame lines look different on every target and engine, so they are only recognized, never compared:
+//   V8:               "    at <module>.a.box (wasm://wasm/...)"
+//   SpiderMonkey/JSC: "a.box@wasm://wasm/..."
+private fun isFrameLine(line: String): Boolean {
+    val trimmed = line.trimStart()
+    return trimmed.startsWith("at ") || isCommonFramesLine(line) || '@' in trimmed
+}
+
+// Everything in a trace except the frames themselves. WASI has no stack frames at all, and how many frames are
+// dropped as common with the enclosing trace differs per target, so only these lines are comparable.
+private fun headerLines(trace: String): List<String> =
+    trace.lines().filter { it.isNotEmpty() && !isFrameLine(it) }
+
+// A stack trace must start with header lines, equal to Throwable.toString().
+// Stack trace header can also contain engine specific header - we don't check it.
+private fun checkTrace(e: Throwable, expectedHeader: String): String? {
+    val actualHeader = e.toString()
+    if (actualHeader != expectedHeader)
+        return "toString(): expected <$expectedHeader>, got <$actualHeader>"
+
+    val trace = e.stackTraceToString()
+    // Parsing stack trace until stack frames provided by the engine.
+    // Check that the `header` is exactly `expectedHeader` - e.g. no additional lines in stack trace header,
+    // like repetitions of Throwable.toString().
+    val header = trace.lines().takeWhile { it.isNotEmpty() && !isFrameLine(it) }
+    if (header != expectedHeader.lines())
+        return "stackTraceToString() header: expected [<$expectedHeader>], got $header\nfull trace:\n$trace"
+
+    return null
+}
+
+fun testTraces(): String? {
+
+    val withoutMessage = try { throw RuntimeException() } catch (e: Throwable) { e }
+    checkTrace(withoutMessage, "kotlin.RuntimeException")?.let { return it }
+
+    // on JVM also has `java.lang.RuntimeException: `
+    val withEmptyMessage = try { throw RuntimeException("") } catch (e: Throwable) { e }
+    checkTrace(withEmptyMessage, "kotlin.RuntimeException: ")?.let { return it }
+
+    val withMessage = try { throw RuntimeException("some error") } catch (e: Throwable) { e }
+    checkTrace(withMessage, "kotlin.RuntimeException: some error")?.let { return it }
+
+    val multiLineMessage = try { throw RuntimeException("first line\nsecond line") } catch (e: Throwable) { e }
+    checkTrace(multiLineMessage, "kotlin.RuntimeException: first line\nsecond line")?.let { return it }
+
+    val custom = try { throw MyException("some error") } catch (e: Throwable) { e }
+    checkTrace(custom, "a.MyException: some error")?.let { return it }
+
+    return null
+}
+
+// Checks how suppressed exceptions and the cause chain are laid out around the frames.
+private fun checkStructure(e: Throwable, expected: List<String>): String? {
+    val trace = e.stackTraceToString()
+    val actual = headerLines(trace)
+    if (actual != expected)
+        return "stackTraceToString() structure:\nexpected $expected\ngot      $actual\nfull trace:\n$trace"
+
+    return null
+}
+
+fun testSuppressionStructure(): String? {
+
+    // Suppressed exceptions are printed after the frames of the throwable they were suppressed by, indented by
+    // four spaces, and before its cause chain.
+    val wrapper = try {
+        try {
+            throw IllegalArgumentException("root cause")
+        } catch (cause: Throwable) {
+            throw RuntimeException("wrapper", cause)
+        }
+    } catch (e: Throwable) { e }
+    wrapper.addSuppressed(IllegalStateException("first suppressed"))
+    wrapper.addSuppressed(IllegalStateException("second suppressed"))
+
+    checkStructure(
+        wrapper,
+        listOf(
+            "kotlin.RuntimeException: wrapper",
+            "    Suppressed: kotlin.IllegalStateException: first suppressed",
+            "    Suppressed: kotlin.IllegalStateException: second suppressed",
+            "Caused by: kotlin.IllegalArgumentException: root cause",
+        )
+    )?.let { return it }
+
+    // A throwable that is reachable twice must be reported as a circular reference instead of being dumped again.
+    val e1 = try { throw RuntimeException("e1") } catch (e: Throwable) { e }
+    val e2 = try { throw RuntimeException("e2") } catch (e: Throwable) { e }
+    e1.addSuppressed(e2)
+    e2.addSuppressed(e1)
+
+    checkStructure(
+        e1,
+        listOf(
+            "kotlin.RuntimeException: e1",
+            "    Suppressed: kotlin.RuntimeException: e2",
+            "        Suppressed: [CIRCULAR REFERENCE, SEE ABOVE: kotlin.RuntimeException: e1]",
+        )
+    )?.let { return it }
+
+    return null
+}
+
+fun box(): String {
+
+    testTraces()?.let { return it }
+
+    testSuppressionStructure()?.let { return it }
+
+    return "OK"
+}

--- a/compiler/testData/codegen/boxWasmJsInterop/exceptionFromGlobalInitializer.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/exceptionFromGlobalInitializer.kt
@@ -28,7 +28,7 @@ try {
         throw Error("Expected instance of Error, but '" + e.name +"' ('" + e.constructor.name + "') was received")
     }
 
-    if (e.name !== "Exception" && e.message == "Some") {
+    if (e.name !== "kotlin.Exception" && e.message == "Some") {
         throw Error("Wrong e.name = '" + e.name + "'")
     }
 }

--- a/compiler/testData/codegen/boxWasmJsInterop/exceptionFromGlobalInitializerNewProposal.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/exceptionFromGlobalInitializerNewProposal.kt
@@ -29,7 +29,7 @@ try {
         throw Error("Expected instance of Error, but '" + e.name +"' ('" + e.constructor.name + "') was received")
     }
 
-    if (e.name !== "Exception" && e.message == "Some") {
+    if (e.name !== "kotlin.Exception" && e.message == "Some") {
         throw Error("Wrong e.name = '" + e.name + "'")
     }
 }

--- a/compiler/testData/codegen/boxWasmJsInterop/exceptionFromMain.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/exceptionFromMain.kt
@@ -22,7 +22,7 @@ try {
         throw Error("Expected instance of Error, but '" + e.name +"' ('" + e.constructor.name + "') was received")
     }
 
-    if (e.name !== "AssertionError" ) {
+    if (e.name !== "kotlin.AssertionError" ) {
         throw Error("Wrong e.name = '" + e.name + "'")
     }
 }

--- a/compiler/testData/codegen/boxWasmJsInterop/exceptionFromMainNewProposal.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/exceptionFromMainNewProposal.kt
@@ -23,7 +23,7 @@ try {
         throw Error("Expected instance of Error, but '" + e.name +"' ('" + e.constructor.name + "') was received")
     }
 
-    if (e.name !== "AssertionError" ) {
+    if (e.name !== "kotlin.AssertionError" ) {
         throw Error("Wrong e.name = '" + e.name + "'")
     }
 }

--- a/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithChainExceptions.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithChainExceptions.kt
@@ -25,7 +25,7 @@ try {
         throw Error("Expected Error");
     }
 
-    if (e.name !== "RuntimeException") {
+    if (e.name !== "kotlin.RuntimeException") {
         throw Error("Wrong e.name");
     }
     if (e.message !== "Outer wrapper") {
@@ -40,7 +40,7 @@ try {
     if (!(c instanceof Error)) {
         throw Error("Expected cause to be Error");
     }
-    if (c.name !== "IllegalStateException") {
+    if (c.name !== "kotlin.IllegalStateException") {
         throw Error("Wrong cause.name");
     }
     if (c.message !== "Inner cause") {

--- a/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithChainExceptionsNewProposal.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithChainExceptionsNewProposal.kt
@@ -26,7 +26,7 @@ try {
         throw Error("Expected Error");
     }
 
-    if (e.name !== "RuntimeException") {
+    if (e.name !== "kotlin.RuntimeException") {
         throw Error("Wrong e.name");
     }
     if (e.message !== "Outer wrapper") {
@@ -43,7 +43,7 @@ try {
             "Expected cause to be Error"
         );
     }
-    if (c.name !== "IllegalStateException") {
+    if (c.name !== "kotlin.IllegalStateException") {
         throw Error("Wrong cause.name");
     }
     if (c.message !== "Inner cause") {

--- a/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithExceptions.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithExceptions.kt
@@ -24,7 +24,7 @@ try {
         throw Error("Expected instance of Error, but '" + e.name +"' ('" + e.constructor.name + "') was received")
     }
 
-    if (e.name !== "AssertionError" ) {
+    if (e.name !== "kotlin.AssertionError" ) {
         throw Error("Wrong e.name = '" + e.name + "'")
     }
 }

--- a/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithExceptionsNewProposal.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/wasmExportWithExceptionsNewProposal.kt
@@ -25,7 +25,7 @@ try {
         throw Error("Expected instance of Error, but '" + e.name +"' ('" + e.constructor.name + "') was received")
     }
 
-    if (e.name !== "AssertionError" ) {
+    if (e.name !== "kotlin.AssertionError" ) {
         throw Error("Wrong e.name = '" + e.name + "'")
     }
 }

--- a/compiler/testData/codegen/boxWasmJsInterop/wasmStacktraceHeaderJsException.kt
+++ b/compiler/testData/codegen/boxWasmJsInterop/wasmStacktraceHeaderJsException.kt
@@ -1,0 +1,142 @@
+// KT-78707, KT-78998
+// TODO KT-88517 [Wasm]: make JsException name/message more clear
+// TARGET_BACKEND: WASM_JS
+// WITH_STDLIB
+
+// "    ... and 3 more common stack frames skipped" - replaces the frames a throwable shares with the trace it is
+// printed inside of. How many are shared is engine-specific, so only the presence of the line is comparable.
+private fun isCommonFramesLine(line: String): Boolean = line.trimStart().startsWith("... and ")
+
+// Frame lines look different on every target and engine, so they are only recognized, never compared:
+//   V8:               "    at <module>.a.box (wasm://wasm/...)"
+//   SpiderMonkey/JSC: "a.box@wasm://wasm/..."
+private fun isFrameLine(line: String): Boolean {
+    val trimmed = line.trimStart()
+    return trimmed.startsWith("at ") || isCommonFramesLine(line) || '@' in trimmed
+}
+
+private fun hasFrames(trace: String): Boolean =
+    trace.lines().any { isFrameLine(it) && !isCommonFramesLine(it) }
+
+// Everything in a trace except the frames themselves.
+private fun headerLines(trace: String): List<String> =
+    trace.lines().filter { it.isNotEmpty() && !isFrameLine(it) }
+
+fun throwJsExceptionWithMessage(): Int = js("{ throw new TypeError('Test'); }")
+
+fun throwJsExceptionWithEmptyMessage(): Int = js("{ throw new TypeError(); }")
+
+fun throwJsExceptionWithNull(): Int = js("{ throw new TypeError(null); }")
+
+fun throwJsExceptionWithMultilineMessage(): Int = js("{ throw new Error('first\\nsecond'); }")
+
+fun throwJsExceptionWithCustomName(): Int = js("{ const e = new Error('Test'); e.name = 'CustomName'; throw e; }")
+
+// ECMA-262 leaves just the message when the name is empty, so there is no leading colon.
+fun throwJsExceptionWithEmptyName(): Int = js("{ const e = new Error('Test'); e.name = ''; throw e; }")
+
+fun throwJsExceptionSubclass(): Int = js("{ class MyError extends Error {}; throw new MyError('Test'); }")
+
+fun throwJsExceptionWithCause(): Int = js("{ throw new Error('outer', { cause: new Error('inner') }); }")
+
+fun throwJsExceptionNull(): Int = js("{ throw null; }")
+
+fun throwJsExceptionString(): Int = js("{ throw 'Test'; }")
+
+fun throwJsExceptionNumber(): Int = js("{ throw 42; }")
+
+fun throwJsExceptionPlainObject(): Int = js("{ throw { message: 'Test' }; }")
+
+private const val NOT_AN_ERROR_MESSAGE = "Exception was thrown while running JavaScript code"
+private const val NOT_AN_ERROR = "kotlin.js.JsException: $NOT_AN_ERROR_MESSAGE"
+
+private fun catchException(block: () -> Unit): Throwable? =
+    try {
+        block()
+        null
+    } catch (e: Throwable) {
+        e
+    }
+
+private fun checkJsException(
+    block: () -> Unit,
+    expectedToString: String,
+    expectedMessage: String?,
+    expectFrames: Boolean,
+): String? {
+    val e = catchException(block) ?: return "nothing was thrown, expected <$expectedToString>"
+    if (e !is JsException) return "expected a JsException, got <${e::class.simpleName}>"
+
+    if (e.toString() != expectedToString)
+        return "toString(): expected <$expectedToString>, got <$e>"
+    if (e.message != expectedMessage)
+        return "message: expected <$expectedMessage>, got <${e.message}>"
+
+    val trace = e.stackTraceToString()
+    if (!trace.startsWith(expectedToString))
+        return "trace header: expected to start with <$expectedToString>\ngot trace:\n$trace"
+    if (hasFrames(trace) != expectFrames)
+        return "expected frames=$expectFrames\nfull trace:\n$trace"
+
+    return null
+}
+
+fun box(): String {
+
+    checkJsException(
+        ::throwJsExceptionWithMessage,
+        expectedToString = "kotlin.js.JsException: Test",
+        expectedMessage = "Test",
+        expectFrames = true,
+    )?.let { return it }
+
+    checkJsException(
+        ::throwJsExceptionWithEmptyMessage,
+        expectedToString = "kotlin.js.JsException: ",
+        expectedMessage = "",
+        expectFrames = true,
+    )?.let { return it }
+
+    // `new TypeError(null)` stringifies its argument, so the message is the four characters \"null\".
+    checkJsException(
+        ::throwJsExceptionWithNull,
+        expectedToString = "kotlin.js.JsException: null",
+        expectedMessage = "null",
+        expectFrames = true,
+    )?.let { return it }
+
+    checkJsException(
+        ::throwJsExceptionWithMultilineMessage,
+        expectedToString = "kotlin.js.JsException: first\nsecond",
+        expectedMessage = "first\nsecond",
+        expectFrames = true,
+    )?.let { return it }
+
+    checkJsException(
+        ::throwJsExceptionWithCustomName,
+        expectedToString = "kotlin.js.JsException: Test",
+        expectedMessage = "Test",
+        expectFrames = true,
+    )?.let { return it }
+
+    checkJsException(
+        ::throwJsExceptionWithEmptyName,
+        expectedToString = "kotlin.js.JsException: Test",
+        expectedMessage = "Test",
+        expectFrames = true,
+    )?.let { return it }
+
+    checkJsException(
+        ::throwJsExceptionSubclass,
+        expectedToString = "kotlin.js.JsException: Test",
+        expectedMessage = "Test",
+        expectFrames = true,
+    )?.let { return it }
+
+    checkJsException(::throwJsExceptionNull, NOT_AN_ERROR, NOT_AN_ERROR_MESSAGE, expectFrames = false)?.let { return it }
+    checkJsException(::throwJsExceptionString, NOT_AN_ERROR, NOT_AN_ERROR_MESSAGE, expectFrames = false)?.let { return it }
+    checkJsException(::throwJsExceptionNumber, NOT_AN_ERROR, NOT_AN_ERROR_MESSAGE, expectFrames = false)?.let { return it }
+    checkJsException(::throwJsExceptionPlainObject, NOT_AN_ERROR, NOT_AN_ERROR_MESSAGE, expectFrames = false)?.let { return it }
+
+    return "OK"
+}

--- a/libraries/stdlib/wasm/js/builtins/kotlin/Throwable.kt
+++ b/libraries/stdlib/wasm/js/builtins/kotlin/Throwable.kt
@@ -8,7 +8,6 @@ package kotlin
 import kotlin.wasm.internal.jsToKotlinStringAdapter
 import kotlin.wasm.internal.wasmGetObjectRtti
 import kotlin.wasm.internal.getQualifiedName
-import kotlin.wasm.internal.getSimpleName
 
 /**
  * The base class for all errors and exceptions. Only instances of this class can be thrown or caught.
@@ -19,12 +18,12 @@ import kotlin.wasm.internal.getSimpleName
 @OptIn(ExperimentalWasmJsInterop::class)
 public actual open class Throwable internal constructor(
     public actual open val message: String?,
-    public actual open val cause: kotlin.Throwable?,
+    public actual open val cause: Throwable?,
     internal val jsError: JsError?
 ) {
     init {
         if (jsError != null) {
-            jsError.name = getSimpleName(wasmGetObjectRtti(this))
+            jsError.name = getQualifiedName(wasmGetObjectRtti(this))
             jsError.kotlinException = toJsReference()
         }
     }
@@ -65,7 +64,9 @@ public actual open class Throwable internal constructor(
 
 internal actual var Throwable.suppressedExceptionsList: MutableList<Throwable>?
     get() = this.suppressedExceptionsList
-    set(value) { this.suppressedExceptionsList = value }
+    set(value) {
+        this.suppressedExceptionsList = value
+    }
 
 internal actual val Throwable.stack: String get() = this.stack
 

--- a/libraries/stdlib/wasm/js/builtins/kotlin/Throwable.kt
+++ b/libraries/stdlib/wasm/js/builtins/kotlin/Throwable.kt
@@ -44,6 +44,15 @@ public actual open class Throwable internal constructor(
             var value = _stack
             if (value == null) {
                 value = jsToKotlinStringAdapter(jsStack)
+
+                // We rely on the fact that the engine emits
+                // header with error name and message
+                // right at the beginning of the stack,
+                // if emits at all.
+                val header = jsError?.stackHeader
+                if (!header.isNullOrEmpty() && value.startsWith(header)) {
+                    value = value.substring(header.length).removePrefix("\n")
+                }
                 _stack = value
             }
 
@@ -73,3 +82,14 @@ internal actual val Throwable.stack: String get() = this.stack
 @OptIn(ExperimentalWasmJsInterop::class)
 internal fun createJsError(message: String?, cause: JsError?): JsError =
     js("new Error(message, { cause })")
+
+// Correctly predict stacktrace header containing error name and message to strip.
+// Currently, V8 engine emits this header (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack).
+private val JsError.stackHeader: String
+    get() = when {
+        // https://tc39.es/ecma262/2020/#sec-error.prototype.tostring:
+        // an empty name leaves just the message, an empty message just the name.
+        name.isEmpty() -> message
+        message.isEmpty() -> name
+        else -> "$name: $message"
+    }

--- a/libraries/stdlib/wasm/src/kotlin/throwableExtensions.kt
+++ b/libraries/stdlib/wasm/src/kotlin/throwableExtensions.kt
@@ -58,7 +58,6 @@ private class ExceptionTraceBuilder {
     private val target = StringBuilder()
     private val visited = mutableListOf<Throwable>()
     private var topStack: String = ""
-    private var topStackStart: Int = 0
 
     fun buildFor(exception: Throwable): String {
         exception.dumpFullTrace("", "")
@@ -86,28 +85,23 @@ private class ExceptionTraceBuilder {
         }
         visited.add(this)
 
-        var stack = this.stack as String?
-        if (stack != null) {
-            val stackStart = stack.indexOf(shortInfo).let { if (it < 0) 0 else it + shortInfo.length }
-            if (stackStart == 0) target.append(shortInfo).append("\n")
+        target.append(shortInfo).append("\n")
+
+        var stack = this.stack
+        if (stack.isNotEmpty()) {
             if (topStack.isEmpty()) {
                 topStack = stack
-                topStackStart = stackStart
             } else {
-                stack = dropCommonFrames(stack, stackStart)
+                stack = dropCommonFrames(stack)
             }
             if (indent.isNotEmpty()) {
-                // indent stack, but avoid indenting exception message lines
-                val messageLines = if (stackStart == 0) 0 else 1 + shortInfo.count { c -> c == '\n' }
-                stack.lineSequence().forEachIndexed { index: Int, line: String ->
-                    if (index >= messageLines) target.append(indent)
-                    target.append(line).append("\n")
+                // indent stack
+                stack.lineSequence().forEach { line: String ->
+                    target.append(indent).append(line).append("\n")
                 }
             } else {
                 target.append(stack).append("\n")
             }
-        } else {
-            target.append(shortInfo).append("\n")
         }
 
         val suppressed = suppressedExceptions
@@ -120,11 +114,11 @@ private class ExceptionTraceBuilder {
         return true
     }
 
-    private fun dropCommonFrames(stack: String, stackStart: Int): String {
-        var commonFrames: Int = 0
-        var lastBreak: Int = 0
-        var preLastBreak: Int = 0
-        for (pos in 0 until minOf(topStack.length - topStackStart, stack.length - stackStart)) {
+    private fun dropCommonFrames(stack: String): String {
+        var commonFrames = 0
+        var lastBreak = 0
+        var preLastBreak = 0
+        for (pos in 0 until minOf(topStack.length, stack.length)) {
             val c = stack[stack.lastIndex - pos]
             if (c != topStack[topStack.lastIndex - pos]) break
             if (c == '\n') {

--- a/libraries/stdlib/wasm/wasi/builtins/kotlin/Throwable.kt
+++ b/libraries/stdlib/wasm/wasi/builtins/kotlin/Throwable.kt
@@ -14,7 +14,7 @@ import kotlin.wasm.internal.*
  * @param cause the cause of this throwable.
  */
 public actual open class Throwable
-public actual constructor(public actual open val message: String?, public actual open val cause: kotlin.Throwable?) {
+public actual constructor(public actual open val message: String?, public actual open val cause: Throwable?) {
     public actual constructor(message: String?) : this(message, null)
 
     public actual constructor(cause: Throwable?) : this(cause?.toString(), cause)
@@ -31,13 +31,15 @@ public actual constructor(public actual open val message: String?, public actual
      * followed by the exception message if it is not null.
      */
     public override fun toString(): String {
-        val s = getSimpleName(wasmGetObjectRtti(this))
+        val s = getQualifiedName(wasmGetObjectRtti(this))
         return if (message != null) "$s: $message" else s
     }
 }
 
 internal actual var Throwable.suppressedExceptionsList: MutableList<Throwable>?
     get() = this.suppressedExceptionsList
-    set(value) { this.suppressedExceptionsList = value }
+    set(value) {
+        this.suppressedExceptionsList = value
+    }
 
 internal actual val Throwable.stack: String get() = this.stack


### PR DESCRIPTION
1. Use qualified name - look [KT-78998](https://youtrack.jetbrains.com/projects/KT/issues/KT-78998)

2. With empty error message, don't print null - look [KT-78707](https://youtrack.jetbrains.com/projects/KT/issues/KT-78707)

3. Don't cut off stacktrace when exception name is not in the header of javascript stackTrace (previously indexOf could find exception name in the middle of stacktrace, if vm didn't print it in a header - and then crop stacktrace from there)
Here: `val stackStart = stack.indexOf(shortInfo).let { if (it < 0) 0 else it + shortInfo.length }`

4. ~~set `Error.stackTraceLimit = Infinity;`, so that VMs don't cut off stacktrace and we get more-or-less consistent stacktrace across VMs
(related to [KT-71725](https://youtrack.jetbrains.com/projects/KT/issues/KT-71725) K/Wasm: consider setting Error.stackTraceLimit = Infinity in tests and maybe dev builds)~~
seems like stackTraceLimit can be considered separately - but I wonder, how is it costly to enable it on every build?

Fixes #[KT-78998](https://youtrack.jetbrains.com/projects/KT/issues/KT-78998)
Fixes #[KT-78707](https://youtrack.jetbrains.com/projects/KT/issues/KT-78707)