### PR TITLE
[JKLIB] Fix Unbound symbols for kotlin.coroutines.SuspendFunctionN

### DIFF
--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.ir.backend.jklib
 
-
 import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideClassFilter
 import org.jetbrains.kotlin.backend.common.overrides.IrLinkerFakeOverrideProvider
 import org.jetbrains.kotlin.backend.common.serialization.*
@@ -14,27 +13,26 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.ir.IrBuiltIns
+import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
+import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition
 import org.jetbrains.kotlin.ir.symbols.IrFieldSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
 import org.jetbrains.kotlin.ir.util.DeclarationStubGenerator
 import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.KotlinMangler
 import org.jetbrains.kotlin.ir.util.SymbolTable
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.library.KotlinAbiVersion
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.load.java.descriptors.JavaCallableMemberDescriptor
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageFragment
-import org.jetbrains.kotlin.ir.declarations.IrProperty
-import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition
-import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
-import org.jetbrains.kotlin.ir.IrElement
-import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
-import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
-import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
@@ -194,8 +192,15 @@ class JKlibIrLinker(
 
         private val deserializedSymbols = mutableMapOf<IdSignature, IrSymbol>()
 
+        private fun isKotlinCloneable(idSig: IdSignature): Boolean {
+            val signature = idSig.asPublic() ?: return false
+            return (signature.packageFqName == "kotlin" && signature.firstNameSegment == "Cloneable")
+        }
+
         override fun contains(idSig: IdSignature): Boolean =
-            super.contains(idSig) || descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null
+            super.contains(idSig) ||
+                    // TODO(KT-88375): remove this when kotlin.Cloneable class descriptor is automatically initialized.
+                    (isKotlinCloneable(idSig) && descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null)
 
         override fun getDefinedPackageNames(): Set<FqName> = getPackagesFqNames(moduleFragment.descriptor)
 


### PR DESCRIPTION
Always calling `descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null`
 in the `JKlibModuleDeserializer.contains()` function breaks the ModuleDeserializer choice logic for `kotlin.coroutines.SuspendFunctionN` fictitious interfaces.
This call was needed to correctly deserialize `kotlin.Cloneable` symbols. We restrict the call for this scenario only.

Fixes KT-88306