### PR TITLE
[cinterop] Set header=true in manifest of header-mode klibs

### DIFF
--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -411,6 +411,9 @@ private fun processCLib(
             warn("The package value `$oldValue` specified in .def file is overridden with explicit $newValue")
     }
     def.manifestAddendProperties[KLIB_PROPERTY_INTEROP] = "true"
+    if (cinteropArguments.headerMode) {
+        def.manifestAddendProperties[KLIB_PROPERTY_HEADER] = "true"
+    }
     if (stubIrOutput is StubIrDriver.Result.Metadata) {
         def.manifestAddendProperties[KLIB_PROPERTY_IR_PROVIDER] = KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
     }

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCInteropTest.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCInteropTest.kt
@@ -22,9 +22,9 @@ import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Tag
 import java.io.File
-import kotlin.test.assertFalse
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact.KLIB
 import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.isHeader
 import org.jetbrains.kotlin.konan.library.components.bitcode
 
 abstract class AbstractNativeCInteropFModulesTest : AbstractNativeCInteropTest() {
@@ -51,6 +51,7 @@ abstract class AbstractNativeCInteropHeaderModeTest : AbstractNativeCInteropNoFM
         val bitcodeFiles = library.bitcode(targets.testTarget)?.bitcodeFilePaths ?: emptyList()
 
         assertTrue(bitcodeFiles.isEmpty()) { "Klib contains bitcode files: $bitcodeFiles" }
+        assertTrue(library.isHeader) { "Expected header klib manifest to contain header=true" }
     }
 }
 

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CInteropHeaderModeValidationTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CInteropHeaderModeValidationTest.kt
@@ -5,9 +5,13 @@
 
 package org.jetbrains.kotlin.konan.test.blackbox
 
+import org.jetbrains.kotlin.konan.library.components.bitcode
 import org.jetbrains.kotlin.konan.test.blackbox.support.*
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.*
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationResult.Companion.assertSuccess
+import org.jetbrains.kotlin.library.isHeader
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
@@ -73,6 +77,12 @@ class CInteropHeaderModeValidationTest : AbstractNativeSimpleTest() {
             TestCInteropArgs(includeArg + "-Xheader-mode")
         ).assertSuccess().resultingArtifact
 
+        val headerLibrary = KlibLoader { libraryPaths(headerKlib.klibFile.path) }.load().librariesStdlibFirst.single()
+        assertTrue(headerLibrary.isHeader) { "Expected header klib to have header=true in manifest" }
+
+        val bitcodeFiles = headerLibrary.bitcode(targets.testTarget)?.bitcodeFilePaths ?: emptyList()
+        assertTrue(bitcodeFiles.isEmpty()) { "Expected no bitcode files in header klib, got: $bitcodeFiles" }
+
         // 2. Compile dependent Kotlin code using the Header-Mode KLIB (Succeeds)
         val dependentKlibSuccess = compileToLibrary(
             dependentKotlinDir,
@@ -88,6 +98,9 @@ class CInteropHeaderModeValidationTest : AbstractNativeSimpleTest() {
             buildDir.resolve("fullModeOut").apply { mkdirs() },
             TestCInteropArgs(includeArg)
         ).assertSuccess().resultingArtifact
+
+        val fullLibrary = KlibLoader { libraryPaths(fullKlib.klibFile.path) }.load().librariesStdlibFirst.single()
+        assertFalse(fullLibrary.isHeader) { "Expected full klib to not have header=true in manifest" }
 
         // 4. Link the pre-compiled dependent KLIB with the Full-Mode KLIB (fails linking)
         val linkTestCase = generateTestCaseWithSingleModule(null, TestCompilerArgs.EMPTY)


### PR DESCRIPTION
Set the 'header=true' manifest property on KLIBs produced by cinterop when header mode (-Xheader-mode) is enabled.

In processCLib, check cinteropArguments.headerMode and add KLIB_PROPERTY_HEADER to def.manifestAddendProperties. Also update AbstractNativeCInteropHeaderModeTest and CInteropHeaderModeValidationTest to assert that header KLIBs have isHeader == true and full KLIBs have isHeader == false.

^KT-86815