### PR TITLE
[Tests] Match `WASM_IGNORE_FOR` runner by `FQN` instead of classloading

### DIFF
--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/utils/WasmDirectiveUtils.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/utils/WasmDirectiveUtils.kt
@@ -6,9 +6,6 @@
 package org.jetbrains.kotlin.test.utils
 
 import org.jetbrains.kotlin.cli.pipeline.web.wasm.WasmCompilationMode
-import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerTest
-import kotlin.reflect.KClass
-import kotlin.reflect.full.isSuperclassOf
 
 /**
  * For each of these, *null means all*, e.g., if `os` is null, the config expects the test to fail regardless of the OS
@@ -17,7 +14,7 @@ data class WasmIgnoreForConfig(
     val mode: WasmCompilationMode? = null,
     val os: String? = null,
     val vmName: String? = null,
-    val runner: KClass<*>? = null,
+    val runner: String? = null,
 ) {
     override fun toString(): String {
         val props = listOfNotNull(
@@ -59,15 +56,16 @@ fun wasmIgnoreForParser(raw: String): WasmIgnoreForConfig? {
         System.err.println("Invalid OS specified in WASM_IGNORE_FOR directive: os=${parts["os"]}. Must be linux, windows, or mac (case insensitive)")
         return null
     }
-    val runnerKClass = if (parts["runner"] != null) {
+    val runnerFqName = parts["runner"]
+    if (runnerFqName != null) {
         try {
-            val runnerKClass = Class.forName(parts["runner"]).kotlin
-            runnerKClass
-        } catch (e: ClassNotFoundException) {
-            System.err.println("Invalid runner specified in WASM_IGNORE_FOR directive: runner=${parts["runner"]}. Must be a valid ***fully-qualified*** class name")
-            return null
+            Class.forName(runnerFqName)
+        } catch (_: ClassNotFoundException) {
+            // Only a warning: generated runner classes are not on the classpath of every module parsing this directive
+            // (e.g. `:wasm:wasm.tests:klib-compatibility`), so an unresolvable name is not necessarily a mistake.
+            System.err.println("WARNING: specified runner=$runnerFqName could not be found among loaded classes")
         }
-    } else null
+    }
 
     // NOTE: mode mismatch will be caught by WasmCompilationMode.valueOf
     // NOTE: vm mismatches will be caught by the test itself, i.e. it will fail, or warn that it should be unmuted,
@@ -79,7 +77,7 @@ fun wasmIgnoreForParser(raw: String): WasmIgnoreForConfig? {
         mode = parts["mode"]?.let { WasmCompilationMode.valueOf(it.uppercase().replace('-', '_')) },
         os = parts["os"]?.lowercase(),
         vmName = parts["vm"],
-        runner = runnerKClass
+        runner = runnerFqName
     )
 }
 

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/utils/DirectiveTestUtils.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/utils/DirectiveTestUtils.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.wasm.test.handlers.WasmVMException
 import org.jetbrains.kotlin.wasm.test.tools.WasmVM
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.function.Executable
-import kotlin.reflect.full.isSuperclassOf
 
 object DirectiveTestUtils {
 
@@ -386,10 +385,10 @@ private class WasmIgnoredTestSuppressorGroup(
         }
 
         private fun hasRunnerMismatch(): Boolean {
-            val expectedRunnerKClass = ignoreForConfig.runner
+            val expectedRunnerFqName = ignoreForConfig.runner
                 ?: return false
 
-            return !testServices.testInfo.className.contains(expectedRunnerKClass.qualifiedName!!)
+            return !testServices.testInfo.className.contains(expectedRunnerFqName)
         }
 
 


### PR DESCRIPTION
KT-88235

Change that is needed to make [this](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_KlibBackwardAndForwardCompatibilityTestsNightly/1023297017) build green again.