### PR TITLE
Revert "[FIR2IR] Remove workaround for KDF in receiver cast generation"

### DIFF
--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrImplicitCastInserter.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.name.StandardClassIds
-import org.jetbrains.kotlin.utils.addToStdlib.applyIf
 
 class Fir2IrImplicitCastInserter(c: Fir2IrComponents, private val conversionScope: Fir2IrConversionScope) : Fir2IrComponents by c {
 
@@ -33,6 +32,7 @@ class Fir2IrImplicitCastInserter(c: Fir2IrComponents, private val conversionScop
      */
     internal fun IrExpression.insertSpecialCast(
         expression: FirExpression,
+        valueType: ConeKotlinType,
         unsubstitutedExpectedType: ConeKotlinType,
         substitutedExpectedType: ConeKotlinType,
     ): IrExpression {
@@ -44,7 +44,7 @@ class Fir2IrImplicitCastInserter(c: Fir2IrComponents, private val conversionScop
             coerceStatementsToUnit(coerceLastExpressionToUnit = type.isUnit())
         }
 
-        val expandedValueType = expression.resolvedType.fullyExpandedType()
+        val expandedValueType = valueType.fullyExpandedType()
         val expandedExpectedType = substitutedExpectedType.fullyExpandedType()
 
         return when {
@@ -117,15 +117,35 @@ class Fir2IrImplicitCastInserter(c: Fir2IrComponents, private val conversionScop
         }
     }
 
-    internal fun IrExpression.insertCastForIntersectionTypeOrSelf(
-        expression: FirExpression,
+    internal fun IrExpression.insertCastForReceiver(
+        argumentType: ConeKotlinType,
         expectedType: ConeKotlinType,
-        forReceiver: Boolean = false,
     ): IrExpression {
-        val argumentTypeLowerBound = expression.resolvedType.fullyExpandedType().lowerBoundIfFlexible()
-        if (argumentTypeLowerBound !is ConeIntersectionType) {
-            return insertCastToNullableNothingOrSelf(expression, expectedType, argumentTypeLowerBound)
-        }
+        return insertCastForIntersectionTypeOrNull(argumentType, expectedType, forReceiver = true)
+        // When we generate an implicit this receiver, we assign it the type of the IR declaration.
+        // However, dataframe generates FIR and IR anonymous functions with different receiver types
+        // and then relies on the fact that FIR2IR generates an implicit cast from the one to the other.
+        // That's why we insert a seemingly redundant cast to the argumentType (not the expected type) here.
+        // See plugins/kotlin-dataframe/testData/box/groupByAdd.kt and plugins/kotlin-dataframe/testData/box/wrongReceiver.kt.
+        // TODO(KT-77691) Remove when fixed on the plugin side.
+            ?: implicitCastOrExpression(this, argumentType, conversionScope.defaultConversionTypeOrigin())
+    }
+
+    internal fun IrExpression.insertCastForIntersectionTypeOrSelf(
+        argumentType: ConeKotlinType,
+        expectedType: ConeKotlinType,
+    ): IrExpression {
+        return insertCastForIntersectionTypeOrNull(argumentType, expectedType, forReceiver = false)
+            ?: this
+    }
+
+    private fun IrExpression.insertCastForIntersectionTypeOrNull(
+        argumentType: ConeKotlinType,
+        expectedType: ConeKotlinType,
+        forReceiver: Boolean,
+    ): IrExpression? {
+        val argumentTypeLowerBound = argumentType.lowerBoundIfFlexible()
+        if (argumentTypeLowerBound !is ConeIntersectionType) return null
 
         val approximatedExpectedType = expectedType.approximateForIrOrSelf()
 
@@ -135,34 +155,16 @@ class Fir2IrImplicitCastInserter(c: Fir2IrComponents, private val conversionScop
         // TODO(KT-77692) Remove if fixed on the plugin side.
         if (!forReceiver) {
             val approximatedArgumentType = argumentTypeLowerBound.approximateForIrOrNull() ?: argumentTypeLowerBound
-            if (approximatedArgumentType.isSubtypeOf(approximatedExpectedType, session)) return this
+            if (approximatedArgumentType.isSubtypeOf(approximatedExpectedType, session)) return null
         }
 
         return argumentTypeLowerBound.intersectedTypes
             .firstOrNull { it.isSubtypeOf(approximatedExpectedType, session) }
             ?.let { generateImplicitCast(this, it.toIrType(conversionScope.defaultConversionTypeOrigin())) }
-            ?: this
-    }
-
-    private fun IrExpression.insertCastToNullableNothingOrSelf(
-        expression: FirExpression,
-        expectedType: ConeKotlinType,
-        argumentTypeLowerBound: ConeRigidType,
-    ): IrExpression {
-        // See compiler/testData/codegen/box/smartCasts/nullSmartCast.kt
-        // where an expression of type Int? is smart-casted to Nothing? and then used for the expected type String?.
-        // Not inserting a cast, makes Wasm fail.
-        val argumentTypeWithoutNullableNothing = (expression as? FirSmartCastExpression)?.smartcastTypeWithoutNullableNothing?.coneType
-            ?: return this
-
-        return applyIf(!argumentTypeWithoutNullableNothing.isSubtypeOf(expectedType.approximateForIrOrSelf(), session)) {
-            assert(argumentTypeLowerBound.isNullableNothing)
-            generateImplicitCast(this, argumentTypeLowerBound.toIrType(conversionScope.defaultConversionTypeOrigin()))
-        }
     }
 
     fun implicitCastOrExpression(
-        original: IrExpression, castType: ConeKotlinType, typeOrigin: ConversionTypeOrigin = ConversionTypeOrigin.DEFAULT,
+        original: IrExpression, castType: ConeKotlinType, typeOrigin: ConversionTypeOrigin = ConversionTypeOrigin.DEFAULT
     ): IrExpression {
         return implicitCastOrExpression(original, castType.toIrType(typeOrigin))
     }

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/Fir2IrVisitor.kt
@@ -1504,9 +1504,8 @@ class Fir2IrVisitor(
                         // compiler/testData/codegen/box/when/stringOptimization/enhancedNullability.kt
                         // See KT-47398.
                         convertToIrExpression(subjectExpression).insertCastForIntersectionTypeOrSelf(
-                            expression = subjectExpression,
+                            argumentType = subjectExpression.resolvedType,
                             expectedType = subjectVariable.returnTypeRef.coneType,
-                            forReceiver = false,
                         )
                     },
                     nameHint = "subject",

--- a/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/utils/ImplicitConversionUtils.kt
+++ b/compiler/fir/fir2ir/src/org/jetbrains/kotlin/fir/backend/utils/ImplicitConversionUtils.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.ir.util.render
 context(c: Fir2IrComponents)
 fun IrExpression.prepareExpressionForGivenExpectedType(
     expression: FirExpression,
+    valueType: ConeKotlinType = expression.resolvedType.fullyExpandedType(),
     expectedType: ConeKotlinType,
     // In most cases, it should be the same as `expectedType`.
     // Currently, it's only used for a case of a call argument to a generic function or for a call argument of a vararg parameter.
@@ -38,12 +39,16 @@ fun IrExpression.prepareExpressionForGivenExpectedType(
     }
 
     val expressionWithCast = with(c.implicitCastInserter) {
-        insertCastForIntersectionTypeOrSelf(expression, expectedType, forReceiver)
-            .insertSpecialCast(
-                expression,
-                unsubstitutedExpectedType = unsubstitutedExpectedType,
-                substitutedExpectedType = expectedType
-            )
+        if (forReceiver) {
+            insertCastForReceiver(valueType, expectedType)
+        } else {
+            insertCastForIntersectionTypeOrSelf(valueType, expectedType)
+        }.insertSpecialCast(
+            expression,
+            valueType = valueType,
+            unsubstitutedExpectedType = unsubstitutedExpectedType,
+            substitutedExpectedType = expectedType
+        )
     }
 
     return expressionWithCast

--- a/compiler/testData/ir/irText/expressions/sam/genericSamProjectedOut.ir.txt
+++ b/compiler/testData/ir/irText/expressions/sam/genericSamProjectedOut.ir.txt
@@ -44,7 +44,8 @@ FILE fqName:<root> fileName:/genericSamProjectedOut.kt
                     RETURN type=kotlin.Nothing from='local final fun <anonymous> (it: @[FlexibleNullability] kotlin.String?): kotlin.Unit declared in <root>.test'
                       GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
       CALL 'public open fun set (i: kotlin.Int, hello: @[FlexibleNullability] example.Hello<@[FlexibleNullability] A of example.SomeJavaClass?>?): kotlin.Unit declared in example.SomeJavaClass' type=kotlin.Unit origin=EQ
-        ARG <this>: GET_VAR 'var a: example.SomeJavaClass<out kotlin.String> declared in <root>.test' type=example.SomeJavaClass<out kotlin.String> origin=null
+        ARG <this>: TYPE_OP type=example.SomeJavaClass<out @[FlexibleNullability] kotlin.String?> origin=IMPLICIT_CAST typeOperand=example.SomeJavaClass<out @[FlexibleNullability] kotlin.String?>
+          GET_VAR 'var a: example.SomeJavaClass<out kotlin.String> declared in <root>.test' type=example.SomeJavaClass<out kotlin.String> origin=null
         ARG i: CONST Int type=kotlin.Int value=0
         ARG hello: TYPE_OP type=example.Hello<out @[FlexibleNullability] kotlin.String?> origin=SAM_CONVERSION typeOperand=example.Hello<out @[FlexibleNullability] kotlin.String?>
           FUN_EXPR type=kotlin.Function1<@[FlexibleNullability] kotlin.String?, kotlin.Unit> origin=LAMBDA

--- a/compiler/testData/ir/irText/expressions/sam/genericSamProjectedOut.kt.txt
+++ b/compiler/testData/ir/irText/expressions/sam/genericSamProjectedOut.kt.txt
@@ -16,9 +16,8 @@ fun test() {
     return Unit
   }
  /*-> Hello<out @FlexibleNullability String?> */) /*!! SomeJavaClass<out @FlexibleNullability String?> */
-  a.set(i = 0, hello = local fun <anonymous>(it: @FlexibleNullability String?) {
+  a /*as SomeJavaClass<out @FlexibleNullability String?> */.set(i = 0, hello = local fun <anonymous>(it: @FlexibleNullability String?) {
     return Unit
   }
  /*-> Hello<out @FlexibleNullability String?> */)
 }
-


### PR DESCRIPTION
This reverts commit 08effe9e74d75ab9483a95c6ab26d5481ff007bf.

^KT-77718 Submitted

See the thread: https://jetbrains.slack.com/archives/C06QB5UHN9Y/p1786026940230509