### PR TITLE
[JS] Fix scope tracking in `TemporaryVariableElimination`

### DIFF
--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/BoxingUnboxingElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/BoxingUnboxingElimination.kt
@@ -21,11 +21,11 @@ import org.jetbrains.kotlin.js.backend.ast.JsExpression.JsExpressionHasArguments
 import org.jetbrains.kotlin.js.backend.ast.metadata.isInlineClassBoxing
 import org.jetbrains.kotlin.js.backend.ast.metadata.isInlineClassUnboxing
 
-// Replaces box(unbox(value)) and unbox(box(value)) with value
-class BoxingUnboxingElimination(private val root: JsBlock) {
-    private var changed = false
-
-    fun apply(): Boolean {
+/**
+ * Replaces `box(unbox(value))` and `unbox(box(value))` with value
+ */
+internal class BoxingUnboxingElimination(private val root: JsBlock) : FunctionPostProcessorStep() {
+    override fun apply() {
         val visitor = object : JsVisitorWithContextImpl() {
             override fun endVisit(x: JsInvocation, ctx: JsContext<JsNode>) {
                 super.endVisit(x, ctx)
@@ -43,10 +43,6 @@ class BoxingUnboxingElimination(private val root: JsBlock) {
                 tryEliminate(x, ctx)
             }
 
-            override fun endVisit(x: JsArrayAccess, ctx: JsContext<*>) {
-                super.endVisit(x, ctx)
-            }
-
             override fun visit(x: JsFunction, ctx: JsContext<JsNode>) = false
 
             private fun tryEliminate(expression: JsExpression, ctx: JsContext<JsNode>) {
@@ -58,7 +54,7 @@ class BoxingUnboxingElimination(private val root: JsBlock) {
 
                 if (firstArg.isInlineClassBoxing != expression.isInlineClassBoxing) {
                     ctx.replaceMe(firstArg.arguments.first())
-                    changed = true
+                    hasChanges = true
                 }
             }
 
@@ -71,7 +67,5 @@ class BoxingUnboxingElimination(private val root: JsBlock) {
         }
 
         visitor.accept(root)
-
-        return changed
     }
 }

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/DeadCodeElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/DeadCodeElimination.kt
@@ -18,12 +18,9 @@ package org.jetbrains.kotlin.js.inline.clean
 
 import org.jetbrains.kotlin.js.backend.ast.*
 
-internal class DeadCodeElimination(private val root: JsStatement) {
-    var hasChanges = false
-
-    fun apply(): Boolean {
+internal class DeadCodeElimination(private val root: JsStatement) : FunctionPostProcessorStep() {
+    override fun apply() {
         EliminationVisitor().accept(root)
-        return hasChanges
     }
 
     inner class EliminationVisitor : RecursiveJsVisitor() {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/DoWhileGuardElimination.kt
@@ -32,16 +32,14 @@ import org.jetbrains.kotlin.js.backend.ast.*
  *
  * A block labeled `guard` can be eliminated with `break guard` converted to `continue`.
  */
-internal class DoWhileGuardElimination(private val root: JsStatement) {
+internal class DoWhileGuardElimination(private val root: JsStatement) : FunctionPostProcessorStep() {
     private val guardLabels = mutableSetOf<JsName>()
-    private var hasChanges = false
     private val loopGuardMap = mutableMapOf<JsDoWhile, JsLabel>()
     private val guardToLoopLabel = mutableMapOf<JsName, JsName?>()
 
-    fun apply(): Boolean {
+    override fun apply() {
         analyze()
         perform()
-        return hasChanges
     }
 
     private fun analyze() {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/EmptyStatementElimination.kt
@@ -20,10 +20,9 @@ import org.jetbrains.kotlin.js.backend.ast.*
 import org.jetbrains.kotlin.js.backend.ast.metadata.synthetic
 import org.jetbrains.kotlin.js.translate.utils.JsAstUtils
 
-internal class EmptyStatementElimination(private val root: JsStatement) {
-    private var hasChanges = false
+internal class EmptyStatementElimination(private val root: JsStatement) : FunctionPostProcessorStep() {
 
-    fun apply(): Boolean {
+    override fun apply() {
         object : JsVisitorWithContextImpl() {
             override fun visit(x: JsFunction, ctx: JsContext<*>) = false
 
@@ -100,6 +99,5 @@ internal class EmptyStatementElimination(private val root: JsStatement) {
 
             private fun isEmpty(statement: JsStatement) = statement is JsBlock && statement.isEmpty || statement is JsEmpty
         }.accept(root)
-        return hasChanges
     }
 }

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/FunctionPostProcessor.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/FunctionPostProcessor.kt
@@ -19,27 +19,41 @@ package org.jetbrains.kotlin.js.inline.clean
 import org.jetbrains.kotlin.js.backend.ast.JsFunction
 import org.jetbrains.kotlin.js.backend.ast.JsName
 
-class FunctionPostProcessor(val root: JsFunction, private val voidName: JsName? = null) {
-    val optimizations = listOf(
-        { RedundantLabelRemoval(root.body).apply() },
-        { EmptyStatementElimination(root.body).apply() },
-        { DoWhileGuardElimination(root.body).apply() },
-        { TemporaryVariableElimination(root).apply() },
-        { RedundantCallElimination(root.body).apply() },
-        { IfStatementReduction(root.body).apply() },
-        { DeadCodeElimination(root.body).apply() },
-        { RedundantVariableDeclarationElimination(root.body).apply() },
-        { RedundantStatementElimination(root).apply() },
-        { BoxingUnboxingElimination(root.body).apply() },
-        { MoveTemporaryVariableDeclarationToAssignment(root.body).apply() },
-        { voidName?.let { VoidPropertiesElimination(root.body, voidName).apply() } ?: false }
+internal abstract class FunctionPostProcessorStep : Function0<Boolean> {
+    var hasChanges: Boolean = false
+        protected set
+
+    protected abstract fun apply()
+
+    final override fun invoke(): Boolean {
+        hasChanges = false
+        apply()
+        return hasChanges
+    }
+}
+
+class FunctionPostProcessor(val root: JsFunction, voidName: JsName? = null) {
+    private val optimizations: List<() -> FunctionPostProcessorStep> = listOfNotNull(
+        { RedundantLabelRemoval(root.body) },
+        { EmptyStatementElimination(root.body) },
+        { DoWhileGuardElimination(root.body) },
+        { TemporaryVariableElimination(root) },
+        { RedundantCallElimination(root.body) },
+        { IfStatementReduction(root.body) },
+        { DeadCodeElimination(root.body) },
+        { RedundantVariableDeclarationElimination(root.body) },
+        { RedundantStatementElimination(root) },
+        { BoxingUnboxingElimination(root.body) },
+        { MoveTemporaryVariableDeclarationToAssignment(root.body) },
+        voidName?.let { { VoidPropertiesElimination(root.body, voidName) } },
     )
     // TODO: reduce to A || B, A && B if possible
 
     fun apply() {
         do {
             var hasChanges = false
-            for (opt in optimizations) {
+            for (passFactory in optimizations) {
+                val opt = passFactory()
                 hasChanges = hasChanges or opt()
             }
         } while (hasChanges)

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/IfStatementReduction.kt
@@ -20,13 +20,9 @@ import org.jetbrains.kotlin.js.backend.ast.*
 import org.jetbrains.kotlin.js.backend.ast.metadata.synthetic
 import org.jetbrains.kotlin.js.translate.utils.JsAstUtils
 
-class IfStatementReduction(private val root: JsStatement) {
-    private var hasChanges = false
-
-    fun apply(): Boolean {
+internal class IfStatementReduction(private val root: JsStatement) : FunctionPostProcessorStep() {
+    override fun apply() {
         visitor.accept(root)
-
-        return hasChanges
     }
 
     val visitor = object : JsVisitorWithContextImpl() {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/MoveTemporaryVariableDeclarationToAssignment.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/MoveTemporaryVariableDeclarationToAssignment.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.js.backend.ast.metadata.HasMetadata
 import org.jetbrains.kotlin.js.backend.ast.metadata.synthetic
 import org.jetbrains.kotlin.js.backend.ast.metadata.wasMovedFromItsDeclarationPlace
 import org.jetbrains.kotlin.js.translate.utils.JsAstUtils
-import java.util.LinkedHashSet
 
 /**
  * Moving a declaration of the temporary variable without an initializer to the closest assignment.
@@ -29,8 +28,7 @@ import java.util.LinkedHashSet
  * 5) Searches for the Lowest Common Ancestor (LCA) among all JsBlocks where the temporary variables are assigned or used.
  * 6) If the LCA is found in the set of JsBlocks where the temporary variable is assigned, we can move the declaration to the assignment.
  */
-class MoveTemporaryVariableDeclarationToAssignment(private val body: JsBlock) {
-    private var hasChanges = false
+internal class MoveTemporaryVariableDeclarationToAssignment(private val body: JsBlock) : FunctionPostProcessorStep() {
 
     private val varUsedInBlocks = hashMapOf<JsName, HashSet<JsBlock>>()
     private val varAssignedInBlocks = hashMapOf<JsName, HashSet<JsBlock>>()
@@ -45,13 +43,11 @@ class MoveTemporaryVariableDeclarationToAssignment(private val body: JsBlock) {
         get() = synthetic || wasMovedFromItsDeclarationPlace
 
 
-    fun apply(): Boolean {
+    override fun apply() {
         analyze()
         perform()
 
         require(removedVarDeclarations.isEmpty())
-
-        return hasChanges
     }
 
     private fun analyze() {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantCallElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantCallElimination.kt
@@ -23,11 +23,11 @@ import org.jetbrains.kotlin.js.backend.ast.RecursiveJsVisitor
 import org.jetbrains.kotlin.js.backend.ast.metadata.isJsCall
 import org.jetbrains.kotlin.js.inline.util.isCallInvocation
 
-// Replaces a.foo.call(a, b) with a.foo(b)
-class RedundantCallElimination(private val root: JsBlock) {
-    private var changed = false
-
-    fun apply(): Boolean {
+/**
+ * Replaces `a.foo.call(a, b)` with `a.foo(b)`
+ */
+internal class RedundantCallElimination(private val root: JsBlock) : FunctionPostProcessorStep() {
+    override fun apply() {
         root.accept(object : RecursiveJsVisitor() {
             override fun visitInvocation(invocation: JsInvocation) {
                 tryEliminate(invocation)
@@ -49,11 +49,9 @@ class RedundantCallElimination(private val root: JsBlock) {
                 if (receiver.qualifier == null && receiver.name != null && firstArg.qualifier == null && receiver.name == firstArg.name) {
                     invocation.arguments.removeAt(0)
                     invocation.qualifier = qualifier
-                    changed = true
+                    hasChanges = true
                 }
             }
         })
-
-        return changed
     }
 }

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantLabelRemoval.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantLabelRemoval.kt
@@ -19,14 +19,12 @@ package org.jetbrains.kotlin.js.inline.clean
 import org.jetbrains.kotlin.js.backend.ast.*
 import org.jetbrains.kotlin.js.backend.ast.metadata.synthetic
 
-internal class RedundantLabelRemoval(private val root: JsStatement) {
+internal class RedundantLabelRemoval(private val root: JsStatement) : FunctionPostProcessorStep() {
     private val labelUsages = mutableMapOf<JsName, Int>()
-    private var hasChanges = false
 
-    fun apply(): Boolean {
+    override fun apply() {
         analyze()
         perform()
-        return hasChanges
     }
 
     private fun analyze() {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantStatementElimination.kt
@@ -24,16 +24,10 @@ import org.jetbrains.kotlin.js.backend.ast.metadata.synthetic
 import org.jetbrains.kotlin.js.inline.util.collectLocalVariables
 import org.jetbrains.kotlin.js.translate.utils.JsAstUtils
 
-class RedundantStatementElimination(private val root: JsFunction) {
+internal class RedundantStatementElimination(private val root: JsFunction) : FunctionPostProcessorStep() {
     private val localVars = root.collectLocalVariables()
-    private var hasChanges = false
 
-    fun apply(): Boolean {
-        process()
-        return hasChanges
-    }
-
-    private fun process() {
+    override fun apply() {
         object : JsVisitorWithContextImpl() {
             override fun visit(x: JsExpressionStatement, ctx: JsContext<JsNode>): Boolean {
                 if (!x.expression.isSuspend) {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantVariableDeclarationElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/RedundantVariableDeclarationElimination.kt
@@ -23,14 +23,12 @@ import org.jetbrains.kotlin.js.backend.ast.metadata.sideEffects
 import org.jetbrains.kotlin.js.backend.ast.metadata.synthetic
 import org.jetbrains.kotlin.js.inline.util.collectFreeVariables
 
-internal class RedundantVariableDeclarationElimination(private val root: JsStatement) {
+internal class RedundantVariableDeclarationElimination(private val root: JsStatement) : FunctionPostProcessorStep() {
     private val usages = mutableSetOf<JsName>()
-    private var hasChanges = false
 
-    fun apply(): Boolean {
+    override fun apply() {
         analyze()
         perform()
-        return hasChanges
     }
 
     private fun analyze() {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt
@@ -96,14 +96,13 @@ import org.jetbrains.kotlin.js.translate.utils.splitToRanges
  * }
  *
  */
-internal class TemporaryVariableElimination(private val function: JsFunction) {
+internal class TemporaryVariableElimination(private val function: JsFunction) : FunctionPostProcessorStep() {
     private val root = function.body
     private val definitions = mutableMapOf<JsName, Int>()
     private val usages = mutableMapOf<JsName, Int>()
     private val definedValues = mutableMapOf<JsName, JsExpression>()
     private val temporary = mutableSetOf<JsName>()
     private val capturedInClosure = mutableSetOf<JsName>()
-    private var hasChanges = false
     private val localVariables = function.collectLocalVariables()
 
     // During `perform` phase we collect all variables we should substitute and all statements we should remove later,
@@ -113,11 +112,10 @@ internal class TemporaryVariableElimination(private val function: JsFunction) {
 
     private val namesWithSideEffects = mutableSetOf<JsName>()
 
-    fun apply(): Boolean {
+    override fun apply() {
         analyze()
         perform()
         cleanUp()
-        return hasChanges
     }
 
     private fun analyze() {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/TemporaryVariableElimination.kt
@@ -1,17 +1,6 @@
 /*
- * Copyright 2010-2017 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
 package org.jetbrains.kotlin.js.inline.clean
@@ -205,6 +194,14 @@ internal class TemporaryVariableElimination(private val function: JsFunction) : 
             override fun visitDefault(x: JsDefault) = withNewScope { super.visitDefault(x) }
 
             override fun visitCatch(x: JsCatch) = withNewScope { super.visitCatch(x) }
+
+            override fun visitBlock(x: JsBlock) {
+                if (x.isTransparent) {
+                    super.visitBlock(x)
+                } else {
+                    withNewScope { super.visitBlock(x) }
+                }
+            }
 
             override fun visitFunction(x: JsFunction) {
                 for (freeVar in x.collectFreeVariables()) {

--- a/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/VoidPropertiesElimination.kt
+++ b/js/js.translator/src/org/jetbrains/kotlin/js/inline/clean/VoidPropertiesElimination.kt
@@ -18,23 +18,21 @@ package org.jetbrains.kotlin.js.inline.clean
 
 import org.jetbrains.kotlin.js.backend.ast.*
 
-// Replaces { a: 2, b: VOID, c: VOID } with { a: 2 }
-class VoidPropertiesElimination(private val root: JsBlock, private val voidName: JsName) {
-    private var changed = false
-
-    fun apply(): Boolean {
+/**
+ * Replaces `{ a: 2, b: VOID, c: VOID }` with `{ a: 2 }`
+ */
+internal class VoidPropertiesElimination(private val root: JsBlock, private val voidName: JsName) : FunctionPostProcessorStep() {
+    override fun apply() {
         val visitor = object : JsVisitorWithContextImpl() {
             override fun endVisit(x: JsPropertyInitializer.KeyValue, ctx: JsContext<JsNode>) {
                 super.endVisit(x, ctx)
                 if ((x.valueExpr as? JsNameRef)?.name === voidName) {
                     ctx.removeMe()
-                    changed = true
+                    hasChanges = true
                 }
             }
         }
 
         visitor.accept(root)
-
-        return changed
     }
 }

--- a/js/js.translator/testData/js-optimizer/temporary-assignment/tryCatch.optimized.js
+++ b/js/js.translator/testData/js-optimizer/temporary-assignment/tryCatch.optimized.js
@@ -26,8 +26,13 @@ function testCatch2() {
 }
 
 function testFinally() {
+    var $tmp;
     var result;
-    result = f("testFinally");
+    try {
+        $tmp = f("testFinally");
+    } finally {
+        result = $tmp;
+    }
     return result;
 }
 


### PR DESCRIPTION
Blocks in JavaScript do define a new lexical scope.  For `TemporaryVariableElimination` to correctly work with const/let, we must take into account `JsBlock`s too.

KT-64348