### PR TITLE
[Wasm] ignore failing coroutines stack switching tests via WASM_IGNORE_FOR directive KT-88366

### DIFF
--- a/compiler/testData/codegen/box/coroutines/intrinsicSemantics/intercepted.kt
+++ b/compiler/testData/codegen/box/coroutines/intrinsicSemantics/intercepted.kt
@@ -1,3 +1,10 @@
+// Test exercises low-level coroutine intrinsics.
+// The Stack Switching implementation intentionally doesn't reproduce full intrinsic semantics.
+// Supporting it would require extra flags/checks for working with special cases of internal testing.
+// WASM_IGNORE_FOR: mode=regular runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingTestGenerated
+// WASM_IGNORE_FOR: mode=single-module runner=org.jetbrains.kotlin.wasm.test.FirWasmJsCodegenCoroutinesStackSwitchingSingleModuleTestGenerated
+// WASM_IGNORE_FOR: mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+
 // WITH_STDLIB
 // WITH_COROUTINES
 

--- a/compiler/testData/codegen/box/coroutines/intrinsicSemantics/startCoroutineUninterceptedOrReturn.kt
+++ b/compiler/testData/codegen/box/coroutines/intrinsicSemantics/startCoroutineUninterceptedOrReturn.kt
@@ -1,3 +1,10 @@
+// Test exercises low-level coroutine intrinsics.
+// The Stack Switching implementation intentionally doesn't reproduce full intrinsic semantics.
+// Supporting it would require extra flags/checks for working with special cases of internal testing.
+// WASM_IGNORE_FOR: mode=regular runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingTestGenerated
+// WASM_IGNORE_FOR: mode=single-module runner=org.jetbrains.kotlin.wasm.test.FirWasmJsCodegenCoroutinesStackSwitchingSingleModuleTestGenerated
+// WASM_IGNORE_FOR: mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+
 // WITH_STDLIB
 // WITH_COROUTINES
 import helpers.*

--- a/compiler/testData/codegen/box/coroutines/intrinsicSemantics/suspendCoroutineUninterceptedOrReturn.kt
+++ b/compiler/testData/codegen/box/coroutines/intrinsicSemantics/suspendCoroutineUninterceptedOrReturn.kt
@@ -1,3 +1,10 @@
+// Test exercises low-level coroutine intrinsics.
+// The Stack Switching implementation intentionally doesn't reproduce full intrinsic semantics.
+// Supporting it would require extra flags/checks for working with special cases of internal testing.
+// WASM_IGNORE_FOR: mode=regular runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingTestGenerated
+// WASM_IGNORE_FOR: mode=single-module runner=org.jetbrains.kotlin.wasm.test.FirWasmJsCodegenCoroutinesStackSwitchingSingleModuleTestGenerated
+// WASM_IGNORE_FOR: mode=multi-module runner=org.jetbrains.kotlin.wasm.test.WasmJsCodegenCoroutinesStackSwitchingMultiModuleTestGenerated
+
 // WITH_STDLIB
 // WITH_COROUTINES
 import helpers.*

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateWasmTests.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/generators/tests/GenerateWasmTests.kt
@@ -36,13 +36,6 @@ fun main(args: Array<String>) {
     // TODO: Remove excludedPattern below after fix of KT-78960 (it's simpler to exclude temporarily than to split test `boxInline/innerClasses/kt12126.kt`)
     val excludedPatternForBoxInlineTestsWithInliner = "kt12126.kt"
 
-    // These tests exercise low-level coroutine intrinsics.
-    // The Stack Switching implementation intentionally doesn't reproduce those intrinsic semantics.
-    // Supporting them would require extra flags/checks for working with special cases of internal testing.
-    // We exclude these tests instead of muting them per-mode.
-    val excludedPatternStackSwitchingCoroutines =
-        "^(intercepted|startCoroutineUninterceptedOrReturn|suspendCoroutineUninterceptedOrReturn)\\.kt$"
-
     generateTestGroupSuiteWithJUnit5(args) {
         testGroup(testsRoot, "compiler/testData/klib/partial-linkage") {
             testClass<AbstractWasmPartialLinkageNoICTestCase> {
@@ -153,27 +146,15 @@ fun main(args: Array<String>) {
             }
 
             testClass<AbstractWasmJsCodegenCoroutinesStackSwitchingTest> {
-                model(
-                    "codegen/box/coroutines",
-                    pattern = jsTranslatorTestPattern,
-                    excludedPattern = excludedPatternStackSwitchingCoroutines
-                )
+                model("codegen/box/coroutines", pattern = jsTranslatorTestPattern)
             }
 
             testClass<AbstractFirWasmJsCodegenCoroutinesStackSwitchingSingleModuleTest> {
-                model(
-                    "codegen/box/coroutines",
-                    pattern = jsTranslatorTestPattern,
-                    excludedPattern = excludedPatternStackSwitchingCoroutines
-                )
+                model("codegen/box/coroutines", pattern = jsTranslatorTestPattern)
             }
 
             testClass<AbstractWasmJsCodegenCoroutinesStackSwitchingMultiModuleTest> {
-                model(
-                    "codegen/box/coroutines",
-                    pattern = jsTranslatorTestPattern,
-                    excludedPattern = excludedPatternStackSwitchingCoroutines
-                )
+                model("codegen/box/coroutines", pattern = jsTranslatorTestPattern)
             }
 
             testClass<AbstractWasmJsCodegenBoxInlinedTest>(annotations = listOf(annotation<WasmJsBoxInlinedTest>())) {


### PR DESCRIPTION
Fixes #[KT-88366](https://youtrack.jetbrains.com/issue/KT-88366) [Wasm] mute failing coroutines stack switching test via WASM_IGNORE_FOR directive

[Wasm Test Aggregate](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_WasmTestAggregate?branch=rr%2Fshefer%2Fignore-coroutines-wasm-ignore-for&buildTypeTab=overview#all-projects)