### PR TITLE
CInterop Klib Correctness Test Prototype for libclangext 

### DIFF
--- a/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
+++ b/kotlin-native/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
@@ -916,19 +916,21 @@ private fun FilterHeadersOutput.filterHeadersByName(
                     // the path relative to the include path element.
                     name
                 } else {
-                    // If it is included with `#include "$name"`, then `name` can also be the path relative to the includer.
-                    // Warning: containingFile is null when one module imports another via AST file
-                    val includerFile = includeLocation.getContainingFile()!!
-                    val includerName = headerToName[includerFile.canonicalPath] ?: ""
-                    val includerPath = includerFile.path
-
-                    val resolvedSibling = Paths.get(includerPath).resolveSibling(name).toString()
-                    if (curUnit.getFile(resolvedSibling) == file) {
-                        // included file is accessible from the includer by `name` used as relative path, so
-                        // `name` seems to be relative to the includer:
-                        Paths.get(includerName).resolveSibling(name).normalize().toString()
-                    } else {
+                    val includerFile = includeLocation.getContainingFile()
+                    if (includerFile == null) {
                         name
+                    } else {
+                        val includerName = headerToName[includerFile.canonicalPath] ?: ""
+                        val includerPath = includerFile.path
+
+                        val resolvedSibling = Paths.get(includerPath).resolveSibling(name).toString()
+                        if (curUnit.getFile(resolvedSibling) == file) {
+                            // included file is accessible from the includer by `name` used as relative path, so
+                            // `name` seems to be relative to the includer:
+                            Paths.get(includerName).resolveSibling(name).normalize().toString()
+                        } else {
+                            name
+                        }
                     }
                 }
 

--- a/kotlin-native/Interop/StubGenerator/build.gradle.kts
+++ b/kotlin-native/Interop/StubGenerator/build.gradle.kts
@@ -72,6 +72,8 @@ projectTests {
         // as an input so the cache is properly invalidated when it changes.
         inputs.dir(project(":kotlin-native").isolated.projectDirectory.dir("konan"))
             .withPathSensitivity(PathSensitivity.RELATIVE)
+        inputs.dir(nativeProtoDistribution.root)
+            .withPathSensitivity(PathSensitivity.RELATIVE)
         // Copy-pasted from Indexer build.gradle.kts.
         dependsOn(nativeDependencies.llvmDependency)
         jvmArgumentProviders.add(objects.newInstance<TestArgumentProvider>().apply {

--- a/kotlin-native/Interop/StubGenerator/test/org/jetbrains/kotlin/native/interop/gen/CInteropKlibCorrectnessTest.kt
+++ b/kotlin-native/Interop/StubGenerator/test/org/jetbrains/kotlin/native/interop/gen/CInteropKlibCorrectnessTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.native.interop.gen
+
+import kotlinx.metadata.klib.KlibMetadataVersion
+import kotlinx.metadata.klib.KlibModuleMetadata
+import kotlin.metadata.ClassKind
+import kotlin.metadata.KmAnnotationArgument
+import kotlin.metadata.kind
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.library.components.metadata
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+/**
+ * Tests that Objective-C header extensions (`swift_name`, `objc_runtime_name`) are properly parsed
+ * by `libclangext` and emitted into KLIB metadata when running `cinterop` in header mode (`-Xheader-mode`)
+ * on a Linux host targeting `macos_x64`.
+ */
+class CInteropKlibCorrectnessTest : InteropTestsBase() {
+
+    @BeforeEach
+    fun onlyOnLinux() {
+        Assumptions.assumeTrue(HostManager.hostIsLinux)
+    }
+
+    @Test
+    fun testObjectiveCExtensionsInHeaderModeKlib() {
+        val files = testFiles()
+        val header = files.file("header.h", """
+            __attribute__((swift_name("RenamedClass")))
+            @interface Foo
+            @end
+
+            __attribute__((objc_runtime_name("CustomProtocol")))
+            @protocol P
+            @end
+        """.trimIndent())
+
+        val defFile = files.file("test.def", """
+            language = Objective-C
+            headers = ${header.name}
+        """.trimIndent())
+
+        val outputKlib = File(files.directory, "test.klib")
+        generateHeaderModeKlib(defFile, header, outputKlib, files)
+
+        val metadataDump = dumpKlibClasses(outputKlib)
+        // Snapshot comparison guarantees all emitted declarations and annotations match without unintended symbols
+        assertEquals(EXPECTED_METADATA_DUMP, metadataDump)
+    }
+
+    /**
+     * Invokes `cinterop` in header-mode (`-Xheader-mode`) targeting `macos_x64`.
+     *
+     * In header-only mode on Linux, no Apple SDK or Xcode installation is present. We provide minimal
+     * stand-alone declarations for standard C types (`stdint.h`, `string.h`) so Clang can parse the Objective-C
+     * headers without needing macOS system headers.
+     */
+    private fun generateHeaderModeKlib(defFile: File, header: File, outputKlib: File, files: TempFiles) {
+        val buildDir = File(files.directory, "test-build")
+        val generatedDir = File(buildDir, "kotlin")
+        val nativesDir = File(buildDir, "natives")
+        val manifest = File(buildDir, "manifest.properties")
+        val konanHome = findKonanHome()
+        val propertyOverrides = System.getProperty("kotlin.native.propertyOverrides")
+
+        // StubIrDriver injects stdint.h/string.h into all units. Standalone stubs satisfy Clang
+        // on Linux without requiring a macOS SDK or conflicting host glibc headers.
+        val sysrootInclude = File(buildDir, "sysroot/usr/include").apply {
+            mkdirs()
+            File(this, "stdint.h").writeText("""
+                #ifndef _STDINT_H
+                #define _STDINT_H
+                typedef signed char int8_t;
+                typedef short int16_t;
+                typedef int int32_t;
+                typedef long long int64_t;
+                typedef unsigned char uint8_t;
+                typedef unsigned short uint16_t;
+                typedef unsigned int uint32_t;
+                typedef unsigned long long uint64_t;
+                typedef long intptr_t;
+                typedef unsigned long uintptr_t;
+                #endif
+            """.trimIndent())
+            File(this, "string.h").writeText("""
+                #ifndef _STRING_H
+                #define _STRING_H
+                typedef unsigned long size_t;
+                void *memcpy(void *dest, const void *src, size_t n);
+                void *memset(void *s, int c, size_t n);
+                size_t strlen(const char *s);
+                #endif
+            """.trimIndent())
+        }
+
+        val interop = org.jetbrains.kotlin.native.interop.gen.jvm.Interop()
+        val result = interop.interop(
+            flavor = "native",
+            args = arrayOf(
+                "-def", defFile.absolutePath,
+                "-o", outputKlib.absolutePath,
+                "-target", "macos_x64",
+                "-Xheader-mode",
+                "-no-default-libs",
+                "-Xoverride-konan-properties", propertyOverrides,
+                "-Xkonan-home", konanHome.absolutePath,
+                "-compiler-option", "-I${header.parentFile.absolutePath}",
+                "-compiler-option", "-isystem${sysrootInclude.absolutePath}"
+            ),
+            additionalArgs = org.jetbrains.kotlin.native.interop.gen.jvm.InternalInteropOptions(
+                generated = generatedDir.absolutePath,
+                natives = nativesDir.absolutePath,
+                manifest = manifest.absolutePath,
+                cstubsName = "cstubs"
+            ),
+            runFromDaemon = false
+        )
+
+        if (result != null) {
+            error("cinterop header mode failed: ${result.joinToString("\n")}")
+        }
+    }
+
+    /**
+     * Reads the generated `.klib` and produces a formatted textual representation of all emitted classes,
+     * companion objects, and their annotations for snapshot verification.
+     */
+    private fun dumpKlibClasses(outputKlib: File): String {
+        val library = KlibLoader { libraryPaths(outputKlib.absolutePath) }.load().librariesStdlibFirst.single()
+        val klibMetadata = library.metadata
+        val module = KlibModuleMetadata.readStrict(object : KlibModuleMetadata.MetadataLibraryProvider {
+            override val moduleHeaderData: ByteArray = klibMetadata.moduleHeaderData
+            override val metadataVersion: KlibMetadataVersion =
+                KlibMetadataVersion(library.versions.metadataVersion!!.toArray())
+            override fun packageMetadataParts(fqName: String): Set<String> =
+                klibMetadata.getPackageFragmentNames(fqName)
+            override fun packageMetadata(fqName: String, partName: String): ByteArray =
+                klibMetadata.getPackageFragment(fqName, partName)
+        })
+
+        return module.fragments.flatMap { it.classes }.sortedBy { it.name }.joinToString("\n") { clazz ->
+            val kind = when (clazz.kind) {
+                ClassKind.CLASS -> "class"
+                ClassKind.INTERFACE -> "interface"
+                ClassKind.COMPANION_OBJECT -> "companion object"
+                ClassKind.OBJECT -> "object"
+                ClassKind.ENUM_CLASS -> "enum class"
+                ClassKind.ENUM_ENTRY -> "enum entry"
+                ClassKind.ANNOTATION_CLASS -> "annotation class"
+            }
+            val annotations = clazz.annotations
+                .sortedBy { it.className }
+                .map { annotation ->
+                    val arguments = annotation.arguments.entries
+                        .sortedBy { it.key }
+                        .map { "${it.key}=${it.value.toSourceLiteral()}" }
+                        .joinToString()
+                    "${annotation.className.replace(".", "/")}($arguments)"
+                }
+                .joinToString()
+            "$kind ${clazz.name} annotations: [$annotations]"
+        }
+    }
+
+    private companion object {
+        /**
+         * Resolves the Kotlin/Native proto-distribution containing standard library KLIBs required for compilation.
+         */
+        fun findKonanHome(): File {
+            val root = generateSequence(File(System.getProperty("user.dir"))) { it.parentFile }
+                .firstOrNull { File(it, "kotlin-native").exists() } ?: File(".")
+            return File(root, "kotlin-native/libclangInterop/build").listFiles()?.firstOrNull {
+                it.name.startsWith("nativeDistribution") && File(it, "klib/common/stdlib").exists()
+            } ?: File(root, "kotlin-native/dist")
+        }
+
+        /**
+         * Formats [KmAnnotationArgument] values into Kotlin-like literal representations for snapshot comparison.
+         */
+        fun KmAnnotationArgument.toSourceLiteral(): String = when (this) {
+            is KmAnnotationArgument.StringValue -> "\"$value\""
+            is KmAnnotationArgument.LiteralValue<*> -> value.toString()
+            is KmAnnotationArgument.EnumValue -> "$enumClassName.$enumEntryName"
+            is KmAnnotationArgument.AnnotationValue -> annotation.className + "(" + annotation.arguments.entries.joinToString { "${it.key}=${it.value.toSourceLiteral()}" } + ")"
+            is KmAnnotationArgument.ArrayValue -> "[" + elements.joinToString { it.toSourceLiteral() } + "]"
+            else -> toString()
+        }
+
+        val EXPECTED_METADATA_DUMP = """
+            class test/Foo annotations: [kotlin/native/ObjCName(swiftName="RenamedClass"), kotlinx/cinterop/ExperimentalForeignApi(), kotlinx/cinterop/ExternalObjCClass()]
+            companion object test/Foo.Companion annotations: []
+            class test/FooMeta annotations: [kotlinx/cinterop/ExperimentalForeignApi(), kotlinx/cinterop/ExternalObjCClass()]
+            interface test/PProtocol annotations: [kotlinx/cinterop/ExperimentalForeignApi(), kotlinx/cinterop/ExternalObjCClass(binaryName="CustomProtocol", protocolGetter="kniprot_test_P_0")]
+            interface test/PProtocolMeta annotations: [kotlinx/cinterop/ExperimentalForeignApi(), kotlinx/cinterop/ExternalObjCClass(binaryName="CustomProtocol", protocolGetter="kniprot_test_P_0")]
+        """.trimIndent()
+    }
+}

--- a/kotlin-native/libclangInterop/build.gradle.kts
+++ b/kotlin-native/libclangInterop/build.gradle.kts
@@ -73,6 +73,9 @@ nativeInteropPlugin {
                     "__ZN4llvm4hlsl7rootsig16dumpRootElementsERNS_11raw_ostreamENS_8ArrayRefINSt3__17variantIJNS_4dxbc9RootFlagsENS1_13RootConstantsENS1_14RootDescriptorENS1_15DescriptorTableENS1_21DescriptorTableClauseENS1_13StaticSamplerEEEEEE"
             ).mapTo(this) { "-Wl,-U,$it" }
             addAll(listOf("-lpthread", "-lz", "-lm", "-lcurses"))
+        } else if (PlatformInfo.isLinux()) {
+            add("-Wl,-z,noexecstack")
+            addAll(listOf("-lrt", "-ldl", "-lpthread", "-lz", "-lm"))
         }
     })
     additionalLinkedStaticLibraries.set(buildList {
@@ -82,7 +85,7 @@ nativeInteropPlugin {
             "lib/${System.mapLibraryName("clang")}"
         }
         add("${nativeDependencies.llvmPath}/$libclang")
-        if (PlatformInfo.isMac()) {
+        if (PlatformInfo.isMac() || PlatformInfo.isLinux()) {
             listOf(
                     "clangAST", "clangASTMatchers", "clangAnalysis", "clangBasic", "clangDriver", "clangEdit",
                     "clangFrontend", "clangFrontendTool", "clangLex", "clangParse", "clangSema",

--- a/kotlin-native/libclangext/build.gradle.kts
+++ b/kotlin-native/libclangext/build.gradle.kts
@@ -42,7 +42,7 @@ native {
             "-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1",
             *reproducibilityCompilerFlags,
     )
-    if (PlatformInfo.isMac()) {
+    if (PlatformInfo.isMac() || PlatformInfo.isLinux()) {
         cxxflags += "-DLIBCLANGEXT_ENABLE=1"
     }
     suffixes {

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/Apple.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/Apple.kt
@@ -29,11 +29,11 @@ class AppleConfigurablesImpl(
     progressCallback: ProgressCallback,
 ) : AppleConfigurables, KonanPropertiesLoader(target, properties, dependenciesDir, progressCallback = progressCallback) {
 
-    private val sdkDependency = this.targetSysRoot!!
-    private val toolchainDependency = this.targetToolchain!!
-    private val xcodeAddonDependency = this.additionalToolsDir!!
+    private val sdkDependency get() = this.targetSysRoot ?: ""
+    private val toolchainDependency get() = this.targetToolchain ?: ""
+    private val xcodeAddonDependency get() = this.additionalToolsDir ?: ""
 
-    override val absoluteTargetSysRoot: String get() = when (val provider = xcodePartsProvider) {
+    override val absoluteTargetSysRoot: String get() = if (!HostManager.hostIsMac) "" else when (val provider = xcodePartsProvider) {
         is XcodePartsProvider.Local -> {
             // In the case of Mac Catalyst, we use sysroot from macOS.
             val platformName = if (targetTriple.isMacabi) "MacOSX" else platformName()
@@ -42,12 +42,12 @@ class AppleConfigurablesImpl(
         XcodePartsProvider.InternalServer -> absolute(sdkDependency)
     }
 
-    override val absoluteTargetToolchain: String get() = when (val provider = xcodePartsProvider) {
+    override val absoluteTargetToolchain: String get() = if (!HostManager.hostIsMac) "" else when (val provider = xcodePartsProvider) {
         is XcodePartsProvider.Local -> provider.xcode.toolchain
         XcodePartsProvider.InternalServer -> "${absolute(toolchainDependency)}/usr"
     }
 
-    override val absoluteAdditionalToolsDir: String get() = when (val provider = xcodePartsProvider) {
+    override val absoluteAdditionalToolsDir: String get() = if (!HostManager.hostIsMac) "" else when (val provider = xcodePartsProvider) {
         is XcodePartsProvider.Local -> provider.xcode.additionalTools
         XcodePartsProvider.InternalServer -> absolute(additionalToolsDir)
     }
@@ -69,6 +69,7 @@ class AppleConfigurablesImpl(
         when {
             useProvisionedXcode -> XcodePartsProvider.Local(provisionedXcode())
             InternalServer.isAvailable -> XcodePartsProvider.InternalServer
+            !HostManager.hostIsMac -> XcodePartsProvider.InternalServer
             else -> XcodePartsProvider.Local(currentXcodeCheckingVersion())
         }
     }

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/HostManager.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/HostManager.kt
@@ -75,7 +75,7 @@ open class HostManager() {
     )
 
     val enabledByHost: Map<KonanTarget, Set<KonanTarget>> = mapOf(
-        LINUX_X64 to commonTargets,
+        LINUX_X64 to commonTargets + appleTargets,
         MINGW_X64 to commonTargets,
         MACOS_X64 to commonTargets + appleTargets,
         MACOS_ARM64 to commonTargets + appleTargets


### PR DESCRIPTION
This PR is a prototype test for verifying header-only klib generation on Linux using libclangext without depending on the Apple SDK. How it works:

- It processes a mock header, produces a klib without the SDK, and dumps the metadata to verify it contains exactly the expected content.
- To make this run on Linux, we added cross-compilation target workarounds in the build configuration and Xcode provider lookup.

This is a prototype and not yet ready for pipeline integration, but it serves as a solid draft to guide our final test design. Any feedback on this testing approach or the configuration workarounds is highly appreciated. 

This PR is an appendix of the current open PR Generate libclangext for Linux- #6583 