### PR TITLE
Revert "[KGP] Native: turn on incremental compilation by default"

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/nativeCacheKindProperties.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/nativeCacheKindProperties.kt
@@ -9,7 +9,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
 
 internal fun Project.isKonanIncrementalCompilationEnabled(): Boolean {
-    return PropertiesProvider(this).incrementalNative ?: true
+    return PropertiesProvider(this).incrementalNative ?: false
 }
 
 internal fun Project.getKonanParallelThreads(): Int {


### PR DESCRIPTION
This reverts commit 63521170ba28dd79fcb0e6492e4bee82c36c5c7b.

Reverting the Native IC back to opt-in for the RC build.