### PR TITLE
[Swift Export] Do not fail the export on an unresolved type

### DIFF
--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/TestDirectives.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/TestDirectives.kt
@@ -73,6 +73,15 @@ object TestDirectives : SimpleDirectivesContainer() {
         applicability = DirectiveApplicability.Module,
     )
 
+    val HIDE_FROM_SWIFT_EXPORT by directive(
+        """
+            Keeps the module out of the Swift Export input set, while it is still compiled to a klib and still acts as a
+            regular Kotlin dependency. Types the module declares are therefore unresolvable during Swift Export and
+            translate to error types.
+        """.trimIndent(),
+        applicability = DirectiveApplicability.Module,
+    )
+
     val SWIFT_EXPORT_CONFIG by valueDirective(
         description = """
             Specify config for Swift Export in the format %KEY_1%=%VALUE_1%, %KEY_2%=%VALUE_2%. Implicitly marks module for Swift Export
@@ -421,6 +430,9 @@ internal fun parseOutputRegex(registeredDirectives: RegisteredDirectives): TestR
 fun TestModule.shouldBeExportedToSwift(): Boolean = (this as? TestModule.Exclusive)?.shouldBeExportedToSwift() ?: false
 fun TestModule.Exclusive.shouldBeExportedToSwift(): Boolean =
     TestDirectives.EXPORT_TO_SWIFT in directives || TestDirectives.SWIFT_EXPORT_CONFIG in directives
+
+fun TestModule.hiddenFromSwiftExport(): Boolean = (this as? TestModule.Exclusive)?.hiddenFromSwiftExport() ?: false
+fun TestModule.Exclusive.hiddenFromSwiftExport(): Boolean = TestDirectives.HIDE_FROM_SWIFT_EXPORT in directives
 
 fun TestModule.Exclusive.swiftExportConfigMap(): Map<String, String> =
     directives[TestDirectives.SWIFT_EXPORT_CONFIG].toMap()

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirProtocolFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirProtocolFromKtSymbol.kt
@@ -482,6 +482,8 @@ internal class SirStubProtocol(
     sirSession
 ) {
     override val declarations: MutableList<SirDeclaration> = mutableListOf()
+
+    override val protocols: List<SirProtocol> get() = emptyList()
 }
 
 /**

--- a/native/swift/sir-light-classes/test/org/jetbrains/kotlin/sir/providers/support/TestFramework.kt
+++ b/native/swift/sir-light-classes/test/org/jetbrains/kotlin/sir/providers/support/TestFramework.kt
@@ -54,6 +54,7 @@ class TestSirSession(
         sirSession = sirSession,
         unsupportedDeclarationReporter = SilentUnsupportedDeclarationReporter,
         enableCoroutinesSupport = true,
+        hiddenModules = emptyList(),
     )
     override val childrenProvider: SirChildrenProvider = SirDeclarationChildrenProviderImpl(
         sirSession = sirSession,

--- a/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirVisibilityCheckerImpl.kt
+++ b/native/swift/sir-providers/src/org/jetbrains/kotlin/sir/providers/impl/SirVisibilityCheckerImpl.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.sir.providers.impl
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.export.utilities.isAllSuperTypesExported
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KaAnnotatedSymbol
 import org.jetbrains.kotlin.analysis.api.types.*
@@ -33,6 +34,7 @@ public class SirVisibilityCheckerImpl(
     private val sirSession: SirSession,
     private val unsupportedDeclarationReporter: UnsupportedDeclarationReporter,
     private val enableCoroutinesSupport: Boolean,
+    private val hiddenModules: List<KaModule>
 ) : SirVisibilityChecker {
     @OptIn(KaExperimentalApi::class)
     override fun KaDeclarationSymbol.sirAvailability(): SirAvailability = sirSession.withSessions {
@@ -47,6 +49,10 @@ public class SirVisibilityCheckerImpl(
                 set(newValue) {
                     field = minOf(field, newValue)
                 }
+        }
+
+        if (hiddenModules.contains(ktSymbol.containingModule)) {
+            return@withSessions SirAvailability.Hidden("Declaration comes from a module excluded from Swift Export")
         }
 
         val containingModule = ktSymbol.containingModule.sirModule()

--- a/native/swift/swift-export-ide/src/org/jetbrains/kotlin/swiftexport/ide/session/IdeSirSession.kt
+++ b/native/swift/swift-export-ide/src/org/jetbrains/kotlin/swiftexport/ide/session/IdeSirSession.kt
@@ -54,6 +54,7 @@ public class IdeSirSession(
         sirSession = sirSession,
         unsupportedDeclarationReporter = unsupportedDeclarationReporter,
         enableCoroutinesSupport = false,
+        hiddenModules = emptyList(),
     )
     override val childrenProvider: SirChildrenProvider = SirDeclarationChildrenProviderImpl(
         sirSession = sirSession,

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectExecutionTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectExecutionTest.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.konan.test.testLibraryBKlibFile
 import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportModule
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftExportConfig
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
+import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleExportMode
 import org.jetbrains.kotlin.swiftexport.standalone.runSwiftExport
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -56,7 +57,7 @@ abstract class AbstractExternalProjectExecutionTest : AbstractSwiftExportExecuti
     private fun runTestsAgainstKlib(klibSettings: Set<KlibExportSettings>, testPath: File) {
         val testModules = klibSettings.map { TestModule.Given(it.path.toFile()) }.toSet()
         val inputModules = klibSettings.map {
-            it.createInputModule(SwiftModuleConfig(rootPackage = it.rootPackage, shouldBeFullyExported = true))
+            it.createInputModule(SwiftModuleConfig(rootPackage = it.rootPackage, exportMode = SwiftModuleExportMode.Full))
         }.toSet()
 
         val swiftConfig = SwiftExportConfig(

--- a/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectGenerationTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/external/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractExternalProjectGenerationTest.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.konan.test.testLibraryAKlibFile
 import org.jetbrains.kotlin.konan.test.testLibraryKotlinxSerializationCoreKlibFile
 import org.jetbrains.kotlin.swiftexport.standalone.SwiftExportModule
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
+import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleExportMode
 import org.jetbrains.kotlin.swiftexport.standalone.runSwiftExport
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -61,7 +62,7 @@ abstract class AbstractExternalProjectGenerationTest : AbstractSwiftExportWithBi
     ) {
         val config = klib.createConfig(outputPath = tmpdir.toPath().resolve(klib.swiftModuleName))
         val inputModule = klib.createInputModule(
-            SwiftModuleConfig(rootPackage = klib.rootPackage, shouldBeFullyExported = true)
+            SwiftModuleConfig(rootPackage = klib.rootPackage, exportMode = SwiftModuleExportMode.Full)
         )
         val result = runSwiftExport(setOf(inputModule), config).getOrThrow()
         validateSwiftExportOutput(testDataDir.resolve(goldenData), result, validateKotlinBridge)

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/ExportedKotlinPackages/ExportedKotlinPackages.swift
@@ -1,0 +1,2 @@
+public enum hidden {
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/hidden/hidden.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/hidden/hidden.h
@@ -1,0 +1,5 @@
+#include <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/hidden/hidden.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/hidden/hidden.kt
@@ -1,0 +1,3 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(hidden.HiddenClass::class, "22ExportedKotlinPackages6hiddenO6hiddenE11HiddenClassC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(hidden.HiddenOpenClass::class, "22ExportedKotlinPackages6hiddenO6hiddenE15HiddenOpenClassC")

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/hidden/hidden.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/hidden/hidden.swift
@@ -1,0 +1,13 @@
+@_exported import ExportedKotlinPackages
+@_implementationOnly import KotlinBridges_hidden
+import KotlinRuntime
+import KotlinRuntimeSupport
+
+extension ExportedKotlinPackages.hidden {
+    public protocol HiddenInterface: KotlinRuntime.KotlinBase {
+    }
+    public final class HiddenClass: KotlinRuntime.KotlinBase {
+    }
+    open class HiddenOpenClass: KotlinRuntime.KotlinBase {
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/main/main.h
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/main/main.h
@@ -1,0 +1,26 @@
+#include <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+int32_t Container_untouched_member__TypesOfArguments__Swift_Int32__(void * self, int32_t arg);
+
+void * __root___Container_init_allocate();
+
+_Bool __root___Container_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * __root___ImplementsHiddenInterface_init_allocate();
+
+_Bool __root___ImplementsHiddenInterface_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * __root___InheritsAndImplements_init_allocate();
+
+_Bool __root___InheritsAndImplements_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+void * __root___InheritsHiddenClass_init_allocate();
+
+_Bool __root___InheritsHiddenClass_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(void * __kt);
+
+int32_t __root___untouched_function__TypesOfArguments__Swift_Int32__(int32_t arg);
+
+NS_ASSUME_NONNULL_END

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/main/main.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/main/main.kt
@@ -1,0 +1,76 @@
+@file:kotlin.Suppress("DEPRECATION_ERROR")
+@file:kotlin.native.internal.objc.BindClassToObjCName(Container::class, "4main9ContainerC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(ImplementsHiddenInterface::class, "4main25ImplementsHiddenInterfaceC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(InheritsAndImplements::class, "4main21InheritsAndImplementsC")
+@file:kotlin.native.internal.objc.BindClassToObjCName(InheritsHiddenClass::class, "4main19InheritsHiddenClassC")
+
+import kotlin.native.internal.ExportedBridge
+import kotlinx.cinterop.*
+import kotlinx.cinterop.internal.convertBlockPtrToKotlinFunction
+
+@ExportedBridge("Container_untouched_member__TypesOfArguments__Swift_Int32__")
+public fun Container_untouched_member__TypesOfArguments__Swift_Int32__(self: kotlin.native.internal.NativePtr, arg: Int): Int {
+    val __self = kotlin.native.internal.ref.dereferenceExternalRCRef(self) as Container
+    val __arg = arg
+    val _result = run { __self.untouched_member(__arg) }
+    return _result
+}
+
+@ExportedBridge("__root___Container_init_allocate")
+public fun __root___Container_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<Container>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("__root___Container_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun __root___Container_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, Container()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("__root___ImplementsHiddenInterface_init_allocate")
+public fun __root___ImplementsHiddenInterface_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<ImplementsHiddenInterface>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("__root___ImplementsHiddenInterface_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun __root___ImplementsHiddenInterface_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, ImplementsHiddenInterface()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("__root___InheritsAndImplements_init_allocate")
+public fun __root___InheritsAndImplements_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<InheritsAndImplements>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("__root___InheritsAndImplements_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun __root___InheritsAndImplements_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, InheritsAndImplements()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("__root___InheritsHiddenClass_init_allocate")
+public fun __root___InheritsHiddenClass_init_allocate(): kotlin.native.internal.NativePtr {
+    val _result = run { kotlin.native.internal.createUninitializedInstance<InheritsHiddenClass>() }
+    return kotlin.native.internal.ref.createRetainedExternalRCRef(_result)
+}
+
+@ExportedBridge("__root___InheritsHiddenClass_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__")
+public fun __root___InheritsHiddenClass_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt: kotlin.native.internal.NativePtr): Boolean {
+    val ____kt = kotlin.native.internal.ref.dereferenceExternalRCRef(__kt)!!
+    val _result = run { kotlin.native.internal.initInstance(____kt, InheritsHiddenClass()) }
+    return run { _result; true }
+}
+
+@ExportedBridge("__root___untouched_function__TypesOfArguments__Swift_Int32__")
+public fun __root___untouched_function__TypesOfArguments__Swift_Int32__(arg: Int): Int {
+    val __arg = arg
+    val _result = run { untouched_function(__arg) }
+    return _result
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/golden_result/main/main.swift
@@ -1,0 +1,95 @@
+@_implementationOnly import KotlinBridges_main
+import KotlinRuntime
+import KotlinRuntimeSupport
+import hidden
+
+public final class Container: KotlinRuntime.KotlinBase {
+    public var member_property: ExportedKotlinPackages.hidden.HiddenClass {
+        get {
+            fatalError()
+        }
+    }
+    public init() {
+        let __kt = __root___Container_init_allocate()
+        super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+        { __root___Container_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+    public func member_consuming_hidden(
+        arg: ExportedKotlinPackages.hidden.HiddenClass
+    ) -> Swift.Void {
+        fatalError()
+    }
+    public func untouched_member(
+        arg: Swift.Int32
+    ) -> Swift.Int32 {
+        return Container_untouched_member__TypesOfArguments__Swift_Int32__(self.__externalRCRef(), arg)
+    }
+}
+public final class ImplementsHiddenInterface: KotlinRuntime.KotlinBase {
+    public init() {
+        let __kt = __root___ImplementsHiddenInterface_init_allocate()
+        super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+        { __root___ImplementsHiddenInterface_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+}
+public final class InheritsAndImplements: ExportedKotlinPackages.hidden.HiddenOpenClass {
+    public init() {
+        let __kt = __root___InheritsAndImplements_init_allocate()
+        super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+        { __root___InheritsAndImplements_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+}
+public final class InheritsHiddenClass: ExportedKotlinPackages.hidden.HiddenOpenClass {
+    public init() {
+        let __kt = __root___InheritsHiddenClass_init_allocate()
+        super.init(__externalRCRefUnsafe: __kt, options: .asBoundBridge);
+        { __root___InheritsHiddenClass_init_initialize__TypesOfArguments__Swift_UnsafeMutableRawPointer__(__kt); return () }()
+    }
+    package override init(
+        __externalRCRefUnsafe: Swift.UnsafeMutableRawPointer?,
+        options: KotlinRuntime.KotlinBaseConstructionOptions
+    ) {
+        super.init(__externalRCRefUnsafe: __externalRCRefUnsafe, options: options);
+    }
+}
+public var hidden_val: ExportedKotlinPackages.hidden.HiddenClass {
+    get {
+        fatalError()
+    }
+}
+public func consume_hidden_class(
+    arg: ExportedKotlinPackages.hidden.HiddenClass
+) -> Swift.Void {
+    fatalError()
+}
+public func consume_hidden_interface(
+    arg: any ExportedKotlinPackages.hidden.HiddenInterface
+) -> Swift.Void {
+    fatalError()
+}
+public func produce_hidden_class() -> ExportedKotlinPackages.hidden.HiddenClass {
+    fatalError()
+}
+public func untouched_function(
+    arg: Swift.Int32
+) -> Swift.Int32 {
+    return __root___untouched_function__TypesOfArguments__Swift_Int32__(arg)
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/hiddenFromSwiftExport.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/hiddenFromSwiftExport/hiddenFromSwiftExport.kt
@@ -1,0 +1,53 @@
+// KIND: STANDALONE
+// MODULE: main(hidden)
+// FILE: main.kt
+import hidden.HiddenClass
+import hidden.HiddenInterface
+import hidden.HiddenOpenClass
+
+// Inheritance: the whole point of hiding rather than making unavailable. A stub is a real Swift type, so it can
+// still be a superclass or a conformance; `Swift.Never` could be neither.
+class InheritsHiddenClass : HiddenOpenClass()
+
+class ImplementsHiddenInterface : HiddenInterface
+
+class InheritsAndImplements : HiddenOpenClass(), HiddenInterface
+
+// Plain references to hidden types.
+fun consume_hidden_class(arg: HiddenClass): Unit = TODO()
+
+fun produce_hidden_class(): HiddenClass = TODO()
+
+fun consume_hidden_interface(arg: HiddenInterface): Unit = TODO()
+
+val hidden_val: HiddenClass = TODO()
+
+class Container {
+    fun member_consuming_hidden(arg: HiddenClass): Unit = TODO()
+
+    val member_property: HiddenClass = TODO()
+
+    fun untouched_member(arg: Int): Int = arg
+}
+
+fun untouched_function(arg: Int): Int = arg
+
+// MODULE: hidden
+// HIDE_FROM_SWIFT_EXPORT
+// FILE: hidden.kt
+package hidden
+
+class HiddenClass {
+    fun member_that_must_not_be_exported(): Int = TODO()
+
+    val property_that_must_not_be_exported: Int = TODO()
+}
+
+open class HiddenOpenClass {
+    open fun overridable_member(): Int = TODO()
+}
+
+interface HiddenInterface
+
+// A hidden declaration nothing refers to must not show up at all.
+class UnreferencedHiddenClass

--- a/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
+++ b/native/swift/swift-export-standalone-integration-tests/testFixtures/org/jetbrains/kotlin/swiftexport/standalone/test/AbstractSwiftExportTest.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.util.*
 import org.jetbrains.kotlin.swiftexport.standalone.*
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftExportConfig
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
+import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleExportMode
 import org.jetbrains.kotlin.test.services.JUnit5Assertions.assertTrue
 import org.jetbrains.kotlin.utils.KotlinNativePaths
 import org.junit.jupiter.api.Assumptions
@@ -108,11 +109,25 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
         extraSwiftCompilerOptions = extraSwiftCompilerOptions +
             discoveredModuleMaps.flatMap { listOf("-Xcc", "-fmodule-map-file=${it.absolutePath}") }
 
+        val hiddenModules = (originalTestCase.rootModules + originalTestCase.modules).filter { it.hiddenFromSwiftExport() }
+        assertTrue(hiddenModules.none { it in originalTestCase.rootModules }) {
+            "A root module cannot be hidden from Swift Export: " +
+                    hiddenModules.filter { it in originalTestCase.rootModules }.map { it.name }
+        }
+        assertTrue(hiddenModules.none { it.shouldBeExportedToSwift() }) {
+            "Module is marked both EXPORT_TO_SWIFT and HIDE_FROM_SWIFT_EXPORT: " +
+                    hiddenModules.filter { it.shouldBeExportedToSwift() }.map { it.name }
+        }
+
         val inputModuleByTestModule = (originalTestCase.rootModules + originalTestCase.modules + givenModules).associateWith {
             createInputModule(
                 testModule = it,
                 originalTestCase = originalTestCase,
-                shouldBeFullyExported = it.shouldBeExportedToSwift() || originalTestCase.rootModules.contains(it)
+                exportMode = when {
+                    it.hiddenFromSwiftExport() -> SwiftModuleExportMode.Excluded
+                    it.shouldBeExportedToSwift() || originalTestCase.rootModules.contains(it) -> SwiftModuleExportMode.Full
+                    else -> SwiftModuleExportMode.Transitive
+                }
             )
         }
         val modulesToExport = inputModuleByTestModule.values.toSet()
@@ -122,8 +137,6 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
             stableDeclarationsOrder = true,
             distribution = Distribution(KonanHome.konanHomePath),
             konanTarget = targets.testTarget,
-            errorTypeStrategy = ErrorTypeStrategy.Fail,
-            unsupportedTypeStrategy = ErrorTypeStrategy.SpecialType,
         )
 
         // run swift export
@@ -167,7 +180,7 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
     private fun createInputModule(
         testModule: TestModule,
         originalTestCase: TestCase,
-        shouldBeFullyExported: Boolean
+        exportMode: SwiftModuleExportMode,
     ): InputModule {
         val config = (testModule as? TestModule.Exclusive)?.swiftExportConfigMap()
         // Whether a module is a cinterop re-export container is detected by Swift Export from the klib
@@ -177,7 +190,7 @@ abstract class AbstractSwiftExportTest : ExternalSourceTransformersProvider {
             SwiftModuleConfig(
                 rootPackage = config?.get(SwiftModuleConfig.ROOT_PACKAGE),
                 unsupportedDeclarationReporterKind = getUnsupportedDeclarationsReporterKind(config),
-                shouldBeFullyExported = shouldBeFullyExported,
+                exportMode = exportMode,
             )
         )
     }

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/SwiftExportRunner.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.sir.providers.utils.SimpleUnsupportedDeclarationRepo
 import org.jetbrains.kotlin.sir.providers.utils.UnsupportedDeclarationReporter
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftExportConfig
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
+import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleExportMode
 import org.jetbrains.kotlin.swiftexport.standalone.translation.TranslationResult
 import org.jetbrains.kotlin.swiftexport.standalone.translation.translateCrossReferencingModulesTransitively
 import org.jetbrains.kotlin.swiftexport.standalone.translation.translateModulePublicApi
@@ -169,10 +170,10 @@ private fun translateModules(
     )
     kaModules.use { kaModules ->
         val explicitModulesTranslationResults = allModules
-            .filter { it.config.shouldBeFullyExported }
+            .filter { it.config.exportMode == SwiftModuleExportMode.Full }
             .map { translateModulePublicApi(it, kaModules, config) }
         val transitiveExportRoots = allModules
-            .filterNot { it.config.shouldBeFullyExported }
+            .filterNot { it.config.exportMode == SwiftModuleExportMode.Full }
             .mapNotNull { kaModules.inputsToModules[it] }
             .associateWith { inputModule ->
                 explicitModulesTranslationResults

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/builders/buildSwiftModule.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/builders/buildSwiftModule.kt
@@ -23,7 +23,9 @@ import org.jetbrains.kotlin.sir.providers.trampolineDeclarations
 import org.jetbrains.kotlin.sir.util.addChild
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftExportConfig
 import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleConfig
+import org.jetbrains.kotlin.swiftexport.standalone.config.SwiftModuleExportMode
 import org.jetbrains.kotlin.swiftexport.standalone.session.StandaloneSirSession
+import kotlin.collections.List
 
 internal fun buildSirSession(
     mainModuleName: String,
@@ -45,6 +47,7 @@ internal fun buildSirSession(
     targetPackageFqName = moduleConfig.targetPackageFqName,
     referencedTypeHandler = referenceHandler,
     enableCoroutinesSupport = config.enableCoroutinesSupport,
+    hiddenModules = kaModules.hiddenModules,
 )
 
 /**
@@ -98,3 +101,8 @@ private fun extractAllTransitively(
 }.flatten()
 
 internal typealias KaModules = org.jetbrains.kotlin.analysis.api.klib.reader.KaModules<SwiftModuleConfig>
+
+internal val KaModules.hiddenModules
+    get() = inputsToModules
+        .filter { it.key.config.exportMode == SwiftModuleExportMode.Excluded }
+        .map { it.value }

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftExportConfig.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftExportConfig.kt
@@ -43,7 +43,7 @@ public data class SwiftExportConfig(
         InputModule(
             "KotlinStdlib",
             Path(distribution.stdlib),
-            SwiftModuleConfig(shouldBeFullyExported = false)
+            SwiftModuleConfig(exportMode = SwiftModuleExportMode.Transitive)
         )
 
     private fun createInputModuleForPlatformLibs(platformLibsRootFile: File) = platformLibsRootFile.list()!!
@@ -51,7 +51,7 @@ public data class SwiftExportConfig(
             InputModule(
                 name = it.split(".").last(),
                 platformLibsRootFile.resolve(it).toPath(),
-                SwiftModuleConfig(shouldBeFullyExported = false)
+                SwiftModuleConfig(exportMode = SwiftModuleExportMode.Transitive)
             )
         }.toSet()
 }

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftModuleConfig.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/config/SwiftModuleConfig.kt
@@ -10,6 +10,12 @@ import org.jetbrains.kotlin.sir.providers.utils.UnsupportedDeclarationReporter
 import org.jetbrains.kotlin.swiftexport.standalone.UnsupportedDeclarationReporterKind
 import org.jetbrains.kotlin.swiftexport.standalone.utils.rootPackageToFqn
 
+public enum class SwiftModuleExportMode {
+    Full,
+    Transitive,
+    Excluded,
+}
+
 /**
  * @param experimentalFeatures currently used to pass custom settings in between KGP and SwiftExport.
  * We plan to improve experiments support and replace the map. See KT-75191 for details.
@@ -19,8 +25,22 @@ public data class SwiftModuleConfig(
     val rootPackage: String? = null,
     val unsupportedDeclarationReporterKind: UnsupportedDeclarationReporterKind = UnsupportedDeclarationReporterKind.Silent,
     val experimentalFeatures: Map<String, String> = emptyMap(),
-    val shouldBeFullyExported: Boolean,
+    val exportMode: SwiftModuleExportMode,
 ) {
+    // TODO: remove me when OSIP-1138 is done
+    public constructor(
+        bridgeModuleName: String = DEFAULT_BRIDGE_MODULE_NAME,
+        rootPackage: String? = null,
+        unsupportedDeclarationReporterKind: UnsupportedDeclarationReporterKind = UnsupportedDeclarationReporterKind.Silent,
+        experimentalFeatures: Map<String, String> = emptyMap(),
+        shouldBeFullyExported: Boolean,
+    ) : this(
+        bridgeModuleName = bridgeModuleName,
+        rootPackage = rootPackage,
+        unsupportedDeclarationReporterKind = unsupportedDeclarationReporterKind,
+        experimentalFeatures = experimentalFeatures,
+        exportMode = if (shouldBeFullyExported) SwiftModuleExportMode.Full else SwiftModuleExportMode.Transitive,
+    )
 
     val targetPackageFqName: FqName? = rootPackage?.rootPackageToFqn()
     val unsupportedDeclarationReporter: UnsupportedDeclarationReporter = unsupportedDeclarationReporterKind.toReporter()

--- a/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/session/StandaloneSirSession.kt
+++ b/native/swift/swift-export-standalone/src/org/jetbrains/kotlin/swiftexport/standalone/session/StandaloneSirSession.kt
@@ -31,6 +31,7 @@ internal class StandaloneSirSession(
     unsupportedDeclarationReporter: UnsupportedDeclarationReporter,
     enableCoroutinesSupport: Boolean,
     override val moduleProvider: SirModuleProvider,
+    val hiddenModules: List<KaModule>,
     val targetPackageFqName: FqName? = null,
     val referencedTypeHandler: SirKaClassReferenceHandler? = null,
 ) : SirSession {
@@ -71,6 +72,7 @@ internal class StandaloneSirSession(
         sirSession,
         unsupportedDeclarationReporter = unsupportedDeclarationReporter,
         enableCoroutinesSupport = enableCoroutinesSupport,
+        hiddenModules = hiddenModules,
     )
     override val childrenProvider = SirDeclarationChildrenProviderImpl(sirSession)
 


### PR DESCRIPTION
For a new Swift Export DSL a functionality of hiding all the API from a module would be added.
For that we already had a flag on the config - errorTypeStrategy.

With this commit we introduce tests for that mode
proving that the generation results can be compiled.

^KT-88386 fixed