### PR TITLE
[JKLIB] Fix Unbound symbols for kotlin.coroutines.SuspendFunctionN

### DIFF
--- a/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
+++ b/compiler/ir/serialization.jklib/src/org/jetbrains/kotlin/ir/backend/jklib/JKlibIrLinker.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.ir.backend.jklib
 
-
 import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideClassFilter
 import org.jetbrains.kotlin.backend.common.overrides.IrLinkerFakeOverrideProvider
 import org.jetbrains.kotlin.backend.common.serialization.*
@@ -17,8 +16,10 @@ import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
+import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition
 import org.jetbrains.kotlin.ir.symbols.IrFieldSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
 import org.jetbrains.kotlin.ir.util.DeclarationStubGenerator
 import org.jetbrains.kotlin.ir.util.IdSignature
 import org.jetbrains.kotlin.ir.util.KotlinMangler
@@ -28,8 +29,6 @@ import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.load.java.descriptors.JavaCallableMemberDescriptor
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaPackageFragment
-import org.jetbrains.kotlin.ir.overrides.IrExternalOverridabilityCondition
-import org.jetbrains.kotlin.ir.types.IrTypeSystemContext
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
@@ -192,8 +191,15 @@ class JKlibIrLinker(
 
         private val deserializedSymbols = mutableMapOf<IdSignature, IrSymbol>()
 
+        private fun isKotlinCloneable(idSig: IdSignature): Boolean {
+            val signature = idSig.asPublic() ?: return false
+            return (signature.packageFqName == "kotlin" && signature.firstNameSegment == "Cloneable")
+        }
+
         override fun contains(idSig: IdSignature): Boolean =
-            super.contains(idSig) || descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null
+            super.contains(idSig) ||
+                    // TODO(KT-88375): remove this when kotlin.Cloneable class descriptor is automatically initialized.
+                    (isKotlinCloneable(idSig) && descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null)
 
         override fun getDefinedPackageNames(): Set<FqName> = getPackagesFqNames(moduleDescriptor)
 


### PR DESCRIPTION
Always calling
`descriptorByIdSignatureFinder.findDescriptorBySignature(idSig) != null`
 in the `JKlibModuleDeserializer.contains()` function breaks the
 ModuleDeserializer choice logic for
 `kotlin.coroutines.SuspendFunctionN` fictitious interfaces.
 This call was needed to correctly deserialize `kotlin.Cloneable`
  symbols. We restrict the call for this scenario only.

Fixes KT-88306

(cherry picked from commit ccc0b97947c352c32255f90126e0e4c0a8af3e05)