### PR TITLE
FIR: Do not report USELESS_JVM_EXPOSE_BOXED on getters and setters

### DIFF
--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirJvmExposeBoxedChecker.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirJvmExposeBoxedChecker.kt
@@ -155,8 +155,8 @@ object FirJvmExposeBoxedChecker : FirBasicDeclarationChecker(MppCheckerKind.Comm
 
     // If the inline class is not return type, it is safe to name both boxed and unboxed versions the same.
     private fun FirCallableDeclaration.canBeOverloadedByExposed(session: FirSession): Boolean {
-        if (receiverParameter?.typeRef?.isInline(session) == true) return true
-        if (contextParameters.any { it.returnTypeRef.isInline(session) }) return true
+        if (propertyIfAccessor.receiverParameter?.typeRef?.isInline(session) == true) return true
+        if (propertyIfAccessor.contextParameters.any { it.returnTypeRef.isInline(session) }) return true
         if (this is FirFunction && valueParameters.any { it.returnTypeRef.isInline(session) }) return true
         // Check dispatch receiver as well - we use `-impl` suffix for them
         if (this !is FirConstructor) {

--- a/compiler/testData/diagnostics/tests/inlineClasses/jvmExposeBoxed/simple.kt
+++ b/compiler/testData/diagnostics/tests/inlineClasses/jvmExposeBoxed/simple.kt
@@ -171,6 +171,34 @@ fun withLocal() {
 <!JVM_EXPOSE_BOXED_CAN_BE_REPLACED_WITH_JVM_NAME!>@JvmExposeBoxed("jvmName")<!>
 fun canBeReplacedWithJvmName() {}
 
+@JvmInline
+value class ICInt(val i: Int) {
+    fun toInt(): Int = i
+}
+
+@get:JvmExposeBoxed val ICInt.extPropValAnnotated: Int
+    get() = this.toInt()
+
+@set:JvmExposeBoxed var ICInt.extPropVarAnnotated: Int
+    get() = this.toInt()
+    set(value) {}
+
+val ICInt.extPropValAnnotatedGetItself: Int
+    @JvmExposeBoxed get() = this.toInt()
+
+var ICInt.extPropVarAnnotatedSetItself: Int
+    get() = this.toInt()
+    @JvmExposeBoxed set(value) {}
+
+context(ic: ICInt)
+val ctxPropValAnnotatedGetItself: Int
+    @JvmExposeBoxed get() = ic.toInt()
+
+context(ic: ICInt)
+var ctxPropVarAnnotatedSetItself: Int
+    get() = ic.toInt()
+    @JvmExposeBoxed set(value) {}
+
 /* GENERATED_FIR_TAGS: annotationUseSiteTargetFile, annotationUseSiteTargetPropertyGetter,
 annotationUseSiteTargetPropertySetter, classDeclaration, classReference, companionObject, funWithExtensionReceiver,
 functionDeclaration, getter, inline, interfaceDeclaration, localFunction, nullableType, objectDeclaration, override,


### PR DESCRIPTION
of properties, which have inline classes as context parameters or extention receivers.
 #KT-88325 Fixed