### PR TITLE
[BTA] Pass PluginsLoader to IC runners

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompilerPlugins/kotlin/ClassLoadersCachingTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompilerPlugins/kotlin/ClassLoadersCachingTest.kt
@@ -8,12 +8,15 @@ package org.jetbrains.kotlin.buildtools.tests.compilation
 import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.BuildOperation
 import org.jetbrains.kotlin.buildtools.api.ExecutionPolicy
+import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
 import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogDoesNotContainPatterns
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.DefaultStrategyAndPlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.DefaultStrategyAndPlatformAgnosticScenarioTest
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectCreator
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.ScenarioCreator
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.DisplayName
 
@@ -35,6 +38,37 @@ class ClassLoadersCachingTest : BaseCompilationTest() {
                 assertLogDoesNotContainPatterns(LogLevel.INFO, "Creating new classloader for classpath.*".toRegex())
             }
         }
+    }
+
+    @DefaultStrategyAndPlatformAgnosticScenarioTest
+    @DisplayName("Test that plugins loader is used to cache compiler plugins with IC runner")
+    fun testPluginsLoaderCacheIc(scenario: ScenarioCreator) {
+        scenario {
+            assumeTrue(this.strategyConfig is ExecutionPolicy.InProcess)
+
+            val module = module("sandbox-plugin", compilationConfigAction = { operation: BaseCompilationOperation.Builder ->
+                operation.compilerArguments[CommonCompilerArguments.COMPILER_PLUGINS] = listOf(PLUGIN_SANDBOX_PLUGIN)
+            })
+
+            // cache was already filled when module was being created for the scenario, so we need to clear it
+            kotlinToolchains.clearClassloadersCache()
+
+            module.replaceFileWithVersion("main.kt", "step1")
+            module.compile(forceOutput = LogLevel.INFO) {
+                assertLogContainsPatterns(LogLevel.INFO, "Creating new classloader for classpath.*".toRegex())
+            }
+
+            module.replaceFileWithVersion("main.kt", "step2")
+            module.compile {
+                assertLogDoesNotContainPatterns(LogLevel.INFO, "Creating new classloader for classpath.*".toRegex())
+            }
+        }
+    }
+
+    private fun KotlinToolchains.clearClassloadersCache() {
+        val cache = javaClass.declaredFields.single { it.name == "classloadersCache" }.apply { isAccessible = true }
+            .get(this)
+        cache?.javaClass?.methods?.find { it.name == "close" }?.invoke(cache)
     }
 
     @DefaultStrategyAndPlatformAgnosticCompilationTest

--- a/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/KotlinToolchains.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/main/kotlin/org/jetbrains/kotlin/buildtools/api/KotlinToolchains.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.buildtools.api
 
-import org.jetbrains.kotlin.buildtools.api.KotlinToolchains.Companion.loadImplementation
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains.Toolchain
 import org.jetbrains.kotlin.buildtools.api.abi.AbiValidationToolchain
 import org.jetbrains.kotlin.buildtools.api.cri.CriToolchain

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/BaseCompilationOperationImpl.kt
@@ -65,7 +65,6 @@ internal abstract class BaseCompilationOperationImpl<BtaCompilerArgs : CommonCom
 
     operator fun <V> get(key: Option<V>): V = options[key]
 
-    @OptIn(UseFromImplModuleRestricted::class)
     operator fun <V> set(key: Option<V>, value: V) {
         options[key] = value
     }

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/CompilationServiceImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/CompilationServiceImpl.kt
@@ -207,7 +207,7 @@ internal object CompilationServiceImpl : CompilationService {
                         outputDirs = options.outputDirs,
                         classpathChanges = classpathChanges,
                         kotlinSourceFilesExtensions = kotlinFilenameExtensions,
-                        icFeatures = icFeatures
+                        icFeatures = icFeatures,
                     )
                 }
 

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsKlibCompilationOperationImpl.kt
@@ -256,7 +256,8 @@ internal class JsKlibCompilationOperationImpl private constructor(
                 )
             ),
             CompileScopeExpansionMode.ALWAYS,
-            icFeatures
+            icFeatures,
+            executionContext.classloadersCache?.asPluginsLoader()
         )
 
         arguments.incrementalCompilation = true

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/jvm/operations/JvmCompilationOperationImpl.kt
@@ -269,7 +269,8 @@ internal class JvmCompilationOperationImpl private constructor(
                 snapshotBasedIcOptionsAccessor,
                 classpathChanges,
                 getKotlinFilenameExtensions(),
-                icFeatures
+                icFeatures,
+                executionContext,
             )
         }
 
@@ -341,6 +342,7 @@ internal class JvmCompilationOperationImpl private constructor(
         classpathChanges: ClasspathChanges.ClasspathSnapshotEnabled,
         kotlinFilenameExtensions: Set<String>,
         icFeatures: IncrementalCompilationFeatures,
+        executionContext: ExecutionContext,
     ): IncrementalJvmCompilerRunner =
         IncrementalJvmCompilerRunner(
             workingDirectory.toFile(),
@@ -352,6 +354,7 @@ internal class JvmCompilationOperationImpl private constructor(
             compilationCanceledStatus = cancellationHandle,
             generateCompilerRefIndex = get(GENERATE_COMPILER_REF_INDEX),
             lookupTrackerDelegate = getLookupTrackerAdapter(),
+            pluginsLoader = executionContext.classloadersCache?.asPluginsLoader()
         )
 
     private fun JvmCompilationOperationImpl.getFirRunner(

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmKlibCompilationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/wasm/operations/WasmKlibCompilationOperationImpl.kt
@@ -255,7 +255,8 @@ internal class WasmKlibCompilationOperationImpl private constructor(
                 )
             ),
             CompileScopeExpansionMode.ALWAYS,
-            icFeatures
+            icFeatures,
+            executionContext.classloadersCache?.asPluginsLoader(),
         )
 
         arguments.incrementalCompilation = true

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalCompilerRunner.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.build.report.warn
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
 import org.jetbrains.kotlin.compilerRunner.OutputItemsCollectorImpl
 import org.jetbrains.kotlin.compilerRunner.toGeneratedFile
 import org.jetbrains.kotlin.config.LanguageVersion
@@ -78,6 +79,7 @@ abstract class IncrementalCompilerRunner<
     protected val icFeatures: IncrementalCompilationFeatures,
 
     private val compilationCanceledStatus: CompilationCanceledStatus? = null,
+    private val pluginsLoader: PluginsLoader?,
 ) {
 
     protected open val lookupTrackerDelegate: LookupTracker = LookupTracker.DO_NOTHING
@@ -494,6 +496,7 @@ abstract class IncrementalCompilerRunner<
             register(ExpectActualTracker::class.java, expectActualTracker)
             register(CompilationCanceledStatus::class.java, compilationCanceledStatus)
             register(ICFileMappingTracker::class.java, fileMappingTracker)
+            pluginsLoader?.let { register(PluginsLoader::class.java, it) }
         }
 
     protected abstract fun runCompiler(

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJsCompilerRunner.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJsCompilerRunner.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.cli.common.arguments.KotlinWasmCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.js.K2JSCompiler
 import org.jetbrains.kotlin.cli.js.KotlinWasmCompiler
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
 import org.jetbrains.kotlin.config.IncrementalCompilation
 import org.jetbrains.kotlin.config.Services
 import org.jetbrains.kotlin.incremental.components.ExpectActualTracker
@@ -54,7 +55,7 @@ fun makeJsIncrementally(
             cachesDir, buildReporter,
             buildHistoryFile = buildHistoryFile,
             modulesApiHistory = modulesApiHistory,
-            scopeExpansion = scopeExpansion
+            scopeExpansion = scopeExpansion,
         )
         compiler.compile(allKotlinFiles, args, messageCollector, providedChangedFiles ?: ChangedFiles.DeterminableFiles.ToBeComputed)
     }
@@ -85,6 +86,7 @@ class IncrementalJsCompilerRunner(
     override val modulesApiHistory: ModulesApiHistory,
     private val scopeExpansion: CompileScopeExpansionMode = CompileScopeExpansionMode.NEVER,
     icFeatures: IncrementalCompilationFeatures = IncrementalCompilationFeatures.DEFAULT_CONFIGURATION,
+    pluginsLoader: PluginsLoader? = null,
 ) : IncrementalCompilerRunner<CommonJsAndWasmCompilerArguments, IncrementalJsCachesManager>(
     workingDir,
     "caches-js",
@@ -92,6 +94,7 @@ class IncrementalJsCompilerRunner(
     buildHistoryFile = buildHistoryFile,
     outputDirs = null,
     icFeatures = icFeatures,
+    pluginsLoader = pluginsLoader,
 ) {
     override val shouldTrackChangesInLookupCache
         get() = false

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunner.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.build.report.metrics.measure
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
 import org.jetbrains.kotlin.incremental.ChangedFiles.DeterminableFiles
 import org.jetbrains.kotlin.incremental.classpathDiff.ClasspathSnapshotBuildReporter
 import org.jetbrains.kotlin.incremental.classpathDiff.shrinkAndSaveClasspathSnapshot
@@ -33,6 +34,7 @@ open class IncrementalJvmCompilerRunner(
     generateCompilerRefIndex: Boolean = false,
     compilationCanceledStatus: CompilationCanceledStatus? = null,
     override val lookupTrackerDelegate: LookupTracker = LookupTracker.DO_NOTHING,
+    pluginsLoader: PluginsLoader? = null,
 ) : IncrementalJvmCompilerRunnerBase(
     workingDir = workingDir,
     reporter = reporter,
@@ -42,6 +44,7 @@ open class IncrementalJvmCompilerRunner(
     icFeatures = icFeatures,
     generateCompilerRefIndex = generateCompilerRefIndex,
     compilationCanceledStatus = compilationCanceledStatus,
+    pluginsLoader = pluginsLoader,
 ) {
     override val shouldTrackChangesInLookupCache
         get() = classpathChanges is ClasspathChanges.ClasspathSnapshotEnabled.IncrementalRun

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunnerBase.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/IncrementalJvmCompilerRunnerBase.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.messages.MessageCollectorImpl
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginsLoader
 import org.jetbrains.kotlin.config.Services
 import org.jetbrains.kotlin.incremental.DifferenceCalculatorForPackageFacade.Companion.getVisibleTypeAliasFqNames
 import org.jetbrains.kotlin.incremental.components.ExpectActualTracker
@@ -60,6 +61,7 @@ abstract class IncrementalJvmCompilerRunnerBase(
     icFeatures: IncrementalCompilationFeatures,
     private val generateCompilerRefIndex: Boolean = false,
     compilationCanceledStatus: CompilationCanceledStatus? = null,
+    pluginsLoader: PluginsLoader?,
 ) : IncrementalCompilerRunner<K2JVMCompilerArguments, IncrementalJvmCachesManager>(
     workingDir,
     "caches-jvm",
@@ -69,6 +71,7 @@ abstract class IncrementalJvmCompilerRunnerBase(
     kotlinSourceFilesExtensions = kotlinSourceFilesExtensions,
     icFeatures = icFeatures,
     compilationCanceledStatus = compilationCanceledStatus,
+    pluginsLoader = pluginsLoader,
 ) {
     override val shouldStoreFullFqNamesInLookupCache = true
 


### PR DESCRIPTION
In addition to using ClassloadersCache as a PluginsLoader compiler service in non-IC operations, this commit adds it to IC runners as well.

^KT-88275