### PR TITLE
[Swift Export] Resolve ObjC wrappers from the Kotlin type alone

### DIFF
--- a/kotlin-native/runtime/src/main/cpp/ObjCExport.mm
+++ b/kotlin-native/runtime/src/main/cpp/ObjCExport.mm
@@ -33,6 +33,7 @@
 #import "Natives.h"
 #import "TypeInfoObjCExportAddition.hpp"
 #import "WritableTypeInfo.hpp"
+#include "ExternalRCRef.hpp"
 #include "swiftExportRuntime/SwiftExport.hpp"
 
 using namespace kotlin;
@@ -40,6 +41,9 @@ using namespace kotlin;
 @interface NSObject (KotlinBaseExtensions)
 // Implemented for KotlinBase
 + (instancetype)createRetainedWrapper:(struct ObjHeader*)obj;
+// Implemented for KotlinBase
++ (id)_createProtocolWrapperForExternalRCRef:(void*)ref
+                                  conformsTo:(NS_NOESCAPE BOOL (^)(Class candidate))conformsTo;
 @end
 
 namespace {
@@ -117,7 +121,16 @@ extern "C" id Kotlin_ObjCExport_convertUnitToRetained(ObjHeader* unitInstance) {
   static id instance = nullptr;
   dispatch_once(&onceToken, ^{
     Class unitClass = getOrCreateClass(unitInstance->type_info());
-    instance = [unitClass createRetainedWrapper:unitInstance];
+
+    if (compiler::swiftExport()) {
+      kotlin::AssertThreadState(kotlin::ThreadState::kRunnable);
+      void* ref = kotlin::mm::createRetainedExternalRCRef(unitInstance);
+      kotlin::ThreadStateGuard guard(kotlin::ThreadState::kNative);
+      instance = [unitClass _createProtocolWrapperForExternalRCRef:ref
+                                                       conformsTo:^BOOL(Class) { return YES; }];
+    } else {
+      instance = [unitClass createRetainedWrapper:unitInstance];
+    }
   });
   return Kotlin_objc_retain_inNative(instance);
 }
@@ -529,7 +542,16 @@ extern "C" OBJ_GETTER(Kotlin_ObjCExport_refFromObjC, id obj) {
 static id convertKotlinObjectToRetained(ObjHeader* obj) {
   Class clazz = objCExport(obj->type_info()).objCClass;
   RuntimeAssert(clazz != nullptr, "");
-  return [clazz createRetainedWrapper:obj];
+
+  if (compiler::swiftExport()) {
+    kotlin::AssertThreadState(kotlin::ThreadState::kRunnable);
+    void* ref = kotlin::mm::createRetainedExternalRCRef(obj);
+    kotlin::ThreadStateGuard guard(kotlin::ThreadState::kNative);
+    return [clazz _createProtocolWrapperForExternalRCRef:ref
+                                             conformsTo:^BOOL(Class) { return YES; }];
+  } else {
+    return [clazz createRetainedWrapper:obj];
+  }
 }
 
 static convertReferenceToRetainedObjC findConvertToRetainedFromInterfaces(const TypeInfo* typeInfo) {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/existentialWrapperViaObjCInterop/existentialWrapperViaObjCInterop.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/existentialWrapperViaObjCInterop/existentialWrapperViaObjCInterop.kt
@@ -1,0 +1,62 @@
+// KIND: STANDALONE
+// WITH_PLATFORM_LIBS
+// MODULE: ExistentialWrapperViaObjCInterop
+// FILE: main.kt
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.objcPtr
+import platform.Foundation.NSMutableArray
+import platform.Foundation.NSStringFromClass
+import platform.objc.object_getClass
+
+// todo: remove me after KT-87457
+interface Anchor {
+    fun ping(): Int
+}
+
+open class Exported
+
+// Not exported and without an exported ancestor: bridging it to Objective-C makes the runtime build a
+// `_KotlinExistential` wrapper.
+private class Hidden
+
+// Not exported, but with an exported ancestor, so it resolves to `Exported`'s bound wrapper class instead.
+private class HiddenChild : Exported()
+
+// Handing a Kotlin object to Objective-C goes through `Kotlin_Interop_refToObjC`
+private fun roundTripThroughObjC(value: Any): Any? =
+    NSMutableArray().apply { addObject(value) }.objectAtIndex(0.convert())
+
+private val Any.objCClassName: String
+    get() = NSStringFromClass(object_getClass(this)!!)
+
+fun exportedRoundTripsThroughObjC(): Boolean = Exported().let { roundTripThroughObjC(it) === it }
+
+fun hiddenRoundTripsThroughObjC(): Boolean = Hidden().let { roundTripThroughObjC(it) === it }
+
+fun hiddenChildRoundTripsThroughObjC(): Boolean = HiddenChild().let { roundTripThroughObjC(it) === it }
+
+fun unitRoundTripsThroughObjC(): Boolean = roundTripThroughObjC(Unit) === Unit
+
+// Which of the two wrapper resolutions the interop layer used is visible in the wrapper's Objective-C class.
+// `classWrapperFor()` hands a non-exported class the bound wrapper class of its closest exported ancestor;
+// `protocolWrapperFor()` would hand it an uncached existential instead. So this equality is exactly the
+// `conformsTo:` predicate in `+_createRetainedWrapperForKotlinObject:` being always-true rather than `nil`.
+fun hiddenChildSharesWrapperClassWithExported(): Boolean =
+    HiddenChild().objCClassName == Exported().objCClassName
+
+// The negative control: without it the assertion above would also hold if everything resolved to `Exported`.
+// `Hidden` has no exported ancestor, so it is the one case that does legitimately get an existential.
+fun hiddenUsesDistinctWrapperClass(): Boolean = Hidden().objCClassName != Exported().objCClassName
+
+// `objcPtr()` is `Kotlin_Interop_refToObjC`, so these observe that a Kotlin object keeps a single wrapper
+// across repeated conversions rather than allocating a fresh one each time.
+fun existentialWrapperIsCached(): Boolean = Hidden().let { it.objcPtr() == it.objcPtr() }
+fun boundWrapperIsCached(): Boolean = HiddenChild().let { it.objcPtr() == it.objcPtr() }
+fun exportedWrapperIsCached(): Boolean = Exported().let { it.objcPtr() == it.objcPtr() }
+
+// Entry points for the Swift side, where the argument already carries a bound bridge wrapper of its own.
+fun roundTripExportedThroughObjC(value: Exported): Exported = roundTripThroughObjC(value) as Exported
+
+fun makeExported(): Exported = Exported()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/existentialWrapperViaObjCInterop/existentialWrapperViaObjCInterop.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/existentialWrapperViaObjCInterop/existentialWrapperViaObjCInterop.swift
@@ -1,0 +1,52 @@
+import ExistentialWrapperViaObjCInterop
+import Testing
+
+/// Bridging a Kotlin object to Objective-C has to produce a wrapper that carries the object itself: storing
+/// the value in an `id`-typed Objective-C container and reading it back must yield the same Kotlin object.
+@Test
+func testKotlinObjectSurvivesObjCRoundTrip() throws {
+    try #require(exportedRoundTripsThroughObjC())
+    try #require(hiddenRoundTripsThroughObjC())
+    try #require(hiddenChildRoundTripsThroughObjC())
+    try #require(unitRoundTripsThroughObjC())
+}
+
+/// Crossing into Objective-C resolves the wrapper class through `classWrapperFor()`, which follows the Kotlin
+/// class hierarchy, rather than through `protocolWrapperFor()`, which would yield an existential.
+@Test
+func testWrapperClassFollowsKotlinHierarchy() throws {
+    try #require(hiddenChildSharesWrapperClassWithExported())
+    try #require(hiddenUsesDistinctWrapperClass())
+}
+
+/// A Kotlin object keeps one wrapper across repeated conversions to Objective-C.
+@Test
+func testWrapperIsReusedAcrossConversions() throws {
+    try #require(existentialWrapperIsCached())
+    try #require(boundWrapperIsCached())
+    try #require(exportedWrapperIsCached())
+}
+
+/// A Swift-created instance of an exported class already carries its bound bridge wrapper, so crossing into
+/// Objective-C has to resolve back to that very instance instead of allocating a second wrapper.
+@Test
+func testExportedInstanceSurvivesObjCRoundTrip() throws {
+    let swiftCreated = Exported()
+    try #require(roundTripExportedThroughObjC(value: swiftCreated) === swiftCreated)
+
+    let kotlinCreated = makeExported()
+    try #require(roundTripExportedThroughObjC(value: kotlinCreated) === kotlinCreated)
+}
+
+/// Here the Objective-C class associated with the Kotlin type is the Swift subclass itself, while the
+/// resolved wrapper class is `Exported`'s bound bridge. Neither descends from the other, which is exactly
+/// what a receiver-constrained wrapper lookup cannot express.
+@Test
+func testSwiftSubclassSurvivesObjCRoundTrip() throws {
+    class SwiftSubclass: Exported {}
+
+    let subclassInstance = SwiftSubclass()
+    let returned = roundTripExportedThroughObjC(value: subclassInstance)
+    try #require(returned === subclassInstance)
+    try #require(returned is SwiftSubclass)
+}


### PR DESCRIPTION
    Under Swift Export, handing a Kotlin object to Objective-C aborted the
    process. Any object that did not already have a wrapper went through

        Kotlin_Interop_refToObjC
        +[KotlinBase createRetainedWrapper:]
        +[KotlinBase _createClassWrapperForExternalRCRef:]

    and tripped the latter's RuntimeAssert:

        Best-fitting class is
        _TtGC20KotlinRuntimeSupport18_KotlinExistentialCSo14Kotlin_kobjcc0_
        which is not a subclass of self (Kotlin_kobjcc0)

    The receiver was objCExport(typeInfo).objCClass. Under Swift Export a
    type with no type adapter gets a synthesized marker class there, not a
    wrapper class. classWrapperFor() ignores the receiver and resolves off
    the Kotlin type, returning either an existential or the bound bridge of
    an exported ancestor. Neither ever descends from a marker, so the
    assert could not hold and the check was unsatisfiable by construction.

    Three kinds of value reached it:

      - a non-exported class with no exported ancestor, which resolves to
        an existential;
      - a non-exported class with an exported ancestor, which resolves to
        that ancestor's bound bridge;
      - kotlin.Unit, via Kotlin_ObjCExport_convertUnitToRetained.

    Kotlin-to-Objective-C interop has no wrapper class to constrain the
    result against, so the lookup has to run off the Kotlin type alone.
    The new entry point therefore routes through
    _createProtocolWrapperForExternalRCRef: with an always-true predicate
    instead of nil. The predicate is what selects AsBestFittingWrapper, so
    the wrapper is still cached on the object and identity is preserved.

    ^KT-88330