### PR TITLE
Build: Add `os.name` input to `:nativekotlin-native-utils:test`

### DIFF
--- a/native/utils/build.gradle.kts
+++ b/native/utils/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.internal.os.OperatingSystem
+
 plugins {
     id("common-configuration")
     id("test-federation-convention")
@@ -36,6 +38,7 @@ configureKotlinCompileTasksGradleCompatibility()
 
 tasks {
     withType<Test>().configureEach {
+        inputs.property("os.name", OperatingSystem.current().name)
         useJUnitPlatform()
     }
 }


### PR DESCRIPTION
When a cacheable test task doesn't declare the OS name as an input, it may reuse a cache entry produced on another OS. This is a problem for OS-dependent tests. If a test is skipped on Linux but runs on macOS, a macOS run that restores a Linux cache entry will report it as skipped there too, and the test silently never runs.

 #KTI-3520