### PR TITLE
Tests: cleanup obsolete K1-based code

### DIFF
--- a/compiler/tests-common/testFixtures/org/jetbrains/kotlin/checkers/CompilerTestLanguageVersionSettings.kt
+++ b/compiler/tests-common/testFixtures/org/jetbrains/kotlin/checkers/CompilerTestLanguageVersionSettings.kt
@@ -5,118 +5,12 @@
 
 package org.jetbrains.kotlin.checkers
 
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.config.*
-import org.jetbrains.kotlin.test.Directives
-import org.jetbrains.kotlin.test.KotlinTestUtils
+import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.test.checkTestInfrastructure
 import org.jetbrains.kotlin.test.testInfraError
 import org.jetbrains.kotlin.test.util.LANGUAGE_FEATURE_PATTERN
-import java.io.File
 
 const val LANGUAGE_DIRECTIVE = "LANGUAGE"
-const val API_VERSION_DIRECTIVE = "API_VERSION"
-
-const val OPT_IN_DIRECTIVE = "OPT_IN"
-const val IGNORE_DATA_FLOW_IN_ASSERT_DIRECTIVE = "IGNORE_DATA_FLOW_IN_ASSERT"
-const val JVM_DEFAULT_MODE = "JVM_DEFAULT_MODE"
-const val SKIP_METADATA_VERSION_CHECK = "SKIP_METADATA_VERSION_CHECK"
-const val INHERIT_MULTIFILE_PARTS = "INHERIT_MULTIFILE_PARTS"
-const val SANITIZE_PARENTHESES = "SANITIZE_PARENTHESES"
-const val ENABLE_JVM_PREVIEW = "ENABLE_JVM_PREVIEW"
-
-data class CompilerTestLanguageVersionSettings(
-    private val initialLanguageFeatures: Map<LanguageFeature, LanguageFeature.State>,
-    override val apiVersion: ApiVersion,
-    override val languageVersion: LanguageVersion,
-    val analysisFlags: Map<AnalysisFlag<*>, Any?> = emptyMap()
-) : LanguageVersionSettings {
-    val extraLanguageFeatures = specificFeaturesForTests() + initialLanguageFeatures
-    private val delegate = LanguageVersionSettingsImpl(languageVersion, apiVersion, emptyMap(), extraLanguageFeatures)
-
-    override fun getFeatureSupport(feature: LanguageFeature): LanguageFeature.State =
-        extraLanguageFeatures[feature] ?: delegate.getFeatureSupport(feature)
-
-    override fun getCustomizedLanguageFeatures(): Map<LanguageFeature, LanguageFeature.State> =
-        delegate.getCustomizedLanguageFeatures()
-
-    override fun isPreRelease(): Boolean = KotlinCompilerVersion.isPreRelease()
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T> getFlag(flag: AnalysisFlag<T>): T = analysisFlags[flag] as T? ?: flag.defaultValue
-}
-
-private fun specificFeaturesForTests(): Map<LanguageFeature, LanguageFeature.State> {
-    return if (System.getProperty("kotlin.ni") == "true")
-        mapOf(LanguageFeature.NewInference to LanguageFeature.State.ENABLED)
-    else
-        emptyMap()
-}
-
-private fun parseLanguageVersionSettingsOrDefault(directiveMap: Directives): CompilerTestLanguageVersionSettings =
-    parseLanguageVersionSettings(directiveMap) ?: defaultLanguageVersionSettings()
-
-@JvmOverloads
-fun parseLanguageVersionSettings(
-    directives: Directives,
-    defaultLanguageVersion: LanguageVersion = LanguageVersion.LATEST_STABLE,
-    extraLanguageFeatures: Map<LanguageFeature, LanguageFeature.State> = emptyMap(),
-): CompilerTestLanguageVersionSettings? {
-    val apiVersionString = directives[API_VERSION_DIRECTIVE]
-    val languageFeaturesString = directives[LANGUAGE_DIRECTIVE]
-
-    val analysisFlags = listOfNotNull(
-        analysisFlag(AnalysisFlags.optIn, directives[OPT_IN_DIRECTIVE]?.split(' ')),
-        analysisFlag(JvmAnalysisFlags.jvmDefaultMode, directives[JVM_DEFAULT_MODE]?.let { JvmDefaultMode.fromStringOrNull(it) }),
-        analysisFlag(AnalysisFlags.ignoreDataFlowInAssert, if (IGNORE_DATA_FLOW_IN_ASSERT_DIRECTIVE in directives) true else null),
-        analysisFlag(AnalysisFlags.skipMetadataVersionCheck, if (SKIP_METADATA_VERSION_CHECK in directives) true else null),
-        analysisFlag(JvmAnalysisFlags.inheritMultifileParts, if (INHERIT_MULTIFILE_PARTS in directives) true else null),
-        analysisFlag(JvmAnalysisFlags.sanitizeParentheses, if (SANITIZE_PARENTHESES in directives) true else null),
-        analysisFlag(JvmAnalysisFlags.enableJvmPreview, if (ENABLE_JVM_PREVIEW in directives) true else null),
-        analysisFlag(AnalysisFlags.explicitApiVersion, if (apiVersionString != null) true else null)
-    )
-
-    if (apiVersionString == null && languageFeaturesString == null && analysisFlags.isEmpty()) {
-        return null
-    }
-
-    val apiVersion = when (apiVersionString) {
-        null -> ApiVersion.LATEST_STABLE
-        "LATEST" -> ApiVersion.LATEST
-        else -> ApiVersion.parse(apiVersionString) ?: testInfraError("Unknown API version: $apiVersionString")
-    }
-
-    val languageVersion = maxOf(defaultLanguageVersion, LanguageVersion.fromVersionString(apiVersion.versionString)!!)
-
-    val languageFeatures = languageFeaturesString?.let(::collectLanguageFeatureMap).orEmpty() + extraLanguageFeatures
-
-    return CompilerTestLanguageVersionSettings(languageFeatures, apiVersion, languageVersion, mapOf(*analysisFlags.toTypedArray()))
-}
-
-fun defaultLanguageVersionSettings(): CompilerTestLanguageVersionSettings =
-    CompilerTestLanguageVersionSettings(emptyMap(), ApiVersion.LATEST_STABLE, LanguageVersion.LATEST_STABLE)
-
-fun languageVersionSettingsFromText(fileTexts: List<String>): LanguageVersionSettings {
-    val allDirectives = Directives()
-    for (fileText in fileTexts) {
-        KotlinTestUtils.parseDirectives(fileText, allDirectives)
-    }
-    return parseLanguageVersionSettingsOrDefault(allDirectives)
-}
-
-fun setupLanguageVersionSettingsForMultifileCompilerTests(files: List<File>, environment: KotlinCoreEnvironment) {
-    environment.configuration.languageVersionSettings = languageVersionSettingsFromText(files.map { it.readText() })
-}
-
-fun setupLanguageVersionSettingsForCompilerTests(originalFileText: String, environment: KotlinCoreEnvironment) {
-    val directives = KotlinTestUtils.parseDirectives(originalFileText)
-    val languageVersionSettings = parseLanguageVersionSettingsOrDefault(directives)
-    environment.configuration.languageVersionSettings = languageVersionSettings
-}
-
-@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "HIDDEN")
-private fun <T : Any> analysisFlag(flag: AnalysisFlag<T?>, value: @kotlin.internal.NoInfer T?): Pair<AnalysisFlag<T?>, T>? =
-    value?.let(flag::to)
 
 fun collectLanguageFeatureMap(directives: String): Map<LanguageFeature, LanguageFeature.State> {
     val matcher = LANGUAGE_FEATURE_PATTERN.matcher(directives)

--- a/compiler/tests-common/testFixtures/org/jetbrains/kotlin/test/KotlinTestUtils.java
+++ b/compiler/tests-common/testFixtures/org/jetbrains/kotlin/test/KotlinTestUtils.java
@@ -6,27 +6,21 @@
 package org.jetbrains.kotlin.test;
 
 import com.google.common.collect.Lists;
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.util.lang.JavaVersion;
-import kotlin.Unit;
-import kotlin.jvm.functions.Function1;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.kotlin.checkers.CompilerTestLanguageVersionSettingsKt;
 import org.jetbrains.kotlin.cli.CompilerConfigurationCreationKt;
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity;
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation;
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector;
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles;
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment;
 import org.jetbrains.kotlin.cli.jvm.config.JvmContentRootsKt;
 import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime;
 import org.jetbrains.kotlin.config.CommonConfigurationKeys;
 import org.jetbrains.kotlin.config.CompilerConfiguration;
 import org.jetbrains.kotlin.config.JVMConfigurationKeys;
-import org.jetbrains.kotlin.jvm.compiler.LoadDescriptorUtil;
 import org.jetbrains.kotlin.psi.KtFile;
 import org.jetbrains.kotlin.psi.KtPsiFactory;
 import org.jetbrains.kotlin.test.util.KtTestUtil;
@@ -47,32 +41,6 @@ public class KotlinTestUtils {
     private static final Pattern DIRECTIVE_PATTERN = Pattern.compile("^//\\s*([A-Z_0-9]+)(:[ \\t]*(.*))?$", Pattern.MULTILINE);
 
     private KotlinTestUtils() {
-    }
-
-    @NotNull
-    public static KotlinCoreEnvironment createEnvironmentWithMockJdkAndIdeaAnnotations(Disposable disposable) {
-        return createEnvironmentWithMockJdkAndIdeaAnnotations(disposable, ConfigurationKind.ALL);
-    }
-
-    @NotNull
-    public static KotlinCoreEnvironment createEnvironmentWithMockJdkAndIdeaAnnotations(Disposable disposable, @NotNull ConfigurationKind configurationKind) {
-        return createEnvironmentWithJdkAndNullabilityAnnotationsFromIdea(disposable, configurationKind, TestJdkKind.MOCK_JDK);
-    }
-
-    @NotNull
-    public static KotlinCoreEnvironment createEnvironmentWithJdkAndNullabilityAnnotationsFromIdea(
-            @NotNull Disposable disposable,
-            @NotNull ConfigurationKind configurationKind,
-            @NotNull TestJdkKind jdkKind
-    ) {
-        return KotlinCoreEnvironment.createForTests(
-                disposable, newConfiguration(configurationKind, jdkKind, KtTestUtil.getAnnotationsJar()), EnvironmentConfigFiles.JVM_CONFIG_FILES
-        );
-    }
-
-    @NotNull
-    private static KotlinCoreEnvironment createEnvironmentWithFullJdkAndIdeaAnnotations(Disposable disposable) {
-        return createEnvironmentWithJdkAndNullabilityAnnotationsFromIdea(disposable, ConfigurationKind.ALL, TestJdkKind.FULL_JDK);
     }
 
     @NotNull
@@ -170,34 +138,6 @@ public class KotlinTestUtils {
         return configuration;
     }
 
-    public static JavaCompilationResult compileKotlinWithJava(
-            @NotNull List<File> javaFiles,
-            @NotNull List<File> ktFiles,
-            @NotNull File outDir,
-            @NotNull Disposable disposable,
-            @Nullable Function1<CompilerConfiguration, Unit> updateConfiguration
-    ) {
-        if (!ktFiles.isEmpty()) {
-            KotlinCoreEnvironment environment = createEnvironmentWithFullJdkAndIdeaAnnotations(disposable);
-            CompilerTestLanguageVersionSettingsKt.setupLanguageVersionSettingsForMultifileCompilerTests(ktFiles, environment);
-            if (updateConfiguration != null) {
-                updateConfiguration.invoke(environment.getConfiguration());
-            }
-            LoadDescriptorUtil.compileKotlinToDirAndGetModule(ktFiles, outDir, environment);
-        }
-        else {
-            boolean mkdirs = outDir.mkdirs();
-            assert mkdirs : "Not created: " + outDir;
-        }
-        if (javaFiles.isEmpty()) return JavaCompilationResult.Success.INSTANCE;
-
-        List<String> options = Arrays.asList(
-                "-classpath", outDir.getPath() + File.pathSeparator + ForTestCompileRuntime.runtimeJarForTests(),
-                "-d", outDir.getPath()
-        );
-        return JvmCompilationUtils.compileJavaFiles(javaFiles, options);
-    }
-
     @NotNull
     public static Directives parseDirectives(String expectedText) {
         return parseDirectives(expectedText, new Directives());
@@ -215,7 +155,7 @@ public class KotlinTestUtils {
     }
 
     @NotNull
-    public static KtFile loadKtFile(@NotNull Project project, @NotNull File ioFile) throws IOException {
+    private static KtFile loadKtFile(@NotNull Project project, @NotNull File ioFile) throws IOException {
         String text = FileUtil.loadFile(ioFile, true);
         return new KtPsiFactory(project).createPhysicalFile(ioFile.getName(), text);
     }
@@ -227,10 +167,5 @@ public class KotlinTestUtils {
             ktFiles.add(loadKtFile(environment.getProject(), file));
         }
         return ktFiles;
-    }
-
-    @NotNull
-    public static File replaceExtension(@NotNull File file, @Nullable String newExtension) {
-        return new File(file.getParentFile(), FileUtil.getNameWithoutExtension(file) + (newExtension == null ? "" : "." + newExtension));
     }
 }

--- a/compiler/tests-compiler-utils/testFixtures/org/jetbrains/kotlin/codegen/GenerationUtils.kt
+++ b/compiler/tests-compiler-utils/testFixtures/org/jetbrains/kotlin/codegen/GenerationUtils.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.ObsoleteTestInfrastructure
 import org.jetbrains.kotlin.analyzer.CompilationErrorException
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory
-import org.jetbrains.kotlin.cli.common.output.writeAllTo
 import org.jetbrains.kotlin.cli.jvm.compiler.AllJavaSourcesInProjectScope
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.convertToIrAndActualizeForJvm
@@ -31,15 +30,8 @@ import org.jetbrains.kotlin.fir.backend.jvm.JvmFir2IrExtensions
 import org.jetbrains.kotlin.load.kotlin.PackagePartProvider
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.test.FirParser
-import java.io.File
 
 object GenerationUtils {
-    @JvmStatic
-    fun compileFilesTo(files: List<KtFile>, environment: KotlinCoreEnvironment, output: File): ClassFileFactory =
-        compileFiles(files, environment).factory.apply {
-            writeAllTo(output)
-        }
-
     @JvmStatic
     @JvmOverloads
     fun compileFiles(

--- a/compiler/tests-integration/tests/org/jetbrains/kotlin/jvm/compiler/MemoryOptimizationsTest.kt
+++ b/compiler/tests-integration/tests/org/jetbrains/kotlin/jvm/compiler/MemoryOptimizationsTest.kt
@@ -16,7 +16,11 @@
 
 package org.jetbrains.kotlin.jvm.compiler
 
+import com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.CoreEnvironmentDeprecation
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -41,13 +45,7 @@ class MemoryOptimizationsTest {
     @Test
     fun testBasicFlexibleTypeCase(): Unit = runWithDisposable { testRootDisposable ->
         @Suppress("DEPRECATION_ERROR")
-        val moduleDescriptor = JvmResolveUtil.analyze(
-            KotlinTestUtils.createEnvironmentWithJdkAndNullabilityAnnotationsFromIdea(
-                testRootDisposable,
-                ConfigurationKind.ALL,
-                TestJdkKind.FULL_JDK
-            )
-        ).moduleDescriptor
+        val moduleDescriptor = JvmResolveUtil.analyze(createEnvironment(testRootDisposable)).moduleDescriptor
 
         val appendableClass =
             moduleDescriptor.findClassAcrossModuleDependencies(ClassId.topLevel(FqName("java.lang.Appendable")))!!
@@ -76,11 +74,7 @@ class MemoryOptimizationsTest {
                 |}
                 """.trimMargin()
 
-        val environment =
-            KotlinTestUtils
-                .createEnvironmentWithJdkAndNullabilityAnnotationsFromIdea(
-                    testRootDisposable, ConfigurationKind.ALL, TestJdkKind.FULL_JDK
-                )
+        val environment = createEnvironment(testRootDisposable)
 
         @Suppress("DEPRECATION_ERROR")
         val moduleDescriptor =
@@ -110,4 +104,12 @@ class MemoryOptimizationsTest {
 
         assertTrue(foo.original !== foo)
     }
+
+    @OptIn(CoreEnvironmentDeprecation::class)
+    private fun createEnvironment(disposable: Disposable): KotlinCoreEnvironment =
+        KotlinCoreEnvironment.createForTests(
+            disposable,
+            KotlinTestUtils.newConfiguration(ConfigurationKind.ALL, TestJdkKind.FULL_JDK, KtTestUtil.getAnnotationsJar()),
+            EnvironmentConfigFiles.JVM_CONFIG_FILES,
+        )
 }


### PR DESCRIPTION
It's possible to remove this obsolete code after bc8282e7c15 and a42aeab5737.