### PR TITLE
Klib loading: Support checks for loaded libraries on 1st stage to be on par with the 2nd stage

### DIFF
--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
@@ -105,7 +105,9 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
             allLibrariesArgument = K2NativeCompilerArguments::libraries.cliArgument
         )
 
+        // TODO(KT-61096): Add a check when -Xinclude argument can be actually used!
         configuration.konanIncludedLibraries = arguments.includes.toList()
+        configuration.konanLibraries += configuration.konanIncludedLibraries
 
         configuration.konanNoStdlib = arguments.nostdlib
         configuration.konanNoDefaultLibs = arguments.nodefaultlibs

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
@@ -86,9 +86,9 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
         } ?: NativePlatforms.unspecifiedNativePlatform
 
         configuration.konanLibraries = arguments.libraries.toList()
+
         arguments.friendModules?.let {
             configuration.konanFriendLibraries = it.split(File.pathSeparator).filterNot(String::isEmpty)
-
             configuration.checkForUnexpectedKlibLibraries(
                 librariesToCheck = configuration.konanFriendLibraries,
                 librariesToCheckArgument = K2NativeCompilerArguments::friendModules.cliArgument,
@@ -96,6 +96,16 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
                 allLibrariesArgument = K2NativeCompilerArguments::libraries.cliArgument
             )
         }
+
+        configuration.exportedLibraries = arguments.exportedLibraries.toList()
+        configuration.checkForUnexpectedKlibLibraries(
+            librariesToCheck = configuration.exportedLibraries,
+            librariesToCheckArgument = K2NativeCompilerArguments::exportedLibraries.cliArgument,
+            allLibraries = configuration.konanLibraries,
+            allLibrariesArgument = K2NativeCompilerArguments::libraries.cliArgument
+        )
+
+        configuration.konanIncludedLibraries = arguments.includes.toList()
 
         configuration.konanNoStdlib = arguments.nostdlib
         configuration.konanNoDefaultLibs = arguments.nodefaultlibs
@@ -112,7 +122,6 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
         arguments.manifestFile?.let { configuration.konanManifestAddend = it }
         arguments.headerKlibPath?.let { configuration.konanGeneratedHeaderKlibPath = it }
         arguments.shortModuleName?.let { configuration.konanShortModuleName = it }
-        configuration.konanIncludedLibraries = arguments.includes.toList()
 
         configuration.konanPrintIr = arguments.printIr
         configuration.konanPrintFiles = arguments.printFiles

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
 import org.jetbrains.kotlin.platform.konan.NativePlatforms
+import org.jetbrains.kotlin.utils.addIfNotNull
 import java.io.File
 
 /**
@@ -70,7 +71,7 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
         configuration: CompilerConfiguration,
         arguments: K2NativeCompilerArguments,
     ) {
-        val commonSources = arguments.commonSources.toSet().map { java.io.File(it).absoluteFile.normalize() }
+        val commonSources = arguments.commonSources.toSet().map { File(it).absoluteFile.normalize() }
         val hmppModuleStructure = configuration.get(CommonConfigurationKeys.HMPP_MODULE_STRUCTURE)
         arguments.freeArgs.forEach { path ->
             val normalizedPath = java.io.File(path).absoluteFile.normalize()
@@ -107,7 +108,15 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
 
         // TODO(KT-61096): Add a check when -Xinclude argument can be actually used!
         configuration.konanIncludedLibraries = arguments.includes.toList()
-        configuration.konanLibraries += configuration.konanIncludedLibraries
+
+        // TODO(KT-61096): Add a check when -Xadd-cache argument can be actually used!
+        arguments.libraryToAddToCache?.let { configuration.konanLibraryToAddToCache = it }
+
+        configuration.konanLibraries = buildList {
+            this += configuration.konanLibraries
+            this += configuration.konanIncludedLibraries
+            addIfNotNull(configuration.konanLibraryToAddToCache)
+        }
 
         configuration.konanNoStdlib = arguments.nostdlib
         configuration.konanNoDefaultLibs = arguments.nodefaultlibs

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/KlibLoaderExtensions.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/KlibLoaderExtensions.kt
@@ -93,15 +93,15 @@ fun KlibLoaderResult.reportLoadingProblemsIfAny(
 }
 
 /**
- * A helper to load the list of "friend" libraries.
+ * A helper to load the list of libraries that are already present in [KlibLoaderResult] given their paths.
  *
- * Note: It is assumed that paths of all "friend" libraries have already been passed to [KlibLoader],
- * so the loaded libraries should be in [KlibLoaderResult]. All we need is to "look up" them from the result.
+ * Note: It is assumed that the paths of the libraries ([libraryPaths])  have already been passed to [KlibLoader],
+ * so the selected libraries should be in [KlibLoaderResult]. All we need is to "look up" them from the result.
  */
-fun KlibLoaderResult.loadFriendLibraries(friendLibraryPaths: List<String>): List<KotlinLibrary> {
-    if (friendLibraryPaths.isEmpty() || librariesStdlibFirst.isEmpty()) return emptyList()
+fun KlibLoaderResult.selectLibrariesByPaths(libraryPaths: List<String>): List<KotlinLibrary> {
+    if (libraryPaths.isEmpty() || librariesStdlibFirst.isEmpty()) return emptyList()
 
-    val canonicalFriendLibraryPaths: Set<String> = friendLibraryPaths.mapNotNullTo(linkedSetOf()) { rawPath ->
+    val canonicalFriendLibraryPaths: Set<String> = libraryPaths.mapNotNullTo(linkedSetOf()) { rawPath ->
         if (rawPath.isEmpty()) return@mapNotNullTo null
 
         val validPath: Path = try {

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/KlibLoaderExtensions.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/KlibLoaderExtensions.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.common
 
 import org.jetbrains.kotlin.backend.common.diagnostics.SerializationErrors
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.testEnvironment
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.DuplicatedUniqueNameStrategy
@@ -78,7 +79,7 @@ fun KlibLoaderResult.eliminateLibrariesWithDuplicatedUniqueNames(configuration: 
  */
 fun KlibLoaderResult.reportLoadingProblemsIfAny(
     configuration: CompilerConfiguration,
-    allAsErrors: Boolean = false,
+    allAsErrors: Boolean = configuration.testEnvironment,
 ) {
     reportLoadingProblemsIfAny { defaultSeverity, message ->
         val factory = if (allAsErrors) SerializationErrors.KLIB_LOADING_ERROR else when (defaultSeverity) {

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/LoadedKlibs.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/LoadedKlibs.kt
@@ -49,10 +49,14 @@ class LoadedKlibs(
  *
  * @property included Only the included KLIBs ([K2NativeCompilerArguments.includes] CLI option), if there were any.
  *  Note: [included] is also in [all].
+ *
+ * @property toAddToCache A library to add to Kotlin/Native static caches ([K2NativeCompilerArguments.libraryToAddToCache] CLI option), if there was any.
+ *  Note: [toAddToCache] is also in [all].
  */
 class LoadedNativeKlibs(
     val all: List<KotlinLibrary>,
     val friends: List<KotlinLibrary> = emptyList(),
     val exported: List<KotlinLibrary> = emptyList(),
     val included: List<KotlinLibrary> = emptyList(),
+    val toAddToCache: KotlinLibrary? = null,
 )

--- a/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/LoadedKlibs.kt
+++ b/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/LoadedKlibs.kt
@@ -44,11 +44,15 @@ class LoadedKlibs(
  * @property friends Only KLIBs having status of "friends" ([K2NativeCompilerArguments.friendModules] CLI option).
  *  Note: All [friends] are also included into [all].
  *
- * @property included Only the included KLIB ([K2NativeCompilerArguments.includes] CLI option), if there were any.
+ * @property exported Only the "exported" KLIBs ([K2NativeCompilerArguments.exportedLibraries] CLI option), if there were any.
+ *  Note: [exported] is also in [all].
+ *
+ * @property included Only the included KLIBs ([K2NativeCompilerArguments.includes] CLI option), if there were any.
  *  Note: [included] is also in [all].
  */
 class LoadedNativeKlibs(
     val all: List<KotlinLibrary>,
     val friends: List<KotlinLibrary> = emptyList(),
+    val exported: List<KotlinLibrary> = emptyList(),
     val included: List<KotlinLibrary> = emptyList(),
 )

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
@@ -7,9 +7,8 @@ package org.jetbrains.kotlin.ir.backend.js
 
 import org.jetbrains.kotlin.backend.common.LoadedKlibs
 import org.jetbrains.kotlin.backend.common.eliminateLibrariesWithDuplicatedUniqueNames
-import org.jetbrains.kotlin.backend.common.loadFriendLibraries
+import org.jetbrains.kotlin.backend.common.selectLibrariesByPaths
 import org.jetbrains.kotlin.backend.common.reportLoadingProblemsIfAny
-import org.jetbrains.kotlin.cli.common.testEnvironment
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.ir.backend.js.checkers.JsLibrarySpecialCompatibilityChecker
 import org.jetbrains.kotlin.ir.backend.js.checkers.WasmLibrarySpecialCompatibilityChecker
@@ -43,8 +42,8 @@ fun loadWebKlibs(
 
     return LoadedKlibs(
         all = result.librariesStdlibFirst,
-        friends = result.loadFriendLibraries(configuration.friendLibraries),
-        included = result.loadFriendLibraries(listOfNotNull(configuration.includes)).firstOrNull()
+        friends = result.selectLibrariesByPaths(libraryPaths = configuration.friendLibraries),
+        included = result.selectLibrariesByPaths(libraryPaths = listOfNotNull(configuration.includes)).firstOrNull()
     ).also { klibs ->
         if (!configuration.skipLibrarySpecialCompatibilityChecks) {
             val isWasm = platformChecker is KlibPlatformChecker.Wasm

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/loadWebKlibs.kt
@@ -37,7 +37,7 @@ fun loadWebKlibs(
         maxPermittedAbiVersion(KotlinAbiVersion.CURRENT)
         configuration.zipFileSystemAccessor?.let { zipFileSystemAccessor(it) }
     }.load()
-        .apply { reportLoadingProblemsIfAny(configuration, allAsErrors = configuration.testEnvironment) }
+        .apply { reportLoadingProblemsIfAny(configuration) }
         // TODO (KT-76785): Handling of duplicated names is a workaround that needs to be removed in the future.
         .eliminateLibrariesWithDuplicatedUniqueNames(configuration)
 

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
 import org.jetbrains.kotlin.backend.common.eliminateLibrariesWithDuplicatedUniqueNames
 import org.jetbrains.kotlin.backend.common.loadFriendLibraries
 import org.jetbrains.kotlin.backend.common.reportLoadingProblemsIfAny
-import org.jetbrains.kotlin.cli.common.testEnvironment
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.konan.config.*
 import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
@@ -63,7 +62,7 @@ fun loadNativeKlibs(
         manifestTransformer(KlibNativeManifestTransformer(nativeTarget))
     }.load()
         .checkForUnknownIrProviders()
-        .apply { reportLoadingProblemsIfAny(configuration, allAsErrors = configuration.testEnvironment) }
+        .apply { reportLoadingProblemsIfAny(configuration) }
         // TODO (KT-76785): Handling of duplicated names is a workaround that needs to be removed in the future.
         .eliminateLibrariesWithDuplicatedUniqueNames(configuration)
 

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -34,6 +34,7 @@ import org.jetbrains.kotlin.utils.KotlinNativePaths
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import java.io.File
 import kotlin.io.path.pathString
+import kotlin.reflect.KProperty1
 
 /**
  * This is the entry point to load Kotlin/Native KLIBs.
@@ -82,8 +83,10 @@ fun loadNativeKlibs(
     return LoadedNativeKlibs(
         all = result.librariesStdlibFirst,
         friends = result.loadFriendLibraries(configuration.konanFriendLibraries),
+        exported = result.loadFriendLibraries(configuration.exportedLibraries)
+            .selectLibrariesEligibleToBeIncludedOrExported(configuration, K2NativeCompilerArguments::exportedLibraries),
         included = result.loadFriendLibraries(configuration.konanIncludedLibraries)
-            .selectLibrariesEligibleToBeIncluded(configuration)
+            .selectLibrariesEligibleToBeIncludedOrExported(configuration, K2NativeCompilerArguments::includes)
     )
 }
 
@@ -120,11 +123,14 @@ private class UnknownIrProvider(val irProviderName: String) : OtherCheckMismatch
 }
 
 /**
- * Select only those libraries that are eligible to be "included":
+ * Select only those libraries that are eligible to be "included" or "exported":
  * - each library should not be a C-interop library
  * - also there should not be libraries from the Kotlin/Native distribution
  */
-private fun List<KotlinLibrary>.selectLibrariesEligibleToBeIncluded(configuration: CompilerConfiguration): List<KotlinLibrary> {
+private fun List<KotlinLibrary>.selectLibrariesEligibleToBeIncludedOrExported(
+    configuration: CompilerConfiguration,
+    cliParameter: KProperty1<out K2NativeCompilerArguments, *>,
+): List<KotlinLibrary> {
     if (isEmpty()) return this
 
     fun reportIssue(library: KotlinLibrary, libraryKind: String) = configuration.report(
@@ -132,7 +138,7 @@ private fun List<KotlinLibrary>.selectLibrariesEligibleToBeIncluded(configuratio
             SerializationErrors.KLIB_LOADING_ERROR
         else
             SerializationErrors.KLIB_LOADING_WARNING,
-        message = "KLIB loader: $libraryKind cannot be used in ${K2NativeCompilerArguments::includes.cliArgument} CLI argument: ${library.path}"
+        message = "KLIB loader: $libraryKind cannot be used in ${cliParameter.cliArgument} CLI argument: ${library.path}"
     )
 
     return mapNotNull { library ->

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.serialization
 import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
 import org.jetbrains.kotlin.backend.common.diagnostics.SerializationErrors
 import org.jetbrains.kotlin.backend.common.eliminateLibrariesWithDuplicatedUniqueNames
-import org.jetbrains.kotlin.backend.common.loadFriendLibraries
+import org.jetbrains.kotlin.backend.common.selectLibrariesByPaths
 import org.jetbrains.kotlin.backend.common.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.cli.common.arguments.K2NativeCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.cliArgument
@@ -82,12 +82,12 @@ fun loadNativeKlibs(
 
     return LoadedNativeKlibs(
         all = result.librariesStdlibFirst,
-        friends = result.loadFriendLibraries(configuration.konanFriendLibraries),
-        exported = result.loadFriendLibraries(configuration.exportedLibraries)
+        friends = result.selectLibrariesByPaths(libraryPaths = configuration.konanFriendLibraries),
+        exported = result.selectLibrariesByPaths(libraryPaths = configuration.exportedLibraries)
             .selectLibrariesEligibleToBeIncludedOrExported(configuration, K2NativeCompilerArguments::exportedLibraries),
-        included = result.loadFriendLibraries(configuration.konanIncludedLibraries)
+        included = result.selectLibrariesByPaths(libraryPaths = configuration.konanIncludedLibraries)
             .selectLibrariesEligibleToBeIncludedOrExported(configuration, K2NativeCompilerArguments::includes),
-        toAddToCache = result.loadFriendLibraries(listOfNotNull(configuration.konanLibraryToAddToCache)).firstOrNull(),
+        toAddToCache = result.selectLibrariesByPaths(libraryPaths = listOfNotNull(configuration.konanLibraryToAddToCache)).firstOrNull(),
     )
 }
 

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -86,7 +86,8 @@ fun loadNativeKlibs(
         exported = result.loadFriendLibraries(configuration.exportedLibraries)
             .selectLibrariesEligibleToBeIncludedOrExported(configuration, K2NativeCompilerArguments::exportedLibraries),
         included = result.loadFriendLibraries(configuration.konanIncludedLibraries)
-            .selectLibrariesEligibleToBeIncludedOrExported(configuration, K2NativeCompilerArguments::includes)
+            .selectLibrariesEligibleToBeIncludedOrExported(configuration, K2NativeCompilerArguments::includes),
+        toAddToCache = result.loadFriendLibraries(listOfNotNull(configuration.konanLibraryToAddToCache)).firstOrNull(),
     )
 }
 

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/loadNativeKlibs.kt
@@ -6,14 +6,20 @@
 package org.jetbrains.kotlin.backend.konan.serialization
 
 import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
+import org.jetbrains.kotlin.backend.common.diagnostics.SerializationErrors
 import org.jetbrains.kotlin.backend.common.eliminateLibrariesWithDuplicatedUniqueNames
 import org.jetbrains.kotlin.backend.common.loadFriendLibraries
 import org.jetbrains.kotlin.backend.common.reportLoadingProblemsIfAny
+import org.jetbrains.kotlin.cli.common.arguments.K2NativeCompilerArguments
+import org.jetbrains.kotlin.cli.common.arguments.cliArgument
+import org.jetbrains.kotlin.cli.common.testEnvironment
+import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.konan.config.*
 import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
 import org.jetbrains.kotlin.konan.library.KlibNativeDistributionLibraryProvider
 import org.jetbrains.kotlin.konan.library.KlibNativeManifestTransformer
+import org.jetbrains.kotlin.konan.library.isFromKotlinNativeDistribution
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.library.KotlinAbiVersion
 import org.jetbrains.kotlin.library.KotlinLibrary
@@ -23,6 +29,7 @@ import org.jetbrains.kotlin.library.loader.KlibLoaderResult
 import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase.OtherCheckMismatch
 import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblematicLibrary
 import org.jetbrains.kotlin.library.loader.KlibPlatformChecker
+import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
 import org.jetbrains.kotlin.utils.KotlinNativePaths
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import java.io.File
@@ -75,7 +82,8 @@ fun loadNativeKlibs(
     return LoadedNativeKlibs(
         all = result.librariesStdlibFirst,
         friends = result.loadFriendLibraries(configuration.konanFriendLibraries),
-        included = result.loadFriendLibraries(configuration.konanIncludedLibraries),
+        included = result.loadFriendLibraries(configuration.konanIncludedLibraries)
+            .selectLibrariesEligibleToBeIncluded(configuration)
     )
 }
 
@@ -109,4 +117,33 @@ private fun KlibLoaderResult.checkForUnknownIrProviders(): KlibLoaderResult {
 private class UnknownIrProvider(val irProviderName: String) : OtherCheckMismatch() {
     override val caption get() = "Library with unsupported IR provider $irProviderName"
     override val details get() = "Only libraries without IR provider or with $KLIB_INTEROP_IR_PROVIDER_IDENTIFIER IR provider are supported."
+}
+
+/**
+ * Select only those libraries that are eligible to be "included":
+ * - each library should not be a C-interop library
+ * - also there should not be libraries from the Kotlin/Native distribution
+ */
+private fun List<KotlinLibrary>.selectLibrariesEligibleToBeIncluded(configuration: CompilerConfiguration): List<KotlinLibrary> {
+    if (isEmpty()) return this
+
+    fun reportIssue(library: KotlinLibrary, libraryKind: String) = configuration.report(
+        factory = if (configuration.testEnvironment)
+            SerializationErrors.KLIB_LOADING_ERROR
+        else
+            SerializationErrors.KLIB_LOADING_WARNING,
+        message = "KLIB loader: $libraryKind cannot be used in ${K2NativeCompilerArguments::includes.cliArgument} CLI argument: ${library.path}"
+    )
+
+    return mapNotNull { library ->
+        if (library.isFromKotlinNativeDistribution) {
+            reportIssue(library, libraryKind = "Library from the Kotlin/Native distribution")
+            return@mapNotNull null
+        } else if (library.isCInteropLibrary()) {
+            reportIssue(library, libraryKind = "C-interop library")
+            return@mapNotNull null
+        }
+
+        library
+    }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
@@ -42,7 +42,6 @@ internal fun getExportedLibraries(
         resolvedLibraries,
         resolver,
         FeaturedLibrariesReporter.forExportedLibraries(configuration),
-        allowDefaultLibs = false
 )
 
 internal fun getIncludedLibraries(
@@ -53,7 +52,6 @@ internal fun getIncludedLibraries(
         includedLibraryFiles.toSet(),
         resolvedLibraries,
         FeaturedLibrariesReporter.forIncludedLibraries(configuration),
-        allowDefaultLibs = false
 )
 
 private sealed class FeaturedLibrariesReporter {
@@ -125,19 +123,16 @@ private fun getFeaturedLibraries(
         resolvedLibraries: KotlinLibraryResolveResult,
         resolver: SearchPathResolver<KotlinLibrary>,
         reporter: FeaturedLibrariesReporter,
-        allowDefaultLibs: Boolean
 ) = getFeaturedLibraries(
         featuredLibraries.toUnresolvedLibraries.map { resolver.resolve(it).path }.toSet(),
         resolvedLibraries,
         reporter,
-        allowDefaultLibs
 )
 
 private fun getFeaturedLibraries(
         featuredLibraryPaths: Set<Path>,
         resolvedLibraries: KotlinLibraryResolveResult,
         reporter: FeaturedLibrariesReporter,
-        allowDefaultLibs: Boolean
 ) : List<KotlinLibrary> {
     val remainingFeaturedLibraries = featuredLibraryPaths.toMutableSet()
     val result = mutableListOf<KotlinLibrary>()
@@ -148,7 +143,7 @@ private fun getFeaturedLibraries(
         val libraryPath = library.path
         if (libraryPath in featuredLibraryPaths) {
             remainingFeaturedLibraries.remove(libraryPath)
-            if (library.isCInteropLibrary() || (!allowDefaultLibs && library.isFromKotlinNativeDistribution)) {
+            if (library.isCInteropLibrary() || library.isFromKotlinNativeDistribution) {
                 reporter.reportIllegalKind(library)
             } else {
                 result += library

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
@@ -37,12 +37,11 @@ internal fun getExportedLibraries(
     configuration: CompilerConfiguration,
     resolvedLibraries: KotlinLibraryResolveResult,
     resolver: SearchPathResolver<KotlinLibrary>,
-    report: Boolean
 ): List<KotlinLibrary> = getFeaturedLibraries(
         configuration.exportedLibraries,
         resolvedLibraries,
         resolver,
-        if (report) FeaturedLibrariesReporter.forExportedLibraries(configuration) else FeaturedLibrariesReporter.Silent,
+        FeaturedLibrariesReporter.forExportedLibraries(configuration),
         allowDefaultLibs = false
 )
 
@@ -68,11 +67,6 @@ private sealed class FeaturedLibrariesReporter {
             isFromKotlinNativeDistribution -> "Default"
             else -> "Unknown kind"
         }
-
-    object Silent: FeaturedLibrariesReporter() {
-        override fun reportIllegalKind(library: KotlinLibrary) {}
-        override fun reportNotIncludedLibraries(includedLibraries: List<KotlinLibrary>, remainingFeaturedLibraries: Set<Path>) {}
-    }
 
     abstract class BaseReporter(val configuration: CompilerConfiguration) : FeaturedLibrariesReporter() {
         protected abstract fun illegalKindMessage(kind: String, libraryName: String): String

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
@@ -118,19 +118,9 @@ private sealed class FeaturedLibrariesReporter {
             "Following libraries are specified to be exported with -Xexport-library, but not included to the build:"
     }
 
-    private class CoveredLibraryReporter(configuration: CompilerConfiguration): BaseReporter(configuration) {
-        override fun illegalKindMessage(kind: String, libraryName: String): String =
-            "Cannot provide the code coverage for the $kind library $libraryName."
-
-        override fun notIncludedLibraryMessageTitle(): String =
-            "The code coverage is enabled for the following libraries, but they are not included to the build:"
-    }
-
     companion object {
         fun forExportedLibraries(configuration: CompilerConfiguration): FeaturedLibrariesReporter =
                 ExportedLibrariesReporter(configuration)
-        fun forCoveredLibraries(configuration: CompilerConfiguration): FeaturedLibrariesReporter =
-                CoveredLibraryReporter(configuration)
         fun forIncludedLibraries(configuration: CompilerConfiguration): FeaturedLibrariesReporter =
                 IncludedLibrariesReporter(configuration)
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -394,7 +394,7 @@ class NativeSecondStageCompilationConfig(
         )
 
     val exportedLibraries: List<KotlinLibrary>
-        get() = getExportedLibraries(configuration, resolve.resolvedLibraries, resolve.resolver.searchPathResolver, report = true)
+        get() = getExportedLibraries(configuration, resolve.resolvedLibraries, resolve.resolver.searchPathResolver)
 
     /**
      * Returns the list of libraries in reverse topological order.

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -299,7 +299,7 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
     }
 
     @Test
-    fun `Compiler rejects libraries from the distribution and C-interop libraries as included libs`() {
+    fun `Compiler rejects libraries from the distribution and C-interop libraries as included and exported libs`() {
         val librariesDir = testRunSettings.get<KotlinNativeHome>().librariesDir
         val target = testRunSettings.get<KotlinNativeTargets>().testTarget
 
@@ -322,25 +322,36 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         checkNotNull(regularLibPath)
         checkNotNull(cinteropLibPath)
 
-        // try it with different combinations of "-no..." flags:
         listOf(
-            emptyList(),
-            listOf("-nostdlib"),
-            listOf("-no-default-libs"),
-            listOf("-nostdlib", "-no-default-libs"),
-        ).forEach { extraNoSmthFlags ->
-            newSourceModules {
-                addRegularModule("test")
-            }.compileToKlibsViaCli(
-                extraCliArgs = extraNoSmthFlags + listOf(
-                    "-l", stdlibPath,
-                    "-l", posixPath,
-                    "-l", regularLibPath,
-                    "-l", cinteropLibPath,
-                    "-Xinclude=$stdlibPath,$posixPath,$regularLibPath,$cinteropLibPath",
-                )
-            ) { _, successKlib ->
-                successKlib.assertProblematicIncludedLibs(stdlibPath, posixPath, cinteropLibPath)
+            K2NativeCompilerArguments::includes.cliArgument,
+            K2NativeCompilerArguments::exportedLibraries.cliArgument,
+        ).forEach { testedCliParameter ->
+            // try it with different combinations of "-no..." flags:
+            listOf(
+                emptyList(),
+                listOf("-nostdlib"),
+                listOf("-no-default-libs"),
+                listOf("-nostdlib", "-no-default-libs"),
+            ).forEach { extraNoSmthFlags ->
+                newSourceModules {
+                    addRegularModule("test")
+                }.compileToKlibsViaCli(
+                    extraCliArgs = extraNoSmthFlags + listOf(
+                        "-l", stdlibPath,
+                        "-l", posixPath,
+                        "-l", regularLibPath,
+                        "-l", cinteropLibPath,
+                        "$testedCliParameter=$stdlibPath",
+                        "$testedCliParameter=$posixPath",
+                        "$testedCliParameter=$regularLibPath",
+                        "$testedCliParameter=$cinteropLibPath",
+                    )
+                ) { _, successKlib ->
+                    successKlib.assertProblematicIncludedOrExportedLibs(
+                        cliParameter = testedCliParameter,
+                        stdlibPath, posixPath, cinteropLibPath
+                    )
+                }
             }
         }
     }
@@ -442,7 +453,10 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         assertTrue(": $friendPath" in toolOutput[0])
     }
 
-    private fun TestCompilationResult.Success<out KLIB>.assertProblematicIncludedLibs(vararg pathsOfExpectedProblematicIncludes: String) {
+    private fun TestCompilationResult.Success<out KLIB>.assertProblematicIncludedOrExportedLibs(
+        cliParameter: String,
+        vararg pathsOfExpectedProblematicIncludes: String,
+    ) {
         val compilationToolCall = loggedData as LoggedData.CompilationToolCall
         assertEquals(ExitCode.OK, compilationToolCall.exitCode)
 
@@ -453,7 +467,7 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         assertEquals(pathsOfExpectedProblematicIncludes.size, toolOutput.size)
 
         val pathsOfActualProblematicIncludes = toolOutput.map { message ->
-            message.substringAfterLast("cannot be used in -Xinclude CLI argument: ").trim()
+            message.substringAfterLast("cannot be used in $cliParameter CLI argument: ").trim()
         }
 
         assertEquals(pathsOfExpectedProblematicIncludes.toSet(), pathsOfActualProblematicIncludes.toSet())

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -298,6 +298,53 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         }
     }
 
+    @Test
+    fun `Compiler rejects libraries from the distribution and C-interop libraries as included libs`() {
+        val librariesDir = testRunSettings.get<KotlinNativeHome>().librariesDir
+        val target = testRunSettings.get<KotlinNativeTargets>().testTarget
+
+        val stdlibPath: String = librariesDir.resolve("common/stdlib").absolutePath
+        val posixPath: String = librariesDir.resolve("platform/${target.name}/org.jetbrains.kotlin.native.platform.posix").absolutePath
+
+        var regularLibPath: String? = null
+        var cinteropLibPath: String? = null
+
+        newSourceModules {
+            addRegularModule("r")
+            addCInteropModule("c")
+        }.compileToKlibsViaCli { module, successKlib ->
+            when (module.name) {
+                "r" -> regularLibPath = successKlib.resultingArtifact.klibFile.absolutePath
+                "c" -> cinteropLibPath = successKlib.resultingArtifact.klibFile.absolutePath
+            }
+        }
+
+        checkNotNull(regularLibPath)
+        checkNotNull(cinteropLibPath)
+
+        // try it with different combinations of "-no..." flags:
+        listOf(
+            emptyList(),
+            listOf("-nostdlib"),
+            listOf("-no-default-libs"),
+            listOf("-nostdlib", "-no-default-libs"),
+        ).forEach { extraNoSmthFlags ->
+            newSourceModules {
+                addRegularModule("test")
+            }.compileToKlibsViaCli(
+                extraCliArgs = extraNoSmthFlags + listOf(
+                    "-l", stdlibPath,
+                    "-l", posixPath,
+                    "-l", regularLibPath,
+                    "-l", cinteropLibPath,
+                    "-Xinclude=$stdlibPath,$posixPath,$regularLibPath,$cinteropLibPath",
+                )
+            ) { _, successKlib ->
+                successKlib.assertProblematicIncludedLibs(stdlibPath, posixPath, cinteropLibPath)
+            }
+        }
+    }
+
     private fun doTestIrProviders(irProviderName: String) {
         newSourceModules {
             addRegularModule("a")
@@ -393,6 +440,23 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
 
         assertEquals(1, toolOutput.size)
         assertTrue(": $friendPath" in toolOutput[0])
+    }
+
+    private fun TestCompilationResult.Success<out KLIB>.assertProblematicIncludedLibs(vararg pathsOfExpectedProblematicIncludes: String) {
+        val compilationToolCall = loggedData as LoggedData.CompilationToolCall
+        assertEquals(ExitCode.OK, compilationToolCall.exitCode)
+
+        val toolOutput = compilationToolCall.toolOutput.lineSequence()
+            .filter { "KLIB loader:" in it }
+            .toList()
+
+        assertEquals(pathsOfExpectedProblematicIncludes.size, toolOutput.size)
+
+        val pathsOfActualProblematicIncludes = toolOutput.map { message ->
+            message.substringAfterLast("cannot be used in -Xinclude CLI argument: ").trim()
+        }
+
+        assertEquals(pathsOfExpectedProblematicIncludes.toSet(), pathsOfActualProblematicIncludes.toSet())
     }
 
     companion object {


### PR DESCRIPTION
Later, we are going to start using these checks on both stages.