### PR TITLE
Tests: another attempt to fix OOM in tests-different-jdk

### DIFF
--- a/compiler/tests-different-jdk/build.gradle.kts
+++ b/compiler/tests-different-jdk/build.gradle.kts
@@ -71,7 +71,11 @@ projectTests {
             systemProperty("kotlin.test.default.jvm.target", "${if (target <= 8) "1." else ""}$target")
             if (jdk.majorVersion >= 17 && kotlinBuildProperties.isTeamcityBuild.get()) {
                 // Reduce parallelism on JDK 17+ to allow test tasks to have more memory to avoid OOM (KTI-2491, KTI-3258).
-                systemProperty("junit.jupiter.execution.parallel.config.fixed.threshold", 2)
+                systemProperty("junit.jupiter.execution.parallel.config.fixed.threshold", 4)
+            }
+            if (jdk.majorVersion < 25) {
+                // Workaround https://bugs.openjdk.org/browse/JDK-8192647 to avoid OOM (KTI-2491, KTI-3258).
+                jvmArgs("-XX:+UnlockDiagnosticVMOptions", "-XX:GCLockerRetryAllocationCount=100")
             }
             body()
             doFirst {


### PR DESCRIPTION
JDK-8192647's description looks similar to what we have on Teamcity, so maybe this workaround will finally fix the issue.

Also, revert the previous attempt in 5fa31c736f, as it didn't help.

 #KTI-3258