### PR TITLE
Begin using a `Constraints` class in the applier inference codebase

### DIFF
--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/ApplierInferencer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/ApplierInferencer.kt
@@ -234,10 +234,14 @@ class ApplierInferencer<Type, Node>(
     private fun Bindings.unify(call: Node?, a: CallBindings, b: CallBindings): Boolean {
         if (!unify(a.target, b.target)) {
             if (call != null) {
-                // It's not possible for unification to fail when either `a` or `b` are allowed to
-                // be bound to every target, so within this if-branch, `effectiveAllowedTokens` must
-                // be non-null for both.
-                errorReporter.reportCallError(call, a.target.effectiveAllowedTokens!!, b.target.effectiveAllowedTokens!!)
+                // It's not possible for unification to fail when either `a.target` or `b.target`
+                // are allowed to be bound to every token, so within this if-branch,
+                // `.effectiveConstraints.allowedTokens` must be safe to access on both targets.
+                errorReporter.reportCallError(
+                    call,
+                    a.target.effectiveConstraints.allowedTokens,
+                    b.target.effectiveConstraints.allowedTokens
+                )
             }
             return false
         }
@@ -253,14 +257,14 @@ class ApplierInferencer<Type, Node>(
             val bp = b.parameters[i]
             if (!unify(null, ap, bp)) {
                 if (call != null) {
-                    // It's not possible for unification to fail when either `a` or `b` are allowed
-                    // to be bound to every target, so within this if-branch,
-                    // `effectiveAllowedTokens` must be non-null for both.
+                    // It's not possible for unification to fail when either `ap.target` or
+                    // `bp.target` are allowed to be bound to every token, so within this if-branch,
+                    // `.effectiveConstraints.allowedTokens` must be safe to access on both targets.
                     errorReporter.reportParameterError(
                         call,
                         i,
-                        bp.target.effectiveAllowedTokens!!,
-                        ap.target.effectiveAllowedTokens!!
+                        bp.target.effectiveConstraints.allowedTokens,
+                        ap.target.effectiveConstraints.allowedTokens
                     )
                 }
             }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Bindings.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Bindings.kt
@@ -18,12 +18,11 @@ package androidx.compose.compiler.plugins.kotlin.inference
 
 /**
  * The value of a binding. If [token] is not null, the binding is bound to [token]. If [token] is
- * null, the binding is open. If [allowedTokens] is not null, then the binding may only be bound to
- * an element of [allowedTokens]. [size] is the number of [Binding] instances that share this value.
- * This is used to optimize unifying open bindings. [index] is not used directly but makes debugging
- * easier.
+ * null, the binding is open. [constraints] dictates what tokens the binding may be bound to. [size]
+ * is the number of [Binding] instances that share this value. This is used to optimize unifying open
+ * bindings. [index] is not used directly but makes debugging easier.
  */
-class Value(var token: String?, var observers: Set<Bindings>, var allowedTokens: Set<String>? = null) {
+class Value(var token: String?, var observers: Set<Bindings>, var constraints: Constraints = Constraints.UNRESTRICTED) {
     var size: Int = 1
     val index = valueIndex++
 }
@@ -31,39 +30,38 @@ class Value(var token: String?, var observers: Set<Bindings>, var allowedTokens:
 private var valueIndex = 0
 
 /**
- * A binding that is either closed (with a non-null [token]) or open. If [allowedTokens] is not
- * null, then the binding may only be bound to an element of [allowedTokens]. Unified bindings are
- * linked together in a circular list by [Bindings]. All linked bindings are all closed
- * simultaneously when anyone of them is unified to a closed binding.
+ * A binding that is either closed (with a non-null [token]) or open. [constraints] dictates what
+ * tokens the binding may be bound to. Unified bindings are linked together in a circular list by
+ * [Bindings]. All linked bindings are all closed simultaneously when anyone of them is unified to a
+ * closed binding.
  *
  * @param token the applier token the binding is bound to if it is closed.
- * @param allowedTokens the set of tokens that this binding may be bound to, or null if this binding
- *        may be bound to any token
+ * @param constraints the constraints that dictate what tokens this binding may be bound to
  */
-class Binding(token: String? = null, observers: Set<Bindings>, allowedTokens: Set<String>? = null) {
+class Binding(token: String? = null, observers: Set<Bindings>, constraints: Constraints = Constraints.UNRESTRICTED) {
     /**
      * The token that is bound to this binding. If [token] is null then the binding is still open.
      */
     val token: String? get() = value.token
-    val allowedTokens: Set<String>? get() = value.allowedTokens
+    val constraints: Constraints get() = value.constraints
 
     /**
-     * The set of tokens that this binding is effectively allowed to be bound to, or null if it may
-     * be to be bound to any token.
+     * The effective constraints that are dictating what tokens this binding may be bound to.
      *
-     * A binding that has a non-null `token` field always has a null `allowedTokens` field, but we
-     * consider it to effectively have one allowed token, the one in its `token` field.
+     * A binding that has a non-null `token` field always has a `constraints` field that allows all
+     * tokens, but we consider the binding to effectively be constrained to only one allowed token,
+     * the one in its `token` field.
      */
-    val effectiveAllowedTokens: Set<String>?
-        get() = token?.let {
-            setOf(it)
-        } ?: allowedTokens
+    val effectiveConstraints: Constraints
+        get() = token?.let { t ->
+            Constraints.restrictedTo(setOf(t))
+        } ?: constraints
 
     /**
      * The value of the binding. All linked bindings share the same value which also maintains
      * the count of linked bindings.
      */
-    var value: Value = Value(token, observers, allowedTokens)
+    var value: Value = Value(token, observers, constraints)
 
     /**
      * The linked list next pointer. The list is circular an always non-empty as a binding will
@@ -76,7 +74,9 @@ class Binding(token: String? = null, observers: Set<Bindings>, allowedTokens: Se
         val sb = StringBuilder()
         sb.append("Binding(")
         value.token?.let { sb.append("token = $it") } ?: sb.append(value.index)
-        value.allowedTokens?.let { sb.append(", allowedTokens = ${it.joinToString(separator = ", ", prefix = "{", postfix = "}")}") }
+        if (!value.constraints.allowsAllTokens) {
+            sb.append(", constraints = ${value.constraints}")
+        }
         sb.append(")")
         return sb.toString()
     }
@@ -94,12 +94,12 @@ class Bindings {
     private val listeners = mutableListOf<() -> Unit>()
 
     /**
-     * Create a fresh open applier binding variable. If [allowedTokens] is not null, then the
-     * binding variable may only be bound to an element of [allowedTokens].
+     * Create a fresh open applier binding variable. [constraints] will dictate what tokens the
+     * binding variable may be bound to.
      */
-    fun open(allowedTokens: Set<String>? = null): Binding {
-        assert(allowedTokens == null || allowedTokens.size > 1)
-        return Binding(token = null, observers = setOf(this), allowedTokens)
+    fun open(constraints: Constraints = Constraints.UNRESTRICTED): Binding {
+        assert(constraints.allowsAllTokens || constraints.allowedTokens.size > 1)
+        return Binding(token = null, observers = setOf(this), constraints)
     }
 
     /**
@@ -161,32 +161,28 @@ class Bindings {
         val bValueSize = bValue.size
         val newObservers = aValue.observers + bValue.observers
 
-        val aEffectiveAllowedTokens = a.effectiveAllowedTokens
-        val bEffectiveAllowedTokens = b.effectiveAllowedTokens
+        val aEffectiveConstraints = a.effectiveConstraints
+        val bEffectiveConstraints = b.effectiveConstraints
 
-        val newAllowedTokens = when {
-            aEffectiveAllowedTokens != null && bEffectiveAllowedTokens != null ->
-                (aEffectiveAllowedTokens intersect bEffectiveAllowedTokens).also {
-                    if (it.isEmpty()) return false
-                }
-            aEffectiveAllowedTokens != null -> aEffectiveAllowedTokens
-            else -> bEffectiveAllowedTokens
+        val newConstraints = (aEffectiveConstraints intersect bEffectiveConstraints)
+        if (newConstraints.blocksAllTokens) {
+            return false
         }
 
-        if (newAllowedTokens != null && newAllowedTokens.size == 1) {
-            val token = newAllowedTokens.single()
+        if (newConstraints.allowsSingleToken) {
+            val token = newConstraints.allowedTokens.single()
             return bind(a, token) && bind(b, token)
         }
 
         if (aValueSize > bValueSize) {
             aValue.size += bValueSize
             aValue.observers = newObservers
-            aValue.allowedTokens = newAllowedTokens
+            aValue.constraints = newConstraints
             unifyValues(b, aValue)
         } else {
             bValue.size += aValueSize
             bValue.observers = newObservers
-            bValue.allowedTokens = newAllowedTokens
+            bValue.constraints = newConstraints
             unifyValues(a, bValue)
         }
 
@@ -209,16 +205,12 @@ class Bindings {
     private fun bind(binding: Binding, token: String): Boolean {
         val value = binding.value
 
-        val allowedTokens = value.allowedTokens
-        if (allowedTokens != null) {
-            if (token in allowedTokens) {
-                value.allowedTokens = null
-            } else {
-                return false
-            }
+        if (!value.constraints.allows(token)) {
+            return false
         }
 
         value.token = token
+        value.constraints = Constraints.UNRESTRICTED
         bindingValueChanged(value)
         value.observers = emptySet()
         return true

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Constraints.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Constraints.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.compiler.plugins.kotlin.inference
+
+/**
+ * Represents constraints that allow a certain (possibly infinite) set of tokens.
+ */
+class Constraints private constructor(private val allowed: Set<String>? = null) {
+    val allowsAllTokens: Boolean get() = allowed == null
+
+    val blocksAllTokens: Boolean get() = allowed?.isEmpty() == true
+
+    /**
+     * Whether these constraints allow exactly one token.
+     */
+    val allowsSingleToken: Boolean get() = allowed?.size == 1
+
+    /**
+     * The set of tokens allowed by these constraints. If these constraints allow all tokens, an
+     * [IllegalStateException] will be thrown.
+     */
+    val allowedTokens: Set<String>
+        get() =
+            allowed ?: throw IllegalStateException("Cannot be accessed on an instance that allows all tokens")
+
+    fun allows(token: String): Boolean = allowed?.contains(token) ?: true
+
+    infix fun intersect(other: Constraints): Constraints = when {
+        this.allowsAllTokens -> other
+        other.allowsAllTokens -> this
+        else -> Constraints(this.allowed!! intersect other.allowed!!)
+    }
+
+    override fun equals(other: Any?) = other is Constraints && other.allowed == allowed
+
+    override fun hashCode() = allowed.hashCode()
+
+    override fun toString(): String =
+        allowed?.joinToString(separator = ", ", prefix = "{", postfix = "}") ?: "unrestricted"
+
+    companion object {
+        /**
+         * Constraints that allow all tokens.
+         */
+        val UNRESTRICTED = Constraints()
+
+        /**
+         * Returns constraints that only allow the tokens in [allowed].
+         */
+        fun restrictedTo(allowed: Set<String>) = Constraints(allowed)
+    }
+}

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/LazyScheme.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/LazyScheme.kt
@@ -57,7 +57,7 @@ class LazyScheme(
         }
 
         fun itemOf(binding: Binding) = binding.token?.let { Token(it) }
-            ?: context[binding.value]?.let { Open(it, binding.allowedTokens) } ?: Open(-1, binding.allowedTokens)
+            ?: context[binding.value]?.let { Open(it, binding.constraints) } ?: Open(-1, binding.constraints)
 
         fun schemeOf(lazyScheme: LazyScheme): Scheme = Scheme(
             itemOf(lazyScheme.target),

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Scheme.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/inference/Scheme.kt
@@ -35,7 +35,7 @@ sealed class Item {
     internal abstract fun serializeTo(
         schemeWriter: SchemeStringSerializationWriter,
         positionalWriter: SchemeStringSerializationWriter,
-        indexed: MutableList<Set<String>?>,
+        indexed: MutableList<Constraints>,
     )
 }
 
@@ -53,7 +53,7 @@ class Token(val value: String) : Item() {
     override fun serializeTo(
         schemeWriter: SchemeStringSerializationWriter,
         positionalWriter: SchemeStringSerializationWriter,
-        indexed: MutableList<Set<String>?>,
+        indexed: MutableList<Constraints>,
     ) {
         schemeWriter.writeToken(value)
         positionalWriter.writeUnderscore()
@@ -61,21 +61,24 @@ class Token(val value: String) : Item() {
 }
 
 /**
- * An open part of a [Scheme]. If [allowedTokens] is non-null, then this part may only be bound to
- * an element of [allowedTokens]. All [Open] items with the same non-negative index should be bound
- * together to the  same applier. [Open] items with a negative index are considered anonymous and
- * are treated as independent.
+ * An open part of a [Scheme]. [constraints] dictates what tokens this part may be bound to. All
+ * [Open] items with the same non-negative index should be bound together to the same applier.
+ * [Open] items with a negative index are considered anonymous and are treated as independent.
  */
-class Open(val index: Int, val allowedTokens: Set<String>? = null, override val isUnspecified: Boolean = false) : Item() {
+class Open(
+    val index: Int,
+    val constraints: Constraints = Constraints.UNRESTRICTED,
+    override val isUnspecified: Boolean = false,
+) : Item() {
     override val isAnonymous: Boolean get() = index < 0
     override fun toBinding(bindings: Bindings, context: MutableList<Binding>): Binding {
-        if (index < 0) return bindings.open(allowedTokens)
+        if (index < 0) return bindings.open(constraints)
         while (index >= context.size) {
             context.add(bindings.open())
         }
         val result = context[index]
-        if (allowedTokens != null) {
-            bindings.unify(result, bindings.open(allowedTokens))
+        if (!constraints.allowsAllTokens) {
+            bindings.unify(result, bindings.open(constraints))
         }
         return result
     }
@@ -84,37 +87,33 @@ class Open(val index: Int, val allowedTokens: Set<String>? = null, override val 
         val sb = StringBuilder()
         sb.append("Open(")
         sb.append(if (index < 0) '_' else index)
-        allowedTokens?.let { sb.append(", allowedTokens = ${it.joinToString(separator = ", ", prefix = "{", postfix = "}")}") }
+        if (!constraints.allowsAllTokens) {
+            sb.append(", constrainedTo = $constraints")
+        }
         sb.append(")")
         return sb.toString()
     }
 
     override fun equals(other: Any?) =
-        other is Open && (other.index == index || (other.index < 0 && index < 0)) && other.allowedTokens == allowedTokens
+        other is Open && (other.index == index || (other.index < 0 && index < 0)) && other.constraints == constraints
 
     override fun hashCode(): Int = if (index < 0) -31 else index * 31
 
     override fun serializeTo(
         schemeWriter: SchemeStringSerializationWriter,
         positionalWriter: SchemeStringSerializationWriter,
-        indexed: MutableList<Set<String>?>,
+        indexed: MutableList<Constraints>,
     ) {
         schemeWriter.writeNumber(index)
 
         if (index < 0) {
-            if (allowedTokens?.isNotEmpty() == true) {
-                positionalWriter.writeTokenSet(allowedTokens)
-            } else {
-                positionalWriter.writeUnderscore()
-            }
+            positionalWriter.writeConstraints(constraints)
         } else {
             positionalWriter.writeUnderscore()
             while (indexed.size <= index) {
-                indexed.add(null)
+                indexed.add(Constraints.UNRESTRICTED)
             }
-            if (allowedTokens != null) {
-                indexed[index] = allowedTokens
-            }
+            indexed[index] = constraints
         }
     }
 }
@@ -122,15 +121,15 @@ class Open(val index: Int, val allowedTokens: Set<String>? = null, override val 
 /**
  * An object whose fields are jointly the serialization of a [Scheme].
  *
- * @param scheme a string that encodes all details about a scheme, except what `allowedTokens`
- *   constraints are on items. This string is in the format expected by the `scheme` parameter of
+ * @param scheme a string that encodes all details about a scheme, except what `constraints` are on
+ *   items. This string is in the format expected by the `scheme` parameter of
  *   `ComposableInferredTarget`.
- * @param positional a string that encodes what `allowedTokens` constraints are on each
- *   negative-indexed [Open] item in a scheme. This string is in the format expected by the
- *   `positional` parameter of `ComposableInferredTargetConstraints`.
- * @param indexed a string that encodes what `allowedTokens` constraints are on each
- *   non-negative-indexed [Open] item in a scheme. This string is in the format expected by the
- *   `indexed` parameter of `ComposableInferredTargetConstraints`.
+ * @param positional a string that encodes what `constraints` are on each negative-indexed [Open]
+ *   item in a scheme. This string is in the format expected by the `positional` parameter of
+ *   `ComposableInferredTargetConstraints`.
+ * @param indexed a string that encodes what `constraints` are on each non-negative-indexed [Open]
+ *   item in a scheme. This string is in the format expected by the `indexed` parameter of
+ *   `ComposableInferredTargetConstraints`.
  */
 data class SerializedScheme(val scheme: String, val positional: String, val indexed: String)
 
@@ -167,19 +166,15 @@ class Scheme(
     fun serialize(): SerializedScheme {
         val schemeWriter = SchemeStringSerializationWriter(StringBuilder())
         val positionalWriter = SchemeStringSerializationWriter(StringBuilder())
-        val indexed = mutableListOf<Set<String>?>()
+        val indexed = mutableListOf<Constraints>()
 
         serializeTo(schemeWriter, positionalWriter, indexed)
         var indexedWriter: SchemeStringSerializationWriter? = null
-        if (indexed.filterNotNull().isNotEmpty()) {
+        if (indexed.any { !it.allowsAllTokens }) {
             indexedWriter = SchemeStringSerializationWriter(StringBuilder())
             indexedWriter.writeOpen()
-            indexed.forEachIndexed { i, allowedTokens ->
-                if (allowedTokens?.isNotEmpty() == true) {
-                    indexedWriter.writeTokenSet(allowedTokens)
-                } else {
-                    indexedWriter.writeUnderscore()
-                }
+            indexed.forEachIndexed { i, constraints ->
+                indexedWriter.writeConstraints(constraints)
                 if (i < indexed.size - 1) {
                     indexedWriter.writeComma()
                 }
@@ -250,7 +245,7 @@ class Scheme(
     private fun serializeTo(
         schemeWriter: SchemeStringSerializationWriter,
         positionalWriter: SchemeStringSerializationWriter,
-        indexed: MutableList<Set<String>?>,
+        indexed: MutableList<Constraints>,
     ) {
         schemeWriter.writeOpen()
         positionalWriter.writeOpen()
@@ -380,9 +375,9 @@ fun deserializeScheme(scheme: String, positional: String? = null, indexed: Strin
         ItemKind.Number -> {
             val index = reader.number()
             if (indexedList != null && index in indexedList.indices) {
-                Open(index, indexedList[index])
+                Open(index, indexedList[index]?.let { Constraints.restrictedTo(it) } ?: Constraints.UNRESTRICTED)
             } else {
-                Open(index, allowedTokensFromPositional)
+                Open(index, allowedTokensFromPositional?.let { Constraints.restrictedTo(it) } ?: Constraints.UNRESTRICTED)
             }
         }
         else -> schemeParseError()
@@ -503,6 +498,14 @@ internal class SchemeStringSerializationWriter(private val builder: StringBuilde
     fun writeTokenSet(tokenSet: Set<String>) {
         builder.append(tokenSet.joinToString(separator = ",", prefix = "{", postfix = "}"))
         hasWrittenToken = true
+    }
+
+    fun writeConstraints(constraints: Constraints) {
+        if (!constraints.allowsAllTokens) {
+            writeTokenSet(constraints.allowedTokens)
+        } else {
+            writeUnderscore()
+        }
     }
 
     override fun toString(): String = builder.toString()

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/k2/ComposableTargetChecker.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/k2/ComposableTargetChecker.kt
@@ -178,7 +178,7 @@ private fun FirCallableSymbol<*>.fileScopeTarget(): Item? {
         (element as? FirFile)?.targetsFromAnnotations()?.let { targets ->
             when {
                 targets.size == 1 -> Token(targets.first())
-                targets.size > 1 -> Open(-1, allowedTokens = targets)
+                targets.size > 1 -> Open(-1, constraints = Constraints.restrictedTo(targets))
                 else -> null
             }
         } ?: element.parent?.let { findFileScope(it) }
@@ -208,7 +208,7 @@ fun FirCallableSymbol<*>.schemeItem(): Item {
     val explicitOpen = compositionOpenTarget()
     return when {
         targets.size == 1 -> Token(targets.first())
-        targets.size > 1 -> Open(explicitOpen ?: -1, allowedTokens = targets)
+        targets.size > 1 -> Open(explicitOpen ?: -1, constraints = Constraints.restrictedTo(targets))
         explicitOpen != null -> Open(explicitOpen)
         else -> Open(-1, isUnspecified = true)
     }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposableTargetAnnotationsTransformer.kt
@@ -359,7 +359,10 @@ class ComposableTargetAnnotationsTransformer(
 
             return when {
                 targetsFromAnnotations.size == 1 -> Token(targetsFromAnnotations.first())
-                targetsFromAnnotations.size > 1 -> Open(explicitOpen ?: -1, allowedTokens = targetsFromAnnotations)
+                targetsFromAnnotations.size > 1 -> Open(
+                    explicitOpen ?: -1,
+                    constraints = Constraints.restrictedTo(targetsFromAnnotations)
+                )
                 explicitOpen != null -> Open(explicitOpen)
                 else -> Open(-1, isUnspecified = true)
             }
@@ -469,12 +472,14 @@ class ComposableTargetAnnotationsTransformer(
                         }
                     )
                 }
-                allowedTokens?.forEach { token ->
-                    annotations.add(
-                        annotation(ComposableTargetClass).also {
-                            it.arguments[0] = irConst(token)
-                        }
-                    )
+                if (!constraints.allowsAllTokens) {
+                    constraints.allowedTokens.forEach { token ->
+                        annotations.add(
+                            annotation(ComposableTargetClass).also {
+                                it.arguments[0] = irConst(token)
+                            }
+                        )
+                    }
                 }
 
                 annotations

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/FakeAst.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/FakeAst.kt
@@ -482,7 +482,7 @@ private fun List<Annotation>.item(): Item? {
     return when {
         targetsFromAnnotations.size == 1 -> Token(targetsFromAnnotations.first())
         targetsFromAnnotations.size > 1 -> Open(
-            explicitOpen ?: -1, allowedTokens = targetsFromAnnotations
+            explicitOpen ?: -1, constraints = Constraints.restrictedTo(targetsFromAnnotations)
         )
         explicitOpen != null -> Open(explicitOpen)
         else -> null

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestBindings.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestBindings.kt
@@ -75,79 +75,79 @@ class TestBindings {
     }
 
     @Test
-    fun canCreateOpenBindingWithAllowedTokens() {
+    fun canCreateOpenBindingWithConstraints() {
         val bindings = Bindings()
-        val open = bindings.open(setOf("W", "X"))
+        val open = bindings.open(Constraints.restrictedTo(setOf("W", "X")))
         assertNull(open.token)
-        assertEquals(setOf("W", "X"), open.allowedTokens)
+        assertEquals(Constraints.restrictedTo(setOf("W", "X")), open.constraints)
     }
 
     @Test
     fun unifyConstrainedAndUnconstrainedOpenBindings() {
         val bindings = Bindings()
-        val open1 = bindings.open(setOf("W", "X"))
+        val open1 = bindings.open(Constraints.restrictedTo(setOf("W", "X")))
         val open2 = bindings.open()
-        
+
         assertTrue(bindings.unify(open1, open2))
         assertNull(open1.token)
-        assertEquals(setOf("W", "X"), open1.allowedTokens)
+        assertEquals(Constraints.restrictedTo(setOf("W", "X")), open1.constraints)
         assertNull(open2.token)
-        assertEquals(setOf("W", "X"), open2.allowedTokens)
+        assertEquals(Constraints.restrictedTo(setOf("W", "X")), open2.constraints)
     }
 
     @Test
-    fun unifyTwoOpenBindingsWithDisjointAllowedTokensFails() {
+    fun unifyTwoOpenBindingsWithDisjointConstraintsFails() {
         val bindings = Bindings()
-        val open1 = bindings.open(setOf("W", "X"))
-        val open2 = bindings.open(setOf("Y", "Z"))
-        
+        val open1 = bindings.open(Constraints.restrictedTo(setOf("W", "X")))
+        val open2 = bindings.open(Constraints.restrictedTo(setOf("Y", "Z")))
+
         assertFalse(bindings.unify(open1, open2))
         assertNull(open1.token)
-        assertEquals(setOf("W", "X"), open1.allowedTokens)
+        assertEquals(Constraints.restrictedTo(setOf("W", "X")), open1.constraints)
         assertNull(open2.token)
-        assertEquals(setOf("Y", "Z"), open2.allowedTokens)
+        assertEquals(Constraints.restrictedTo(setOf("Y", "Z")), open2.constraints)
     }
 
     @Test
-    fun unifyTwoOpenBindingsWithIntersectingAllowedTokens() {
+    fun unifyTwoOpenBindingsWithIntersectingConstraints() {
         val bindings = Bindings()
-        val open1 = bindings.open(setOf("W", "X", "Y"))
-        val open2 = bindings.open(setOf("X", "Y", "Z"))
-        
+        val open1 = bindings.open(Constraints.restrictedTo(setOf("W", "X", "Y")))
+        val open2 = bindings.open(Constraints.restrictedTo(setOf("X", "Y", "Z")))
+
         assertTrue(bindings.unify(open1, open2))
         assertNull(open1.token)
-        assertEquals(setOf("X", "Y"), open1.allowedTokens)
+        assertEquals(Constraints.restrictedTo(setOf("X", "Y")), open1.constraints)
         assertNull(open2.token)
-        assertEquals(setOf("X", "Y"), open2.allowedTokens)
+        assertEquals(Constraints.restrictedTo(setOf("X", "Y")), open2.constraints)
     }
 
     @Test
     fun unifyTwoOpenBindingsWithIntersectionOfOneTokenClosesThem() {
         val bindings = Bindings()
-        val open1 = bindings.open(setOf("W", "X"))
-        val open2 = bindings.open(setOf("X", "Y", "Z"))
-        
+        val open1 = bindings.open(Constraints.restrictedTo(setOf("W", "X")))
+        val open2 = bindings.open(Constraints.restrictedTo(setOf("X", "Y", "Z")))
+
         assertTrue(bindings.unify(open1, open2))
         assertEquals("X", open1.token)
-        assertNull(open1.allowedTokens)
+        assertEquals(Constraints.UNRESTRICTED, open1.constraints)
         assertEquals("X", open2.token)
-        assertNull(open2.allowedTokens)
+        assertEquals(Constraints.UNRESTRICTED, open2.constraints)
     }
 
     @Test
     fun unifyConstrainedOpenBindingAndClosedBinding() {
         val bindings = Bindings()
-        val open = bindings.open(setOf("W", "X"))
+        val open = bindings.open(Constraints.restrictedTo(setOf("W", "X")))
         val closed1 = bindings.closed("W")
         val closed2 = bindings.closed("Y")
-        
+
         assertFalse(bindings.unify(open, closed2))
         assertNull(open.token)
-        assertEquals(setOf("W", "X"), open.allowedTokens)
-        
+        assertEquals(Constraints.restrictedTo(setOf("W", "X")), open.constraints)
+
         assertTrue(bindings.unify(open, closed1))
         assertEquals("W", open.token)
-        assertNull(open.allowedTokens)
+        assertEquals(Constraints.UNRESTRICTED, open.constraints)
     }
 
     @Test

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestInferApplier.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestInferApplier.kt
@@ -162,10 +162,10 @@ class TestInferApplier {
         expect("useIdentity", "[Open(0), [Open(0)]]")
         expect("useRun", "[UI, [UI]]")
         expect("useVarAndIdentity", "[UI, [UI], [Vector]]")
-        expect("WX", "[Open(_, allowedTokens = {w, x})]")
-        expect("CallWX/0", "[Open(_, allowedTokens = {w, x})]")
-        expect("CallWX/1", "[Open(_, allowedTokens = {w, x}), [Open(_, allowedTokens = {y, z})]]")
-        expect("CallContent", "[Open(0, allowedTokens = {w, x}), [Open(0, allowedTokens = {w, x})]: [Open(_, allowedTokens = {y, z})]]")
+        expect("WX", "[Open(_, constrainedTo = {w, x})]")
+        expect("CallWX/0", "[Open(_, constrainedTo = {w, x})]")
+        expect("CallWX/1", "[Open(_, constrainedTo = {w, x}), [Open(_, constrainedTo = {y, z})]]")
+        expect("CallContent", "[Open(0, constrainedTo = {w, x}), [Open(0, constrainedTo = {w, x})]: [Open(_, constrainedTo = {y, z})]]")
 
         assertEquals(expectations.joinToString("\n"), results.joinToString("\n"))
     }

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestLazyScheme.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestLazyScheme.kt
@@ -71,20 +71,20 @@ class TestLazyScheme {
     fun canUpdateResultThroughUnificationWithConstrainedOpenBindings() {
         val lazyScheme = LazyScheme(schemeOf("[0, [1], [2]:[0, [2], [1]]"))
         val bindings = lazyScheme.bindings
-        val a = bindings.open(allowedTokens = setOf("U", "V"))
-        val b = bindings.open(allowedTokens = setOf("W", "X"))
-        val c = bindings.open(allowedTokens = setOf("Y", "Z"))
+        val a = bindings.open(constraints = Constraints.restrictedTo(setOf("U", "V")))
+        val b = bindings.open(constraints = Constraints.restrictedTo(setOf("W", "X")))
+        val c = bindings.open(constraints = Constraints.restrictedTo(setOf("Y", "Z")))
         bindings.unify(lazyScheme.target, a)
         bindings.unify(lazyScheme.parameters[0].target, b)
         bindings.unify(lazyScheme.parameters[1].target, c)
         assertEquals(
             "[" +
-                    "Open(0, allowedTokens = {U, V}), " +
-                    "[Open(2, allowedTokens = {W, X})], [Open(1, allowedTokens = {Y, Z})]" +
+                    "Open(0, constrainedTo = {U, V}), " +
+                    "[Open(2, constrainedTo = {W, X})], [Open(1, constrainedTo = {Y, Z})]" +
                     ": " +
                     "[" +
-                    "Open(0, allowedTokens = {U, V}), " +
-                    "[Open(1, allowedTokens = {Y, Z})], [Open(2, allowedTokens = {W, X})]" +
+                    "Open(0, constrainedTo = {U, V}), " +
+                    "[Open(1, constrainedTo = {Y, Z})], [Open(2, constrainedTo = {W, X})]" +
                     "]" +
                     "]",
             lazyScheme.toScheme().toString()

--- a/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestScheme.kt
+++ b/plugins/compose/compiler-hosted/src/test/kotlin/androidx/compose/compiler/plugins/kotlin/inference/TestScheme.kt
@@ -37,18 +37,22 @@ class TestScheme {
     fun canCreateASchemeWithConstrainedOpenItems() {
         val scheme =
             Scheme(
-                Open(0, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(0, allowedTokens = setOf("W", "X")))),
+                Open(0, constraints = Constraints.restrictedTo(setOf("W", "X"))),
+                listOf(Scheme(Open(0, constraints = Constraints.restrictedTo(setOf("W", "X"))))),
                 result =
-                    Scheme(Open(-1, allowedTokens = setOf("Y", "Z")), listOf(Scheme(Open(-1, allowedTokens = setOf("Y", "Z"))))),
+                    Scheme(
+                        Open(-1, constraints = Constraints.restrictedTo(setOf("Y", "Z"))),
+                        listOf(Scheme(Open(-1, constraints = Constraints.restrictedTo(setOf("Y", "Z")))))
+                    ),
             )
 
         assertEquals(
             "[" +
-                    "Open(0, allowedTokens = {W, X}), " +
-                    "[Open(0, allowedTokens = {W, X})]: " +
+                    "Open(0, constrainedTo = {W, X}), " +
+                    "[Open(0, constrainedTo = {W, X})]: " +
                     "[" +
-                    "Open(_, allowedTokens = {Y, Z}), " +
-                    "[Open(_, allowedTokens = {Y, Z})]" +
+                    "Open(_, constrainedTo = {Y, Z}), " +
+                    "[Open(_, constrainedTo = {Y, Z})]" +
                     "]" +
                     "]",
             scheme.toString()
@@ -155,16 +159,24 @@ class TestScheme {
             Scheme(a, listOf(aScheme, aScheme, aScheme)),
             Scheme(one, listOf(oneScheme, aScheme, oneScheme, aScheme)),
             Scheme(Open(Int.MIN_VALUE), listOf(Scheme(Open(Int.MIN_VALUE)))),
-            Scheme(Open(-1, allowedTokens = setOf("W", "X"))),
+            Scheme(Open(-1, constraints = Constraints.restrictedTo(setOf("W", "X")))),
             Scheme(
-                Open(-1, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(-1, allowedTokens = setOf("Y", "Z")))),
+                Open(-1, constraints = Constraints.restrictedTo(setOf("W", "X"))),
+                listOf(Scheme(Open(-1, constraints = Constraints.restrictedTo(setOf("Y", "Z"))))),
                 result =
-                    Scheme(Open(-1, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(-1, allowedTokens = setOf("Y", "Z"))))),
+                    Scheme(
+                        Open(-1, constraints = Constraints.restrictedTo(setOf("W", "X"))),
+                        listOf(Scheme(Open(-1, constraints = Constraints.restrictedTo(setOf("Y", "Z")))))
+                    ),
             ),
             Scheme(
-                Open(0, allowedTokens = setOf("W", "X")), listOf(Scheme(Open(0, allowedTokens = setOf("W", "X")))),
+                Open(0, constraints = Constraints.restrictedTo(setOf("W", "X"))),
+                listOf(Scheme(Open(0, constraints = Constraints.restrictedTo(setOf("W", "X"))))),
                 result =
-                    Scheme(Open(1, allowedTokens = setOf("Y", "Z")), listOf(Scheme(Open(1, allowedTokens = setOf("Y", "Z"))))),
+                    Scheme(
+                        Open(1, constraints = Constraints.restrictedTo(setOf("Y", "Z"))),
+                        listOf(Scheme(Open(1, constraints = Constraints.restrictedTo(setOf("Y", "Z")))))
+                    ),
             ),
         )
 


### PR DESCRIPTION
This PR replaces `allowedTokens: Set<String>?` fields with `constraints: Constraints` fields. This means that constraints that allow all tokens are now represented by `Constraints.UNRESTRICTED` instead of `null`, and this removed several awkward `null` checks from our code.

This change was suggested in https://github.com/JetBrains/kotlin/pull/7081#discussion_r3714450915