### PR TITLE
Clean up util-klib-metadata module

### DIFF
--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebFir2IrPipelinePhase.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/WebFir2IrPipelinePhase.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.fir.backend.Fir2IrExtensions
 import org.jetbrains.kotlin.fir.backend.Fir2IrVisibilityConverter
 import org.jetbrains.kotlin.fir.descriptors.FirModuleDescriptor
 import org.jetbrains.kotlin.fir.pipeline.*
-import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
 import org.jetbrains.kotlin.ir.backend.js.JsFactories
 import org.jetbrains.kotlin.ir.backend.js.checkers.JsKlibCheckers
@@ -38,6 +37,9 @@ import org.jetbrains.kotlin.js.config.wasmCompilation
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isJsStdlib
 import org.jetbrains.kotlin.library.isWasmStdlib
+import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
+import org.jetbrains.kotlin.library.uniqueName
+import org.jetbrains.kotlin.name.Name.special
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 
 object WebFir2IrPipelinePhase : PipelinePhase<WebFrontendPipelineArtifact, WebFir2IrPipelineArtifact>(
@@ -79,13 +81,13 @@ object WebFir2IrPipelinePhase : PipelinePhase<WebFrontendPipelineArtifact, WebFi
         val librariesDescriptors = resolvedLibraries.map { resolvedLibrary ->
             val storageManager = LockBasedStorageManager("ModulesStructure")
 
-            val moduleDescriptor = JsFactories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
-                resolvedLibrary,
-                configuration.languageVersionSettings,
-                storageManager,
-                builtInsModule,
-                lookupTracker = LookupTracker.DO_NOTHING
-            )
+            val moduleName = special("<${resolvedLibrary.uniqueName}>")
+            val moduleOrigin = DeserializedKlibModuleOrigin(resolvedLibrary)
+            val moduleDescriptor = if (builtInsModule != null)
+                JsFactories.DefaultDescriptorFactory.createDescriptor(moduleName, storageManager, builtInsModule, moduleOrigin)
+            else
+                JsFactories.DefaultDescriptorFactory.createDescriptorAndNewBuiltIns(moduleName, storageManager, moduleOrigin)
+
             dependencies += moduleDescriptor
             moduleDescriptor.setDependencies(ArrayList(dependencies))
 

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/JsIrLinkerLoader.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/JsIrLinkerLoader.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.config.perfManager
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
-import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.ir.InternalSymbolFinderAPI
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
@@ -36,6 +35,8 @@ import org.jetbrains.kotlin.ir.util.ExternalDependenciesGenerator
 import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.library.*
+import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
+import org.jetbrains.kotlin.name.Name.special
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import org.jetbrains.kotlin.util.PhaseType
 import org.jetbrains.kotlin.util.tryMeasurePhaseTime
@@ -161,15 +162,13 @@ internal class JsIrLinkerLoader(
 
             val isBuiltIns = current.isJsStdlib || current.isWasmStdlib
 
-            val lookupTracker = LookupTracker.DO_NOTHING
+            val moduleName = special("<${current.uniqueName}>")
+            val moduleOrigin = DeserializedKlibModuleOrigin(current)
+            val md = if (runtimeModule?.builtIns != null)
+                JsFactories.DefaultDescriptorFactory.createDescriptor(moduleName, LockBasedStorageManager.NO_LOCKS, runtimeModule!!.builtIns, moduleOrigin)
+            else
+                JsFactories.DefaultDescriptorFactory.createDescriptorAndNewBuiltIns(moduleName, LockBasedStorageManager.NO_LOCKS, moduleOrigin)
 
-            val md = JsFactories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
-                current,
-                compilerConfiguration.languageVersionSettings,
-                LockBasedStorageManager.NO_LOCKS,
-                runtimeModule?.builtIns,
-                lookupTracker = lookupTracker
-            )
             if (isBuiltIns) runtimeModule = md
 
             descriptors[current] = md

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/ModulesStructure.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/ModulesStructure.kt
@@ -6,16 +6,17 @@
 package org.jetbrains.kotlin.ir.backend.js
 
 import org.jetbrains.kotlin.backend.common.LoadedKlibs
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
-import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isJsStdlib
 import org.jetbrains.kotlin.library.isWasmStdlib
+import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
+import org.jetbrains.kotlin.library.uniqueName
+import org.jetbrains.kotlin.name.Name.special
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 
 class ModulesStructure(
@@ -47,17 +48,14 @@ class ModulesStructure(
 
         val isBuiltIns = current.isJsStdlib || current.isWasmStdlib
 
-        val lookupTracker = compilerConfiguration[CommonConfigurationKeys.LOOKUP_TRACKER] ?: LookupTracker.DO_NOTHING
+        val moduleName = special("<${current.uniqueName}>")
+        val moduleOrigin = DeserializedKlibModuleOrigin(current)
+        val md = if (runtimeModule?.builtIns != null)
+            JsFactories.DefaultDescriptorFactory.createDescriptor(moduleName, storageManager, runtimeModule!!.builtIns, moduleOrigin)
+        else
+            JsFactories.DefaultDescriptorFactory.createDescriptorAndNewBuiltIns(moduleName, storageManager, moduleOrigin)
 
-        val md = JsFactories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
-            current,
-            languageVersionSettings,
-            storageManager,
-            runtimeModule?.builtIns,
-            lookupTracker = lookupTracker
-        )
         if (isBuiltIns) runtimeModule = md
-
         descriptors[current] = md
 
         return md

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/AbstractFir2IrResultsConverter.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/AbstractFir2IrResultsConverter.kt
@@ -12,8 +12,6 @@ import org.jetbrains.kotlin.builtins.DefaultBuiltIns
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.compiler.plugin.getCompilerExtensions
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.LanguageVersionSettings
-import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.diagnostics.impl.BaseDiagnosticsCollector
@@ -24,14 +22,16 @@ import org.jetbrains.kotlin.fir.backend.Fir2IrExtensions
 import org.jetbrains.kotlin.fir.backend.Fir2IrVisibilityConverter
 import org.jetbrains.kotlin.fir.descriptors.FirModuleDescriptor
 import org.jetbrains.kotlin.fir.pipeline.*
-import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
 import org.jetbrains.kotlin.ir.util.KotlinMangler
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isAnyPlatformStdlib
+import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
 import org.jetbrains.kotlin.library.metadata.KlibMetadataFactories
+import org.jetbrains.kotlin.library.uniqueName
+import org.jetbrains.kotlin.name.Name.special
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import org.jetbrains.kotlin.test.backend.ir.IrBackendInput
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
@@ -95,7 +95,6 @@ abstract class AbstractFir2IrResultsConverter(
         val libraries: List<KotlinLibrary> = resolveLibraries(module, compilerConfiguration)
         val [dependencies: List<ModuleDescriptor>, builtIns: KotlinBuiltIns?] = loadModuleDescriptors(
             libraries,
-            compilerConfiguration.languageVersionSettings,
             testServices
         )
 
@@ -147,7 +146,6 @@ abstract class AbstractFir2IrResultsConverter(
 
     private fun loadModuleDescriptors(
         libraries: List<KotlinLibrary>,
-        languageVersionSettings: LanguageVersionSettings,
         testServices: TestServices
     ): Pair<List<ModuleDescriptor>, KotlinBuiltIns?> {
         val stdlib: KotlinLibrary? = libraries.firstOrNull { it.isAnyPlatformStdlib }
@@ -160,13 +158,12 @@ abstract class AbstractFir2IrResultsConverter(
                 // TODO: check safety of the approach of creating a separate storage manager per library
                 val storageManager = LockBasedStorageManager("ModulesStructure")
 
-                val moduleDescriptor = klibFactories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
-                    library,
-                    languageVersionSettings,
-                    storageManager,
-                    builtIns,
-                    lookupTracker = LookupTracker.DO_NOTHING
-                )
+                val moduleName = special("<${library.uniqueName}>")
+                val moduleOrigin = DeserializedKlibModuleOrigin(library)
+                val moduleDescriptor = if (builtIns != null)
+                    klibFactories.DefaultDescriptorFactory.createDescriptor(moduleName, storageManager, builtIns!!, moduleOrigin)
+                else
+                    klibFactories.DefaultDescriptorFactory.createDescriptorAndNewBuiltIns(moduleName, storageManager, moduleOrigin)
                 dependencies += moduleDescriptor
                 moduleDescriptor.setDependencies(dependencies.toList())
 

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataModuleDescriptorFactory.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataModuleDescriptorFactory.kt
@@ -67,15 +67,6 @@ interface KlibMetadataModuleDescriptorFactory {
         lookupTracker: LookupTracker
     ): ModuleDescriptorImpl
 
-    fun createPackageFragmentProvider(
-        library: KotlinLibrary,
-        storageManager: StorageManager,
-        moduleDescriptor: ModuleDescriptor,
-        configuration: DeserializationConfiguration,
-        compositePackageFragmentAddend: PackageFragmentProvider?,
-        lookupTracker: LookupTracker
-    ): PackageFragmentProvider
-
     fun createCachedPackageFragmentProvider(
         byteArrays: List<ByteArray>,
         storageManager: StorageManager,

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataModuleDescriptorFactory.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibMetadataModuleDescriptorFactory.kt
@@ -66,12 +66,4 @@ interface KlibMetadataModuleDescriptorFactory {
         builtIns: KotlinBuiltIns?,
         lookupTracker: LookupTracker
     ): ModuleDescriptorImpl
-
-    fun createCachedPackageFragmentProvider(
-        byteArrays: List<ByteArray>,
-        storageManager: StorageManager,
-        moduleDescriptor: ModuleDescriptor,
-        configuration: DeserializationConfiguration,
-        lookupTracker: LookupTracker
-    ): PackageFragmentProvider
 }

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
@@ -74,24 +74,6 @@ class KlibMetadataModuleDescriptorFactoryImpl(
         return moduleDescriptor
     }
 
-    override fun createCachedPackageFragmentProvider(
-        byteArrays: List<ByteArray>,
-        storageManager: StorageManager,
-        moduleDescriptor: ModuleDescriptor,
-        configuration: DeserializationConfiguration,
-        lookupTracker: LookupTracker
-    ): PackageFragmentProvider {
-        val deserializedPackageFragments = byteArrays.map { byteArray ->
-            KlibMetadataCachedPackageFragment(byteArray, storageManager, moduleDescriptor)
-        }
-
-        val provider = PackageFragmentProviderImpl(deserializedPackageFragments)
-
-        @OptIn(K1Deprecation::class)
-        return initializePackageFragmentProvider(provider, deserializedPackageFragments, storageManager,
-            moduleDescriptor, configuration, null, lookupTracker)
-    }
-
     private fun createPackageFragmentProvider(
         library: KotlinLibrary,
         storageManager: StorageManager,

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibMetadataModuleDescriptorFactoryImpl.kt
@@ -92,7 +92,7 @@ class KlibMetadataModuleDescriptorFactoryImpl(
             moduleDescriptor, configuration, null, lookupTracker)
     }
 
-    override fun createPackageFragmentProvider(
+    private fun createPackageFragmentProvider(
         library: KotlinLibrary,
         storageManager: StorageManager,
         moduleDescriptor: ModuleDescriptor,

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/NativeCliBasedFacades.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/NativeCliBasedFacades.kt
@@ -18,8 +18,11 @@ import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isNativeStdlib
 import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
 import org.jetbrains.kotlin.library.metadata.KlibMetadataFactories
 import org.jetbrains.kotlin.library.metadata.NullFlexibleTypeDeserializer
+import org.jetbrains.kotlin.library.uniqueName
+import org.jetbrains.kotlin.name.Name.special
 import org.jetbrains.kotlin.native.pipeline.*
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import org.jetbrains.kotlin.test.backend.ir.IrBackendFacade
@@ -104,14 +107,14 @@ class KlibSerializerNativeCliFacade(
 
         val library = libraryLoadingResult.librariesStdlibFirst.single()
 
-        val moduleDescriptor = klibFactories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
-            library,
-            languageVersionSettings,
-            // TODO: check safety of the approach of creating a separate storage manager per library
-            LockBasedStorageManager("ModulesStructure"),
-            builtIns,
-            lookupTracker = LookupTracker.DO_NOTHING
-        )
+        val storageManager = LockBasedStorageManager("ModulesStructure")
+        val moduleName = special("<${library.uniqueName}>")
+        val moduleOrigin = DeserializedKlibModuleOrigin(library)
+        val moduleDescriptor = if (builtIns != null)
+            klibFactories.DefaultDescriptorFactory.createDescriptor(moduleName, storageManager, builtIns, moduleOrigin)
+        else
+            klibFactories.DefaultDescriptorFactory.createDescriptorAndNewBuiltIns(moduleName, storageManager, moduleOrigin)
+
         moduleDescriptor.setDependencies(dependencyModuleDescriptors + moduleDescriptor)
 
         testServices.libraryProvider.setDescriptorAndLibraryByName(outputKlibPath, moduleDescriptor, library)


### PR DESCRIPTION
In this PR we
1. Simplify the creation of ModuleDescriptor in Web backends. We don't need to deserialize metadata there anymore.
~2. Remove `DefaultResolvedDescriptorsFactory` by moving it to the only usage in `TopDownAnalyzerFacadeForKonan` (that will be removed later with K1).~

Never mind. kotlinx.benchmark project still uses `DefaultResolvedDescriptorsFactory`. Question: what should we do with it? I see 2 options
1. Hard deprecate and wait for the lib team to handle it.
2. Copy it into kotlinx.benchmark. I would say this is the easiest option, but I am afraid there could be some other client of util-klib-metadata who will be surprised.

Next step: drop `DefaultDeserializedDescriptorFactory`. It has 3 groups of usages (+1 more in kotlinx.benchmark)
1. In JKlib. Will just copy `DefaultDeserializedDescriptorFactory` over there.
2. `KotlinKlibSerializerTest`. Probably can be just dropped, but I need confirmation from someone.
3. In Native. I would like to do the same trick with copying as in JKlib, but the usages are in different places that are not connected with the common module (`TopDownAnalyzerFacadeForKonan` and `Fe10Utils`). I can copy it several times, but I would like not to. If you have any ideas, I would be glad to listen.

KT-87387