### PR TITLE
[Header mode] Preserve delegated fields for downstream compilation.

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/optimization/FirReachabilityAnalyzer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/optimization/FirReachabilityAnalyzer.kt
@@ -166,6 +166,11 @@ class FirReachabilityAnalyzer(private val session: FirSession) : FirVisitorVoid(
                 // It is required for every class to have a primary constructor.
                 mark(decl.symbol)
             }
+            if (decl.origin == FirDeclarationOrigin.Synthetic.DelegateField) {
+                // Synthetic delegate fields (e.g. $$delegate_0) are required for FirDelegatedMemberScope
+                // to generate delegated members.
+                mark(decl.symbol)
+            }
             if (shouldPreserveAnchor(decl)) {
                 // The backend derives the name of anonymous objects from its declaring parent.
                 mark(decl.symbol)

--- a/compiler/testData/ir/irText/headerMode/anonymousObjects.kt
+++ b/compiler/testData/ir/irText/headerMode/anonymousObjects.kt
@@ -1,4 +1,4 @@
-// FIR_DUMP
+// HEADER_MODE
 
 private fun createPrivateObject() =
         object {

--- a/compiler/testData/ir/irText/headerMode/classDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/classDeclaration.kt
@@ -1,5 +1,5 @@
+// HEADER_MODE
 // IGNORE_BACKEND: JS_IR, WASM_JS, NATIVE
-// FIR_DUMP
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 

--- a/compiler/testData/ir/irText/headerMode/constructorDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/constructorDeclaration.kt
@@ -1,4 +1,4 @@
-// FIR_DUMP
+// HEADER_MODE
 class A(val a: String, val b: Int) {
     constructor(e: String): this(e, 0) {
         val message = "Secondary constructor body"

--- a/compiler/testData/ir/irText/headerMode/dataClassDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/dataClassDeclaration.kt
@@ -1,4 +1,4 @@
-// FIR_DUMP
+// HEADER_MODE
 data class User(val name: String, val age: Int)
 
 /* GENERATED_FIR_TAGS: classDeclaration, data, primaryConstructor, propertyDeclaration */

--- a/compiler/testData/ir/irText/headerMode/enumClassDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/enumClassDeclaration.kt
@@ -1,4 +1,4 @@
-// FIR_DUMP
+// HEADER_MODE
 enum class A {
     EAST,
     WEST

--- a/compiler/testData/ir/irText/headerMode/functionDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/functionDeclaration.kt
@@ -1,4 +1,4 @@
-// FIR_DUMP
+// HEADER_MODE
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 

--- a/compiler/testData/ir/irText/headerMode/kt86572.asm.txt
+++ b/compiler/testData/ir/irText/headerMode/kt86572.asm.txt
@@ -1,0 +1,63 @@
+Module: lib
+public class def/MyBase : java/lang/Object, def/MyInterface {
+    private final def.MyInterface $$delegate_0
+
+    public void <init>(def.MyInterface delegate) {
+        LABEL (L0)
+          ACONST_NULL
+          ATHROW
+        LABEL (L1)
+    }
+
+    public java.lang.String foo() {
+        LABEL (L0)
+          ACONST_NULL
+          ATHROW
+        LABEL (L1)
+    }
+}
+
+public class def/MyDelegate : java/lang/Object, def/MyInterface {
+    public void <init>() {
+        LABEL (L0)
+          ACONST_NULL
+          ATHROW
+        LABEL (L1)
+    }
+
+    public java.lang.String foo() {
+        LABEL (L0)
+          ACONST_NULL
+          ATHROW
+        LABEL (L1)
+    }
+}
+
+public abstract interface def/MyInterface : java/lang/Object {
+    public abstract java.lang.String foo()
+}
+Module: main
+public final class MainKt : java/lang/Object {
+    public final static java.lang.String box() {
+        LABEL (L0)
+        LINENUMBER (25)
+          LDC (OK)
+          ARETURN
+    }
+}
+
+public final class MySub : def/MyBase {
+    public void <init>(def.MyInterface delegate) {
+        LABEL (L0)
+          ALOAD (1)
+          LDC (delegate)
+          INVOKESTATIC (kotlin/jvm/internal/Intrinsics, checkNotNullParameter, (Ljava/lang/Object;Ljava/lang/String;)V)
+        LABEL (L1)
+        LINENUMBER (22)
+          ALOAD (0)
+          ALOAD (1)
+          INVOKESPECIAL (def/MyBase, <init>, (Ldef/MyInterface;)V)
+          RETURN
+        LABEL (L2)
+    }
+}

--- a/compiler/testData/ir/irText/headerMode/kt86572.fir.txt
+++ b/compiler/testData/ir/irText/headerMode/kt86572.fir.txt
@@ -1,0 +1,32 @@
+Module: lib
+FILE: lib.kt
+    package def
+
+    public abstract interface MyInterface : R|kotlin/Any| {
+        public abstract fun foo(): R|kotlin/String|
+
+    }
+    public open class MyDelegate : R|def/MyInterface| {
+        public constructor(): R|def/MyDelegate|
+
+        public open override fun foo(): R|kotlin/String| {
+        }
+
+    }
+    public open class MyBase : R|def/MyInterface| {
+        public constructor(delegate: R|def/MyInterface|): R|def/MyBase|
+
+        private final field $$delegate_0: R|def/MyInterface| = R|<local>/delegate|
+
+    }
+Module: main
+FILE: main.kt
+    public final class MySub : R|def/MyBase| {
+        public constructor(delegate: R|def/MyInterface|): R|MySub| {
+            super<R|def/MyBase|>(R|<local>/delegate|)
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        ^box String(OK)
+    }

--- a/compiler/testData/ir/irText/headerMode/kt86572.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/kt86572.ir.txt
@@ -1,0 +1,100 @@
+Module: lib
+FILE fqName:def fileName:/lib.kt
+  CLASS CLASS name:MyBase modality:OPEN visibility:public superTypes:[def.MyInterface]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:def.MyBase
+    FIELD DELEGATE name:$$delegate_0 type:def.MyInterface visibility:private [final]
+      EXPRESSION_BODY
+        GET_VAR 'delegate: def.MyInterface declared in def.MyBase.<init>' type=def.MyInterface origin=null
+    CONSTRUCTOR visibility:public returnType:def.MyBase [primary]
+      VALUE_PARAMETER kind:Regular name:delegate index:0 type:def.MyInterface
+    FUN DELEGATED_MEMBER name:foo visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:def.MyBase
+      overridden:
+        public abstract fun foo (): kotlin.String declared in def.MyInterface
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun foo (): kotlin.String declared in def.MyBase'
+          CALL 'public abstract fun foo (): kotlin.String declared in def.MyInterface' type=kotlin.String origin=null
+            ARG <this>: GET_FIELD 'FIELD DELEGATE name:$$delegate_0 type:def.MyInterface visibility:private [final] declared in def.MyBase' type=def.MyInterface origin=null
+              receiver: GET_VAR '<this>: def.MyBase declared in def.MyBase.foo' type=def.MyBase origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in def.MyInterface
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in def.MyInterface
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in def.MyInterface
+  CLASS CLASS name:MyDelegate modality:OPEN visibility:public superTypes:[def.MyInterface]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:def.MyDelegate
+    CONSTRUCTOR visibility:public returnType:def.MyDelegate [primary]
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in def.MyInterface
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in def.MyInterface
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in def.MyInterface
+    FUN name:foo visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:def.MyDelegate
+      overridden:
+        public abstract fun foo (): kotlin.String declared in def.MyInterface
+      BLOCK_BODY
+  CLASS INTERFACE name:MyInterface modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:def.MyInterface
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:foo visibility:public modality:ABSTRACT returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:def.MyInterface
+Module: main
+FILE fqName:<root> fileName:/main.kt
+  CLASS CLASS name:MySub modality:FINAL visibility:public superTypes:[def.MyBase]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.MySub
+    CONSTRUCTOR visibility:public returnType:<root>.MySub [primary]
+      VALUE_PARAMETER kind:Regular name:delegate index:0 type:def.MyInterface
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> (delegate: def.MyInterface) declared in def.MyBase'
+          ARG delegate: GET_VAR 'delegate: def.MyInterface declared in <root>.MySub.<init>' type=def.MyInterface origin=null
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:MySub modality:FINAL visibility:public superTypes:[def.MyBase]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in def.MyBase
+    FUN FAKE_OVERRIDE name:foo visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:def.MyBase
+      overridden:
+        public open fun foo (): kotlin.String declared in def.MyBase
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in def.MyBase
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in def.MyBase
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/compiler/testData/ir/irText/headerMode/kt86572.klib_abi.txt
+++ b/compiler/testData/ir/irText/headerMode/kt86572.klib_abi.txt
@@ -1,0 +1,29 @@
+Module: lib
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <lib>
+open class def/MyBase : def/MyInterface { // def/MyBase|null[0]
+    constructor <init>(def/MyInterface) // def/MyBase.<init>|<init>(def.MyInterface){}[0]
+    open fun foo(): kotlin/String // def/MyBase.foo|foo(){}[0]
+}
+open class def/MyDelegate : def/MyInterface { // def/MyDelegate|null[0]
+    constructor <init>() // def/MyDelegate.<init>|<init>(){}[0]
+    open fun foo(): kotlin/String // def/MyDelegate.foo|foo(){}[0]
+}
+abstract interface def/MyInterface { // def/MyInterface|null[0]
+    abstract fun foo(): kotlin/String // def/MyInterface.foo|foo(){}[0]
+}
+Module: main
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <main>
+final class /MySub : def/MyBase { // /MySub|null[0]
+    constructor <init>(def/MyInterface) // /MySub.<init>|<init>(def.MyInterface){}[0]
+}
+final fun /box(): kotlin/String // /box|box(){}[0]

--- a/compiler/testData/ir/irText/headerMode/kt86572.kt
+++ b/compiler/testData/ir/irText/headerMode/kt86572.kt
@@ -1,0 +1,26 @@
+// MODULE: lib
+// HEADER_MODE
+// FILE: lib.kt
+
+package def
+
+interface MyInterface {
+    fun foo(): String
+}
+
+open class MyDelegate : MyInterface {
+    override fun foo(): String = "OK"
+}
+
+open class MyBase(delegate: MyInterface) : MyInterface by delegate
+
+// MODULE: main(lib)
+// FILE: main.kt
+
+import def.*
+
+class MySub(delegate: MyInterface) : MyBase(delegate)
+
+fun box(): String {
+    return "OK"
+}

--- a/compiler/testData/ir/irText/headerMode/kt86572.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/kt86572.kt.txt
@@ -1,0 +1,43 @@
+// MODULE: lib
+// FILE: lib.kt
+package def
+
+open class MyBase : MyInterface {
+  private /* final field */ val $$delegate_0: MyInterface = delegate
+  constructor(delegate: MyInterface) /* primary */
+
+  override fun foo(): String {
+    return <this>.#$$delegate_0.foo()
+  }
+
+}
+
+open class MyDelegate : MyInterface {
+  constructor() /* primary */
+
+  override fun foo(): String {
+  }
+
+}
+
+interface MyInterface {
+  abstract fun foo(): String
+
+}
+
+// MODULE: main
+// FILE: main.kt
+
+class MySub : MyBase {
+  constructor(delegate: MyInterface) /* primary */ {
+    super/*MyBase*/(delegate = delegate)
+    /* <init>() */
+
+  }
+
+}
+
+fun box(): String {
+  return "OK"
+}
+

--- a/compiler/testData/ir/irText/headerMode/objectDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/objectDeclaration.kt
@@ -1,4 +1,4 @@
-// FIR_DUMP
+// HEADER_MODE
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 

--- a/compiler/testData/ir/irText/headerMode/privateDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/privateDeclaration.kt
@@ -1,5 +1,5 @@
+// HEADER_MODE
 // IGNORE_BACKEND: JS_IR, WASM_JS, NATIVE
-// FIR_DUMP
 
 class TestClass {
     // 1. Properties

--- a/compiler/testData/ir/irText/headerMode/propertyDeclaration.kt
+++ b/compiler/testData/ir/irText/headerMode/propertyDeclaration.kt
@@ -1,6 +1,6 @@
+// HEADER_MODE
 // WITH_STDLIB
 // IGNORE_BACKEND: JS_IR, WASM_JS, NATIVE
-// FIR_DUMP
 // Public property with explicit type
 val a: String = "A"
 // Public property with implicit type

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.asm.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.asm.txt
@@ -34,15 +34,20 @@ Module: main
 public final class main/App : java/lang/Object {
     public void <init>() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (19)
+          ALOAD (0)
+          INVOKESPECIAL (java/lang/Object, <init>, ()V)
+          RETURN
         LABEL (L1)
     }
 
     public final void run() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (21)
+          INVOKESTATIC (lib/FirstKt, myFunc, ()V)
         LABEL (L1)
+        LINENUMBER (22)
+          RETURN
+        LABEL (L2)
     }
 }

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.fir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.fir.txt
@@ -1,0 +1,29 @@
+Module: lib
+FILE: first.kt
+    package lib
+
+    private sealed class SealedClass : R|kotlin/Any| {
+        protected constructor(): R|lib/SealedClass|
+
+        public final class Implementation : R|lib/SealedClass| {
+            public constructor(): R|lib/SealedClass.Implementation|
+
+        }
+
+    }
+    public final fun myFunc(): R|kotlin/Unit| {
+    }
+Module: main
+FILE: main.kt
+    package main
+
+    public final class App : R|kotlin/Any| {
+        public constructor(): R|main/App| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final fun run(): R|kotlin/Unit| {
+            R|lib/myFunc|()
+        }
+
+    }

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.ir.txt
@@ -41,6 +41,9 @@ FILE fqName:main fileName:/main.kt
   CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
     CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
@@ -57,3 +60,4 @@ FILE fqName:main fileName:/main.kt
     FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
       BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.klib_abi.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.klib_abi.txt
@@ -1,0 +1,19 @@
+Module: lib
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <lib>
+final fun lib/myFunc() // lib/myFunc|myFunc(){}[0]
+Module: main
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <main>
+final class main/App { // main/App|null[0]
+    constructor <init>() // main/App.<init>|<init>(){}[0]
+    final fun run() // main/App.run|run(){}[0]
+}

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt
@@ -1,5 +1,3 @@
-// DISABLE_WITH_PARSER: Psi
-// TARGET_BACKEND: JVM_IR
 // MODULE: lib
 // HEADER_MODE
 // FILE: first.kt

--- a/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedClassNestedSubclass.kt.txt
@@ -20,9 +20,14 @@ fun myFunc() {
 package main
 
 class App {
-  constructor() /* primary */
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
 
   fun run() {
+    myFunc()
   }
 
 }

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.asm.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.asm.txt
@@ -22,15 +22,20 @@ Module: main
 public final class main/App : java/lang/Object {
     public void <init>() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (19)
+          ALOAD (0)
+          INVOKESPECIAL (java/lang/Object, <init>, ()V)
+          RETURN
         LABEL (L1)
     }
 
     public final void run() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (21)
+          INVOKESTATIC (lib/FirstKt, myFunc, ()V)
         LABEL (L1)
+        LINENUMBER (22)
+          RETURN
+        LABEL (L2)
     }
 }

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.fir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.fir.txt
@@ -1,0 +1,27 @@
+Module: lib
+FILE: first.kt
+    package lib
+
+    private sealed interface SealedInterface : R|kotlin/Any| {
+        public final class Implementation : R|lib/SealedInterface| {
+            public constructor(): R|lib/SealedInterface.Implementation|
+
+        }
+
+    }
+    public final fun myFunc(): R|kotlin/Unit| {
+    }
+Module: main
+FILE: main.kt
+    package main
+
+    public final class App : R|kotlin/Any| {
+        public constructor(): R|main/App| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final fun run(): R|kotlin/Unit| {
+            R|lib/myFunc|()
+        }
+
+    }

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.ir.txt
@@ -40,6 +40,9 @@ FILE fqName:main fileName:/main.kt
   CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
     CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
@@ -56,3 +59,4 @@ FILE fqName:main fileName:/main.kt
     FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
       BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.klib_abi.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.klib_abi.txt
@@ -1,0 +1,19 @@
+Module: lib
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <lib>
+final fun lib/myFunc() // lib/myFunc|myFunc(){}[0]
+Module: main
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <main>
+final class main/App { // main/App|null[0]
+    constructor <init>() // main/App.<init>|<init>(){}[0]
+    final fun run() // main/App.run|run(){}[0]
+}

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt
@@ -1,5 +1,3 @@
-// DISABLE_WITH_PARSER: Psi
-// TARGET_BACKEND: JVM_IR
 // MODULE: lib
 // HEADER_MODE
 // FILE: first.kt

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceNestedSubclass.kt.txt
@@ -18,9 +18,14 @@ fun myFunc() {
 package main
 
 class App {
-  constructor() /* primary */
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
 
   fun run() {
+    myFunc()
   }
 
 }

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.asm.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.asm.txt
@@ -22,15 +22,20 @@ Module: main
 public final class main/App : java/lang/Object {
     public void <init>() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (19)
+          ALOAD (0)
+          INVOKESPECIAL (java/lang/Object, <init>, ()V)
+          RETURN
         LABEL (L1)
     }
 
     public final void run() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (21)
+          INVOKESTATIC (lib/FirstKt, myFunc, ()V)
         LABEL (L1)
+        LINENUMBER (22)
+          RETURN
+        LABEL (L2)
     }
 }

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.fir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.fir.txt
@@ -1,0 +1,26 @@
+Module: lib
+FILE: first.kt
+    package lib
+
+    private sealed interface SealedInterface : R|kotlin/Any| {
+    }
+    public final class TopLevelImplementation : R|lib/SealedInterface| {
+        public constructor(): R|lib/TopLevelImplementation|
+
+    }
+    public final fun myFunc(): R|kotlin/Unit| {
+    }
+Module: main
+FILE: main.kt
+    package main
+
+    public final class App : R|kotlin/Any| {
+        public constructor(): R|main/App| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final fun run(): R|kotlin/Unit| {
+            R|lib/myFunc|()
+        }
+
+    }

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.ir.txt
@@ -40,6 +40,9 @@ FILE fqName:main fileName:/main.kt
   CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
     CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
@@ -56,3 +59,4 @@ FILE fqName:main fileName:/main.kt
     FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
       BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.klib_abi.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.klib_abi.txt
@@ -1,0 +1,22 @@
+Module: lib
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <lib>
+final class lib/TopLevelImplementation { // lib/TopLevelImplementation|null[0]
+    constructor <init>() // lib/TopLevelImplementation.<init>|<init>(){}[0]
+}
+final fun lib/myFunc() // lib/myFunc|myFunc(){}[0]
+Module: main
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <main>
+final class main/App { // main/App|null[0]
+    constructor <init>() // main/App.<init>|<init>(){}[0]
+    final fun run() // main/App.run|run(){}[0]
+}

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt
@@ -1,5 +1,3 @@
-// DISABLE_WITH_PARSER: Psi
-// TARGET_BACKEND: JVM_IR
 // MODULE: lib
 // HEADER_MODE
 // FILE: first.kt

--- a/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedInterfaceTopLevelSubclass.kt.txt
@@ -18,9 +18,14 @@ fun myFunc() {
 package main
 
 class App {
-  constructor() /* primary */
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
 
   fun run() {
+    myFunc()
   }
 
 }

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.asm.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.asm.txt
@@ -26,15 +26,20 @@ Module: main
 public final class main/App : java/lang/Object {
     public void <init>() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (21)
+          ALOAD (0)
+          INVOKESPECIAL (java/lang/Object, <init>, ()V)
+          RETURN
         LABEL (L1)
     }
 
     public final void run() {
         LABEL (L0)
-          ACONST_NULL
-          ATHROW
+        LINENUMBER (23)
+          INVOKESTATIC (lib/FirstKt, myFunc, ()V)
         LABEL (L1)
+        LINENUMBER (24)
+          RETURN
+        LABEL (L2)
     }
 }

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.fir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.fir.txt
@@ -1,0 +1,30 @@
+Module: lib
+FILE: first.kt
+    package lib
+
+    private sealed interface GrandParent : R|kotlin/Any| {
+        public sealed interface Parent : R|lib/GrandParent| {
+            public final class Leaf : R|lib/GrandParent.Parent| {
+                public constructor(): R|lib/GrandParent.Parent.Leaf|
+
+            }
+
+        }
+
+    }
+    public final fun myFunc(): R|kotlin/Unit| {
+    }
+Module: main
+FILE: main.kt
+    package main
+
+    public final class App : R|kotlin/Any| {
+        public constructor(): R|main/App| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final fun run(): R|kotlin/Unit| {
+            R|lib/myFunc|()
+        }
+
+    }

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.ir.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.ir.txt
@@ -57,6 +57,9 @@ FILE fqName:main fileName:/main.kt
   CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]
     thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:main.App
     CONSTRUCTOR visibility:public returnType:main.App [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:App modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
     FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
@@ -73,3 +76,4 @@ FILE fqName:main fileName:/main.kt
     FUN name:run visibility:public modality:FINAL returnType:kotlin.Unit
       VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:main.App
       BLOCK_BODY
+        CALL 'public final fun myFunc (): kotlin.Unit declared in lib' type=kotlin.Unit origin=null

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.klib_abi.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.klib_abi.txt
@@ -1,0 +1,19 @@
+Module: lib
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <lib>
+final fun lib/myFunc() // lib/myFunc|myFunc(){}[0]
+Module: main
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <main>
+final class main/App { // main/App|null[0]
+    constructor <init>() // main/App.<init>|<init>(){}[0]
+    final fun run() // main/App.run|run(){}[0]
+}

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt
@@ -1,5 +1,3 @@
-// DISABLE_WITH_PARSER: Psi
-// TARGET_BACKEND: JVM_IR
 // MODULE: lib
 // HEADER_MODE
 // FILE: first.kt

--- a/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt.txt
+++ b/compiler/testData/ir/irText/headerMode/sealedTransitiveSubclass.kt.txt
@@ -21,9 +21,14 @@ fun myFunc() {
 package main
 
 class App {
-  constructor() /* primary */
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
 
   fun run() {
+    myFunc()
   }
 
 }

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/configuration/BaseIrTextConfiguration.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/configuration/BaseIrTextConfiguration.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.DUMP_KT_IR
 import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.DIAGNOSTICS
 import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.REPORT_ONLY_EXPLICITLY_DEFINED_DEBUG_INFO
 import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives.DISABLE_WITH_PARSER
+import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives.FIR_DUMP
 import org.jetbrains.kotlin.test.directives.KlibAbiDumpDirectives.DUMP_KLIB_ABI
 import org.jetbrains.kotlin.test.directives.KlibAbiDumpDirectives.KlibAbiDumpMode
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives
@@ -77,9 +78,9 @@ fun TestConfigurationBuilder.additionalK2ConfigurationForIrTextTest(parser: FirP
 
     forTestsMatching("compiler/testData/ir/irText/headerMode/*") {
         defaultDirectives {
-            +HEADER_MODE
             +CHECK_ASM_LIKE_INSTRUCTIONS
             DISABLE_WITH_PARSER with FirParser.Psi
+            +FIR_DUMP
         }
     }
 


### PR DESCRIPTION
Synthetic delegate fields are required for FirDelegatedMemberScope to generate delegated members.

Also made some cleanups and improvements to the headerMode custom tests.

^KT-86572