### PR TITLE
Start using `KlibLoader` on 2nd compilation stage in Kotlin/Native

### DIFF
--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/NativeFirstStageCompilationConfig.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/NativeFirstStageCompilationConfig.kt
@@ -30,7 +30,7 @@ import kotlin.io.path.name
 class NativeFirstStageCompilationConfig private constructor(
     override val configuration: CompilerConfiguration,
     override val target: KonanTarget,
-    val loadedKlibs: LoadedNativeKlibs,
+    override val loadedKlibs: LoadedNativeKlibs,
 ) : NativeCompilationConfig {
 
     override val moduleId: String

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/NativeFirstStageCompilationConfig.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/NativeFirstStageCompilationConfig.kt
@@ -27,7 +27,7 @@ import java.util.Properties
 import kotlin.io.path.Path
 import kotlin.io.path.name
 
-class NativeFirstStageCompilationConfig(
+class NativeFirstStageCompilationConfig private constructor(
     override val configuration: CompilerConfiguration,
     override val target: KonanTarget,
     val loadedKlibs: LoadedNativeKlibs,
@@ -43,6 +43,24 @@ class NativeFirstStageCompilationConfig(
 
     fun withConfiguration(newConfiguration: CompilerConfiguration): NativeFirstStageCompilationConfig {
         return NativeFirstStageCompilationConfig(newConfiguration, target, loadedKlibs)
+    }
+
+    companion object {
+        operator fun invoke(configuration: CompilerConfiguration): NativeFirstStageCompilationConfig {
+            val targetName = configuration.konanTarget
+            val target = if (targetName != null) {
+                KonanTarget.predefinedTargets[targetName]
+                    ?: error("Unknown target: $targetName")
+            } else {
+                HostManager.host
+            }
+
+            return NativeFirstStageCompilationConfig(
+                configuration = configuration,
+                target = target,
+                loadedKlibs = loadNativeKlibs(configuration, target),
+            )
+        }
     }
 }
 
@@ -68,20 +86,4 @@ class NativeFirstStagePhaseContext(
     fun withConfiguration(newConfiguration: CompilerConfiguration): NativeFirstStagePhaseContext {
         return NativeFirstStagePhaseContext(config.withConfiguration(newConfiguration))
     }
-}
-
-internal fun createFirstStageCompilationConfig(configuration: CompilerConfiguration): NativeFirstStageCompilationConfig {
-    val targetName = configuration.konanTarget
-    val target = if (targetName != null) {
-        KonanTarget.predefinedTargets[targetName]
-            ?: error("Unknown target: $targetName")
-    } else {
-        HostManager.host
-    }
-
-    return NativeFirstStageCompilationConfig(
-        configuration = configuration,
-        target = target,
-        loadedKlibs = loadNativeKlibs(configuration, target),
-    )
 }

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.native.pipeline
 
+import com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.backend.common.linkage.partial.PartialLinkageDiagnostics
 import org.jetbrains.kotlin.backend.common.linkage.partial.setupPartialLinkageConfig
 import org.jetbrains.kotlin.backend.konan.NativeBackendDiagnostics
@@ -12,9 +13,12 @@ import org.jetbrains.kotlin.cli.CliDiagnostics.KONAN_ARGUMENT_ERROR
 import org.jetbrains.kotlin.cli.CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING
 import org.jetbrains.kotlin.cli.common.arguments.K2NativeCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.cliArgument
+import org.jetbrains.kotlin.cli.common.arguments.isNativeSecondStage
 import org.jetbrains.kotlin.cli.common.checkForUnexpectedKlibLibraries
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoot
+import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.createPhaseConfig
+import org.jetbrains.kotlin.cli.common.prohibitExportKlibToOlderAbiVersionAtSecondStage
 import org.jetbrains.kotlin.cli.common.setupCommonKlibArguments
 import org.jetbrains.kotlin.cli.diagnosticFactoriesStorage
 import org.jetbrains.kotlin.cli.pipeline.*
@@ -24,6 +28,7 @@ import org.jetbrains.kotlin.ir.inline.diagnostics.IrInlinerErrors
 import org.jetbrains.kotlin.konan.config.*
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind
 import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.target.isCache
 import org.jetbrains.kotlin.metadata.deserialization.BinaryVersion
 import org.jetbrains.kotlin.metadata.deserialization.MetadataVersion
 import org.jetbrains.kotlin.platform.konan.NativePlatforms
@@ -52,6 +57,12 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
     override fun fillConfiguration(
         input: ArgumentsPipelineArtifact<K2NativeCompilerArguments>,
         configuration: CompilerConfiguration,
+    ) = fillConfiguration(input.arguments, input.rootDisposable, configuration)
+
+    fun fillConfiguration(
+        arguments: K2NativeCompilerArguments,
+        rootDisposable: Disposable,
+        configuration: CompilerConfiguration,
     ) {
         configuration.diagnosticFactoriesStorage?.registerDiagnosticContainers(
             PartialLinkageDiagnostics,
@@ -59,110 +70,141 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
             NativeBackendDiagnostics
         )
 
-        val arguments = input.arguments
-        val rootDisposable = input.rootDisposable
-        configuration.setupCommonKlibArguments(arguments, canBeMetadataKlibCompilation = true, rootDisposable)
-        val phaseConfig = createPhaseConfig(arguments)
-        configuration.phaseConfig = phaseConfig
-        setupNativeKlibConfiguration(configuration, arguments)
+        configuration.setupCommonKlibArguments(arguments, canBeMetadataKlibCompilation = !arguments.isNativeSecondStage(), rootDisposable)
+        configuration.setupSources(arguments)
+        val outputKind = configuration.setupNativeBasicSettings(arguments)
+        configuration.setupLibraries(arguments, outputKind)
+        configuration.setupMisc(arguments)
+        configuration.setupPartialLinkageConfig(arguments, KONAN_ARGUMENT_ERROR)
+
+        if (arguments.isNativeSecondStage()) {
+            configuration.phaseConfig = createPhaseConfig(arguments)
+            configuration.prohibitExportKlibToOlderAbiVersionAtSecondStage()
+        }
     }
 
-    private fun setupNativeKlibConfiguration(
-        configuration: CompilerConfiguration,
-        arguments: K2NativeCompilerArguments,
-    ) {
+    private fun CompilerConfiguration.setupSources(arguments: K2NativeCompilerArguments) {
         val commonSources = arguments.commonSources.toSet().map { File(it).absoluteFile.normalize() }
-        val hmppModuleStructure = configuration.get(CommonConfigurationKeys.HMPP_MODULE_STRUCTURE)
+        val hmppModuleStructure = this[CommonConfigurationKeys.HMPP_MODULE_STRUCTURE]
         arguments.freeArgs.forEach { path ->
-            val normalizedPath = java.io.File(path).absoluteFile.normalize()
-            configuration.addKotlinSourceRoot(path, normalizedPath in commonSources, hmppModuleStructure?.getModuleNameForSource(path))
+            val normalizedPath = File(path).absoluteFile.normalize()
+            addKotlinSourceRoot(path, normalizedPath in commonSources, hmppModuleStructure?.getModuleNameForSource(path))
+        }
+    }
+
+    private fun CompilerConfiguration.setupNativeBasicSettings(arguments: K2NativeCompilerArguments): CompilerOutputKind {
+        val outputKind = CompilerOutputKind.valueOf((arguments.produce ?: "program").uppercase())
+        konanProducedArtifactKind = outputKind
+
+        arguments.kotlinHome?.let { konanHome = it }
+        arguments.konanDataDir?.let { konanDataDir = it }
+
+        arguments.moduleName?.let { moduleName = it }
+        parseShortModuleName(arguments, outputKind)?.let { konanShortModuleName = it }
+
+        arguments.target?.let { konanTarget = it }
+        targetPlatform = konanTarget?.let { NativePlatforms.nativePlatformByTargetNames(listOf(it)) }
+            ?: NativePlatforms.unspecifiedNativePlatform
+
+        arguments.manifestNativeTargets.takeIf { it.isNotEmpty() }?.let {
+            konanManifestNativeTargets = parseManifestNativeTargets(it)
         }
 
-        configuration.konanProducedArtifactKind = CompilerOutputKind.LIBRARY
-        arguments.moduleName?.let { configuration.moduleName = it }
-        arguments.kotlinHome?.let { configuration.konanHome = it }
-        arguments.target?.let { configuration.konanTarget = it }
-        configuration.targetPlatform = configuration.konanTarget?.let {
-            NativePlatforms.nativePlatformByTargetNames(listOf(it))
-        } ?: NativePlatforms.unspecifiedNativePlatform
+        arguments.outputName?.let { konanOutputPath = it }
 
-        configuration.konanLibraries = arguments.libraries.toList()
+        // We need to download dependencies only if we use them ( = there are files to compile).
+        checkDependencies = kotlinSourceRoots.isNotEmpty() ||
+                arguments.includes.isNotEmpty() ||
+                arguments.exportedLibraries.isNotEmpty() ||
+                (outputKind == CompilerOutputKind.PROGRAM && arguments.libraries.isNotEmpty()) ||
+                outputKind.isCache ||
+                arguments.checkDependencies
+
+        konanRefinesModules = arguments.refinesPaths.filterNot(String::isEmpty)
+
+        return outputKind
+    }
+
+    private fun CompilerConfiguration.setupLibraries(arguments: K2NativeCompilerArguments, outputKind: CompilerOutputKind) {
+        konanLibraries = arguments.libraries.toList()
 
         arguments.friendModules?.let {
-            configuration.konanFriendLibraries = it.split(File.pathSeparator).filterNot(String::isEmpty)
-            configuration.checkForUnexpectedKlibLibraries(
-                librariesToCheck = configuration.konanFriendLibraries,
+            konanFriendLibraries = it.split(File.pathSeparator).filterNot(String::isEmpty)
+            checkForUnexpectedKlibLibraries(
+                librariesToCheck = konanFriendLibraries,
                 librariesToCheckArgument = K2NativeCompilerArguments::friendModules.cliArgument,
-                allLibraries = configuration.konanLibraries,
+                allLibraries = konanLibraries,
                 allLibrariesArgument = K2NativeCompilerArguments::libraries.cliArgument
             )
         }
 
-        configuration.exportedLibraries = arguments.exportedLibraries.toList()
-        configuration.checkForUnexpectedKlibLibraries(
-            librariesToCheck = configuration.exportedLibraries,
+        exportedLibraries = parseSelectedLibraries(arguments, outputKind)
+        checkForUnexpectedKlibLibraries(
+            librariesToCheck = exportedLibraries,
             librariesToCheckArgument = K2NativeCompilerArguments::exportedLibraries.cliArgument,
-            allLibraries = configuration.konanLibraries,
+            allLibraries = konanLibraries,
             allLibrariesArgument = K2NativeCompilerArguments::libraries.cliArgument
         )
 
-        // TODO(KT-61096): Add a check when -Xinclude argument can be actually used!
-        configuration.konanIncludedLibraries = arguments.includes.toList()
+        konanIncludedLibraries = parseIncludedLibraries(arguments, outputKind)
 
-        // TODO(KT-61096): Add a check when -Xadd-cache argument can be actually used!
-        arguments.libraryToAddToCache?.let { configuration.konanLibraryToAddToCache = it }
+        parseLibraryToAddToCache(arguments, outputKind)?.let { konanLibraryToAddToCache = it }
 
-        configuration.konanLibraries = buildList {
-            this += configuration.konanLibraries
-            this += configuration.konanIncludedLibraries
-            addIfNotNull(configuration.konanLibraryToAddToCache)
+        konanLibraries = buildList {
+            this += konanLibraries
+            this += konanIncludedLibraries
+            addIfNotNull(konanLibraryToAddToCache)
         }
 
-        configuration.konanNoStdlib = arguments.nostdlib
-        configuration.konanNoDefaultLibs = arguments.nodefaultlibs
-        configuration.konanPurgeUserLibs = arguments.purgeUserLibs
+        konanNoDefaultLibs = arguments.nodefaultlibs || !konanLibraryToAddToCache.isNullOrEmpty()
+        konanNoStdlib = arguments.nostdlib || !konanLibraryToAddToCache.isNullOrEmpty()
+        konanPurgeUserLibs = arguments.purgeUserLibs
 
-        configuration.konanDontCompressKlib = arguments.nopack
+        konanDontCompressKlib = arguments.nopack
+        arguments.manifestFile?.let { konanManifestAddend = it }
 
-        arguments.outputName?.let { configuration.konanOutputPath = it }
-        configuration.konanRefinesModules = arguments.refinesPaths.filterNot(String::isEmpty)
+        konanIncludedBinaries = arguments.includeBinaries.toList()
+        konanNativeLibraries = arguments.nativeLibraries.toList()
 
-        configuration.konanIncludedBinaries = arguments.includeBinaries.toList()
-        configuration.konanNativeLibraries = arguments.nativeLibraries.toList()
+        arguments.headerKlibPath?.let { konanGeneratedHeaderKlibPath = it }
 
-        arguments.manifestFile?.let { configuration.konanManifestAddend = it }
-        arguments.headerKlibPath?.let { configuration.konanGeneratedHeaderKlibPath = it }
-        arguments.shortModuleName?.let { configuration.konanShortModuleName = it }
-
-        configuration.konanPrintIr = arguments.printIr
-        configuration.konanPrintFiles = arguments.printFiles
-        arguments.verifyCompiler?.let {
-            configuration.verifyCompiler = it == "true"
-        }
-        arguments.konanDataDir?.let { configuration.konanDataDir = it }
-
-        configuration.checkDependencies = arguments.checkDependencies
-        arguments.writeDependenciesOfProducedKlibTo?.let {
-            configuration.konanWriteDependenciesOfProducedKlibTo = it
-        }
-        arguments.manifestNativeTargets.takeIf { it.isNotEmpty() }?.let {
-            configuration.konanManifestNativeTargets = parseManifestNativeTargets(it, configuration)
-        }
-
-        configuration.setupPartialLinkageConfig(arguments, KONAN_ARGUMENT_ERROR)
+        arguments.writeDependenciesOfProducedKlibTo?.let { konanWriteDependenciesOfProducedKlibTo = it }
     }
 
-    private fun parseManifestNativeTargets(
-        targetStrings: Array<String>,
-        configuration: CompilerConfiguration,
-    ): List<KonanTarget> {
+    private fun CompilerConfiguration.setupMisc(arguments: K2NativeCompilerArguments) {
+        konanPrintIr = arguments.printIr
+        konanPrintFiles = arguments.printFiles
+        konanPrintBitcode = arguments.printBitCode
+
+        arguments.verifyCompiler?.let { verifyCompiler = it == "true" }
+        verifyBitcode = arguments.verifyBitCode
+    }
+
+    // TODO: Support short names for current module in ObjC export and lift this limitation.
+    private fun CompilerConfiguration.parseShortModuleName(
+        arguments: K2NativeCompilerArguments,
+        outputKind: CompilerOutputKind
+    ): String? {
+        val input = arguments.shortModuleName ?: return null
+
+        return if (outputKind != CompilerOutputKind.LIBRARY) {
+            report(
+                KONAN_ARGUMENT_STRONG_WARNING,
+                "${K2NativeCompilerArguments::shortModuleName.cliArgument} CLI argument is only supported when producing a Kotlin library, " +
+                        "but the compiler is producing ${outputKind.name.lowercase()}"
+            )
+            null
+        } else input
+    }
+
+    private fun CompilerConfiguration.parseManifestNativeTargets(targetStrings: Array<String>): List<KonanTarget> {
         val trimmedTargetStrings = targetStrings.map { it.trim() }
         val [recognizedTargetNames, unrecognizedTargetNames] = trimmedTargetStrings.partition {
             it in KonanTarget.predefinedTargets.keys
         }
 
         if (unrecognizedTargetNames.isNotEmpty()) {
-            configuration.report(
+            report(
                 KONAN_ARGUMENT_STRONG_WARNING,
                 """
                     The following target names passed to the -Xmanifest-native-targets are not recognized:
@@ -175,5 +217,66 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
         }
 
         return recognizedTargetNames.map { KonanTarget.predefinedTargets[it]!! }
+    }
+
+    private fun CompilerConfiguration.parseSelectedLibraries(
+        arguments: K2NativeCompilerArguments,
+        outputKind: CompilerOutputKind,
+    ): List<String> {
+        val exportedLibraries = arguments.exportedLibraries.toList()
+
+        return if (exportedLibraries.isNotEmpty() &&
+            outputKind != CompilerOutputKind.FRAMEWORK &&
+            outputKind != CompilerOutputKind.STATIC &&
+            outputKind != CompilerOutputKind.DYNAMIC
+        ) {
+            report(
+                KONAN_ARGUMENT_STRONG_WARNING,
+                "${K2NativeCompilerArguments::exportedLibraries.cliArgument} CLI argument is only supported when producing frameworks or native libraries, " +
+                        "but the compiler is producing ${outputKind.name.lowercase()}"
+            )
+
+            emptyList()
+        } else {
+            exportedLibraries
+        }
+    }
+
+    private fun CompilerConfiguration.parseIncludedLibraries(
+        arguments: K2NativeCompilerArguments,
+        outputKind: CompilerOutputKind
+    ): List<String> {
+        val includes = arguments.includes.toList()
+
+        return if (includes.isNotEmpty() && outputKind == CompilerOutputKind.LIBRARY) {
+            report(
+                KONAN_ARGUMENT_ERROR,
+                "${K2NativeCompilerArguments::includes.cliArgument} CLI argument is not supported when producing ${outputKind.name.lowercase()}"
+            )
+            emptyList()
+        } else {
+            includes
+        }
+    }
+
+    private fun CompilerConfiguration.parseLibraryToAddToCache(
+        arguments: K2NativeCompilerArguments,
+        outputKind: CompilerOutputKind,
+    ): String? {
+        val input = arguments.libraryToAddToCache ?: return null
+
+        return if (!outputKind.isCache) {
+            report(
+                KONAN_ARGUMENT_ERROR,
+                "${K2NativeCompilerArguments::libraryToAddToCache.cliArgument} can't be used when not producing cache"
+            )
+            null
+        } else if (!arguments.outputName.isNullOrEmpty()) {
+            report(
+                KONAN_ARGUMENT_ERROR,
+                "${K2NativeCompilerArguments::libraryToAddToCache.cliArgument} already implicitly sets output file name"
+            )
+            null
+        } else input
     }
 }

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
@@ -126,14 +126,14 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
     }
 
     private fun CompilerConfiguration.setupLibraries(arguments: K2NativeCompilerArguments, outputKind: CompilerOutputKind) {
-        konanLibraries = arguments.libraries.toList()
+        val regularLibraries = arguments.libraries.toList()
 
         arguments.friendModules?.let {
             konanFriendLibraries = it.split(File.pathSeparator).filterNot(String::isEmpty)
             checkForUnexpectedKlibLibraries(
                 librariesToCheck = konanFriendLibraries,
                 librariesToCheckArgument = K2NativeCompilerArguments::friendModules.cliArgument,
-                allLibraries = konanLibraries,
+                allLibraries = regularLibraries,
                 allLibrariesArgument = K2NativeCompilerArguments::libraries.cliArgument
             )
         }
@@ -142,7 +142,7 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
         checkForUnexpectedKlibLibraries(
             librariesToCheck = exportedLibraries,
             librariesToCheckArgument = K2NativeCompilerArguments::exportedLibraries.cliArgument,
-            allLibraries = konanLibraries,
+            allLibraries = regularLibraries,
             allLibrariesArgument = K2NativeCompilerArguments::libraries.cliArgument
         )
 
@@ -151,7 +151,7 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
         parseLibraryToAddToCache(arguments, outputKind)?.let { konanLibraryToAddToCache = it }
 
         konanLibraries = buildList {
-            this += konanLibraries
+            this += regularLibraries
             this += konanIncludedLibraries
             addIfNotNull(konanLibraryToAddToCache)
         }

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeFrontendPipelinePhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeFrontendPipelinePhase.kt
@@ -25,8 +25,8 @@ import org.jetbrains.kotlin.fir.resolve.ImplicitIntegerCoercionModuleCapability
 import org.jetbrains.kotlin.konan.config.konanPrintFiles
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.native.NativeFirstStageCompilationConfig
 import org.jetbrains.kotlin.native.NativeFirstStagePhaseContext
-import org.jetbrains.kotlin.native.createFirstStageCompilationConfig
 import kotlin.io.path.absolutePathString
 
 object NativeFrontendPipelinePhase : PipelinePhase<ConfigurationPipelineArtifact, NativeFrontendArtifact>(
@@ -36,7 +36,7 @@ object NativeFrontendPipelinePhase : PipelinePhase<ConfigurationPipelineArtifact
 ) {
     override fun executePhase(input: ConfigurationPipelineArtifact): NativeFrontendArtifact {
         val (configuration, rootDisposable) = input
-        val config = createFirstStageCompilationConfig(configuration)
+        val config = NativeFirstStageCompilationConfig(configuration)
         val phaseContext = NativeFirstStagePhaseContext(config)
 
         @OptIn(CoreEnvironmentDeprecation::class)

--- a/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeCompilationConfig.kt
+++ b/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeCompilationConfig.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan
 
+import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.metadataKlib
 import org.jetbrains.kotlin.konan.config.NativeConfigurationKeys
@@ -34,6 +35,8 @@ interface NativeCompilationConfig {
     val target: KonanTarget
 
     val moduleId: String
+
+    val loadedKlibs: LoadedNativeKlibs
 
     val produce: CompilerOutputKind
         get() = configuration.konanProducedArtifactKind!!

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -560,7 +560,7 @@ class CacheBuilder(
             konanLibraryToAddToCache = libraryPath
             konanNoDefaultLibs = true
             konanNoStdlib = true
-            konanLibraries = libraries
+            konanLibraries = libraries + libraryPath
             val generateTestRunner = this@CacheBuilder.generateTestRunner
             if (generateTestRunner != TestRunnerKind.NONE && libraryPath in this@CacheBuilder.includedLibraries) {
                 konanFriendLibraries = config.friendModuleFiles.map { it.absolutePathString() }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/DependenciesTracker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/DependenciesTracker.kt
@@ -213,7 +213,7 @@ internal class DependenciesTrackerImpl(
                         }
                     }
 
-                    if (filesUsed.isEmpty() || library in config.includedLibraries) {
+                    if (filesUsed.isEmpty() || library in config.loadedKlibs.included) {
                         // This is the case when we depend on the whole module rather than on a number of files.
                         moduleDependencies.add(library)
                         addAllDependencies(cache)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
@@ -5,21 +5,15 @@
 
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.cli.CliDiagnostics
-import org.jetbrains.kotlin.cli.report
-import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.konan.config.exportedLibraries
-import org.jetbrains.kotlin.konan.library.isFromKotlinNativeDistribution
 import org.jetbrains.kotlin.library.KotlinLibrary
-import org.jetbrains.kotlin.library.SearchPathResolver
-import org.jetbrains.kotlin.library.metadata.*
-import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
-import org.jetbrains.kotlin.library.toUnresolvedLibraries
-import java.nio.file.Path
+import org.jetbrains.kotlin.library.metadata.CurrentKlibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.SyntheticModulesOrigin
+import org.jetbrains.kotlin.library.metadata.klibModuleOrigin
 
 internal fun ModuleDescriptor.getExportedDependencies(config: NativeSecondStageCompilationConfig): List<ModuleDescriptor> =
-        getDescriptorsFromLibraries((config.exportedLibraries + config.loadedKlibs.included).toSet())
+        getDescriptorsFromLibraries((config.loadedKlibs.exported + config.loadedKlibs.included).toSet())
 
 internal fun ModuleDescriptor.getIncludedLibraryDescriptors(config: NativeSecondStageCompilationConfig): List<ModuleDescriptor> =
         getDescriptorsFromLibraries(config.loadedKlibs.included.toSet())
@@ -31,104 +25,3 @@ private fun ModuleDescriptor.getDescriptorsFromLibraries(libraries: Set<KotlinLi
             is DeserializedKlibModuleOrigin -> origin.library in libraries
         }
     }
-
-internal fun getExportedLibraries(
-    configuration: CompilerConfiguration,
-    resolvedLibraries: KotlinLibraryResolveResult,
-    resolver: SearchPathResolver<KotlinLibrary>,
-): List<KotlinLibrary> = getFeaturedLibraries(
-        configuration.exportedLibraries,
-        resolvedLibraries,
-        resolver,
-        FeaturedLibrariesReporter.forExportedLibraries(configuration),
-)
-
-private sealed class FeaturedLibrariesReporter {
-
-    abstract fun reportIllegalKind(library: KotlinLibrary)
-    abstract fun reportNotIncludedLibraries(includedLibraries: List<KotlinLibrary>, remainingFeaturedLibraries: Set<Path>)
-
-    protected val KotlinLibrary.reportedKind: String
-        get() = when {
-            isCInteropLibrary() -> "Interop"
-            isFromKotlinNativeDistribution -> "Default"
-            else -> "Unknown kind"
-        }
-
-    abstract class BaseReporter(val configuration: CompilerConfiguration) : FeaturedLibrariesReporter() {
-        protected abstract fun illegalKindMessage(kind: String, libraryName: String): String
-        protected abstract fun notIncludedLibraryMessageTitle(): String
-
-        override fun reportIllegalKind(library: KotlinLibrary) {
-            configuration.report(
-                    CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING,
-                    illegalKindMessage(library.reportedKind, library.path.toString())
-            )
-        }
-
-        override fun reportNotIncludedLibraries(includedLibraries: List<KotlinLibrary>, remainingFeaturedLibraries: Set<Path>) {
-            val message = buildString {
-                appendLine(notIncludedLibraryMessageTitle())
-                remainingFeaturedLibraries.forEach { appendLine(it) }
-                appendLine()
-                appendLine("Included libraries:")
-                includedLibraries.forEach { appendLine(it.path) }
-            }
-
-            configuration.report(CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING, message)
-        }
-    }
-
-    private class ExportedLibrariesReporter(configuration: CompilerConfiguration) : BaseReporter(configuration) {
-        override fun illegalKindMessage(kind: String, libraryName: String): String =
-            "$kind library $libraryName can't be exported with -Xexport-library"
-
-        override fun notIncludedLibraryMessageTitle(): String =
-            "Following libraries are specified to be exported with -Xexport-library, but not included to the build:"
-    }
-
-    companion object {
-        fun forExportedLibraries(configuration: CompilerConfiguration): FeaturedLibrariesReporter =
-                ExportedLibrariesReporter(configuration)
-    }
-}
-
-private fun getFeaturedLibraries(
-        featuredLibraries: List<String>,
-        resolvedLibraries: KotlinLibraryResolveResult,
-        resolver: SearchPathResolver<KotlinLibrary>,
-        reporter: FeaturedLibrariesReporter,
-) = getFeaturedLibraries(
-        featuredLibraries.toUnresolvedLibraries.map { resolver.resolve(it).path }.toSet(),
-        resolvedLibraries,
-        reporter,
-)
-
-private fun getFeaturedLibraries(
-        featuredLibraryPaths: Set<Path>,
-        resolvedLibraries: KotlinLibraryResolveResult,
-        reporter: FeaturedLibrariesReporter,
-) : List<KotlinLibrary> {
-    val remainingFeaturedLibraries = featuredLibraryPaths.toMutableSet()
-    val result = mutableListOf<KotlinLibrary>()
-    //TODO: please add type checks before cast.
-    val libraries = resolvedLibraries.getFullList()
-
-    for (library in libraries) {
-        val libraryPath = library.path
-        if (libraryPath in featuredLibraryPaths) {
-            remainingFeaturedLibraries.remove(libraryPath)
-            if (library.isCInteropLibrary() || library.isFromKotlinNativeDistribution) {
-                reporter.reportIllegalKind(library)
-            } else {
-                result += library
-            }
-        }
-    }
-
-    if (remainingFeaturedLibraries.isNotEmpty()) {
-        reporter.reportNotIncludedLibraries(libraries, remainingFeaturedLibraries)
-    }
-
-    return result
-}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/FeaturedLibraries.kt
@@ -17,13 +17,12 @@ import org.jetbrains.kotlin.library.metadata.*
 import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.library.toUnresolvedLibraries
 import java.nio.file.Path
-import kotlin.io.path.absolutePathString
 
 internal fun ModuleDescriptor.getExportedDependencies(config: NativeSecondStageCompilationConfig): List<ModuleDescriptor> =
-        getDescriptorsFromLibraries((config.exportedLibraries + config.includedLibraries).toSet())
+        getDescriptorsFromLibraries((config.exportedLibraries + config.loadedKlibs.included).toSet())
 
 internal fun ModuleDescriptor.getIncludedLibraryDescriptors(config: NativeSecondStageCompilationConfig): List<ModuleDescriptor> =
-        getDescriptorsFromLibraries(config.includedLibraries.toSet())
+        getDescriptorsFromLibraries(config.loadedKlibs.included.toSet())
 
 private fun ModuleDescriptor.getDescriptorsFromLibraries(libraries: Set<KotlinLibrary>) =
     allDependencyModules.filter {
@@ -42,16 +41,6 @@ internal fun getExportedLibraries(
         resolvedLibraries,
         resolver,
         FeaturedLibrariesReporter.forExportedLibraries(configuration),
-)
-
-internal fun getIncludedLibraries(
-        includedLibraryFiles: List<Path>,
-        configuration: CompilerConfiguration,
-        resolvedLibraries: KotlinLibraryResolveResult
-): List<KotlinLibrary> = getFeaturedLibraries(
-        includedLibraryFiles.toSet(),
-        resolvedLibraries,
-        FeaturedLibrariesReporter.forIncludedLibraries(configuration),
 )
 
 private sealed class FeaturedLibrariesReporter {
@@ -90,18 +79,6 @@ private sealed class FeaturedLibrariesReporter {
         }
     }
 
-    private class IncludedLibrariesReporter(val configuration: CompilerConfiguration) : FeaturedLibrariesReporter() {
-        override fun reportIllegalKind(library: KotlinLibrary) = with(library) {
-            val message = "$reportedKind library $path cannot be passed with -Xinclude " +
-                    "(library path: ${path.absolutePathString()})"
-            configuration.report(CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING, message)
-        }
-
-        override fun reportNotIncludedLibraries(includedLibraries: List<KotlinLibrary>, remainingFeaturedLibraries: Set<Path>) {
-            error("An included library is not found among resolved libraries")
-        }
-    }
-
     private class ExportedLibrariesReporter(configuration: CompilerConfiguration) : BaseReporter(configuration) {
         override fun illegalKindMessage(kind: String, libraryName: String): String =
             "$kind library $libraryName can't be exported with -Xexport-library"
@@ -113,8 +90,6 @@ private sealed class FeaturedLibrariesReporter {
     companion object {
         fun forExportedLibraries(configuration: CompilerConfiguration): FeaturedLibrariesReporter =
                 ExportedLibrariesReporter(configuration)
-        fun forIncludedLibraries(configuration: CompilerConfiguration): FeaturedLibrariesReporter =
-                IncludedLibrariesReporter(configuration)
     }
 }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.backend.common.serialization.proto.IrFile
 import org.jetbrains.kotlin.backend.konan.driver.NativeCompilerDriver
 import org.jetbrains.kotlin.cli.CliDiagnostics
 import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
-import org.jetbrains.kotlin.cli.common.prohibitExportKlibToOlderAbiVersionAtSecondStage
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -119,8 +118,6 @@ class KonanDriver(
             configuration.report(CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING,
                     "target ${config.target} is deprecated and will be removed soon. See: $DEPRECATION_LINK")
         }
-
-        configuration.prohibitExportKlibToOlderAbiVersionAtSecondStage()
 
         ensureModuleName(config)
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -7,11 +7,13 @@ package org.jetbrains.kotlin.backend.konan
 
 import com.google.common.base.StandardSystemProperty
 import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
 import org.jetbrains.kotlin.backend.common.linkage.partial.partialLinkageConfig
 import org.jetbrains.kotlin.backend.konan.ir.BridgesPolicy
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCEntryPoints
 import org.jetbrains.kotlin.backend.konan.objcexport.readObjCEntryPoints
 import org.jetbrains.kotlin.backend.konan.serialization.PartialCacheInfo
+import org.jetbrains.kotlin.backend.konan.serialization.loadNativeKlibs
 import org.jetbrains.kotlin.backend.konan.util.reportCompilationErrorAndThrow
 import org.jetbrains.kotlin.backend.konan.util.systemCacheRootDirectory
 import org.jetbrains.kotlin.backend.konan.util.toObsoleteKind
@@ -91,6 +93,7 @@ class NativeSecondStageCompilationConfig(
     private val platformManager = PlatformManager(distribution)
     internal val targetManager = platformManager.targetManager(configuration.konanTarget)
     override val target = targetManager.target
+
     internal val phaseConfig = configuration.phaseConfig!!
 
     // See https://youtrack.jetbrains.com/issue/KT-67692.
@@ -412,6 +415,22 @@ class NativeSecondStageCompilationConfig(
             // of them will be added.
             it.library.isExplicitlySpecifiedByUserInCLIArgument && !purgeUserLibs
         }.getFullList()
+    }
+
+    override val loadedKlibs = loadNativeKlibs(configuration, target).let { original ->
+        // Avoid having duplicates of the same `KotlinLibrary` loaded by the KLIB resolver and `KlibLoader`.
+        // TODO(KT-61096): Drop this `let { ... }` block when completely switching to `KlibLoader`.
+        val canonicalPathToLibraryLoadedByKlibResolver: Map<Path, KotlinLibrary> = resolvedLibraries.getFullList().associateBy { it.canonicalPath }
+
+        val substituted = LoadedNativeKlibs(
+                all = original.all.map { canonicalPathToLibraryLoadedByKlibResolver.getValue(it.canonicalPath) },
+                friends = original.friends.map { canonicalPathToLibraryLoadedByKlibResolver.getValue(it.canonicalPath) },
+                exported = original.exported.map { canonicalPathToLibraryLoadedByKlibResolver.getValue(it.canonicalPath) },
+                included = original.included.map { canonicalPathToLibraryLoadedByKlibResolver.getValue(it.canonicalPath) },
+                toAddToCache = original.toAddToCache?.let { canonicalPathToLibraryLoadedByKlibResolver.getValue(it.canonicalPath) },
+        )
+
+        substituted
     }
 
     internal val externalDependenciesFile = configuration.externalDependencies?.let(::Path)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -389,13 +389,6 @@ class NativeSecondStageCompilationConfig(
 
     val resolvedLibraries get() = resolve.resolvedLibraries
 
-    val includedLibraries: List<KotlinLibrary>
-        get() = getIncludedLibraries(
-                configuration.konanIncludedLibraries.map { Path(it) },
-                configuration,
-                resolve.resolvedLibraries
-        )
-
     val exportedLibraries: List<KotlinLibrary>
         get() = getExportedLibraries(configuration, resolve.resolvedLibraries, resolve.resolver.searchPathResolver)
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -389,9 +389,6 @@ class NativeSecondStageCompilationConfig(
 
     val resolvedLibraries get() = resolve.resolvedLibraries
 
-    val exportedLibraries: List<KotlinLibrary>
-        get() = getExportedLibraries(configuration, resolve.resolvedLibraries, resolve.resolver.searchPathResolver)
-
     /**
      * Returns the list of libraries in reverse topological order.
      */

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
@@ -5,75 +5,46 @@
 
 package org.jetbrains.kotlin.backend.konan
 
+import com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.backend.common.linkage.partial.setupPartialLinkageConfig
 import org.jetbrains.kotlin.cli.CliDiagnostics.KONAN_ARGUMENT_ERROR
 import org.jetbrains.kotlin.cli.CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING
 import org.jetbrains.kotlin.cli.CliDiagnostics.KONAN_ARGUMENT_WARNING
 import org.jetbrains.kotlin.cli.common.arguments.K2NativeCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.cliArgument
-import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoot
-import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.cli.reportLog
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CommonConfigurationKeys.MODULE_NAME
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.getModuleNameForSource
 import org.jetbrains.kotlin.config.nativeBinaryOptions.*
-import org.jetbrains.kotlin.config.targetPlatform
 import org.jetbrains.kotlin.konan.config.*
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind
-import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.util.visibleName
-import org.jetbrains.kotlin.platform.konan.NativePlatforms
-import java.io.File
+import org.jetbrains.kotlin.native.pipeline.NativeKlibConfigurationUpdater
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
 
-fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArguments) = with(NativeConfigurationKeys) {
-    val commonSources = arguments.commonSources.toSet().map { it.absoluteNormalizedFile() }
-    val hmppModuleStructure = get(CommonConfigurationKeys.HMPP_MODULE_STRUCTURE)
-    arguments.freeArgs.forEach {
-        addKotlinSourceRoot(it, isCommon = it.absoluteNormalizedFile() in commonSources, hmppModuleStructure?.getModuleNameForSource(it))
-    }
+fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArguments, rootDisposable: Disposable) = with(NativeConfigurationKeys) {
+    NativeKlibConfigurationUpdater.fillConfiguration(arguments, rootDisposable, this@setupFromArguments)
 
     // Can be overwritten by explicit arguments below.
     parseBinaryOptions(arguments, this@setupFromArguments).forEach { optionWithValue ->
         put(optionWithValue)
     }
 
-    arguments.kotlinHome?.let { put(KONAN_HOME, it) }
-
-    konanNoDefaultLibs = arguments.nodefaultlibs || !arguments.libraryToAddToCache.isNullOrEmpty()
-    konanNoStdlib = arguments.nostdlib || !arguments.libraryToAddToCache.isNullOrEmpty()
-    konanDontCompressKlib = arguments.nopack
     put(NOMAIN, arguments.nomain)
-    konanLibraries = arguments.libraries.toNonNullList()
     put(LINKER_ARGS, arguments.linkerArguments.toNonNullList() +
             arguments.singleLinkerArguments.toNonNullList())
-    arguments.moduleName?.let { put(MODULE_NAME, it) }
 
     // TODO: allow overriding the prefix directly.
     // With Swift Export, exported prefix must be Kotlin.
     ("Kotlin".takeIf { get(BinaryOptions.swiftExport) == true } ?: arguments.moduleName)?.let { put(FULL_EXPORTED_NAME_PREFIX, it) }
 
-    arguments.target?.let { konanTarget = it }
-
-    konanIncludedBinaries = arguments.includeBinaries.toNonNullList()
-    konanNativeLibraries = arguments.nativeLibraries.toNonNullList()
-
     // TODO: Collect all the explicit file names into an object
     // and teach the compiler to work with temporaries and -save-temps.
 
-    arguments.outputName?.let { konanOutputPath = it }
-    val outputKind = CompilerOutputKind.valueOf(
-            (arguments.produce ?: "program").uppercase())
-    konanProducedArtifactKind = outputKind
-    arguments.headerKlibPath?.let { konanGeneratedHeaderKlibPath = it }
-
     arguments.mainPackage?.let { konanEntryPoint = it }
-    arguments.manifestFile?.let { konanManifestAddend = it }
     arguments.runtimeFile?.let { put(RUNTIME_FILE, it) }
     arguments.temporaryFilesDir?.let { put(TEMPORARY_FILES_DIR, it) }
     put(SAVE_LLVM_IR, arguments.saveLlvmIrAfter.toList())
@@ -81,6 +52,8 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
     if (arguments.optimization && arguments.debug) {
         report(KONAN_ARGUMENT_WARNING, "Unsupported combination of flags: -opt and -g. Please pick one.")
     }
+
+    val outputKind = konanProducedArtifactKind!!
 
     put(LIST_TARGETS, arguments.listTargets)
     put(OPTIMIZATION, arguments.optimization)
@@ -105,18 +78,6 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
     })
     put(STATIC_FRAMEWORK, selectFrameworkType(this@setupFromArguments, arguments, outputKind))
     put(OVERRIDE_CLANG_OPTIONS, arguments.clangOptions.toNonNullList())
-
-    konanPrintIr = arguments.printIr
-    konanPrintBitcode = arguments.printBitCode
-    konanPrintFiles = arguments.printFiles
-
-    konanPurgeUserLibs = arguments.purgeUserLibs
-
-    arguments.writeDependenciesOfProducedKlibTo?.let { konanWriteDependenciesOfProducedKlibTo = it }
-
-    if (arguments.verifyCompiler != null)
-        put(VERIFY_COMPILER, arguments.verifyCompiler == "true")
-    put(VERIFY_BITCODE, arguments.verifyBitCode)
 
     put(ENABLE_ASSERTIONS, arguments.enableAssertions)
 
@@ -162,22 +123,7 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
         arguments.generateNoExitTestRunner -> put(GENERATE_TEST_RUNNER, TestRunnerKind.MAIN_THREAD_NO_EXIT)
         else -> put(GENERATE_TEST_RUNNER, TestRunnerKind.NONE)
     }
-    // We need to download dependencies only if we use them ( = there are files to compile).
-    put(CHECK_DEPENDENCIES,
-            kotlinSourceRoots.isNotEmpty()
-                    || arguments.includes.isNotEmpty()
-                    || arguments.exportedLibraries.isNotEmpty()
-                    || (outputKind == CompilerOutputKind.PROGRAM && arguments.libraries.isNotEmpty())
-                    || outputKind.isCache
-                    || arguments.checkDependencies
-    )
-    if (arguments.friendModules != null)
-        konanFriendLibraries = arguments.friendModules!!.split(File.pathSeparator).filterNot(String::isEmpty)
 
-    konanRefinesModules = arguments.refinesPaths.filterNot(String::isEmpty)
-
-    put(EXPORTED_LIBRARIES, selectExportedLibraries(this@setupFromArguments, arguments, outputKind))
-    konanIncludedLibraries = selectIncludes(this@setupFromArguments, arguments, outputKind)
     put(FRAMEWORK_IMPORT_HEADERS, arguments.frameworkImportHeaders.toNonNullList())
     arguments.emitLazyObjCHeader?.let { put(EMIT_LAZY_OBJC_HEADER_FILE, it) }
 
@@ -185,10 +131,6 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
     put(OBJC_GENERICS, !arguments.noObjcGenerics)
     put(DEBUG_PREFIX_MAP, parseDebugPrefixMap(arguments, this@setupFromArguments))
 
-    val libraryToAddToCache = parseLibraryToAddToCache(arguments, this@setupFromArguments, outputKind)
-    if (libraryToAddToCache != null && !arguments.outputName.isNullOrEmpty())
-        report(KONAN_ARGUMENT_ERROR, "${K2NativeCompilerArguments::libraryToAddToCache.cliArgument} already implicitly sets output file name")
-    libraryToAddToCache?.let { konanLibraryToAddToCache = it }
     put(CACHED_LIBRARIES, parseCachedLibraries(arguments, this@setupFromArguments))
     put(CACHE_DIRECTORIES, arguments.cacheDirectories.toNonNullList())
     put(AUTO_CACHEABLE_FROM, arguments.autoCacheableFrom.toNonNullList())
@@ -212,9 +154,6 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
     }
     put(CommonConfigurationKeys.PARALLEL_BACKEND_THREADS, nThreads)
 
-    parseShortModuleName(arguments, this@setupFromArguments, outputKind)?.let {
-        konanShortModuleName = it
-    }
     putIfNotNull(PRE_LINK_CACHES, parsePreLinkCachesValue(this@setupFromArguments, arguments.preLinkCaches))
     putIfNotNull(OVERRIDE_KONAN_PROPERTIES, parseOverrideKonanProperties(arguments, this@setupFromArguments))
 
@@ -303,11 +242,6 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
     putIfNotNull(SERIALIZED_DEPENDENCIES, parseSerializedDependencies(arguments, this@setupFromArguments))
     putIfNotNull(SAVE_DEPENDENCIES_PATH, arguments.saveDependenciesPath)
     putIfNotNull(SAVE_LLVM_IR_DIRECTORY, arguments.saveLlvmIrDirectory)
-    putIfNotNull(KONAN_DATA_DIR, arguments.konanDataDir)
-
-    val manifestNativeTargets = parseManifestNativeTargets(arguments.manifestNativeTargets)
-    konanManifestNativeTargets = manifestNativeTargets
-    this@setupFromArguments.targetPlatform = NativePlatforms.nativePlatformByTargets(manifestNativeTargets)
 
     putIfNotNull(LLVM_MODULE_PASSES, arguments.llvmModulePasses)
     putIfNotNull(LLVM_LTO_PASSES, arguments.llvmLTOPasses)
@@ -376,43 +310,6 @@ private fun parsePreLinkCachesValue(
     }
 }
 
-private fun selectExportedLibraries(
-        configuration: CompilerConfiguration,
-        arguments: K2NativeCompilerArguments,
-        outputKind: CompilerOutputKind
-): List<String> {
-    val exportedLibraries = arguments.exportedLibraries.toList()
-
-    return if (exportedLibraries.isNotEmpty() && outputKind != CompilerOutputKind.FRAMEWORK &&
-            outputKind != CompilerOutputKind.STATIC && outputKind != CompilerOutputKind.DYNAMIC) {
-        configuration.report(KONAN_ARGUMENT_STRONG_WARNING,
-                "-Xexport-library is only supported when producing frameworks or native libraries, " +
-                        "but the compiler is producing ${outputKind.name.lowercase()}")
-
-        emptyList()
-    } else {
-        exportedLibraries
-    }
-}
-
-private fun selectIncludes(
-        configuration: CompilerConfiguration,
-        arguments: K2NativeCompilerArguments,
-        outputKind: CompilerOutputKind
-): List<String> {
-    val includes = arguments.includes.toList()
-
-    return if (includes.isNotEmpty() && outputKind == CompilerOutputKind.LIBRARY) {
-        configuration.report(
-                KONAN_ARGUMENT_ERROR,
-                "The ${K2NativeCompilerArguments::includes.cliArgument} flag is not supported when producing ${outputKind.name.lowercase()}"
-        )
-        emptyList()
-    } else {
-        includes
-    }
-}
-
 private fun parseCachedLibraries(
         arguments: K2NativeCompilerArguments,
         configuration: CompilerConfiguration
@@ -429,47 +326,12 @@ private fun parseCachedLibraries(
     }
 }.toMap()
 
-private fun parseLibraryToAddToCache(
-        arguments: K2NativeCompilerArguments,
-        configuration: CompilerConfiguration,
-        outputKind: CompilerOutputKind
-): String? {
-    val input = arguments.libraryToAddToCache
-
-    return if (input != null && !outputKind.isCache) {
-        configuration.report(KONAN_ARGUMENT_ERROR, "${K2NativeCompilerArguments::libraryToAddToCache.cliArgument} can't be used when not producing cache")
-        null
-    } else {
-        input
-    }
-}
-
 private fun parseBackendThreads(stringValue: String): Int {
     val value = stringValue.toIntOrNull()
             ?: throw KonanCompilationException("Cannot parse -Xbackend-threads value: \"$stringValue\". Please use an integer number")
     if (value < 0)
         throw KonanCompilationException("-Xbackend-threads value cannot be negative")
     return value
-}
-
-// TODO: Support short names for current module in ObjC export and lift this limitation.
-private fun parseShortModuleName(
-        arguments: K2NativeCompilerArguments,
-        configuration: CompilerConfiguration,
-        outputKind: CompilerOutputKind
-): String? {
-    val input = arguments.shortModuleName
-
-    return if (input != null && outputKind != CompilerOutputKind.LIBRARY) {
-        configuration.report(
-                KONAN_ARGUMENT_STRONG_WARNING,
-                "${K2NativeCompilerArguments::shortModuleName.cliArgument} is only supported when producing a Kotlin library, " +
-                        "but the compiler is producing ${outputKind.name.lowercase()}"
-        )
-        null
-    } else {
-        input
-    }
 }
 
 private fun parseDebugPrefixMap(
@@ -537,24 +399,4 @@ private fun parseCompileFromBitcode(
                 "Compilation from bitcode is not available when producing ${outputKind.visibleName}")
     }
     return arguments.compileFromBitcode
-}
-
-private fun CompilerConfiguration.parseManifestNativeTargets(targetStrings: Array<String>): List<KonanTarget> {
-    val trimmedTargetStrings = targetStrings.map { it.trim() }
-    val [recognizedTargetNames, unrecognizedTargetNames] = trimmedTargetStrings.partition { it in KonanTarget.predefinedTargets.keys }
-
-    if (unrecognizedTargetNames.isNotEmpty()) {
-        report(
-                KONAN_ARGUMENT_WARNING,
-                """
-                    The following target names passed to the -Xmanifest-native-targets are not recognized:
-                    ${unrecognizedTargetNames.joinToString(separator = ", ")}
-                    
-                    List of known target names:
-                    ${KonanTarget.predefinedTargets.keys.joinToString(separator = ", ")}
-                """.trimIndent()
-        )
-    }
-
-    return recognizedTargetNames.map { KonanTarget.predefinedTargets[it]!! }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -45,7 +45,7 @@ internal object TopDownAnalyzerFacadeForKonan {
         val resolvedModuleDescriptors = nativeFactories.DefaultResolvedDescriptorsFactory.createResolved2(
                 config.resolvedLibraries, projectContext.storageManager, module.builtIns, config.languageVersionSettings,
                 config.friendModuleFiles, config.refinesModuleFiles,
-                config.includedLibraries.map { it.path }.toSet(), listOf(module),
+                config.loadedKlibs.included.map { it.path }.toSet(), listOf(module),
                 isForMetadataCompilation = config.metadataKlib)
 
         val additionalPackages = mutableListOf<PackageFragmentProvider>()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.cli.common.diagnosticsCollector
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.*
-import org.jetbrains.kotlin.ir.declarations.DescriptorMetadataSource
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
@@ -33,7 +32,6 @@ import org.jetbrains.kotlin.library.metadata.impl.isForwardDeclarationModule
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
 import org.jetbrains.kotlin.library.metadata.kotlinLibrary
 import org.jetbrains.kotlin.library.uniqueName
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.CommonCompilerDeserializationConfiguration
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.serialization.deserialization.DeserializationConfiguration
@@ -156,7 +154,7 @@ private fun LinkKlibsContext.createIrLinker(moduleDescriptor: ModuleDescriptor, 
 
     val friendModulesMap = (
             listOf(moduleDescriptor.name.asStringStripSpecialMarkers()) +
-                    config.includedLibraries.map { it.uniqueName }
+                    config.loadedKlibs.included.map { it.uniqueName }
             ).associateWith { friendModules }
 
     val irDiagnosticReporter = KtDiagnosticReporterWithImplicitIrBasedContext(

--- a/native/cli-native/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/native/cli-native/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -112,8 +112,9 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
 
         configuration.perfManager = performanceManager
         try {
+            val rootDisposable = Disposer.newDisposable("Disposable for ${CLICompiler::class.simpleName}.execImpl")
             setupCommonArguments(configuration, arguments)
-            configuration.setupFromArguments(arguments)
+            configuration.setupFromArguments(arguments, rootDisposable)
             if (CheckDiagnosticCollector.checkHasErrorsAndReportToMessageCollector(configuration)) {
                 return ExitCode.COMPILATION_ERROR
             }
@@ -121,7 +122,6 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
             val canceledStatus = services[CompilationCanceledStatus::class.java]
             ProgressIndicatorAndCompilationCanceledStatus.setCompilationCanceledStatus(canceledStatus)
 
-            val rootDisposable = Disposer.newDisposable("Disposable for ${CLICompiler::class.simpleName}.execImpl")
             try {
                 setIdeaIoUseFallback()
 
@@ -310,7 +310,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                     spawnedConfiguration.messageCollector = configuration.messageCollector
                     spawnedConfiguration.perfManager = spawnedPerfManager
                     spawnedConfiguration.setupCommonArguments(spawnedArguments, this@K2Native::createMetadataVersion)
-                    spawnedConfiguration.setupFromArguments(spawnedArguments)
+                    spawnedConfiguration.setupFromArguments(spawnedArguments, rootDisposable)
                     spawnedConfiguration.setupPartialLinkageConfig(configuration.partialLinkageConfig)
                     configuration.get(CommonConfigurationKeys.USE_FIR)?.let {
                         spawnedConfiguration.put(CommonConfigurationKeys.USE_FIR, it)

--- a/native/cli-native/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/native/cli-native/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -112,47 +112,46 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
 
         configuration.perfManager = performanceManager
         try {
-            val rootDisposable = Disposer.newDisposable("Disposable for ${CLICompiler::class.simpleName}.execImpl")
-            setupCommonArguments(configuration, arguments)
-            configuration.setupFromArguments(arguments, rootDisposable)
-            if (CheckDiagnosticCollector.checkHasErrorsAndReportToMessageCollector(configuration)) {
-                return ExitCode.COMPILATION_ERROR
-            }
+            withRootDisposable { rootDisposable ->
+                setupCommonArguments(configuration, arguments)
+                configuration.setupFromArguments(arguments, rootDisposable)
+                if (CheckDiagnosticCollector.checkHasErrorsAndReportToMessageCollector(configuration)) {
+                    return ExitCode.COMPILATION_ERROR
+                }
 
-            val canceledStatus = services[CompilationCanceledStatus::class.java]
-            ProgressIndicatorAndCompilationCanceledStatus.setCompilationCanceledStatus(canceledStatus)
+                val canceledStatus = services[CompilationCanceledStatus::class.java]
+                ProgressIndicatorAndCompilationCanceledStatus.setCompilationCanceledStatus(canceledStatus)
 
-            try {
-                setIdeaIoUseFallback()
+                try {
+                    setIdeaIoUseFallback()
 
-                val code = doExecute(arguments, configuration, rootDisposable, services)
+                    val code = doExecute(arguments, configuration, rootDisposable, services)
 
-                performanceManager.notifyCompilationFinished()
-                if (arguments.reportPerf) {
-                    collector.report(LOGGING, "PERF: " + performanceManager.getTargetInfo())
-                    performanceManager.forEachStringMeasurement {
-                        collector.report(LOGGING, "PERF: $it", null)
+                    performanceManager.notifyCompilationFinished()
+                    if (arguments.reportPerf) {
+                        collector.report(LOGGING, "PERF: " + performanceManager.getTargetInfo())
+                        performanceManager.forEachStringMeasurement {
+                            collector.report(LOGGING, "PERF: $it", null)
+                        }
+                    }
+
+                    if (arguments.dumpPerf != null) {
+                        performanceManager.dumpPerformanceReport(arguments.dumpPerf!!)
+                    }
+
+                    return if (CheckDiagnosticCollector.checkHasErrorsAndReportToMessageCollector(configuration)) ExitCode.COMPILATION_ERROR else code
+                } catch (e: CompilationCanceledException) {
+                    collector.reportCompilationCancelled(e)
+                    return ExitCode.OK
+                } catch (e: RuntimeException) {
+                    val cause = e.cause
+                    if (cause is CompilationCanceledException) {
+                        collector.reportCompilationCancelled(cause)
+                        return ExitCode.OK
+                    } else {
+                        throw e
                     }
                 }
-
-                if (arguments.dumpPerf != null) {
-                    performanceManager.dumpPerformanceReport(arguments.dumpPerf!!)
-                }
-
-                return if (CheckDiagnosticCollector.checkHasErrorsAndReportToMessageCollector(configuration)) ExitCode.COMPILATION_ERROR else code
-            } catch (e: CompilationCanceledException) {
-                collector.reportCompilationCancelled(e)
-                return ExitCode.OK
-            } catch (e: RuntimeException) {
-                val cause = e.cause
-                if (cause is CompilationCanceledException) {
-                    collector.reportCompilationCancelled(cause)
-                    return ExitCode.OK
-                } else {
-                    throw e
-                }
-            } finally {
-                disposeRootInWriteAction(rootDisposable)
             }
         } catch (_: CompilationErrorException) {
             return ExitCode.COMPILATION_ERROR
@@ -393,6 +392,15 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                 if (doMainNoExit(K2Native(), args, messageRenderer) != ExitCode.OK) {
                     throw KonanCompilationException("Compilation finished with errors")
                 }
+            }
+        }
+
+        private inline fun <T> withRootDisposable(block: (rootDisposable: Disposable) -> T): T {
+            val rootDisposable = Disposer.newDisposable("Disposable for ${CLICompiler::class.simpleName}.execImpl")
+            try {
+                return block(rootDisposable)
+            } finally {
+                disposeRootInWriteAction(rootDisposable)
             }
         }
     }

--- a/native/cli-native/src/org/jetbrains/kotlin/cli/bc/oneStageMode.kt
+++ b/native/cli-native/src/org/jetbrains/kotlin/cli/bc/oneStageMode.kt
@@ -31,9 +31,10 @@ internal fun prepareKlibArgumentsForOneStage(
     intermediateKlibPath: String
 ): K2NativeCompilerArguments {
     val klibArgs = original.copyOf()
-    // Override produce and output as we should produce an intermediate KLib
+    // Override produce, output and includes as we should produce an intermediate KLib
     klibArgs.produce = "library"
     klibArgs.outputName = intermediateKlibPath
+    klibArgs.includes = emptyArray()
     return klibArgs
 }
 

--- a/native/cli-native/src/org/jetbrains/kotlin/cli/bc/oneStageMode.kt
+++ b/native/cli-native/src/org/jetbrains/kotlin/cli/bc/oneStageMode.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.useFir
 import org.jetbrains.kotlin.konan.config.emitLazyObjcHeaderFile
 import org.jetbrains.kotlin.konan.config.konanIncludedLibraries
+import org.jetbrains.kotlin.konan.config.konanLibraries
 import java.nio.file.Path
 import java.util.*
 import kotlin.io.path.Path
@@ -49,7 +50,10 @@ internal fun adjustConfigurationForSecondStage(
     // We need to remove this flag, as it would otherwise override header written previously.
     // Unfortunately, there is no way to remove the flag, so empty string is put instead
     configuration.emitLazyObjcHeaderFile?.let { configuration.emitLazyObjcHeaderFile = "" }
-    configuration.konanIncludedLibraries += listOf(intermediateKLib.absolutePathString())
+
+    val intermediateKlibPath = intermediateKLib.absolutePathString()
+    configuration.konanIncludedLibraries += intermediateKlibPath
+    configuration.konanLibraries += intermediateKlibPath
 }
 
 internal fun createIntermediateKlib(): Path =

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -29,7 +29,6 @@ import org.jetbrains.kotlin.test.utils.patchManifestAsMap
 import org.jetbrains.kotlin.test.utils.patchManifestToBumpAbiVersion
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -361,7 +360,6 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         }
     }
 
-    @Disabled // TODO(KT-61096) Re-enable the test once we stop calling `getFeaturedLibraries()` on 2nd stage.
     @Test
     fun `Compiler rejects libraries from the distribution and C-interop libraries as exported libs`() {
         // Frameworks can be built only on Apple.

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -298,6 +298,21 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         }
     }
 
+    private fun doTestIrProviders(irProviderName: String) {
+        newSourceModules {
+            addRegularModule("a")
+            addRegularModule("b") { dependsOn("a") }
+        }.compileToKlibsViaCli { module, successKlib ->
+            successKlib.assertNoKlibLoaderIssues()
+
+            if (module.name == "a") {
+                patchManifestAsMap(JUnit5Assertions, successKlib.resultingArtifact.klibFile) { properties ->
+                    properties[KLIB_PROPERTY_IR_PROVIDER] = irProviderName
+                }
+            }
+        }
+    }
+
     @Test
     fun `Compiler rejects libraries from the distribution and C-interop libraries as included and exported libs`() {
         val librariesDir = testRunSettings.get<KotlinNativeHome>().librariesDir
@@ -351,21 +366,6 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
                         cliParameter = testedCliParameter,
                         stdlibPath, posixPath, cinteropLibPath
                     )
-                }
-            }
-        }
-    }
-
-    private fun doTestIrProviders(irProviderName: String) {
-        newSourceModules {
-            addRegularModule("a")
-            addRegularModule("b") { dependsOn("a") }
-        }.compileToKlibsViaCli { module, successKlib ->
-            successKlib.assertNoKlibLoaderIssues()
-
-            if (module.name == "a") {
-                patchManifestAsMap(JUnit5Assertions, successKlib.resultingArtifact.klibFile) { properties ->
-                    properties[KLIB_PROPERTY_IR_PROVIDER] = irProviderName
                 }
             }
         }

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -345,7 +345,6 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         }
     }
 
-    @Disabled // TODO(KT-61096) Re-enable the test once we stop calling `getFeaturedLibraries()` on 2nd stage.
     @Test
     fun `Compiler rejects libraries from the distribution and C-interop libraries as included libs`() {
         doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(testedCliParameter = K2NativeCompilerArguments::includes) { cliArgs ->

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.collections.set
 import kotlin.io.path.absolutePathString
+import kotlin.reflect.KProperty1
 import kotlin.text.contains
 
 @Tag("klib")
@@ -314,7 +315,18 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
     }
 
     @Test
-    fun `Compiler rejects libraries from the distribution and C-interop libraries as included and exported libs`() {
+    fun `Compiler rejects libraries from the distribution and C-interop libraries as included libs`() {
+        doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(testedCliParameter = K2NativeCompilerArguments::includes)
+    }
+
+    @Test
+    fun `Compiler rejects libraries from the distribution and C-interop libraries as exported libs`() {
+        doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(testedCliParameter = K2NativeCompilerArguments::exportedLibraries)
+    }
+
+    private fun doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(
+        testedCliParameter: KProperty1<K2NativeCompilerArguments, Array<String>>,
+    ) {
         val librariesDir = testRunSettings.get<KotlinNativeHome>().librariesDir
         val target = testRunSettings.get<KotlinNativeTargets>().testTarget
 
@@ -337,36 +349,31 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         checkNotNull(regularLibPath)
         checkNotNull(cinteropLibPath)
 
+        // try it with different combinations of "-no..." flags:
         listOf(
-            K2NativeCompilerArguments::includes.cliArgument,
-            K2NativeCompilerArguments::exportedLibraries.cliArgument,
-        ).forEach { testedCliParameter ->
-            // try it with different combinations of "-no..." flags:
-            listOf(
-                emptyList(),
-                listOf("-nostdlib"),
-                listOf("-no-default-libs"),
-                listOf("-nostdlib", "-no-default-libs"),
-            ).forEach { extraNoSmthFlags ->
-                newSourceModules {
-                    addRegularModule("test")
-                }.compileToKlibsViaCli(
-                    extraCliArgs = extraNoSmthFlags + listOf(
-                        "-l", stdlibPath,
-                        "-l", posixPath,
-                        "-l", regularLibPath,
-                        "-l", cinteropLibPath,
-                        "$testedCliParameter=$stdlibPath",
-                        "$testedCliParameter=$posixPath",
-                        "$testedCliParameter=$regularLibPath",
-                        "$testedCliParameter=$cinteropLibPath",
-                    )
-                ) { _, successKlib ->
-                    successKlib.assertProblematicIncludedOrExportedLibs(
-                        cliParameter = testedCliParameter,
-                        stdlibPath, posixPath, cinteropLibPath
-                    )
-                }
+            emptyList(),
+            listOf("-nostdlib"),
+            listOf("-no-default-libs"),
+            listOf("-nostdlib", "-no-default-libs"),
+        ).forEach { extraNoSmthFlags ->
+            newSourceModules {
+                addRegularModule("test")
+            }.compileToKlibsViaCli(
+                extraCliArgs = extraNoSmthFlags + listOf(
+                    "-l", stdlibPath,
+                    "-l", posixPath,
+                    "-l", regularLibPath,
+                    "-l", cinteropLibPath,
+                    testedCliParameter.cliArgument(stdlibPath),
+                    testedCliParameter.cliArgument(posixPath),
+                    testedCliParameter.cliArgument(regularLibPath),
+                    testedCliParameter.cliArgument(cinteropLibPath),
+                )
+            ) { _, successKlib ->
+                successKlib.assertProblematicIncludedOrExportedLibs(
+                    cliParameter = testedCliParameter,
+                    stdlibPath, posixPath, cinteropLibPath
+                )
             }
         }
     }
@@ -454,7 +461,7 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
     }
 
     private fun TestCompilationResult.Success<out KLIB>.assertProblematicIncludedOrExportedLibs(
-        cliParameter: String,
+        cliParameter: KProperty1<K2NativeCompilerArguments, *>,
         vararg pathsOfExpectedProblematicIncludes: String,
     ) {
         val compilationToolCall = loggedData as LoggedData.CompilationToolCall
@@ -467,7 +474,7 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         assertEquals(pathsOfExpectedProblematicIncludes.size, toolOutput.size)
 
         val pathsOfActualProblematicIncludes = toolOutput.map { message ->
-            message.substringAfterLast("cannot be used in $cliParameter CLI argument: ").trim()
+            message.substringAfterLast("cannot be used in ${cliParameter.cliArgument} CLI argument: ").trim()
         }
 
         assertEquals(pathsOfExpectedProblematicIncludes.toSet(), pathsOfActualProblematicIncludes.toSet())

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/klib/KlibCliSanityTest.kt
@@ -12,7 +12,12 @@ import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
 import org.jetbrains.kotlin.konan.test.blackbox.AbstractNativeSimpleTest
 import org.jetbrains.kotlin.konan.test.blackbox.buildDir
 import org.jetbrains.kotlin.konan.test.blackbox.support.LoggedData
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestCase
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestCompilerArgs
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.CompilationToolException
+import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.ExecutableCompilation
+import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.ObjCFrameworkCompilation
+import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationArtifact.KLIB
 import org.jetbrains.kotlin.konan.test.blackbox.support.compilation.TestCompilationResult
 import org.jetbrains.kotlin.konan.test.blackbox.support.settings.KotlinNativeHome
@@ -22,17 +27,14 @@ import org.jetbrains.kotlin.library.KLIB_PROPERTY_IR_PROVIDER
 import org.jetbrains.kotlin.test.services.JUnit5Assertions
 import org.jetbrains.kotlin.test.utils.patchManifestAsMap
 import org.jetbrains.kotlin.test.utils.patchManifestToBumpAbiVersion
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.io.File
-import kotlin.collections.set
 import kotlin.io.path.absolutePathString
 import kotlin.reflect.KProperty1
-import kotlin.text.contains
 
 @Tag("klib")
 class KlibCliSanityTest : AbstractNativeSimpleTest() {
@@ -120,15 +122,6 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
                 extraCliArgs = listOf(
                     CLI_PARAM_LIBRARIES, libraryPath,
                     CLI_PARAM_FRIENDS, libraryPath,
-                )
-            ) { _, successKlib ->
-                successKlib.assertLibraryNotFound(libraryPath)
-            }
-
-            modules.compileToKlibsViaCli(
-                extraCliArgs = listOf(
-                    CLI_PARAM_LIBRARIES, libraryPath,
-                    CLI_ARG_INCLUDES(libraryPath),
                 )
             ) { _, successKlib ->
                 successKlib.assertLibraryNotFound(libraryPath)
@@ -315,17 +308,81 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
     }
 
     @Test
-    fun `Compiler rejects libraries from the distribution and C-interop libraries as included libs`() {
-        doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(testedCliParameter = K2NativeCompilerArguments::includes)
+    fun `Included libs are forbidden on 1st phase`() {
+        var aPath: String? = null
+        newSourceModules { addRegularModule("a") }.compileToKlibsViaCli { _, successKlib ->
+            aPath = successKlib.resultingArtifact.klibFile.absolutePath
+        }
+        requireNotNull(aPath)
+
+        try {
+            newSourceModules { addRegularModule("b") }.compileToKlibsViaCli(
+                extraCliArgs = listOf(K2NativeCompilerArguments::includes.cliArgument(aPath))
+            )
+            fail { "Normally unreachable code" }
+        } catch (cte: CompilationToolException) {
+            if (!cte.reason.contains("-Xinclude CLI argument is not supported when producing library"))
+                throw cte
+        }
     }
 
     @Test
+    fun `Exported libs are forbidden on 1st phase`() {
+        var aPath: String? = null
+        newSourceModules { addRegularModule("a") }.compileToKlibsViaCli { _, successKlib ->
+            aPath = successKlib.resultingArtifact.klibFile.absolutePath
+        }
+        requireNotNull(aPath)
+
+        try {
+            newSourceModules { addRegularModule("b") }.compileToKlibsViaCli(
+                extraCliArgs = listOf(K2NativeCompilerArguments::exportedLibraries.cliArgument(aPath))
+            )
+            fail { "Normally unreachable code" }
+        } catch (cte: CompilationToolException) {
+            if (!cte.reason.contains("-Xexport-library CLI argument is only supported when producing frameworks or native libraries"))
+                throw cte
+        }
+    }
+
+    @Disabled // TODO(KT-61096) Re-enable the test once we stop calling `getFeaturedLibraries()` on 2nd stage.
+    @Test
+    fun `Compiler rejects libraries from the distribution and C-interop libraries as included libs`() {
+        doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(testedCliParameter = K2NativeCompilerArguments::includes) { cliArgs ->
+            val executableFile = buildDir.resolve("kexe.kexe").also { it.delete() }
+            val compilation = ExecutableCompilation(
+                settings = testRunSettings,
+                freeCompilerArgs = TestCompilerArgs(cliArgs),
+                sourceModules = emptyList(),
+                extras = TestCase.NoTestRunnerExtras(entryPoint = "r.main"),
+                dependencies = emptySet(),
+                expectedArtifact = TestCompilationArtifact.Executable(executableFile),
+            )
+            compilation.result
+        }
+    }
+
+    @Disabled // TODO(KT-61096) Re-enable the test once we stop calling `getFeaturedLibraries()` on 2nd stage.
+    @Test
     fun `Compiler rejects libraries from the distribution and C-interop libraries as exported libs`() {
-        doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(testedCliParameter = K2NativeCompilerArguments::exportedLibraries)
+        // Frameworks can be built only on Apple.
+        assumeTrue(testRunSettings.get<KotlinNativeTargets>().hostTarget.family.isAppleFamily)
+        doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(testedCliParameter = K2NativeCompilerArguments::exportedLibraries) { cliArgs ->
+            val frameworkDir = buildDir.resolve("frameworkDir").also { it.deleteRecursively() }
+            val compilation = ObjCFrameworkCompilation(
+                settings = testRunSettings,
+                freeCompilerArgs = TestCompilerArgs(cliArgs),
+                sourceModules = emptyList(),
+                dependencies = emptySet(),
+                expectedArtifact = TestCompilationArtifact.ObjCFramework(frameworkDir, "myFramework"),
+            )
+            compilation.result
+        }
     }
 
     private fun doTestCompilerRejectsLibrariesFromDistributionAndCInteropLibraries(
         testedCliParameter: KProperty1<K2NativeCompilerArguments, Array<String>>,
+        run2StageCompilation: (cliArgs: List<String>) -> TestCompilationResult<*>,
     ) {
         val librariesDir = testRunSettings.get<KotlinNativeHome>().librariesDir
         val target = testRunSettings.get<KotlinNativeTargets>().testTarget
@@ -337,7 +394,7 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         var cinteropLibPath: String? = null
 
         newSourceModules {
-            addRegularModule("r")
+            addRegularModule("r") { sourceFileAddend("fun main() = Unit") }
             addCInteropModule("c")
         }.compileToKlibsViaCli { module, successKlib ->
             when (module.name) {
@@ -356,25 +413,24 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
             listOf("-no-default-libs"),
             listOf("-nostdlib", "-no-default-libs"),
         ).forEach { extraNoSmthFlags ->
-            newSourceModules {
-                addRegularModule("test")
-            }.compileToKlibsViaCli(
-                extraCliArgs = extraNoSmthFlags + listOf(
-                    "-l", stdlibPath,
-                    "-l", posixPath,
-                    "-l", regularLibPath,
-                    "-l", cinteropLibPath,
-                    testedCliParameter.cliArgument(stdlibPath),
-                    testedCliParameter.cliArgument(posixPath),
-                    testedCliParameter.cliArgument(regularLibPath),
-                    testedCliParameter.cliArgument(cinteropLibPath),
-                )
-            ) { _, successKlib ->
-                successKlib.assertProblematicIncludedOrExportedLibs(
-                    cliParameter = testedCliParameter,
-                    stdlibPath, posixPath, cinteropLibPath
-                )
-            }
+            val compilerOutput = run2StageCompilation(
+                buildList {
+                    this += extraNoSmthFlags
+                    this += listOf("-l", stdlibPath)
+                    this += listOf("-l", posixPath)
+                    this += listOf("-l", regularLibPath)
+                    this += listOf("-l", cinteropLibPath)
+                    this += testedCliParameter.cliArgument(stdlibPath)
+                    this += testedCliParameter.cliArgument(posixPath)
+                    this += testedCliParameter.cliArgument(regularLibPath)
+                    this += testedCliParameter.cliArgument(cinteropLibPath)
+                }
+            )
+
+            compilerOutput.assertProblematicIncludedOrExportedLibs(
+                cliParameter = testedCliParameter,
+                stdlibPath, posixPath, cinteropLibPath
+            )
         }
     }
 
@@ -460,21 +516,20 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
         assertTrue(": $friendPath" in toolOutput[0])
     }
 
-    private fun TestCompilationResult.Success<out KLIB>.assertProblematicIncludedOrExportedLibs(
+    private fun TestCompilationResult<*>.assertProblematicIncludedOrExportedLibs(
         cliParameter: KProperty1<K2NativeCompilerArguments, *>,
         vararg pathsOfExpectedProblematicIncludes: String,
     ) {
-        val compilationToolCall = loggedData as LoggedData.CompilationToolCall
-        assertEquals(ExitCode.OK, compilationToolCall.exitCode)
+        val compilationToolCall = (this as TestCompilationResult.ImmediateResult<*>).loggedData as LoggedData.CompilationToolCall
 
-        val toolOutput = compilationToolCall.toolOutput.lineSequence()
-            .filter { "KLIB loader:" in it }
-            .toList()
+        val messagePattern = "cannot be used in ${cliParameter.cliArgument} CLI argument: "
+        val toolOutput = compilationToolCall.toolOutput.lines()
 
-        assertEquals(pathsOfExpectedProblematicIncludes.size, toolOutput.size)
-
-        val pathsOfActualProblematicIncludes = toolOutput.map { message ->
-            message.substringAfterLast("cannot be used in ${cliParameter.cliArgument} CLI argument: ").trim()
+        val pathsOfActualProblematicIncludes = toolOutput.mapNotNull { line ->
+            if (messagePattern in line)
+                line.substringAfterLast(messagePattern).trim()
+            else
+                null
         }
 
         assertEquals(pathsOfExpectedProblematicIncludes.toSet(), pathsOfActualProblematicIncludes.toSet())
@@ -483,8 +538,5 @@ class KlibCliSanityTest : AbstractNativeSimpleTest() {
     companion object {
         private val CLI_PARAM_LIBRARIES: String = K2NativeCompilerArguments::libraries.cliArgument
         private val CLI_PARAM_FRIENDS: String = K2NativeCompilerArguments::friendModules.cliArgument
-
-        @Suppress("TestFunctionName")
-        private fun CLI_ARG_INCLUDES(path: String): String = K2NativeCompilerArguments::includes.cliArgument(path)
     }
 }

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/CompilerOutputKind.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/CompilerOutputKind.kt
@@ -45,3 +45,12 @@ enum class CompilerOutputKind {
     abstract fun suffix(target: KonanTarget? = null): String
     open fun prefix(target: KonanTarget? = null): String = ""
 }
+
+val CompilerOutputKind.isFullCache: Boolean
+    get() = this == CompilerOutputKind.STATIC_CACHE || this == CompilerOutputKind.DYNAMIC_CACHE
+
+val CompilerOutputKind.isHeaderCache: Boolean
+    get() = this == CompilerOutputKind.HEADER_CACHE
+
+val CompilerOutputKind.isCache: Boolean
+    get() = this.isFullCache || this.isHeaderCache


### PR DESCRIPTION
[KT-61096](https://youtrack.jetbrains.com/issue/KT-61096) [KLIB Resolve] Drop KLIB resolve inside the Kotlin/Native compiler
[KT-81624](https://youtrack.jetbrains.com/issue/KT-81624) [KLIB Resolve] Kotlin/Native: -no-default-libs may lead to the final binary depending on a lot of system frameworks

Next PR: https://github.com/JetBrains/kotlin/pull/7440