### PR TITLE
[Gradle] Fix creating project dependency crashes on older Gradle releases

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftimport/SwiftImportSetupAction.kt
@@ -559,7 +559,7 @@ private fun Project.updateDependenciesWithAggregatedResults(
             aggregationService.get().buildAggregatedResultDependencies(
                 packageResolvedSynchronizationIdentifier
             ).map {
-                project.dependencies.project(it)
+                project.dependencies.project(mapOf("path" to it))
             }
         }
     )


### PR DESCRIPTION
'DependencyHandler.project(String)' method was only added in the Gradle
9.5.0 release. Fell back to old method based on map params.

^KT-87993
