### PR TITLE
JVM: Fix synthetic accessors used by properties delegated to private …

### DIFF
--- a/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
+++ b/compiler/ir/backend.jvm/lower/src/org/jetbrains/kotlin/backend/jvm/lower/PropertyReferenceDelegationLowering.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irExprBody
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetField
+import org.jetbrains.kotlin.ir.builders.typeOperator
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
@@ -119,7 +120,8 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
             irExprBody(irBlock {
                 +delegateReference.getterFunction.inline(
                     getter,
-                    createAccessorArgumentsList(getter, delegateReference.getterFunction, isGetter = true, receiverProvider)
+                    createAccessorArgumentsList(getter, delegateReference.getterFunction, isGetter = true, receiverProvider),
+                    moveBody = false,
                 )
             })
         }
@@ -134,7 +136,8 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
         return irExprBody(irBlock {
             +delegateSetter.inline(
                 setter,
-                createAccessorArgumentsList(setter, delegateSetter, isGetter = false, receiverProvider)
+                createAccessorArgumentsList(setter, delegateSetter, isGetter = false, receiverProvider),
+                moveBody = false,
             )
         })
     }
@@ -154,7 +157,22 @@ private class PropertyReferenceDelegationTransformer(val context: JvmBackendCont
             if (boundReceiverOrNull != null) add(createTmpVariable(boundReceiverOrNull.deepCopyWithSymbols(accessor)))
             if (size + (if (isGetter) 0 else 1) < delegateAccessor.parameters.size) {
                 val unboundReceiver = accessor.getReceiverParameterOrNull()
-                if (unboundReceiver != null) add(unboundReceiver)
+                if (unboundReceiver != null) {
+                    add(
+                        createTmpVariable(
+                            /**
+                             * This implicit cast is needed so that [org.jetbrains.kotlin.backend.jvm.lower.SyntheticAccessorLowering]
+                             * correctly selects the parent class for the synthetic accessor.
+                             */
+                            typeOperator(
+                                delegateAccessor.parameters.first().type,
+                                irGet(unboundReceiver),
+                                IrTypeOperator.IMPLICIT_CAST,
+                                unboundReceiver.type
+                            )
+                        )
+                    )
+                }
             }
             if (setterParam != null) add(setterParam)
         }.also {

--- a/compiler/testData/codegen/box/syntheticAccessors/accessorForPrivatePropertyReference.kt
+++ b/compiler/testData/codegen/box/syntheticAccessors/accessorForPrivatePropertyReference.kt
@@ -1,0 +1,17 @@
+// ISSUE: KT-88228
+
+open class A {
+    private val aVal = "O"
+    private var aVar = ""
+
+    class B : A() {
+        val bVal by A::aVal
+        var bVar by A::aVar
+    }
+}
+
+fun box(): String {
+    val b = A.B()
+    b.bVar = "K"
+    return b.bVal + b.bVar
+}


### PR DESCRIPTION
…properties of superclass

`SyntheticAccessorLowering` used to select a wrong parent class for the accessor to be placed in. Adding an implicit cast helps with that.

Another approach would be to adjust `SyntheticAccessorLowering`, in particular `IrDeclarationWithVisibility.accessorParent` of `SyntheticAccessorGenerator`. Though that seems more risky.

^KT-88228 Fixed