### PR TITLE
[JS] Wrap JS polyfills in IIFEs

### DIFF
--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/JsIrBackendContext.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.config.phaseConfig
 import org.jetbrains.kotlin.config.phaser.PhaseConfig
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
 import org.jetbrains.kotlin.ir.backend.js.lower.JsInnerClassesSupport
@@ -50,7 +49,7 @@ class JsIrBackendContext(
 ) : JsCommonBackendContext {
     val phaseConfig = configuration.phaseConfig ?: PhaseConfig()
 
-    val polyfills = JsPolyfills()
+    val polyfills = JsPolyfills(configuration)
     val globalIrInterner = IrInterningService()
 
     val minimizedNameGenerator: MinimizedNameGenerator =

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsPolyfills.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/transformers/irToJs/JsPolyfills.kt
@@ -6,17 +6,25 @@
 package org.jetbrains.kotlin.ir.backend.js.transformers.irToJs
 
 import org.jetbrains.kotlin.backend.common.compilationException
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.ir.backend.js.utils.JsAnnotations
+import org.jetbrains.kotlin.ir.backend.js.utils.emptyScope
 import org.jetbrains.kotlin.ir.backend.js.utils.hasJsPolyfill
-import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.expressions.IrConst
-import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.util.getAnnotation
+import org.jetbrains.kotlin.js.backend.ast.JsBlock
+import org.jetbrains.kotlin.js.backend.ast.JsFunction
+import org.jetbrains.kotlin.js.backend.ast.JsInvocation
 import org.jetbrains.kotlin.js.backend.ast.JsStatement
+import org.jetbrains.kotlin.js.config.compileLambdasAsEs6ArrowFunctions
 import org.jetbrains.kotlin.name.Name
-import java.util.TreeMap
+import java.util.*
 
-class JsPolyfills {
+class JsPolyfills(configuration: CompilerConfiguration) {
+    private val useEs6Arrows = configuration.compileLambdasAsEs6ArrowFunctions
+
     private val polyfillsPerFile = hashMapOf<IrFile, MutableSet<IrDeclaration>>()
 
     fun registerDeclarationNativeImplementation(file: IrFile, declaration: IrDeclaration) {
@@ -34,6 +42,14 @@ class JsPolyfills {
     fun getAllPolyfillsFor(file: IrFile): List<JsStatement> =
         polyfillsPerFile[file].orEmpty().asImplementationList()
 
+    private fun List<JsStatement>.wrapInIIFE(): List<JsStatement> {
+        val funExpr = JsFunction(emptyScope, JsBlock(this), "polyfill iife").apply {
+            isEs6Arrow = useEs6Arrows
+        }
+        val invocation = JsInvocation(funExpr)
+        return listOf(invocation.makeStmt())
+    }
+
     private fun Iterable<IrDeclaration>.asImplementationList(): List<JsStatement> {
         val orderedMapOfPolyfills = TreeMap<String, List<JsStatement>>()
 
@@ -49,7 +65,11 @@ class JsPolyfills {
 
             if (polyfillCodeString in orderedMapOfPolyfills) continue
 
-            orderedMapOfPolyfills[polyfillCodeString] = translateJsCodeIntoStatementList(polyfillCodeExpression, declaration) ?: emptyList()
+            orderedMapOfPolyfills[polyfillCodeString] = translateJsCodeIntoStatementList(polyfillCodeExpression, declaration)
+                // Wrap the polyfill code in an immediately invoked function expression so that 'var's declared in the polyfill
+                // don't pollute the global scope.
+                ?.wrapInIIFE()
+                ?: emptyList()
         }
 
         return orderedMapOfPolyfills.flatMap { it.value }


### PR DESCRIPTION
(IIFE == immediately invoked function expression)

This is needed so that `var`s declared in the polyfill code don't pollute the global scope.