### PR TITLE
[PowerAssert] Handle implicit context parameters in arguments

### DIFF
--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/IrUtils.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/IrUtils.kt
@@ -22,21 +22,15 @@ package org.jetbrains.kotlin.powerassert
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.BuiltInOperatorNames
-import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
-import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionExpressionImpl
-import org.jetbrains.kotlin.ir.expressions.isComparisonOperator
-import org.jetbrains.kotlin.ir.irAttribute
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.hasAnnotation
-import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
-import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 
@@ -71,43 +65,10 @@ fun IrBuilderWithScope.irLambda(
     return IrFunctionExpressionImpl(startOffset, endOffset, lambdaType, lambda, IrStatementOrigin.LAMBDA)
 }
 
-val IrElement.earliestStartOffset: Int
-    get() {
-        var offset = startOffset
-        this.acceptChildrenVoid(
-            object : IrVisitorVoid() {
-                override fun visitElement(element: IrElement) {
-                    if (element.startOffset < offset) offset = element.startOffset
-                    element.acceptChildrenVoid(this)
-                }
-            },
-        )
-        return offset
-    }
-
-private var IrElement.sourceRangeAttribute: ClosedRange<Int>? by irAttribute(copyByDefault = false)
-val IrElement.sourceRange: ClosedRange<Int>
-    get() {
-        sourceRangeAttribute?.let { return it }
-
-        var range = startOffset..endOffset
-        acceptChildrenVoid(
-            object : IrVisitorVoid() {
-                override fun visitElement(element: IrElement) {
-                    val childRange = element.sourceRange
-                    range = minOf(range.start, childRange.start)..maxOf(range.endInclusive, childRange.endInclusive)
-                }
-            },
-        )
-
-        sourceRangeAttribute = range
-        return range
-    }
-
 /**
- * An implicit argument may only be either `this` class dispatch receiver ([IrGetField])
- * or `this` extension function receiver ([IrGetValue]). As such, these are the only two
- * IR elements that need to be checked for [IrStatementOrigin.IMPLICIT_ARGUMENT].
+ * An implicit argument may only be either `this` class dispatch receiver ([IrGetField]),
+ * `this` extension function receiver ([IrGetValue]), or an implicit context parameter ([IrGetValue]).
+ * As such, these are the only IR elements that need to be checked for [IrStatementOrigin.IMPLICIT_ARGUMENT].
  */
 internal fun IrExpression.isImplicitArgument(): Boolean = when (this) {
     is IrGetValue -> origin == IrStatementOrigin.IMPLICIT_ARGUMENT

--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/builder/parameter/CallExplanationParameterBuilder.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/builder/parameter/CallExplanationParameterBuilder.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.powerassert.diagram.IrDiagramVariable
 import org.jetbrains.kotlin.powerassert.diagram.SourceFile
-import org.jetbrains.kotlin.powerassert.sourceRange
+import org.jetbrains.kotlin.powerassert.diagram.sourceRange
 
 class CallExplanationParameterBuilder(
     private val factory: ExplanationFactory,

--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/builder/parameter/ExplanationFactory.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/builder/parameter/ExplanationFactory.kt
@@ -20,8 +20,8 @@ import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.powerassert.PowerAssertBuiltIns
 import org.jetbrains.kotlin.powerassert.diagram.IrDiagramVariable
+import org.jetbrains.kotlin.powerassert.diagram.sourceRange
 import org.jetbrains.kotlin.powerassert.diagram.toDisplayOffset
-import org.jetbrains.kotlin.powerassert.sourceRange
 
 class ExplanationFactory(
     private val builtIns: PowerAssertBuiltIns,

--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/ExpressionTree.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/ExpressionTree.kt
@@ -184,6 +184,9 @@ fun <T> buildTree(
                 } else if (expression.isWhenSubjectAccess()) {
                     // Do not diagram implicit when-subjects.
                     data.addChild(HiddenNode(expression))
+                } else if (expression.startOffset < 0) {
+                    // Do not diagram expressions without source.
+                    data.addChild(HiddenNode(expression))
                 } else {
                     val chainNode = data as? ChainNode ?: ChainNode().also { data.addChild(it) }
                     expression.acceptChildren(this, chainNode)

--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/SourceFile.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/SourceFile.kt
@@ -19,15 +19,12 @@
 
 package org.jetbrains.kotlin.powerassert.diagram
 
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.fir.backend.FirMetadataSource
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.PsiIrFileEntry
 import org.jetbrains.kotlin.ir.SourceRangeInfo
 import org.jetbrains.kotlin.ir.declarations.IrFile
-import org.jetbrains.kotlin.ir.declarations.path
 import org.jetbrains.kotlin.ir.expressions.IrCall
-import org.jetbrains.kotlin.powerassert.earliestStartOffset
 import org.jetbrains.kotlin.powerassert.getExplicitReceiver
 
 class SourceFile private constructor(
@@ -54,7 +51,8 @@ class SourceFile private constructor(
                 if (explicitReceiver != null) {
                     // When a function is called *not* with infix notation, the startOffset will not include the receiver.
                     // Force the range to include the receiver, so it is visible.
-                    range = element.earliestStartOffset..element.endOffset
+                    val sourceRange = element.sourceRange
+                    range = sourceRange.start..element.endOffset
 
                     // The offsets of the receiver will *not* include surrounding parentheses,
                     // so these need to be checked for manually.
@@ -73,18 +71,13 @@ class SourceFile private constructor(
     }
 
     fun getText(start: Int, end: Int): String {
+        if (start < 0 || end < 0) return ""
         return source.substring(maxOf(start, 0), minOf(end, source.length))
     }
 
     fun getRedactedTextBlock(info: SourceRangeInfo): String {
         val block = getText(info.startOffset - info.startColumnNumber, info.endOffset)
         return block.clearSourcePrefix(info.startColumnNumber)
-    }
-
-    fun getCompilerMessageLocation(element: IrElement): CompilerMessageLocation {
-        val info = getSourceRangeInfo(element)
-        val lineContent = getText(info)
-        return CompilerMessageLocation.create(irFile.path, info.startLineNumber, info.startColumnNumber, lineContent)!!
     }
 }
 

--- a/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/SourceOffsetRange.kt
+++ b/plugins/power-assert/power-assert-compiler/power-assert.backend/src/org/jetbrains/kotlin/powerassert/diagram/SourceOffsetRange.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.powerassert.diagram
+
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.irAttribute
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+
+class SourceOffsetRange(
+    override val start: Int,
+    val end: Int,
+) : ClosedRange<Int> {
+    override val endInclusive: Int
+        get() = end
+
+    fun expand(other: SourceOffsetRange): SourceOffsetRange {
+        if (other.start < 0) return this
+        return SourceOffsetRange(
+            start = minOf(start, other.start),
+            end = maxOf(end, other.end)
+        )
+    }
+}
+
+private var IrElement.sourceRangeAttribute: SourceOffsetRange? by irAttribute(copyByDefault = false)
+val IrElement.sourceRange: SourceOffsetRange
+    get() {
+        sourceRangeAttribute?.let { return it }
+
+        var range = SourceOffsetRange(startOffset, endOffset)
+        acceptChildrenVoid(
+            object : IrVisitorVoid() {
+                override fun visitElement(element: IrElement) {
+                    range = range.expand(element.sourceRange)
+                }
+            },
+        )
+
+        sourceRangeAttribute = range
+        return range
+    }

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/operator/OperatorReceiver.box.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/operator/OperatorReceiver.box.txt
@@ -31,6 +31,14 @@ assert(dispatch - dispatch == Failure)
        Dispatch(n=1)
 ---
 test5: ---
+assert(dispatch - dispatch == Failure)
+       |        | |        |
+       |        | |        false
+       |        | Dispatch(n=1)
+       |        Dispatch(n=0)
+       Dispatch(n=1)
+---
+test6: ---
 assert(extension - extension == Failure)
        |         | |         |
        |         | |         false
@@ -38,7 +46,15 @@ assert(extension - extension == Failure)
        |         Extension(n=2)
        Extension(n=1)
 ---
-test6: ---
+test7: ---
+assert(extension - extension == Failure)
+       |         | |         |
+       |         | |         false
+       |         | Extension(n=1)
+       |         Extension(n=2)
+       Extension(n=1)
+---
+test8: ---
 assert(extension * extension == Failure)
        |         | |         |
        |         | |         false
@@ -46,33 +62,20 @@ assert(extension * extension == Failure)
        |         Extension(n=1)
        Extension(n=1)
 ---
-test7: ---
+test9: ---
+assert(extension * extension == Failure)
+       |         | |         |
+       |         | |         false
+       |         | Extension(n=1)
+       |         Extension(n=1)
+       Extension(n=1)
+---
+test10: ---
 assert(dispatch in dispatch)
        |        |  |
        |        |  Dispatch(n=1)
        |        false
        Dispatch(n=1)
----
-test8: ---
-assert(dispatch in extension)
-       |        |  |
-       |        |  Extension(n=1)
-       |        false
-       Dispatch(n=1)
----
-test9: ---
-assert(extension in extension)
-       |         |  |
-       |         |  Extension(n=1)
-       |         false
-       Extension(n=1)
----
-test10: ---
-assert(context in dispatch)
-       |       |  |
-       |       |  Dispatch(n=1)
-       |       false
-       Context(n=1)
 ---
 test11: ---
 assert(dispatch in extension)
@@ -82,13 +85,55 @@ assert(dispatch in extension)
        Dispatch(n=1)
 ---
 test12: ---
+assert(extension in extension)
+       |         |  |
+       |         |  Extension(n=1)
+       |         false
+       Extension(n=1)
+---
+test13: ---
+assert(context in dispatch)
+       |       |  |
+       |       |  Dispatch(n=1)
+       |       false
+       Context(n=1)
+---
+test14: ---
+assert(context in dispatch)
+       |       |  |
+       |       |  Dispatch(n=1)
+       |       false
+       Context(n=1)
+---
+test15: ---
+assert(dispatch in extension)
+       |        |  |
+       |        |  Extension(n=1)
+       |        false
+       Dispatch(n=1)
+---
+test16: ---
+assert(dispatch in extension)
+       |        |  |
+       |        |  Extension(n=1)
+       |        false
+       Dispatch(n=1)
+---
+test17: ---
 assert(context in extension)
        |       |  |
        |       |  Extension(n=1)
        |       false
        Context(n=1)
 ---
-test13: ---
+test18: ---
+assert(context in extension)
+       |       |  |
+       |       |  Extension(n=1)
+       |       false
+       Context(n=1)
+---
+test19: ---
 assert(dispatch.plus(dispatch) == Failure)
        |        |    |         |
        |        |    |         false
@@ -96,7 +141,7 @@ assert(dispatch.plus(dispatch) == Failure)
        |        Dispatch(n=2)
        Dispatch(n=1)
 ---
-test14: ---
+test20: ---
 assert(extension.plus(extension) == Failure)
        |         |    |          |
        |         |    |          false
@@ -104,7 +149,7 @@ assert(extension.plus(extension) == Failure)
        |         Extension(n=2)
        Extension(n=1)
 ---
-test15: ---
+test21: ---
 assert(extension.minus(extension) == Failure)
        |         |     |          |
        |         |     |          false
@@ -112,7 +157,7 @@ assert(extension.minus(extension) == Failure)
        |         Extension(n=0)
        Extension(n=1)
 ---
-test16: ---
+test22: ---
 assert(dispatch.minus(dispatch) == Failure)
        |        |     |         |
        |        |     |         false
@@ -120,7 +165,15 @@ assert(dispatch.minus(dispatch) == Failure)
        |        Dispatch(n=0)
        Dispatch(n=1)
 ---
-test17: ---
+test23: ---
+assert(dispatch.minus(dispatch) == Failure)
+       |        |     |         |
+       |        |     |         false
+       |        |     Dispatch(n=1)
+       |        Dispatch(n=0)
+       Dispatch(n=1)
+---
+test24: ---
 assert(extension.minus(extension) == Failure)
        |         |     |          |
        |         |     |          false
@@ -128,7 +181,15 @@ assert(extension.minus(extension) == Failure)
        |         Extension(n=2)
        Extension(n=1)
 ---
-test18: ---
+test25: ---
+assert(extension.minus(extension) == Failure)
+       |         |     |          |
+       |         |     |          false
+       |         |     Extension(n=1)
+       |         Extension(n=2)
+       Extension(n=1)
+---
+test26: ---
 assert(extension.times(extension) == Failure)
        |         |     |          |
        |         |     |          false
@@ -136,37 +197,63 @@ assert(extension.times(extension) == Failure)
        |         Extension(n=1)
        Extension(n=1)
 ---
-test19: ---
+test27: ---
+assert(extension.times(extension) == Failure)
+       |         |     |          |
+       |         |     |          false
+       |         |     Extension(n=1)
+       |         Extension(n=1)
+       Extension(n=1)
+---
+test28: ---
 assert(dispatch.contains(dispatch))
        |        |        |
        |        false    Dispatch(n=1)
        Dispatch(n=1)
 ---
-test20: ---
+test29: ---
 assert(extension.contains(dispatch))
        |         |        |
        |         false    Dispatch(n=1)
        Extension(n=1)
 ---
-test21: ---
+test30: ---
 assert(extension.contains(extension))
        |         |        |
        |         false    Extension(n=1)
        Extension(n=1)
 ---
-test22: ---
+test31: ---
 assert(dispatch.contains(context))
        |        |        |
        |        false    Context(n=1)
        Dispatch(n=1)
 ---
-test23: ---
+test32: ---
+assert(dispatch.contains(context))
+       |        |        |
+       |        false    Context(n=1)
+       Dispatch(n=1)
+---
+test33: ---
 assert(extension.contains(dispatch))
        |         |        |
        |         false    Dispatch(n=1)
        Extension(n=1)
 ---
-test24: ---
+test34: ---
+assert(extension.contains(dispatch))
+       |         |        |
+       |         false    Dispatch(n=1)
+       Extension(n=1)
+---
+test35: ---
+assert(extension.contains(context))
+       |         |        |
+       |         false    Context(n=1)
+       Extension(n=1)
+---
+test36: ---
 assert(extension.contains(context))
        |         |        |
        |         false    Context(n=1)

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/operator/OperatorReceiver.kt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/operator/OperatorReceiver.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +ContextParameters
-// ISSUE: KT-73870, KT-73898
+// ISSUE: KT-73870, KT-73898, KT-88179
 
 fun box(): String {
     return listOf(
@@ -27,6 +27,18 @@ fun box(): String {
         "test22: " to { test22() },
         "test23: " to { test23() },
         "test24: " to { test24() },
+        "test25: " to { test25() },
+        "test26: " to { test26() },
+        "test27: " to { test27() },
+        "test28: " to { test28() },
+        "test29: " to { test29() },
+        "test30: " to { test30() },
+        "test31: " to { test31() },
+        "test32: " to { test32() },
+        "test33: " to { test33() },
+        "test34: " to { test34() },
+        "test35: " to { test35() },
+        "test36: " to { test36() },
     ).joinToString("") { (name, test) -> name + test() }
 }
 
@@ -97,12 +109,24 @@ fun test4() = expectThrowableMessage {
 }
 
 fun test5() = expectThrowableMessage {
+    context(context) {
+        assert(dispatch - dispatch == Failure)
+    }
+}
+
+fun test6() = expectThrowableMessage {
     with(context) {
         assert(extension - extension == Failure)
     }
 }
 
-fun test6() = expectThrowableMessage {
+fun test7() = expectThrowableMessage {
+    context(context) {
+        assert(extension - extension == Failure)
+    }
+}
+
+fun test8() = expectThrowableMessage {
     with(dispatch) {
         with(context) {
             assert(extension * extension == Failure)
@@ -110,27 +134,41 @@ fun test6() = expectThrowableMessage {
     }
 }
 
-fun test7() = expectThrowableMessage {
+fun test9() = expectThrowableMessage {
+    with(dispatch) {
+        context(context) {
+            assert(extension * extension == Failure)
+        }
+    }
+}
+
+fun test10() = expectThrowableMessage {
     assert(dispatch in dispatch)
 }
 
-fun test8() = expectThrowableMessage {
+fun test11() = expectThrowableMessage {
     assert(dispatch in extension)
 }
 
-fun test9() = expectThrowableMessage {
+fun test12() = expectThrowableMessage {
     with(dispatch) {
         assert(extension in extension)
     }
 }
 
-fun test10() = expectThrowableMessage {
+fun test13() = expectThrowableMessage {
     with(context) {
         assert(context in dispatch)
     }
 }
 
-fun test11() = expectThrowableMessage {
+fun test14() = expectThrowableMessage {
+    context(context) {
+        assert(context in dispatch)
+    }
+}
+
+fun test15() = expectThrowableMessage {
     context(_: Context)
     operator fun Extension.contains(other: Dispatch): Boolean = false
 
@@ -139,9 +177,26 @@ fun test11() = expectThrowableMessage {
     }
 }
 
-fun test12() = expectThrowableMessage {
+fun test16() = expectThrowableMessage {
+    context(_: Context)
+    operator fun Extension.contains(other: Dispatch): Boolean = false
+
+    context(context) {
+        assert(dispatch in extension)
+    }
+}
+
+fun test17() = expectThrowableMessage {
     with(dispatch) {
         with(context) {
+            assert(context in extension)
+        }
+    }
+}
+
+fun test18() = expectThrowableMessage {
+    with(dispatch) {
+        context(context) {
             assert(context in extension)
         }
     }
@@ -151,33 +206,45 @@ fun test12() = expectThrowableMessage {
 // Regular Call //
 // ============ //
 
-fun test13() = expectThrowableMessage {
+fun test19() = expectThrowableMessage {
     assert(dispatch.plus(dispatch) == Failure)
 }
 
-fun test14() = expectThrowableMessage {
+fun test20() = expectThrowableMessage {
     assert(extension.plus(extension) == Failure)
 }
 
-fun test15() = expectThrowableMessage {
+fun test21() = expectThrowableMessage {
     with(dispatch) {
         assert(extension.minus(extension) == Failure)
     }
 }
 
-fun test16() = expectThrowableMessage {
+fun test22() = expectThrowableMessage {
     with(context) {
         assert(dispatch.minus(dispatch) == Failure)
     }
 }
 
-fun test17() = expectThrowableMessage {
+fun test23() = expectThrowableMessage {
+    context(context) {
+        assert(dispatch.minus(dispatch) == Failure)
+    }
+}
+
+fun test24() = expectThrowableMessage {
     with(context) {
         assert(extension.minus(extension) == Failure)
     }
 }
 
-fun test18() = expectThrowableMessage {
+fun test25() = expectThrowableMessage {
+    context(context) {
+        assert(extension.minus(extension) == Failure)
+    }
+}
+
+fun test26() = expectThrowableMessage {
     with(dispatch) {
         with(context) {
             assert(extension.times(extension) == Failure)
@@ -185,27 +252,41 @@ fun test18() = expectThrowableMessage {
     }
 }
 
-fun test19() = expectThrowableMessage {
+fun test27() = expectThrowableMessage {
+    with(dispatch) {
+        context(context) {
+            assert(extension.times(extension) == Failure)
+        }
+    }
+}
+
+fun test28() = expectThrowableMessage {
     assert(dispatch.contains(dispatch))
 }
 
-fun test20() = expectThrowableMessage {
+fun test29() = expectThrowableMessage {
     assert(extension.contains(dispatch))
 }
 
-fun test21() = expectThrowableMessage {
+fun test30() = expectThrowableMessage {
     with(dispatch) {
         assert(extension.contains(extension))
     }
 }
 
-fun test22() = expectThrowableMessage {
+fun test31() = expectThrowableMessage {
     with(context) {
         assert(dispatch.contains(context))
     }
 }
 
-fun test23() = expectThrowableMessage {
+fun test32() = expectThrowableMessage {
+    context(context) {
+        assert(dispatch.contains(context))
+    }
+}
+
+fun test33() = expectThrowableMessage {
     context(_: Context)
     operator fun Extension.contains(other: Dispatch): Boolean = false
 
@@ -214,9 +295,26 @@ fun test23() = expectThrowableMessage {
     }
 }
 
-fun test24() = expectThrowableMessage {
+fun test34() = expectThrowableMessage {
+    context(_: Context)
+    operator fun Extension.contains(other: Dispatch): Boolean = false
+
+    context(context) {
+        assert(extension.contains(dispatch))
+    }
+}
+
+fun test35() = expectThrowableMessage {
     with(dispatch) {
         with(context) {
+            assert(extension.contains(context))
+        }
+    }
+}
+
+fun test36() = expectThrowableMessage {
+    with(dispatch) {
+        context(context) {
             assert(extension.contains(context))
         }
     }

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/ContextReceivers.box.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/ContextReceivers.box.txt
@@ -4,6 +4,16 @@ context1Assert("test".length == 5)
                       4      false
 ---
 test2: ---
+context1Assert("test".length == 5)
+                      |      |
+                      4      false
+---
+test3: ---
+context2Assert("test".length == 5)
+                      |      |
+                      4      false
+---
+test4: ---
 context2Assert("test".length == 5)
                       |      |
                       4      false

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/ContextReceivers.kt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/ContextReceivers.kt
@@ -3,9 +3,13 @@
 // FUNCTION: context2Assert
 // DUMP_KT_IR
 
+// ISSUE: KT-88179
+
 fun box(): String = runAll(
     "test1" to { test1() },
     "test2" to { test2() },
+    "test3" to { test3() },
+    "test4" to { test4() },
 )
 
 data object Asserter
@@ -27,7 +31,19 @@ fun test1() {
 }
 
 fun test2() {
+    context(Asserter) {
+        context1Assert("test".length == 5)
+    }
+}
+
+fun test3() {
     with(Asserter) {
+        context2Assert("test".length == 5)
+    }
+}
+
+fun test4() {
+    context(Asserter) {
         context2Assert("test".length == 5)
     }
 }

--- a/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/ContextReceivers.kt.txt
+++ b/plugins/power-assert/power-assert-compiler/testData/codegen/parameters/ContextReceivers.kt.txt
@@ -33,6 +33,12 @@ fun box(): String {
 ), to<String, Function0<Unit>>(/* <this> = "test2", */ that = local fun <anonymous>() {
     test2()
   }
+), to<String, Function0<Unit>>(/* <this> = "test3", */ that = local fun <anonymous>() {
+    test3()
+  }
+), to<String, Function0<Unit>>(/* <this> = "test4", */ that = local fun <anonymous>() {
+    test4()
+  }
 )])
 }
 
@@ -59,7 +65,7 @@ fun test1() {
         val tmp2_Explain: Int = tmp1_Explain.<get-length>()
         val tmp3_Explain: Int = 5
         val tmp4_Explain: Boolean = EQEQ(arg0 = tmp2_Explain, arg1 = tmp3_Explain)
-        context1Assert(/* $context-Asserter = tmp0_Explain, */ condition = tmp4_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 540, source = "        context1Assert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [null, Argument(startOffset = 23, endOffset = 41, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 23, endOffset = 29, displayOffset = 23, value = tmp1_Explain), ValueExpression(startOffset = 23, endOffset = 36, displayOffset = 30, value = tmp2_Explain), LiteralExpression(startOffset = 40, endOffset = 41, displayOffset = 40, value = tmp3_Explain), EqualityExpression(startOffset = 23, endOffset = 41, displayOffset = 37, value = tmp4_Explain, lhs = tmp2_Explain, rhs = tmp3_Explain)])), null])) */))
+        context1Assert(/* $context-Asserter = tmp0_Explain, */ condition = tmp4_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 616, source = "        context1Assert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [null, Argument(startOffset = 23, endOffset = 41, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 23, endOffset = 29, displayOffset = 23, value = tmp1_Explain), ValueExpression(startOffset = 23, endOffset = 36, displayOffset = 30, value = tmp2_Explain), LiteralExpression(startOffset = 40, endOffset = 41, displayOffset = 40, value = tmp3_Explain), EqualityExpression(startOffset = 23, endOffset = 41, displayOffset = 37, value = tmp4_Explain, lhs = tmp2_Explain, rhs = tmp3_Explain)])), null])) */))
       }
     }
   }
@@ -67,6 +73,23 @@ fun test1() {
 }
 
 fun test2() {
+  context<Asserter, Unit>(with = Asserter, block = context($context-Asserter: Asserter)
+  local fun <anonymous>() {
+    { // BLOCK
+      val tmp0_Explain: Asserter = $context-Asserter
+      { // BLOCK
+        val tmp1_Explain: String = "test"
+        val tmp2_Explain: Int = tmp1_Explain.<get-length>()
+        val tmp3_Explain: Int = 5
+        val tmp4_Explain: Boolean = EQEQ(arg0 = tmp2_Explain, arg1 = tmp3_Explain)
+        context1Assert(/* $context-Asserter = tmp0_Explain, */ condition = tmp4_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 706, source = "        context1Assert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [null, Argument(startOffset = 23, endOffset = 41, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 23, endOffset = 29, displayOffset = 23, value = tmp1_Explain), ValueExpression(startOffset = 23, endOffset = 36, displayOffset = 30, value = tmp2_Explain), LiteralExpression(startOffset = 40, endOffset = 41, displayOffset = 40, value = tmp3_Explain), EqualityExpression(startOffset = 23, endOffset = 41, displayOffset = 37, value = tmp4_Explain, lhs = tmp2_Explain, rhs = tmp3_Explain)])), null])) */))
+      }
+    }
+  }
+)
+}
+
+fun test3() {
   with<Asserter, Unit>(receiver = Asserter, block = local fun Asserter.<anonymous>() {
     { // BLOCK
       val tmp0_Explain: Asserter = $this$with
@@ -77,7 +100,27 @@ fun test2() {
           val tmp3_Explain: Int = tmp2_Explain.<get-length>()
           val tmp4_Explain: Int = 5
           val tmp5_Explain: Boolean = EQEQ(arg0 = tmp3_Explain, arg1 = tmp4_Explain)
-          context2Assert(/* $context-Asserter$1 = tmp0_Explain, $context-Asserter$2 = tmp1_Explain, */ condition = tmp5_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 627, source = "        context2Assert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [null, null, Argument(startOffset = 23, endOffset = 41, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 23, endOffset = 29, displayOffset = 23, value = tmp2_Explain), ValueExpression(startOffset = 23, endOffset = 36, displayOffset = 30, value = tmp3_Explain), LiteralExpression(startOffset = 40, endOffset = 41, displayOffset = 40, value = tmp4_Explain), EqualityExpression(startOffset = 23, endOffset = 41, displayOffset = 37, value = tmp5_Explain, lhs = tmp3_Explain, rhs = tmp4_Explain)])), null])) */))
+          context2Assert(/* $context-Asserter$1 = tmp0_Explain, $context-Asserter$2 = tmp1_Explain, */ condition = tmp5_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 793, source = "        context2Assert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [null, null, Argument(startOffset = 23, endOffset = 41, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 23, endOffset = 29, displayOffset = 23, value = tmp2_Explain), ValueExpression(startOffset = 23, endOffset = 36, displayOffset = 30, value = tmp3_Explain), LiteralExpression(startOffset = 40, endOffset = 41, displayOffset = 40, value = tmp4_Explain), EqualityExpression(startOffset = 23, endOffset = 41, displayOffset = 37, value = tmp5_Explain, lhs = tmp3_Explain, rhs = tmp4_Explain)])), null])) */))
+        }
+      }
+    }
+  }
+)
+}
+
+fun test4() {
+  context<Asserter, Unit>(with = Asserter, block = context($context-Asserter: Asserter)
+  local fun <anonymous>() {
+    { // BLOCK
+      val tmp0_Explain: Asserter = $context-Asserter
+      { // BLOCK
+        val tmp1_Explain: Asserter = $context-Asserter
+        { // BLOCK
+          val tmp2_Explain: String = "test"
+          val tmp3_Explain: Int = tmp2_Explain.<get-length>()
+          val tmp4_Explain: Int = 5
+          val tmp5_Explain: Boolean = EQEQ(arg0 = tmp3_Explain, arg1 = tmp4_Explain)
+          context2Assert(/* $context-Asserter$1 = tmp0_Explain, $context-Asserter$2 = tmp1_Explain, */ condition = tmp5_Explain, msg = "\n" + toDefaultMessage(/* <this> = CallExplanation(offset = 883, source = "        context2Assert(\"test\".length == 5)", arguments = listOf<Argument>(elements = [null, null, Argument(startOffset = 23, endOffset = 41, kind = Kind.VALUE, expressions = listOf<Expression>(elements = [LiteralExpression(startOffset = 23, endOffset = 29, displayOffset = 23, value = tmp2_Explain), ValueExpression(startOffset = 23, endOffset = 36, displayOffset = 30, value = tmp3_Explain), LiteralExpression(startOffset = 40, endOffset = 41, displayOffset = 40, value = tmp4_Explain), EqualityExpression(startOffset = 23, endOffset = 41, displayOffset = 37, value = tmp5_Explain, lhs = tmp3_Explain, rhs = tmp4_Explain)])), null])) */))
         }
       }
     }


### PR DESCRIPTION
Improve Power-Assert's detection of expressions with synthetic or undefined source offsets. These elements should be excluded from the resulting display, since they do not have a valid source range.

^RCA: Power-Assert tests for context parameters only used `with()` to introduce the available implicit argument. This results in different access expressions for IR from an implicit argument introduced using `contenxt()`. Adding tests using this function helped reproduce the regression.

^KT-88179 Fixed

Merge to master: https://github.com/JetBrains/kotlin/pull/7208