### PR TITLE
2.4.20 [Parcelize] Fix plugin crashes with NoSuchElementException when @WriteWith Parceler uses an intermediate generic interface 

### DIFF
--- a/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelerScope.kt
+++ b/plugins/parcelize/parcelize-compiler/parcelize.backend/src/org/jetbrains/kotlin/parcelize/IrParcelerScope.kt
@@ -9,10 +9,9 @@ import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.classId
-import org.jetbrains.kotlin.ir.util.constructedClass
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.getAllSubstitutedSupertypes
 import org.jetbrains.kotlin.ir.util.isNullable
-import org.jetbrains.kotlin.ir.util.superTypes
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.TYPE_PARCELER_FQ_NAMES
 import org.jetbrains.kotlin.parcelize.ParcelizeNames.WRITE_WITH_FQ_NAMES
 
@@ -35,8 +34,8 @@ fun IrParcelerScope?.getCustomSerializer(irType: IrType): IrParcelSerializer? {
     }
     writeWithArgumentType?.getClass()?.let { parceler ->
         val customSerializer = IrCustomParcelSerializer(parceler)
-        val parcelerSupertype = writeWithArgumentType.superTypes()
-            .single { it.classOrNull?.owner?.classId in ParcelizeNames.PARCELER_CLASS_IDS } as IrSimpleType
+        val parcelerSupertype = getAllSubstitutedSupertypes(parceler)
+            .first { it.classOrNull?.owner?.classId in ParcelizeNames.PARCELER_CLASS_IDS }
         val parcelerTypeArgument = parcelerSupertype.arguments.single().typeOrFail
         return if (irType.isNullable() && !parcelerTypeArgument.isNullable()) IrNullAwareParcelSerializer(customSerializer)
         else customSerializer

--- a/plugins/parcelize/parcelize-compiler/testData/box/542958359.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/box/542958359.kt
@@ -1,0 +1,67 @@
+// WITH_STDLIB
+
+@file:JvmName("TestKt")
+package test
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+
+class MyClass(val name: String)
+
+interface MyIntermediateParceler<T> : Parceler<T>
+
+object MyClassParceler : MyIntermediateParceler<MyClass> {
+    override fun create(parcel: Parcel) = MyClass(parcel.readString()!!)
+    override fun MyClass.write(parcel: Parcel, flags: Int) = parcel.writeString(name)
+}
+
+object MyNullableClassParceler : MyIntermediateParceler<MyClass?> {
+    override fun create(parcel: Parcel): MyClass? {
+        val name = parcel.readString() ?: return null
+        return MyClass(name)
+    }
+    override fun MyClass?.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(this?.name)
+    }
+}
+
+@Parcelize
+data class MyParcelableThing1(
+    val p: @WriteWith<MyNullableClassParceler> MyClass?
+) : Parcelable
+
+@Parcelize
+data class MyParcelableThing2(
+    val p: @WriteWith<MyClassParceler> MyClass?
+) : Parcelable
+
+fun box() = parcelTest { parcel ->
+    val thing1NonNull = MyParcelableThing1(MyClass("A"))
+    val thing1Null = MyParcelableThing1(null)
+
+    val thing2NonNull = MyParcelableThing2(MyClass("B"))
+    val thing2Null = MyParcelableThing2(null)
+
+    thing1NonNull.writeToParcel(parcel, 0)
+    thing1Null.writeToParcel(parcel, 0)
+    thing2NonNull.writeToParcel(parcel, 0)
+    thing2Null.writeToParcel(parcel, 0)
+
+    val bytes = parcel.marshall()
+    parcel.unmarshall(bytes, 0, bytes.size)
+    parcel.setDataPosition(0)
+
+    val thing1NonNull2 = parcelableCreator<MyParcelableThing1>().createFromParcel(parcel)
+    assert(thing1NonNull2.p?.name == "A")
+
+    val thing1Null2 = parcelableCreator<MyParcelableThing1>().createFromParcel(parcel)
+    assert(thing1Null2.p == null)
+
+    val thing2NonNull2 = parcelableCreator<MyParcelableThing2>().createFromParcel(parcel)
+    assert(thing2NonNull2.p?.name == "B")
+
+    val thing2Null2 = parcelableCreator<MyParcelableThing2>().createFromParcel(parcel)
+    assert(thing2Null2.p == null)
+
+}

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/542958359.asm.txt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/542958359.asm.txt
@@ -1,0 +1,165 @@
+public final class MyClass : java/lang/Object {
+    public void <init>()
+}
+
+public final class MyClassParceler : java/lang/Object, MyIntermediateParceler {
+    public final static MyClassParceler INSTANCE
+
+    static void <clinit>()
+
+    private void <init>()
+
+    public MyClass create(android.os.Parcel parcel)
+
+    public java.lang.Object create(android.os.Parcel parcel)
+
+    public MyClass[] newArray(int size)
+
+    public java.lang.Object[] newArray(int size)
+
+    public void write(MyClass $this$write, android.os.Parcel parcel, int flags)
+
+    public void write(java.lang.Object $this$write, android.os.Parcel parcel, int flags)
+}
+
+public final class MyIntermediateParceler$DefaultImpls : java/lang/Object {
+    public static java.lang.Object[] newArray(MyIntermediateParceler $this, int size)
+}
+
+public abstract interface MyIntermediateParceler : java/lang/Object, kotlinx/parcelize/Parceler {
+
+}
+
+public final class MyNonNullableClassParceler : java/lang/Object, MyIntermediateParceler {
+    public final static MyNonNullableClassParceler INSTANCE
+
+    static void <clinit>()
+
+    private void <init>()
+
+    public MyClass create(android.os.Parcel parcel)
+
+    public java.lang.Object create(android.os.Parcel parcel)
+
+    public MyClass[] newArray(int size)
+
+    public java.lang.Object[] newArray(int size)
+
+    public void write(MyClass $this$write, android.os.Parcel parcel, int flags)
+
+    public void write(java.lang.Object $this$write, android.os.Parcel parcel, int flags)
+}
+
+public final class MyParcelable$Creator : java/lang/Object, android/os/Parcelable$Creator {
+    public void <init>()
+
+    public final MyParcelable createFromParcel(android.os.Parcel parcel) {
+        LABEL (L0)
+          ALOAD (1)
+          LDC (parcel)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+        LABEL (L1)
+          NEW (MyParcelable)
+          DUP
+          GETSTATIC (MyClassParceler, INSTANCE, LMyClassParceler;)
+          ALOAD (1)
+          INVOKEVIRTUAL (MyClassParceler, create, (Landroid/os/Parcel;)LMyClass;)
+          ALOAD (1)
+          INVOKEVIRTUAL (android/os/Parcel, readInt, ()I)
+          IFNE (L2)
+          ACONST_NULL
+          GOTO (L3)
+        LABEL (L2)
+          GETSTATIC (MyNonNullableClassParceler, INSTANCE, LMyNonNullableClassParceler;)
+          ALOAD (1)
+          INVOKEVIRTUAL (MyNonNullableClassParceler, create, (Landroid/os/Parcel;)LMyClass;)
+        LABEL (L3)
+          INVOKESPECIAL (MyParcelable, <init>, (LMyClass;LMyClass;)V)
+          ARETURN
+        LABEL (L4)
+    }
+
+    public java.lang.Object createFromParcel(android.os.Parcel source) {
+        LABEL (L0)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKEVIRTUAL (MyParcelable$Creator, createFromParcel, (Landroid/os/Parcel;)LMyParcelable;)
+          ARETURN
+        LABEL (L1)
+    }
+
+    public final MyParcelable[] newArray(int size)
+
+    public java.lang.Object[] newArray(int size)
+}
+
+public final class MyParcelable : java/lang/Object, android/os/Parcelable {
+    public final static android.os.Parcelable$Creator CREATOR
+
+    private final MyClass myProperty1
+
+    private final MyClass myProperty2
+
+    static void <clinit>()
+
+    public void <init>(MyClass myProperty1, MyClass myProperty2)
+
+    public void <init>(MyClass p0, MyClass p1, int p2, kotlin.jvm.internal.DefaultConstructorMarker p3)
+
+    public void <init>()
+
+    public final MyClass component1()
+
+    public final MyClass component2()
+
+    public final MyParcelable copy(MyClass myProperty1, MyClass myProperty2)
+
+    public static MyParcelable copy$default(MyParcelable p0, MyClass p1, MyClass p2, int p3, java.lang.Object p4)
+
+    public final int describeContents()
+
+    public boolean equals(java.lang.Object other)
+
+    public final MyClass getMyProperty1()
+
+    public final MyClass getMyProperty2()
+
+    public int hashCode()
+
+    public java.lang.String toString()
+
+    public final void writeToParcel(android.os.Parcel dest, int flags) {
+        LABEL (L0)
+          ALOAD (1)
+          LDC (dest)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+          GETSTATIC (MyClassParceler, INSTANCE, LMyClassParceler;)
+          ALOAD (0)
+          GETFIELD (MyParcelable, myProperty1, LMyClass;)
+          ALOAD (1)
+          ILOAD (2)
+          INVOKEVIRTUAL (MyClassParceler, write, (LMyClass;Landroid/os/Parcel;I)V)
+          ALOAD (0)
+          GETFIELD (MyParcelable, myProperty2, LMyClass;)
+          ASTORE (3)
+          ALOAD (3)
+          IFNONNULL (L1)
+          ALOAD (1)
+          ICONST_0
+          INVOKEVIRTUAL (android/os/Parcel, writeInt, (I)V)
+          GOTO (L2)
+        LABEL (L1)
+          ALOAD (1)
+          ICONST_1
+          INVOKEVIRTUAL (android/os/Parcel, writeInt, (I)V)
+          GETSTATIC (MyNonNullableClassParceler, INSTANCE, LMyNonNullableClassParceler;)
+          ALOAD (3)
+          ALOAD (1)
+          ILOAD (2)
+          INVOKEVIRTUAL (MyNonNullableClassParceler, write, (LMyClass;Landroid/os/Parcel;I)V)
+        LABEL (L2)
+        LINENUMBER (28)
+          RETURN
+        LABEL (L3)
+    }
+}

--- a/plugins/parcelize/parcelize-compiler/testData/codegen/542958359.kt
+++ b/plugins/parcelize/parcelize-compiler/testData/codegen/542958359.kt
@@ -1,0 +1,28 @@
+// WITH_STDLIB
+// CURIOUS_ABOUT: createFromParcel, writeToParcel
+
+import kotlinx.parcelize.*
+import android.os.Parcel
+import android.os.Parcelable
+import java.io.Serializable
+
+class MyClass()
+
+interface MyIntermediateParceler<T> : Parceler<T>
+
+object MyClassParceler : MyIntermediateParceler<MyClass?> {
+    override fun create(parcel: Parcel): MyClass? = null
+    override fun MyClass?.write(parcel: Parcel, flags: Int) {}
+}
+
+object MyNonNullableClassParceler : MyIntermediateParceler<MyClass> {
+    override fun create(parcel: Parcel): MyClass = TODO()
+    override fun MyClass.write(parcel: Parcel, flags: Int) {}
+}
+
+
+@Parcelize
+data class MyParcelable(
+    val myProperty1: @WriteWith<MyClassParceler> MyClass? = null,
+    val myProperty2: @WriteWith<MyNonNullableClassParceler> MyClass? = null,
+) : Parcelable


### PR DESCRIPTION
Cherry pick of #7291