### PR TITLE
JVM: Generate non-null check in exposed functions

### DIFF
--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ExpressionCodegen.kt
@@ -346,9 +346,12 @@ class ExpressionCodegen(
             param.origin == IrDeclarationOrigin.MOVED_DISPATCH_RECEIVER
         )
             return
-        val asmType = param.type.asmType
+        // `@JvmExposeBoxed` exposes boxed inline classes, so, we need to check them for null,
+        // since they are designed to be called from Java.
+        val isBoxed = isBoxedParameterOfExposedFunction(irFunction, param)
+        val asmType = typeMapper.mapType(param.type, wrapInlineClassesForExposedFunctions(irFunction, param))
         val expandedType =
-            if (param.type.isInlineClassType())
+            if (param.type.isInlineClassType() && !isBoxed)
                 context.typeSystem.computeExpandedTypeForInlineClass(param.type) as? IrType ?: param.type
             else param.type
         if (!expandedType.isNullable() && !isPrimitive(asmType)) {

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/FunctionCodegen.kt
@@ -322,11 +322,6 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
         return frameMap
     }
 
-    private fun wrapInlineClassesForExposedFunctions(function: IrFunction, parameter: IrValueParameter): TypeMappingMode =
-        if (function.hasAnnotation(JvmStandardClassIds.JVM_EXPOSE_BOXED_ANNOTATION_FQ_NAME) && parameter.type.isInlineClassType())
-            TypeMappingMode.DEFAULT.wrapInlineClassesMode()
-        else TypeMappingMode.DEFAULT
-
     private fun generateParameterAnnotations(
         irFunction: IrFunction,
         mv: MethodVisitor,
@@ -394,6 +389,15 @@ class FunctionCodegen(private val irFunction: IrFunction, private val classCodeg
 
 private fun IrValueParameter.isSyntheticMarkerParameter(): Boolean =
     origin == IrDeclarationOrigin.DEFAULT_CONSTRUCTOR_MARKER
+
+// `@JvmExposeBoxed` exposes boxed inline classes, so they occupy Object slot.
+internal fun isBoxedParameterOfExposedFunction(function: IrFunction, parameter: IrValueParameter): Boolean =
+    function.hasAnnotation(JvmStandardClassIds.JVM_EXPOSE_BOXED_ANNOTATION_FQ_NAME) && parameter.type.isInlineClassType()
+
+internal fun wrapInlineClassesForExposedFunctions(function: IrFunction, parameter: IrValueParameter): TypeMappingMode =
+    if (isBoxedParameterOfExposedFunction(function, parameter))
+        TypeMappingMode.DEFAULT.wrapInlineClassesMode()
+    else TypeMappingMode.DEFAULT
 
 private fun generateParameterNames(irFunction: IrFunction, mv: MethodVisitor, config: JvmBackendConfig) {
     for (parameter in irFunction.parameters) {

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/nullCheck.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/directive/nullCheck.kt
@@ -1,0 +1,28 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+// JVM_EXPOSE_BOXED
+
+// FILE: IC.kt
+@JvmInline
+value class IntWrapper(val i: Int)
+
+fun f(p: IntWrapper): Int = p.i
+
+// FILE: Main.java
+public class Main {
+    public String test() {
+        try {
+            ICKt.f(null);
+        } catch (NullPointerException e) {
+            return e.getMessage();
+        }
+        return "no exception";
+    }
+}
+
+// FILE: Box.kt
+fun box(): String {
+    val message = Main().test()
+    if (!message.startsWith("Parameter specified as non-null is null")) return "FAIL: $message"
+    return "OK"
+}

--- a/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/nullCheck.kt
+++ b/compiler/testData/codegen/boxJvm/inlineClasses/jvmExposeBoxed/nullCheck.kt
@@ -1,0 +1,27 @@
+// WITH_STDLIB
+// TARGET_BACKEND: JVM_IR
+
+// FILE: Test.kt
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmExposeBoxed
+fun f(p: UInt): Int = p.toInt()
+
+// FILE: Main.java
+public class Main {
+    public String test() {
+        try {
+            TestKt.f(null);
+        } catch (NullPointerException e) {
+            return e.getMessage();
+        }
+        return "no exception";
+    }
+}
+
+// FILE: Box.kt
+fun box(): String {
+    val message = Main().test()
+    if (!message.startsWith("Parameter specified as non-null is null")) return "FAIL: $message"
+    return "OK"
+}

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForExposedBoxedParameters.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForExposedBoxedParameters.kt
@@ -1,0 +1,19 @@
+// WITH_STDLIB
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmInline
+value class IntWrapper(val i: Int)
+
+// The mangled counterpart takes an `int`, only the exposed overload takes a boxed `IntWrapper`.
+@JvmExposeBoxed
+fun nonNull(p: IntWrapper) {} // assertion in the exposed overload
+
+@JvmExposeBoxed
+fun nullable(p: IntWrapper?) {}
+
+@JvmExposeBoxed
+context(_: IntWrapper)
+fun IntWrapper.receiver(p: IntWrapper) {} // 3 assertions in the exposed overload
+
+// 0 checkParameterIsNotNull
+// 4 checkNotNullParameter

--- a/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForExposedBoxedParametersOfNullableUnderlyingTypes.kt
+++ b/compiler/testData/codegen/bytecodeText/inlineClasses/assertionsForExposedBoxedParametersOfNullableUnderlyingTypes.kt
@@ -1,0 +1,17 @@
+// WITH_STDLIB
+
+@file:OptIn(ExperimentalStdlibApi::class)
+
+@JvmInline
+value class AsAny(val a: Any?)
+
+// The underlying type is nullable, so the mangled counterpart gets no assertion,
+// but the exposed overload takes a boxed `AsAny`, which is not nullable.
+@JvmExposeBoxed
+fun nonNull(p: AsAny) {} // assertion in the exposed overload
+
+@JvmExposeBoxed
+fun nullable(p: AsAny?) {}
+
+// 0 checkParameterIsNotNull
+// 1 checkNotNullParameter


### PR DESCRIPTION
 #KT-88339 Fixed