### PR TITLE
[BTA] Promote the deprecated shrunkClasspathSnapshot to an error

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testCompatibility/kotlin/SnapshotPathSmokeTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testCompatibility/kotlin/SnapshotPathSmokeTest.kt
@@ -16,19 +16,19 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import kotlin.io.path.createDirectories
-import kotlin.io.path.exists
 
 /**
- * These tests verify the behavior documented in KT-75837:
- * - The deprecated 4-parameter `snapshotBasedIcConfigurationBuilder` accepts a custom snapshot path,
- *   but internally only the parent directory is used - the filename is always "shrunk-classpath-snapshot.bin"
- * - The new 3-parameter version auto-generates the path under workingDirectory
+ * These tests verify snapshot path handling, introduced in KT-75837 and finalized in KT-83937:
+ * - The deprecated 4-parameter `snapshotBasedIcConfigurationBuilder` (now a `DeprecationLevel.ERROR`) still accepts
+ *   a custom snapshot path, but the path is ignored entirely - the snapshot is always stored as
+ *   "shrunk-classpath-snapshot.bin" under workingDirectory
+ * - The new 3-parameter version stores the snapshot at that same location
  */
 class SnapshotPathSmokeTest : BaseCompilationTest() {
-    @DisplayName("Deprecated 4-parameter builder creates snapshot with hardcoded filename ignoring custom name")
+    @DisplayName("Deprecated 4-parameter builder ignores the custom snapshot path and uses workingDirectory")
     @DefaultStrategyAgnosticCompilationTest
     @TestMetadata("basic-multimodule-project/module-1")
-    fun testDeprecatedBuilderIgnoresCustomSnapshotFilename(strategyConfig: CompilerExecutionStrategyConfiguration) {
+    fun testDeprecatedBuilderIgnoresCustomSnapshotPath(strategyConfig: CompilerExecutionStrategyConfiguration) {
         jvmProject(strategyConfig) {
             val module1 = module("basic-multimodule-project/module-1")
             val customSnapshotDir = module1.buildDirectory.resolve("my-custom-snapshot")
@@ -37,7 +37,7 @@ class SnapshotPathSmokeTest : BaseCompilationTest() {
 
             module1.compile(
                 compilationConfigAction = { compilationOperation ->
-                    @Suppress("DEPRECATION")
+                    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
                     val icConfig = compilationOperation.snapshotBasedIcConfiguration(
                         workingDirectory = module1.icCachesDir,
                         sourcesChanges = SourcesChanges.Unknown,
@@ -49,13 +49,13 @@ class SnapshotPathSmokeTest : BaseCompilationTest() {
                 }
             )
 
-            val expectedSnapshotFile = customSnapshotDir.resolve("shrunk-classpath-snapshot.bin")
+            val expectedSnapshotFile = module1.icCachesDir.resolve("shrunk-classpath-snapshot.bin")
             assertTrue(expectedSnapshotFile.exists()) {
                 "Expected snapshot file at $expectedSnapshotFile to exist. " +
-                        "The hardcoded filename 'shrunk-classpath-snapshot.bin' should be used, not the custom filename."
+                        "The snapshot is always stored as 'shrunk-classpath-snapshot.bin' under workingDirectory."
             }
             assertFalse(customSnapshotFile.exists()) {
-                "Custom snapshot path $customSnapshotFile should not exist - the filename is ignored."
+                "Custom snapshot path $customSnapshotFile should not exist - the configured path is ignored."
             }
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/SnapshotPathSmokeTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/SnapshotPathSmokeTest.kt
@@ -19,16 +19,17 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 
 /**
- * These tests verify the behavior documented in KT-75837:
- * - The deprecated 4-parameter `snapshotBasedIcConfigurationBuilder` accepts a custom snapshot path,
- *   but internally only the parent directory is used - the filename is always "shrunk-classpath-snapshot.bin"
- * - The new 3-parameter version auto-generates the path under workingDirectory
+ * These tests verify snapshot path handling, introduced in KT-75837 and finalized in KT-83937:
+ * - The deprecated 4-parameter `snapshotBasedIcConfigurationBuilder` (now a `DeprecationLevel.ERROR`) still accepts
+ *   a custom snapshot path, but the path is ignored entirely - the snapshot is always stored as
+ *   "shrunk-classpath-snapshot.bin" under workingDirectory
+ * - The new 3-parameter version stores the snapshot at that same location
  */
 class SnapshotPathSmokeTest : BaseCompilationTest() {
-    @DisplayName("Deprecated 4-parameter builder creates snapshot with hardcoded filename ignoring custom name")
+    @DisplayName("Deprecated 4-parameter builder ignores the custom snapshot path and uses workingDirectory")
     @DefaultStrategyAgnosticCompilationTest
     @TestMetadata("basic-multimodule-project/module-1")
-    fun testDeprecatedBuilderIgnoresCustomSnapshotFilename(strategyConfig: CompilerExecutionStrategyConfiguration) {
+    fun testDeprecatedBuilderIgnoresCustomSnapshotPath(strategyConfig: CompilerExecutionStrategyConfiguration) {
         jvmProject(strategyConfig) {
             val module1 = module("basic-multimodule-project/module-1")
             val customSnapshotDir = module1.buildDirectory.resolve("my-custom-snapshot")
@@ -37,7 +38,7 @@ class SnapshotPathSmokeTest : BaseCompilationTest() {
 
             module1.compile(
                 compilationConfigAction = { compilationOperation ->
-                    @Suppress("DEPRECATION")
+                    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
                     val icConfig = compilationOperation.snapshotBasedIcConfiguration(
                         workingDirectory = module1.icCachesDir,
                         sourcesChanges = SourcesChanges.Unknown,
@@ -49,13 +50,13 @@ class SnapshotPathSmokeTest : BaseCompilationTest() {
                 }
             )
 
-            val expectedSnapshotFile = customSnapshotDir.resolve("shrunk-classpath-snapshot.bin")
+            val expectedSnapshotFile = module1.icCachesDir.resolve("shrunk-classpath-snapshot.bin")
             assertTrue(expectedSnapshotFile.exists()) {
                 "Expected snapshot file at $expectedSnapshotFile to exist. " +
-                        "The hardcoded filename 'shrunk-classpath-snapshot.bin' should be used, not the custom filename."
+                        "The snapshot is always stored as 'shrunk-classpath-snapshot.bin' under workingDirectory."
             }
             assertFalse(customSnapshotFile.exists()) {
-                "Custom snapshot path $customSnapshotFile should not exist - the filename is ignored."
+                "Custom snapshot path $customSnapshotFile should not exist - the configured path is ignored."
             }
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/internal/wrappers/KotlinWrapperPre2_3_20.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/internal/wrappers/KotlinWrapperPre2_3_20.kt
@@ -194,7 +194,7 @@ internal class KotlinWrapperPre2_3_20(
             @Deprecated(
                 "The shrunkClasspathSnapshot parameter is no longer required",
                 replaceWith = ReplaceWith("snapshotBasedIcConfigurationBuilder(workingDirectory, sourcesChanges, dependenciesSnapshotFiles)"),
-                level = DeprecationLevel.WARNING
+                level = DeprecationLevel.ERROR
             )
             override fun snapshotBasedIcConfigurationBuilder(
                 workingDirectory: Path,

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/internal/wrappers/KotlinWrapperPre2_4_0.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/internal/wrappers/KotlinWrapperPre2_4_0.kt
@@ -88,6 +88,7 @@ internal class KotlinWrapperPre2_4_0(
     ) : JvmCompilationOperation.Builder by base {
         override val compilerArguments: JvmCompilerArguments.Builder = JvmCompilerArgumentsBuilderWrapper(base.compilerArguments)
 
+        @Suppress("DEPRECATION_ERROR")
         override fun snapshotBasedIcConfigurationBuilder(
             workingDirectory: Path,
             sourcesChanges: SourcesChanges,
@@ -105,8 +106,9 @@ internal class KotlinWrapperPre2_4_0(
         @Deprecated(
             "The shrunkClasspathSnapshot parameter is no longer required",
             replaceWith = ReplaceWith("snapshotBasedIcConfigurationBuilder(workingDirectory, sourcesChanges, dependenciesSnapshotFiles)"),
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         )
+        @Suppress("DEPRECATION_ERROR")
         override fun snapshotBasedIcConfigurationBuilder(
             workingDirectory: Path,
             sourcesChanges: SourcesChanges,

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/jvm/JvmSnapshotBasedIncrementalCompilationConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/jvm/JvmSnapshotBasedIncrementalCompilationConfiguration.kt
@@ -33,7 +33,7 @@ public interface JvmIncrementalCompilationConfiguration
  * @property workingDirectory the working directory for the IC operation to store internal objects.
  * @property sourcesChanges changes in the source files, which can be unknown, to-be-calculated, or known.
  * @property dependenciesSnapshotFiles a list of paths to dependency snapshot files produced by [org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmClasspathSnapshottingOperation].
- * @property shrunkClasspathSnapshot The path to the shrunk classpath snapshot file from a previous compilation.
+ * @property shrunkClasspathSnapshot Unused; the shrunk classpath snapshot file is managed internally under [workingDirectory].
  * @property options is deprecated and unused
  *
  * @see JvmCompilationOperation.Builder.snapshotBasedIcConfigurationBuilder
@@ -49,7 +49,7 @@ constructor(
     public val workingDirectory: Path,
     public val sourcesChanges: SourcesChanges,
     public val dependenciesSnapshotFiles: List<Path>,
-    @Deprecated("This property is no longer required and will be removed in a future release.")
+    @Deprecated("This property is no longer required and will be removed in a future release.", level = DeprecationLevel.ERROR)
     public val shrunkClasspathSnapshot: Path,
     @Deprecated("Use `get` directly instead or a `Builder` instance to set options. This property will be removed in a future release.", level = DeprecationLevel.ERROR)
     public open val options: JvmSnapshotBasedIncrementalCompilationOptions,
@@ -133,11 +133,11 @@ constructor(
 
         /**
          * The path to the shrunk classpath snapshot file from a previous compilation.
-         * @deprecated The property is no longer required. Will be promoted to an error in KT-83937.
+         * @deprecated The property is no longer required.
          *
          * @since 2.3.20
          */
-        @Deprecated("This property is no longer required and will be removed in a future release.")
+        @Deprecated("This property is no longer required and will be removed in a future release.", level = DeprecationLevel.ERROR)
         public val shrunkClasspathSnapshot: Path
 
         /**

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/jvm/operations/JvmCompilationOperation.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/jvm/operations/JvmCompilationOperation.kt
@@ -130,14 +130,13 @@ public interface JvmCompilationOperation : BaseCompilationOperation, Cancellable
          * Creates the configuration object for snapshot-based incremental compilation (IC) in JVM projects.
          *
          * @deprecated The shrunkClasspathSnapshot parameter is no longer used. Use the 3-parameter overload instead.
-         * Will be promoted to an error in KT-83937.
          * @see org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration
          * @since 2.3.20
          */
         @Deprecated(
             message = "The shrunkClasspathSnapshot parameter is no longer required",
             replaceWith = ReplaceWith("snapshotBasedIcConfigurationBuilder(workingDirectory, sourcesChanges, dependenciesSnapshotFiles)"),
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         )
         public fun snapshotBasedIcConfigurationBuilder(
             workingDirectory: Path,
@@ -286,7 +285,6 @@ public inline fun JvmCompilationOperation.Builder.snapshotBasedIcConfiguration(
  * Convenience function for creating a [JvmSnapshotBasedIncrementalCompilationConfiguration] with options configured by [builderAction].
  *
  * @deprecated The shrunkClasspathSnapshot parameter is no longer required. Use the 3-parameter overload instead.
- * Will be promoted to an error in KT-83937.
  * @return an immutable `JvmSnapshotBasedIncrementalCompilationConfiguration`.
  * @see JvmCompilationOperation.Builder.snapshotBasedIcConfigurationBuilder
  * @since 2.3.20
@@ -294,7 +292,7 @@ public inline fun JvmCompilationOperation.Builder.snapshotBasedIcConfiguration(
 @Deprecated(
     message = "The shrunkClasspathSnapshot parameter is no longer required",
     replaceWith = ReplaceWith("snapshotBasedIcConfiguration(workingDirectory, sourcesChanges, dependenciesSnapshotFiles, builderAction)"),
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 @OptIn(ExperimentalContracts::class)
 @ExperimentalBuildToolsApi
@@ -308,7 +306,7 @@ public inline fun JvmCompilationOperation.Builder.snapshotBasedIcConfiguration(
     contract {
         callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE)
     }
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     return snapshotBasedIcConfigurationBuilder(workingDirectory, sourcesChanges, dependenciesSnapshotFiles, shrunkClasspathSnapshot).apply(
         builderAction
     ).build()

--- a/compiler/build-tools/kotlin-build-tools-compat/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/compat/KotlinToolchainsV1Adapter.kt
+++ b/compiler/build-tools/kotlin-build-tools-compat/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/compat/KotlinToolchainsV1Adapter.kt
@@ -211,8 +211,9 @@ private class JvmCompilationOperationV1Adapter private constructor(
     @Deprecated(
         "The shrunkClasspathSnapshot parameter is no longer required",
         replaceWith = ReplaceWith("snapshotBasedIcConfigurationBuilder(workingDirectory, sourcesChanges, dependenciesSnapshotFiles)"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
+    @Suppress("DEPRECATION_ERROR")
     override fun snapshotBasedIcConfigurationBuilder(
         workingDirectory: Path,
         sourcesChanges: SourcesChanges,

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/icAdapters.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/icAdapters.kt
@@ -78,7 +78,7 @@ internal val HasSnapshotBasedIcOptionsAccessor.classpathChanges: ClasspathChange
         val snapshotFiles =
             ClasspathSnapshotFiles(
                 options.dependenciesSnapshotFiles.map { it.toFile() },
-                options.shrunkClasspathSnapshot.toFile().parentFile
+                options.workingDirectory.toFile()
             )
         return when {
             !snapshotFiles.shrunkPreviousClasspathSnapshotFile.exists() -> ClasspathChanges.ClasspathSnapshotEnabled.NotAvailableDueToMissingClasspathSnapshot(

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/JvmSnapshotBasedIncrementalCompilationConfigurationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/JvmSnapshotBasedIncrementalCompilationConfigurationImpl.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.buildtools.internal.*
 import java.nio.file.Path
 
 @Suppress("DEPRECATION_ERROR")
-internal class JvmSnapshotBasedIncrementalCompilationConfigurationImpl @Suppress("DEPRECATION") private constructor(
+internal class JvmSnapshotBasedIncrementalCompilationConfigurationImpl private constructor(
     workingDirectory: Path,
     sourcesChanges: SourcesChanges,
     dependenciesSnapshotFiles: List<Path>,
@@ -163,7 +163,6 @@ internal interface HasSnapshotBasedIcOptionsAccessor {
     val workingDirectory: Path
     val sourcesChanges: SourcesChanges
     val dependenciesSnapshotFiles: List<Path>
-    val shrunkClasspathSnapshot: Path
     operator fun <V> get(key: BaseOptionWithDefault<V>): V
 }
 
@@ -192,10 +191,6 @@ internal fun JvmSnapshotBasedIncrementalCompilationConfiguration.toOptions(): Ha
                 this@toOptions::class.java.getMethod("getDependenciesSnapshotFiles").invoke(this@toOptions) as List<Path>
             }
 
-            override val shrunkClasspathSnapshot: Path by lazy(LazyThreadSafetyMode.PUBLICATION) {
-                this@toOptions::class.java.getMethod("getShrunkClasspathSnapshot").invoke(this@toOptions) as Path
-            }
-
             override fun <V> get(key: BaseOptionWithDefault<V>): V {
                 val baseOption = Option(key)
                 @Suppress("UNCHECKED_CAST")
@@ -216,10 +211,6 @@ internal fun JvmSnapshotBasedIncrementalCompilationConfiguration.toOptions(): Ha
                 get() = this@toOptions.sourcesChanges
             override val dependenciesSnapshotFiles: List<Path>
                 get() = this@toOptions.dependenciesSnapshotFiles
-
-            @Suppress("DEPRECATION")
-            override val shrunkClasspathSnapshot: Path
-                get() = this@toOptions.shrunkClasspathSnapshot
 
             override fun <V> get(key: BaseOptionWithDefault<V>): V {
                 return options[key]

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/JvmSnapshotBasedIncrementalCompilationOptionsImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/JvmSnapshotBasedIncrementalCompilationOptionsImpl.kt
@@ -50,8 +50,6 @@ internal class JvmSnapshotBasedIncrementalCompilationOptionsImpl internal constr
         get() = error("should not be used")
     override val dependenciesSnapshotFiles: List<Path>
         get() = error("should not be used")
-    override val shrunkClasspathSnapshot: Path
-        get() = error("should not be used")
 
     override fun <V> get(key: BaseOptionWithDefault<V>): V {
         return options[key]

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
@@ -118,7 +118,7 @@ internal class JvmCompilationOperationImpl private constructor(
     @Deprecated(
         "The shrunkClasspathSnapshot parameter is no longer required.",
         replaceWith = ReplaceWith("snapshotBasedIcConfigurationBuilder(workingDirectory, sourcesChanges, dependenciesSnapshotFiles)"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     override fun snapshotBasedIcConfigurationBuilder(
         workingDirectory: Path,

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/IncrementalCompilationMultiProjectIT.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.gradle
 
-import org.gradle.api.logging.LogLevel
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.build.report.metrics.BuildAttribute
@@ -866,8 +865,10 @@ abstract class BaseIncrementalCompilationMultiProjectIT : IncrementalCompilation
                     jsOptions = JsOptions(incrementalJs = false, incrementalJsKlib = false),
                 ),
             ) {
-                projectPath.resolve("lib/build/kotlin/${compileKotlinTaskName}/classpath-snapshot").let {
-                    assert(!it.exists() || it.listDirectoryEntries().isEmpty())
+                projectPath.resolve("lib/build/kotlin/$compileKotlinTaskName/cacheable").let {
+                    assert(!it.exists() || it.listDirectoryEntries().isEmpty()) {
+                        "No incremental state should be produced by a non-incremental build, but '$it' is not empty"
+                    }
                 }
             }
 

--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -6145,7 +6145,6 @@ public abstract class org/jetbrains/kotlin/gradle/tasks/KotlinCompile : org/jetb
 public abstract class org/jetbrains/kotlin/gradle/tasks/KotlinCompile$ClasspathSnapshotProperties {
 	public fun <init> ()V
 	public abstract fun getClasspathSnapshot ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getClasspathSnapshotDir ()Lorg/gradle/api/file/DirectoryProperty;
 }
 
 public abstract class org/jetbrains/kotlin/gradle/tasks/KotlinCompileCommon : org/jetbrains/kotlin/gradle/tasks/AbstractKotlinCompile, org/jetbrains/kotlin/gradle/dsl/KotlinCommonCompile, org/jetbrains/kotlin/gradle/tasks/KotlinCompilationTask {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/jvm/JvmIncrementalConfigurationStrategy.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/jvm/JvmIncrementalConfigurationStrategy.kt
@@ -27,11 +27,10 @@ internal class JvmIncrementalConfigurationStrategy(
     override fun configureIncrementalCompilationConfiguration(buildOperation: JvmCompilationOperation.Builder) {
         val classpathChanges = icEnv.classpathChanges
         if (classpathChanges is ClasspathChanges.ClasspathSnapshotEnabled) {
-            @Suppress("DEPRECATION") val classpathSnapshotsOptions = buildOperation.snapshotBasedIcConfigurationBuilder(
+            val classpathSnapshotsOptions = buildOperation.snapshotBasedIcConfigurationBuilder(
                 icEnv.workingDir.toPath(),
                 icEnv.changedFiles,
                 classpathChanges.classpathSnapshotFiles.currentClasspathEntrySnapshotFiles.map(File::toPath),
-                classpathChanges.classpathSnapshotFiles.shrunkPreviousClasspathSnapshotFile.toPath(),
             ).apply {
                 setupBaseIncrementalConfiguration(icEnv, outputDirs.toSet())
                 this[FORCE_RECOMPILATION] = classpathChanges !is ClasspathChanges.ClasspathSnapshotEnabled.IncrementalRun

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.gradle.tasks
 
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.model.ObjectFactory
@@ -49,8 +48,6 @@ import org.jetbrains.kotlin.incremental.ClasspathSnapshotFiles
 import org.jetbrains.kotlin.incremental.IncrementalCompilationFeatures
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import javax.inject.Inject
-import kotlin.collections.map
-import kotlin.collections.toTypedArray
 
 @CacheableTask
 abstract class KotlinCompile @Inject constructor(
@@ -107,11 +104,6 @@ abstract class KotlinCompile @Inject constructor(
         @get:Incremental
         @get:Optional // Set if useClasspathSnapshot == true
         abstract val classpathSnapshot: ConfigurableFileCollection
-
-        @get:OutputDirectory
-        @get:Optional // Set if useClasspathSnapshot == true
-        @Deprecated("The classpathSnapshotDir parameter is no longer required. Scheduled for removal in Kotlin 2.5.")
-        abstract val classpathSnapshotDir: DirectoryProperty
     }
 
     override val incrementalProps: List<FileCollection>
@@ -434,11 +426,7 @@ abstract class KotlinCompile @Inject constructor(
         @Suppress("DEPRECATION")
         val environment = GradleCompilerEnvironment(
             defaultCompilerClasspath, gradleMessageCollector, outputItemCollector,
-            // In the incremental compiler, outputFiles will be cleaned on rebuild. However, because classpathSnapshotDir is not included in
-            // TaskOutputsBackup, we don't want classpathSnapshotDir to be cleaned immediately on rebuild, and therefore we exclude it from
-            // outputFiles here. (See TaskOutputsBackup's kdoc for more info.)
-            outputFiles = allOutputFiles()
-                    - (classpathSnapshotProperties.classpathSnapshotDir.orNull?.asFile?.let { setOf(it) } ?: emptySet()),
+            outputFiles = allOutputFiles(),
             reportingSettings = reportingSettings(),
             incrementalCompilationEnvironment = icEnv,
             kotlinScriptExtensions = scriptExtensions.get().toTypedArray(),
@@ -538,10 +526,9 @@ abstract class KotlinCompile @Inject constructor(
     }
 
     private fun getClasspathChanges(inputChanges: InputChanges): ClasspathChanges {
-        @Suppress("DEPRECATION")
         val classpathSnapshotFiles = ClasspathSnapshotFiles(
             classpathSnapshotProperties.classpathSnapshot.files.toList(),
-            classpathSnapshotProperties.classpathSnapshotDir.get().asFile
+            taskBuildCacheableOutputDirectory.get().asFile
         )
         return when {
             !inputChanges.isIncremental -> NotAvailableForNonIncrementalRun(classpathSnapshotFiles)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/AbstractKotlinCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/AbstractKotlinCompileConfig.kt
@@ -15,12 +15,15 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.compilerRunner.CompilerSystemPropertiesService
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.topLevelExtension
-import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.plugin.AbstractKotlinMultiplatformPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilationInfo
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
+import org.jetbrains.kotlin.gradle.plugin.getTestedVariantData
 import org.jetbrains.kotlin.gradle.plugin.internal.BuildIdService
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinMetadataTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.internal
+import org.jetbrains.kotlin.gradle.plugin.tcs
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KOTLIN_BUILD_DIR_NAME
 
@@ -87,9 +90,6 @@ internal abstract class AbstractKotlinCompileConfig<TASK : AbstractKotlinCompile
 
     private fun getKotlinBuildDir(task: TASK): Provider<Directory> =
         task.project.layout.buildDirectory.dir("$KOTLIN_BUILD_DIR_NAME/${task.name}")
-
-    protected fun getClasspathSnapshotDir(task: TASK): Provider<Directory> =
-        getKotlinBuildDir(task).map { it.dir("classpath-snapshot") }
 
     constructor(compilationInfo: KotlinCompilationInfo) : this(
         compilationInfo.project,

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KotlinCompileConfig.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaCompilation
 import org.jetbrains.kotlin.gradle.tasks.DefaultKotlinJavaToolchain
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.utils.detachedResolvable
-import org.jetbrains.kotlin.gradle.utils.providerWithLazyConvention
 import org.jetbrains.kotlin.gradle.utils.registerTransformForArtifactType
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import java.io.File
@@ -64,15 +63,6 @@ internal open class BaseKotlinCompileConfig<TASK : KotlinCompile> : AbstractKotl
                     it.attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, CLASSPATH_ENTRY_SNAPSHOT_ARTIFACT_TYPE)
                 }.files
                 task.classpathSnapshotProperties.classpathSnapshot.from(classpathEntrySnapshotFiles).disallowChanges()
-                @Suppress("DEPRECATION")
-                task.classpathSnapshotProperties.classpathSnapshotDir.value(getClasspathSnapshotDir(task)).disallowChanges()
-                @Suppress("DEPRECATION")
-                task.taskOutputsBackupExcludes.addAll(
-                    task.classpathSnapshotProperties.classpathSnapshotDir.asFile.flatMap {
-                        // it looks weird, but it's required to work around this issue: https://github.com/gradle/gradle/issues/17704
-                        objectFactory.providerWithLazyConvention { listOf(it) }
-                    }.orElse(emptyList())
-                )
 
                 task.project.plugins.withId("org.gradle.kotlin.kotlin-dsl") {
                     task.kotlinDslPluginIsPresent.value(true).disallowChanges()


### PR DESCRIPTION
The parameter and property were deprecated with a warning and were already ignored; promote them to DeprecationLevel.ERROR.

^KT-83937 Fixed