### PR TITLE
[JVM] Optimize captured refs across SWAP

### DIFF
--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt
@@ -29,7 +29,7 @@ class CapturedVarsOptimizationMethodTransformer : MethodTransformer() {
     //
     // The 'kotlin.jvm.internal.Ref.*' instance can be replaced with a local variable, if
     //  * it is created inside a current method;
-    //  * the only operations on it are ALOAD, ASTORE, DUP, POP, GETFIELD element, PUTFIELD element.
+    //  * the only operations on it are ALOAD, ASTORE, DUP, SWAP, POP, GETFIELD element, PUTFIELD element.
     //
     // Note that for code that doesn't create Ref objects explicitly these conditions are true,
     // unless the Ref object escapes to a local class constructor (including local classes for lambdas).
@@ -54,6 +54,7 @@ class CapturedVarsOptimizationMethodTransformer : MethodTransformer() {
     private class Transformer(private val internalClassName: String, private val methodNode: MethodNode) {
         private val refValues = ArrayList<CapturedVarDescriptor>()
         private val refValuesByNewInsn = LinkedHashMap<TypeInsnNode, CapturedVarDescriptor>()
+        private val swapDescriptors = LinkedHashMap<AbstractInsnNode, MutableSet<CapturedVarDescriptor>>()
 
         fun run() {
             createRefValues()
@@ -61,6 +62,7 @@ class CapturedVarsOptimizationMethodTransformer : MethodTransformer() {
 
             val frames = analyze(internalClassName, methodNode, Interpreter())
             trackPops(frames)
+            validateSwapUsages()
             assignLocalVars(frames)
 
             for (refValue in refValues) {
@@ -100,6 +102,7 @@ class CapturedVarsOptimizationMethodTransformer : MethodTransformer() {
                         insn.opcode == Opcodes.DUP -> descriptor.wrapperInsns.add(insn)
                         insn.opcode == Opcodes.ALOAD -> descriptor.wrapperInsns.add(insn)
                         insn.opcode == Opcodes.ASTORE -> descriptor.wrapperInsns.add(insn)
+                        insn.opcode == Opcodes.SWAP -> swapDescriptors.getOrPut(insn) { LinkedHashSet() }.add(descriptor)
                         insn.opcode == Opcodes.GETFIELD && insn is FieldInsnNode && insn.name == REF_ELEMENT_FIELD && position == 0 ->
                             descriptor.getFieldInsns.add(insn)
                         insn.opcode == Opcodes.PUTFIELD && insn is FieldInsnNode && insn.name == REF_ELEMENT_FIELD && position == 0 ->
@@ -129,6 +132,16 @@ class CapturedVarsOptimizationMethodTransformer : MethodTransformer() {
                             frame.peek(1)?.getCapturedVarOrNull()?.hazard = true
                         }
                     }
+                }
+            }
+        }
+
+        private fun validateSwapUsages() {
+            for ([swap, descriptors] in swapDescriptors) {
+                if (descriptors.size == 1 && descriptors.single().valueType.size == 1) {
+                    descriptors.single().wrapperInsns.add(swap)
+                } else {
+                    descriptors.forEach { it.hazard = true }
                 }
             }
         }

--- a/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt
+++ b/compiler/backend/src/org/jetbrains/kotlin/codegen/optimization/CapturedVarsOptimizationMethodTransformer.kt
@@ -138,7 +138,7 @@ class CapturedVarsOptimizationMethodTransformer : MethodTransformer() {
 
         private fun validateSwapUsages() {
             for ([swap, descriptors] in swapDescriptors) {
-                if (descriptors.size == 1 && descriptors.single().valueType.size == 1) {
+                if (descriptors.size == 1) {
                     descriptors.single().wrapperInsns.add(swap)
                 } else {
                     descriptors.forEach { it.hazard = true }

--- a/compiler/testData/codegen/box/closures/capturedVarsOptimization/callableReferenceWithSwap.kt
+++ b/compiler/testData/codegen/box/closures/capturedVarsOptimization/callableReferenceWithSwap.kt
@@ -1,0 +1,20 @@
+// WITH_STDLIB
+
+private inline fun scan(n: Int, charAt: (Int) -> Char): Int {
+    var acc = 0
+    var i = 0
+    while (i < n) {
+        var c = charAt(i).code
+        acc += run { c = charAt(i).code; c }
+        i++
+    }
+    return acc
+}
+
+private fun test(s: String): Int = run { scan(s.length, s::get) }
+
+fun box(): String {
+    val result = test("OK")
+    val expected = 'O'.code + 'K'.code
+    return if (result == expected) "OK" else "fail: $result"
+}

--- a/compiler/testData/codegen/bytecodeText/capturedVarsOptimization/callableReferenceWithSwap.kt
+++ b/compiler/testData/codegen/bytecodeText/capturedVarsOptimization/callableReferenceWithSwap.kt
@@ -1,0 +1,16 @@
+private inline fun scan(n: Int, charAt: (Int) -> Char): Int {
+    var acc = 0
+    var i = 0
+    while (i < n) {
+        var c = charAt(i).code
+        acc += run { c = charAt(i).code; c }
+        i++
+    }
+    return acc
+}
+
+fun test(s: String): Int = run { scan(s.length, s::get) }
+
+// 0 NEW kotlin/jvm/internal/Ref\$IntRef
+// 0 java/lang/Character\.valueOf
+// 2 java/lang/Character\.charValue


### PR DESCRIPTION
Allow captured-variable scalar replacement to remove SWAP instructions that only rearrange a tracked Ref, so redundant boxing can eliminate callable-reference Char conversions. Keep wide captured references conservative and reject SWAP instructions shared by multiple tracked references. This prevents the optimizer from deleting a shared instruction twice or changing the stack of an unoptimized reference.

^KT-88352