### PR TITLE
[BTA] Fix incremental compilation loses compiler diagnotics ids

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerCustomRendererTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testKotlinLogger/kotlin/KotlinLoggerCustomRendererTest.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfigurat
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.jvmProject
+import org.jetbrains.kotlin.buildtools.tests.compilation.scenario.jvmScenario
+import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -59,6 +61,37 @@ class KotlinLoggerCustomRendererTest : BaseCompilationTest() {
             module.compile(compilationConfigAction = {
                 it[BaseCompilationOperation.COMPILER_MESSAGE_RENDERER] = renderer
             }) {
+                expectFail()
+                val errorLines = logLines[LogLevel.ERROR].orEmpty()
+                assertTrue(errorLines.any { "[CUSTOM ERROR][UNRESOLVED_REFERENCE]" in it }) {
+                    "Expected custom-rendered unresolved reference error at ERROR level, got: $errorLines"
+                }
+                assertEquals(listOf("UNRESOLVED_REFERENCE"), diagnosticIds.filterNotNull().distinct())
+            }
+        }
+    }
+
+    @BtaV2StrategyAgnosticCompilationTest
+    @DisplayName("Custom renderer receives compiler diagnostic identifier during incremental compilation")
+    @TestMetadata("basic-multimodule-project/module-1")
+    fun customRendererReceivesDiagnosticIdentifierDuringIncrementalCompilation(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val diagnosticIds = mutableListOf<String?>()
+        val renderer = object : CompilerMessageRendererWithDiagnosticId {
+            override fun render(severity: Severity, message: String, location: SourceLocation?, diagnosticId: String?): String {
+                diagnosticIds += diagnosticId
+                return "[CUSTOM $severity][$diagnosticId] $message"
+            }
+        }
+
+        jvmScenario(strategyConfig) {
+            val module = module("basic-multimodule-project/module-1", compilationConfigAction = {
+                it[BaseCompilationOperation.COMPILER_MESSAGE_RENDERER] = renderer
+            })
+            diagnosticIds.clear()
+
+            module.changeFile("bar.kt") { it.replace("foo()", "doesNotExist()") }
+
+            module.compile {
                 expectFail()
                 val errorLines = logLines[LogLevel.ERROR].orEmpty()
                 assertTrue(errorLines.any { "[CUSTOM ERROR][UNRESOLVED_REFERENCE]" in it }) {

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.build.report.warn
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.common.messages.MessageCollectorImpl
 import org.jetbrains.kotlin.compilerRunner.OutputItemsCollectorImpl
 import org.jetbrains.kotlin.compilerRunner.toGeneratedFile
 import org.jetbrains.kotlin.config.LanguageVersion
@@ -35,6 +34,7 @@ import org.jetbrains.kotlin.incremental.snapshots.librarySetRemovedSentinel
 import org.jetbrains.kotlin.incremental.storage.BasicFileToPathConverter
 import org.jetbrains.kotlin.incremental.storage.FileLocations
 import org.jetbrains.kotlin.incremental.storage.FileToPathConverter
+import org.jetbrains.kotlin.incremental.util.BufferingMessageCollector
 import org.jetbrains.kotlin.incremental.util.ExceptionLocation
 import org.jetbrains.kotlin.incremental.util.reportException
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
@@ -604,7 +604,7 @@ abstract class IncrementalCompilerRunner<
             ).build()
 
             args.reportOutputFiles = true
-            val bufferingMessageCollector = MessageCollectorImpl()
+            val bufferingMessageCollector = BufferingMessageCollector()
 
             val compiledSources = reporter.measure(COMPILATION_ROUND) {
                 runCompiler(

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/util/BufferingMessageCollector.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/util/BufferingMessageCollector.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.incremental.util
+
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.messages.MessageCollectorWithDiagnosticId
+
+internal class BufferingMessageCollector : MessageCollectorWithDiagnosticId {
+    val messages: List<Message>
+        field = mutableListOf<Message>()
+
+    fun forward(other: MessageCollector) {
+        for ((severity, message, location, diagnosticId) in messages) {
+            if (other is MessageCollectorWithDiagnosticId) {
+                other.report(severity, message, location, diagnosticId)
+            } else {
+                other.report(severity, message, location)
+            }
+        }
+    }
+
+    override fun clear() {
+        messages.clear()
+    }
+
+    override fun report(
+        severity: CompilerMessageSeverity,
+        message: String,
+        location: CompilerMessageSourceLocation?,
+    ) {
+        messages.add(Message(severity, message, location, null))
+    }
+
+    override fun report(
+        severity: CompilerMessageSeverity,
+        message: String,
+        location: CompilerMessageSourceLocation?,
+        diagnosticId: String?,
+    ) {
+        messages.add(Message(severity, message, location, diagnosticId))
+    }
+
+    override fun hasErrors(): Boolean =
+        messages.any { it.severity.isError }
+
+    override fun toString(): String = messages.joinToString("\n")
+
+    data class Message(
+        val severity: CompilerMessageSeverity,
+        val message: String,
+        val location: CompilerMessageSourceLocation?,
+        val diagnosticId: String?,
+    ) {
+        override fun toString(): String = buildString {
+            if (location != null) {
+                append(location)
+                append(": ")
+            }
+            append(severity.presentableName)
+            if (diagnosticId != null) append(" $diagnosticId")
+            append(": ")
+            append(message)
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerDiagnosticsProblemsApiIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerDiagnosticsProblemsApiIT.kt
@@ -10,6 +10,7 @@ import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.testbase.*
 import org.junit.jupiter.api.DisplayName
 import org.jetbrains.kotlin.gradle.testbase.assertProblemsReportContainsDiagnostic
+import kotlin.io.path.writeText
 
 @DisplayName("Compiler Diagnostics Problems API tests")
 @GradleTestVersions(
@@ -31,10 +32,11 @@ class CompilerDiagnosticsProblemsApiIT : KGPBaseTest() {
             }
 
             kotlinSourcesDir().source("deprecatedUsage.kt") {
+                //language=kotlin
                 """
                 @Deprecated("Use newFunction instead")
                 fun oldFunction(): String = "old"
-
+                
                 fun callerOfOldFunction(): String = oldFunction()
                 """.trimIndent()
             }
@@ -43,7 +45,7 @@ class CompilerDiagnosticsProblemsApiIT : KGPBaseTest() {
                 assertOutputContains(Regex("""file:///.*deprecatedUsage\.kt"""))
                 assertOutputContainsAny("is deprecated", "Use newFunction instead")
                 assertProblemsReportContainsDiagnostic(
-                    "compiler-warning",
+                    "DEPRECATION",
                     "Use newFunction instead",
                     gradleVersion,
                 )
@@ -85,7 +87,7 @@ class CompilerDiagnosticsProblemsApiIT : KGPBaseTest() {
 
                 // The warning should be reported to the Problems API HTML report
                 assertProblemsReportContainsDiagnostic(
-                    "compiler-warning",
+                    "DEPRECATION",
                     "Use newFunction instead",
                     gradleVersion,
                 )
@@ -114,7 +116,7 @@ class CompilerDiagnosticsProblemsApiIT : KGPBaseTest() {
                 assertOutputContains(Regex("""file:///.*errorFile\.kt"""))
                 assertOutputContains(Regex("""[Uu]nresolved reference"""))
                 assertProblemsReportContainsDiagnostic(
-                    "compiler-error",
+                    "UNRESOLVED_REFERENCE",
                     "nresolved reference",
                     gradleVersion,
                 )


### PR DESCRIPTION
'IncrementalCompilerRunner' used previously 'MessageCollectorImpl' as
buffer compiler messages collector to relay them at some point to
consumers. The problem is that `MessageCollectorImpl` does not implement
 'MessageCollectorWithDiagnosticId' interface causing losing the info
 about diagnostic ids.

 ^KT-88348 Verification Pending
