### PR TITLE
[JS] Introduce a helper for creating TypeScript Export input modules

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
@@ -22,12 +22,9 @@ import org.jetbrains.kotlin.js.config.TsCompilationStrategy
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.tsexport.TypeScriptExportConfig
 import org.jetbrains.kotlin.js.tsexport.TypeScriptModuleConfig
+import org.jetbrains.kotlin.js.tsexport.createTypeScriptExportInputModule
 import org.jetbrains.kotlin.js.tsexport.runTypeScriptExport
-import org.jetbrains.kotlin.library.jsOutputName
-import org.jetbrains.kotlin.library.loader.KlibLoader
-import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.library.metadata.KlibInputModule
-import org.jetbrains.kotlin.library.uniqueName
 import org.jetbrains.kotlin.platform.js.JsPlatforms
 import java.io.File
 import java.nio.file.Path
@@ -86,13 +83,10 @@ internal class JsDtsGenerationOperationImpl private constructor(
         logger: KotlinLogger?,
     ): List<KlibInputModule<TypeScriptModuleConfig>> =
         klibs.map { path ->
-            val result = KlibLoader { libraryPaths(path.toString()) }.load()
-            result.reportLoadingProblemsIfAny { _, message ->
+            createTypeScriptExportInputModule(path) { _, message ->
                 logger?.error(message)
                 error(message)
             }
-            val library = result.librariesStdlibFirst.single()
-            KlibInputModule(library.uniqueName, path, TypeScriptModuleConfig(outputName = library.jsOutputName))
         }
 
     override fun configureFrom(linkingOperation: JsLinkingOperation) {

--- a/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
+++ b/compiler/build-tools/kotlin-build-tools-impl/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/js/operations/JsDtsGenerationOperationImpl.kt
@@ -5,28 +5,17 @@
 
 package org.jetbrains.kotlin.buildtools.internal.js.operations
 
-import org.jetbrains.kotlin.buildtools.api.CompilationResult
-import org.jetbrains.kotlin.buildtools.api.CompilerArgumentsParseException
-import org.jetbrains.kotlin.buildtools.api.ExecutionPolicy
-import org.jetbrains.kotlin.buildtools.api.KotlinLogger
-import org.jetbrains.kotlin.buildtools.api.ProjectId
+import org.jetbrains.kotlin.buildtools.api.*
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsEcmaVersion
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind
 import org.jetbrains.kotlin.buildtools.api.js.JsDtsCompilationStrategy
 import org.jetbrains.kotlin.buildtools.api.js.JsDtsGranularity
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsDtsGenerationOperation
 import org.jetbrains.kotlin.buildtools.api.js.operations.JsLinkingOperation
-import org.jetbrains.kotlin.buildtools.internal.BaseOptionWithDefault
-import org.jetbrains.kotlin.buildtools.internal.BuildOperationImpl
-import org.jetbrains.kotlin.buildtools.internal.DeepCopyable
-import org.jetbrains.kotlin.buildtools.internal.Options
-import org.jetbrains.kotlin.buildtools.internal.UseFromImplModuleRestricted
+import org.jetbrains.kotlin.buildtools.internal.*
 import org.jetbrains.kotlin.buildtools.internal.arguments.CommonCompilerArgumentsImpl
 import org.jetbrains.kotlin.buildtools.internal.arguments.JsArgumentsImpl
-import org.jetbrains.kotlin.buildtools.internal.checkOptionIsAvailableForVersion
-import org.jetbrains.kotlin.buildtools.internal.initializeOptions
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
-import org.jetbrains.kotlin.ir.backend.js.jsOutputName
 import org.jetbrains.kotlin.js.config.JsGenerationGranularity
 import org.jetbrains.kotlin.js.config.ModuleKind
 import org.jetbrains.kotlin.js.config.TsCompilationStrategy
@@ -34,6 +23,7 @@ import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.tsexport.TypeScriptExportConfig
 import org.jetbrains.kotlin.js.tsexport.TypeScriptModuleConfig
 import org.jetbrains.kotlin.js.tsexport.runTypeScriptExport
+import org.jetbrains.kotlin.library.jsOutputName
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.library.metadata.KlibInputModule

--- a/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/KotlinIr2WasmIrCompiler.kt
+++ b/compiler/cli/cli-js/src/org/jetbrains/kotlin/cli/pipeline/web/wasm/KotlinIr2WasmIrCompiler.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.backend.wasm.ir2wasm.*
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.ir.backend.js.dce.DceDumpNameCache
 import org.jetbrains.kotlin.ir.backend.js.dce.dumpDeclarationIrSizesIfNeed
-import org.jetbrains.kotlin.ir.backend.js.jsOutputName
 import org.jetbrains.kotlin.ir.declarations.IdSignatureRetriever
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
@@ -24,6 +23,7 @@ import org.jetbrains.kotlin.js.config.outputName
 import org.jetbrains.kotlin.js.config.sourceMap
 import org.jetbrains.kotlin.js.config.useDebuggerCustomFormatters
 import org.jetbrains.kotlin.library.isWasmStdlib
+import org.jetbrains.kotlin.library.jsOutputName
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 import org.jetbrains.kotlin.wasm.config.*
 import java.net.URLEncoder

--- a/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/KotlinLibraryHeader.kt
+++ b/compiler/ir/backend.js/src/org/jetbrains/kotlin/ir/backend/js/ic/KotlinLibraryHeader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -7,9 +7,11 @@ package org.jetbrains.kotlin.ir.backend.js.ic
 
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.backend.common.serialization.proto.IrFile
-import org.jetbrains.kotlin.ir.backend.js.*
+import org.jetbrains.kotlin.ir.backend.js.serializedIrFileFingerprints
+import org.jetbrains.kotlin.ir.backend.js.serializedKlibFingerprint
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.components.irOrFail
+import org.jetbrains.kotlin.library.jsOutputName
 import org.jetbrains.kotlin.protobuf.ExtensionRegistryLite
 import java.io.File
 

--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/klib.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.ir.backend.js
 
+import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.KtPsiSourceFile
 import org.jetbrains.kotlin.backend.common.*
 import org.jetbrains.kotlin.backend.common.linkage.partial.partialLinkageConfig
@@ -28,7 +29,6 @@ import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import org.jetbrains.kotlin.library.*
 import org.jetbrains.kotlin.library.impl.BuiltInsPlatform
-import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.library.metadata.KlibMetadataFactories
 import org.jetbrains.kotlin.library.metadata.addMetadataFlagsToManifest
 import org.jetbrains.kotlin.library.writer.KlibWriter
@@ -44,13 +44,10 @@ import org.jetbrains.kotlin.util.tryMeasurePhaseTime
 import org.jetbrains.kotlin.utils.toSmartList
 import java.io.File
 import java.nio.file.Path
-import java.util.Properties
+import java.util.*
 
 val KotlinLibrary.moduleName: String
     get() = manifestProperties.getProperty(KLIB_PROPERTY_UNIQUE_NAME)
-
-val KotlinLibrary.jsOutputName: String?
-    get() = manifestProperties.getProperty(KLIB_PROPERTY_JS_OUTPUT_NAME)
 
 val KotlinLibrary.serializedIrFileFingerprints: List<SerializedIrFileFingerprint>?
     get() = manifestProperties.getProperty(KLIB_PROPERTY_SERIALIZED_IR_FILE_FINGERPRINTS)?.parseSerializedIrFileFingerprints()
@@ -370,7 +367,6 @@ fun serializeModuleIntoKlib(
     }
 }
 
-const val KLIB_PROPERTY_JS_OUTPUT_NAME = "jsOutputName"
 const val KLIB_PROPERTY_SERIALIZED_IR_FILE_FINGERPRINTS = "serializedIrFileFingerprints"
 const val KLIB_PROPERTY_SERIALIZED_KLIB_FINGERPRINT = "serializedKlibFingerprint"
 

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinLibrary.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/KotlinLibrary.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.library.components.ir
 import org.jetbrains.kotlin.library.impl.BuiltInsPlatform
 import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
-import java.util.Properties
+import java.util.*
 
 /**
  * [org.jetbrains.kotlin.library.KotlinAbiVersion]
@@ -40,6 +40,9 @@ const val KLIB_PROPERTY_DEPENDS = "depends"
 const val KLIB_PROPERTY_PACKAGE = "package"
 const val KLIB_PROPERTY_BUILTINS_PLATFORM = "builtins_platform"
 const val KLIB_PROPERTY_NEW_COMPANION_INITIALIZATION = "new_companion_initialization"
+
+// JS-specific
+const val KLIB_PROPERTY_JS_OUTPUT_NAME = "jsOutputName"
 
 // Native-specific:
 const val KLIB_PROPERTY_INTEROP = "interop"
@@ -139,6 +142,9 @@ val BaseKotlinLibrary.hasDependencies: Boolean
     get() = !manifestProperties.getProperty(KLIB_PROPERTY_DEPENDS).isNullOrBlank()
 
 interface KotlinLibrary : Klib, BaseKotlinLibrary
+
+val KotlinLibrary.jsOutputName: String?
+    get() = manifestProperties.getProperty(KLIB_PROPERTY_JS_OUTPUT_NAME)
 
 val BaseKotlinLibrary.interopFlag: String?
     get() = manifestProperties.getProperty(KLIB_PROPERTY_INTEROP)

--- a/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
+++ b/compiler/util-klib/src/org/jetbrains/kotlin/library/loader/KlibLoaderResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -8,11 +8,7 @@ package org.jetbrains.kotlin.library.loader
 import org.jetbrains.kotlin.library.KotlinAbiVersion
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.KotlinLibraryVersioning
-import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase.IncompatibleAbiVersion
-import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase.InvalidLibraryFormat
-import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase.LibraryNotFound
-import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase.OtherCheckMismatch
-import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase.PlatformCheckMismatch
+import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblemCase.*
 import org.jetbrains.kotlin.library.loader.KlibLoaderResult.ProblematicLibrary
 
 /**
@@ -123,13 +119,13 @@ class KlibLoaderResult(
     }
 }
 
+typealias KlibLoaderErrorReporterCallback = (defaultSeverity: KlibLoaderResult.ProblemSeverity, message: String) -> Unit
+
 /**
  * Report any problems with loading KLIBs stored in [KlibLoaderResult] to the supplied [reporter] lambda.
  * Returns `true` if there were any problems reported.
  */
-fun KlibLoaderResult.reportLoadingProblemsIfAny(
-    reporter: (defaultSeverity: KlibLoaderResult.ProblemSeverity, message: String) -> Unit
-): Boolean {
+fun KlibLoaderResult.reportLoadingProblemsIfAny(reporter: KlibLoaderErrorReporterCallback): Boolean {
     if (problematicLibraries.isEmpty()) return false
 
     problematicLibraries.forEach { problematicLibrary ->

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/AnalysisApiBasedDtsGenerationHandler.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/AnalysisApiBasedDtsGenerationHandler.kt
@@ -13,12 +13,9 @@ import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.config.moduleKind
 import org.jetbrains.kotlin.js.tsexport.TypeScriptExportConfig
 import org.jetbrains.kotlin.js.tsexport.TypeScriptModuleConfig
+import org.jetbrains.kotlin.js.tsexport.createTypeScriptExportInputModule
 import org.jetbrains.kotlin.js.tsexport.runTypeScriptExport
-import org.jetbrains.kotlin.library.jsOutputName
-import org.jetbrains.kotlin.library.loader.KlibLoader
-import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.library.metadata.KlibInputModule
-import org.jetbrains.kotlin.library.uniqueName
 import org.jetbrains.kotlin.test.backend.handlers.KlibArtifactHandler
 import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives.TS_COMPILATION_STRATEGY
@@ -80,12 +77,8 @@ class AnalysisApiBasedDtsGenerationHandler(testServices: TestServices) : KlibArt
         }
     }
 
-    private fun createInputModule(libraryPath: String): KlibInputModule<TypeScriptModuleConfig> {
-        val result = KlibLoader { libraryPaths(libraryPath) }.load()
-        result.reportLoadingProblemsIfAny { _, message -> testServices.assertions.fail { message } }
-        val library = result.librariesStdlibFirst[0]
-        return KlibInputModule(library.uniqueName, Path(libraryPath), TypeScriptModuleConfig(outputName = library.jsOutputName))
-    }
+    private fun createInputModule(libraryPath: String): KlibInputModule<TypeScriptModuleConfig> =
+        createTypeScriptExportInputModule(Path(libraryPath)) { _, message -> testServices.assertions.fail { message } }
 
     private fun createInputModule(testModule: TestModule): KlibInputModule<TypeScriptModuleConfig> {
         val klib = testServices.artifactsProvider.getArtifact(testModule, ArtifactKinds.KLib).outputFile

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/AnalysisApiBasedDtsGenerationHandler.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/AnalysisApiBasedDtsGenerationHandler.kt
@@ -8,13 +8,13 @@ package org.jetbrains.kotlin.js.test.converters
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.config.moduleName
-import org.jetbrains.kotlin.ir.backend.js.jsOutputName
 import org.jetbrains.kotlin.js.config.ModuleKind
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.config.moduleKind
 import org.jetbrains.kotlin.js.tsexport.TypeScriptExportConfig
 import org.jetbrains.kotlin.js.tsexport.TypeScriptModuleConfig
 import org.jetbrains.kotlin.js.tsexport.runTypeScriptExport
+import org.jetbrains.kotlin.library.jsOutputName
 import org.jetbrains.kotlin.library.loader.KlibLoader
 import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.library.metadata.KlibInputModule

--- a/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeScriptExportRunner.kt
+++ b/js/typescript-export-standalone/src/org/jetbrains/kotlin/js/tsexport/TypeScriptExportRunner.kt
@@ -14,10 +14,16 @@ import org.jetbrains.kotlin.ir.backend.js.tsexport.toTypeScriptFragment
 import org.jetbrains.kotlin.js.config.JsGenerationGranularity
 import org.jetbrains.kotlin.js.config.TsCompilationStrategy
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
+import org.jetbrains.kotlin.library.jsOutputName
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.loader.KlibLoaderErrorReporterCallback
+import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.library.metadata.KlibInputModule
+import org.jetbrains.kotlin.library.uniqueName
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.platform.TargetPlatform
 import java.io.File
+import java.nio.file.Path
 
 public data class TypeScriptExportConfig(
     public val targetPlatform: TargetPlatform,
@@ -77,6 +83,16 @@ public fun runTypeScriptExport(klibs: List<KlibInputModule<TypeScriptModuleConfi
             }
         }
     }
+}
+
+public fun createTypeScriptExportInputModule(
+    klibPath: Path,
+    errorReporter: KlibLoaderErrorReporterCallback,
+): KlibInputModule<TypeScriptModuleConfig> {
+    val result = KlibLoader { libraryPaths(klibPath.toString()) }.load()
+    result.reportLoadingProblemsIfAny(errorReporter)
+    val library = result.librariesStdlibFirst.single()
+    return KlibInputModule(library.uniqueName, klibPath, TypeScriptModuleConfig(outputName = library.jsOutputName))
 }
 
 private fun writeMergedTsFile(


### PR DESCRIPTION
This will help avoid code duplication in Build Tools API and in tests.