### PR TITLE
Cherry-pick "Fix composable singleton in function with type parameters" to 2.4.20

### DIFF
--- a/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/memoizationOfEmptyComposable.txt
+++ b/plugins/compose/compiler-hosted/integration-tests/testResources/golden/androidx.compose.compiler.plugins.kotlin.LambdaMemoizationRegressionTests/memoizationOfEmptyComposable.txt
@@ -1,0 +1,98 @@
+//
+// Source
+// ------------------------------------------
+
+import androidx.compose.runtime.*
+
+@Composable
+fun <S> Test(vm: S, content: @Composable (S) -> Unit = { vm -> Effect(vm) }) {
+    content(vm)
+}
+
+@Composable fun <S> Effect(vm: S) {}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+@Composable
+@FunctionKeyMeta(key = 1406395989, startOffset = 72, endOffset = 184)
+fun <S> Test(vm: S, content: Function3<S, Composer, Int, Unit>?, %composer: Composer?, %changed: Int, %default: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(Test)N(vm,content)<conten...>:Test.kt")
+  val %dirty = %changed
+  if (%changed and 0b0110 == 0) {
+    %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+      %composer.changed(vm)
+    } else {
+      %composer.changedInstance(vm)
+    }
+    ) 0b0100 else 0b0010
+  }
+  if (%default and 0b0010 != 0) {
+    %dirty = %dirty or 0b00110000
+  } else if (%changed and 0b00110000 == 0) {
+    %dirty = %dirty or if (%composer.changedInstance(content)) 0b00100000 else 0b00010000
+  }
+  if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
+    if (%default and 0b0010 != 0) {
+      content = ComposableSingletons%TestKt.lambda%773808165
+    }
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    content as Function3<S, Composer, Int, Unit>(vm, %composer, 0b1000 and %dirty or 0b1110 and %dirty or 0b01110000 and %dirty)
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Test(vm, content, %composer, updateChangedFlags(%changed or 0b0001), %default)
+  }
+}
+@Composable
+@FunctionKeyMeta(key = 954568310, startOffset = 206, endOffset = 230)
+fun <S> Effect(vm: S, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  sourceInformation(%composer, "C(Effect)N(vm):Test.kt")
+  if (%composer.shouldExecute(%changed and 0b0001 != 0, %changed and 0b0001)) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Effect(vm, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+internal object ComposableSingletons%TestKt {
+  val lambda%773808165: Function3<S, Composer, Int, Unit> = composableLambdaInstance(<>, false) { vm: S, %composer: Composer?, %changed: Int ->
+    sourceInformation(%composer, "invalid source info at 1: 'CN(vm)4@135L10:Test.kt'")
+    val %dirty = %changed
+    if (%changed and 0b0110 == 0) {
+      %dirty = %dirty or if (if (%changed and 0b1000 == 0) {
+        %composer.changed(vm)
+      } else {
+        %composer.changedInstance(vm)
+      }
+      ) 0b0100 else 0b0010
+    }
+    if (%composer.shouldExecute(%dirty and 0b00010011 != 0b00010010, %dirty and 0b0001)) {
+      if (isTraceInProgress()) {
+        traceEventStart(<>, %dirty, -1, <>)
+      }
+      Effect(vm, %composer, 0b1000 and %dirty or 0b1110 and %dirty)
+      if (isTraceInProgress()) {
+        traceEventEnd()
+      }
+    } else {
+      %composer.skipToGroupEnd()
+    }
+  }
+}

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ComposeBytecodeCodegenTest.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/ComposeBytecodeCodegenTest.kt
@@ -1141,4 +1141,18 @@ class ComposeBytecodeCodegenTest : AbstractCodegenTest() {
             }
         }
     }
+
+    @Test
+    fun memoizationOfDefaultComposable() = testCompile(
+        source = """
+        import androidx.compose.runtime.*
+
+        @Composable
+        fun <S> Test(vm: S, content: @Composable (S) -> Unit = { vm -> Effect(vm) }) {
+            content(vm)
+        }
+
+        @Composable fun <S> Effect(vm: S) {}
+        """
+    )
 }

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/LambdaMemoizationRegressionTests.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/LambdaMemoizationRegressionTests.kt
@@ -179,4 +179,18 @@ class LambdaMemoizationRegressionTests : AbstractIrTransformTest() {
             }
     """
     )
+
+    @Test
+    fun memoizationOfEmptyComposable() = verifyGoldenComposeIrTransform(
+        source = """
+        import androidx.compose.runtime.*
+
+        @Composable
+        fun <S> Test(vm: S, content: @Composable (S) -> Unit = { vm -> Effect(vm) }) {
+            content(vm)
+        }
+
+        @Composable fun <S> Effect(vm: S) {}
+        """
+    )
 }

--- a/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/plugins/compose/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -38,7 +38,9 @@ import org.jetbrains.kotlin.ir.builders.declarations.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.isUnit
@@ -903,7 +905,7 @@ class ComposerLambdaMemoization(
         declarationContext: DeclarationContext,
         expression: IrFunctionExpression,
         collector: CaptureCollector,
-        useComposableFactory: Boolean
+        useComposableFactory: Boolean,
     ): IrCall {
         val function = expression.function
         val argumentCount = function.parameters.size
@@ -965,6 +967,22 @@ class ComposerLambdaMemoization(
             arguments[index] = expression.markIsTransformedLambda()
         }
 
+        // Copy type parameters to ensure that types are captured correctly.
+        val functionContext = currentFunctionContext
+        if (functionContext != null && functionContext.composable && functionContext.declaration.typeParameters.isNotEmpty()) {
+            expression.function.copyTypeParametersFrom(functionContext.declaration)
+            expression.function.remapTypes(SimpleTypeRemapper(
+                object : SymbolRemapper by SymbolRemapper.EMPTY {
+                    override fun getReferencedClassifier(symbol: IrClassifierSymbol): IrClassifierSymbol =
+                        if (symbol is IrTypeParameterSymbol && symbol.owner.parent == functionContext.declaration) {
+                            expression.function.typeParameters[symbol.owner.index].symbol
+                        } else {
+                            symbol
+                        }
+                }
+            ))
+        }
+
         return composableLambdaExpression.markHasTransformedLambda()
     }
 
@@ -981,7 +999,7 @@ class ComposerLambdaMemoization(
                             // K2 uses invokedynamic for lambdas, which doesn't perform lambda optimization
                             // on Android.
                             context.platform.isJvm()
-                    )
+                            )
 
         // If the function doesn't capture, Kotlin's default optimization is sufficient
         if (!memoizeLambdasWithoutCaptures && captures.isEmpty()) {


### PR DESCRIPTION
It was capturing $dirty for the original function.

Fixes: 543684938