### PR TITLE
[K/N][tests] Retry LLDB-driven test runs once on failure 

### DIFF
--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/AbstractRunner.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/AbstractRunner.kt
@@ -21,7 +21,39 @@ abstract class AbstractRunner<R> : Runner<R> {
     protected abstract fun getLoggedParameters(): LoggedData.TestRunParameters
     protected abstract fun handleUnexpectedFailure(t: Throwable): Nothing
 
-    final override fun run(): R = try {
+    /**
+     * The number of times [runAttempt] may be repeated if it does not succeed.
+     *
+     * @see TestRunParameter.WithRetriesOnFailure
+     */
+    protected open val maxRetries: Int get() = 0
+
+    final override fun run(): R {
+        val failures = mutableListOf<Throwable>()
+
+        repeat(maxRetries + 1) { attempt ->
+            try {
+                return runAttempt()
+            } catch (t: TestInfrastructureException) {
+                // A broken test infrastructure invariant, not a flaky test run. Retrying it makes no sense.
+                throw t.withSuppressed(failures)
+            } catch (t: Throwable) {
+                failures += t
+
+                if (attempt < maxRetries) {
+                    // Note: printing the whole failure would flood the log, because its message includes all the logged data
+                    // (the compiler call, the entire output of the test executable, etc.).
+                    // The failures of all the attempts are reported in full if the last attempt fails too.
+                    println("Test run attempt ${attempt + 1} of ${maxRetries + 1} failed, retrying: ${t.shortDescription}")
+                }
+            }
+        }
+
+        // All the attempts have failed. Report the last failure, with the previous ones attached to it.
+        throw failures.last().withSuppressed(failures.dropLast(1))
+    }
+
+    private fun runAttempt(): R = try {
         val run = buildRun()
         val runResult = run.run()
         val resultHandler = buildResultHandler(runResult)
@@ -70,3 +102,11 @@ abstract class AbstractResultHandler<R>(protected val runResult: RunResult) {
             .buildAndThrow()
     }
 }
+
+private fun Throwable.withSuppressed(failures: List<Throwable>): Throwable = apply { failures.forEach(::addSuppressed) }
+
+/**
+ * A short summary of the failure, as opposed to its [Throwable.message], which may include all the logged data.
+ */
+private val Throwable.shortDescription: String
+    get() = "${this::class.java.name}: ${message?.lineSequence()?.firstOrNull()}"

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/BaseTestRunProvider.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/BaseTestRunProvider.kt
@@ -36,6 +36,9 @@ open class BaseTestRunProvider {
                 // Note: TestRunParameter.WithLLDB adds program arguments and would therefore conflict
                 // with other TestRunParameters that do the same (such as WithTCTestLogger).
                 add(TestRunParameter.WithLLDB(testCase.extras<NoTestRunnerExtras>().arguments))
+                // LLDB-driven test runs are flaky for reasons unrelated to the code under test
+                // (e.g. KT-84923, KT-87414), so give them a second chance.
+                add(TestRunParameter.WithRetriesOnFailure(maxRetries = 1))
             }
             TestKind.STANDALONE_NO_TR -> {
                 assertTrue(testName == null)

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/RunnerWithExecutor.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/RunnerWithExecutor.kt
@@ -33,6 +33,9 @@ open class RunnerWithExecutor(
         testRun.runParameters.forEach { it.applyTo(this) }
     }
 
+    override val maxRetries: Int
+        get() = testRun.runParameters.firstIsInstanceOrNull<TestRunParameter.WithRetriesOnFailure>()?.maxRetries ?: 0
+
     private fun inputStreamFromTestParameter(): InputStream? =
         testRun.runParameters.firstIsInstanceOrNull<TestRunParameter.WithInputData>()
             ?.let {

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRun.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRun.kt
@@ -130,6 +130,16 @@ sealed interface TestRunParameter {
         }
     }
 
+    /**
+     * Enables the test run retry: if the run itself or the checks of its result fail,
+     * the whole sequence is re-executed, up to [maxRetries] times.
+     *
+     * @see AbstractRunner.run
+     */
+    class WithRetriesOnFailure(val maxRetries: Int) : TestRunParameter {
+        override fun applyTo(programArgs: MutableList<String>) = Unit
+    }
+
     // Currently, used only for logging the data.
     class WithExpectedOutputData(val expectedOutputDataFile: File) : TestRunParameter {
         override fun applyTo(programArgs: MutableList<String>) = Unit


### PR DESCRIPTION
Tests of kind `STANDALONE_LLDB` and `STANDALONE_STEPPING` (in particular, the flaky NativeSteppingTestGenerated suite) drive a real lldb process, which makes them fail sporadically for reasons unrelated to the code under test, such as KT-84923 and KT-87414.

Retry such test runs, giving them a second attempt. A single retry is enough for sporadic failures, while a higher limit would mostly make genuinely broken tests slower and hide more actual problems.

The retrying machinery is implemented in a generic way, so it can be reused for other tests later.