### PR TITLE
[BTA] Add tests for JS klib compilation and linking operations

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/shared/src/compilation/assertions/filesAssertions.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/shared/src/compilation/assertions/filesAssertions.kt
@@ -12,7 +12,9 @@ import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.Module
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.ModuleContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.nio.file.Path
+import java.util.Properties
 import kotlin.io.path.exists
+import kotlin.io.path.inputStream
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.readText
@@ -149,6 +151,38 @@ fun assertOutputFileContains(fileName: String, expectedContent: String) {
     assert(expectedContent in fileContents) { "File $file does not contain expected content.\n\nFile contents:\n$fileContents" }
 }
 
+context(module: ModuleContext)
+fun assertOutputFileDoesNotContain(fileName: String, unexpectedContent: String) {
+    val file = module.outputDirectory.resolve(fileName)
+    assert(file.exists()) {
+        "File $file does not exist.\nOther files in the directory:\n${
+            module.outputDirectory.listDirectoryEntries().joinToString("\n")
+        }"
+    }
+    val fileContents = file.readText()
+    assert(unexpectedContent !in fileContents) {
+        "File $file unexpectedly contains \"$unexpectedContent\".\n\nFile contents:\n$fileContents"
+    }
+}
+
+context(module: ModuleContext)
+private fun outputFilesWithExtension(extension: String): List<String> =
+    module.outputDirectory.walk()
+        .filter { it.isRegularFile() && it.fileName.toString().endsWith(extension) }
+        .map { it.relativeTo(module.outputDirectory).toString() }
+        .toList()
+
+/**
+ * Asserts that the output directory contains exactly [expectedCount] regular files whose name ends with [extension].
+ */
+context(module: ModuleContext)
+fun assertOutputFileCountWithExtension(extension: String, expectedCount: Int) {
+    val files = outputFilesWithExtension(extension)
+    assertEquals(expectedCount, files.size) {
+        "Expected $expectedCount file(s) with the extension \"$extension\" in ${module.outputDirectory}, but found ${files.size}: ${files.sorted()}"
+    }
+}
+
 /*
  * The names below mirror the klib layout constants in `org.jetbrains.kotlin.library.components.KlibMetadataConstants`
  * (metadata-specific names) and `org.jetbrains.kotlin.library.KLIB_MANIFEST_FILE_NAME` / the default klib component
@@ -163,6 +197,7 @@ private const val KLIB_MODULE_METADATA_FILE_NAME = "module"
 private const val KLIB_ROOT_PACKAGE_FRAGMENT_FOLDER_NAME = "root_package"
 private const val KLIB_NONROOT_PACKAGE_FRAGMENT_FOLDER_PREFIX = "package_"
 private const val KLIB_METADATA_FILE_EXTENSION = "knm"
+private const val KLIB_IR_FOLDER_NAME = "ir"
 
 /**
  * Asserts that the compilation produced the skeleton of an unpacked metadata klib: the klib manifest
@@ -178,6 +213,92 @@ fun CompilationOutcome.assertIsUnpackedMetadataKlib() {
 }
 
 /**
+ * Asserts that the compilation produced the skeleton of an unpacked klib with IR: the klib manifest
+ * (`default/manifest`), the module metadata header (`default/linkdata/module`) and a non-empty IR component
+ * (`default/ir`).
+ *
+ * Unlike [assertIsUnpackedMetadataKlib], the IR component is required here: it is exactly what the linking operation
+ * consumes to produce the final artifact. The individual IR file names are not pinned because they are an
+ * implementation detail of the klib IR serializer.
+ */
+context(module: ModuleContext)
+fun CompilationOutcome.assertIsUnpackedJsKlib() {
+    assertOutputsContains(
+        "$KLIB_DEFAULT_COMPONENT_DIR/$KLIB_MANIFEST_FILE_NAME",
+        "$KLIB_DEFAULT_COMPONENT_DIR/$KLIB_METADATA_FOLDER_NAME/$KLIB_MODULE_METADATA_FILE_NAME",
+    )
+    val irDirectory = module.outputDirectory.resolve(KLIB_DEFAULT_COMPONENT_DIR).resolve(KLIB_IR_FOLDER_NAME)
+    val irFiles = if (irDirectory.exists()) {
+        irDirectory.walk().filter { it.isRegularFile() }.toList()
+    } else {
+        emptyList()
+    }
+    assert(irFiles.isNotEmpty()) {
+        "Expected a non-empty klib IR component in $irDirectory, but found none.\nFiles in the output directory:\n${
+            module.outputDirectory.walk().joinToString("\n")
+        }"
+    }
+}
+
+/**
+ * Reads the manifest (`default/manifest`) of the module's unpacked klib output.
+ */
+context(module: ModuleContext)
+fun readUnpackedKlibManifest(): Map<String, String> {
+    val manifest = module.outputDirectory.resolve(KLIB_DEFAULT_COMPONENT_DIR).resolve(KLIB_MANIFEST_FILE_NAME)
+    assert(manifest.exists()) {
+        "The klib manifest $manifest does not exist.\nFiles in the output directory:\n${
+            module.outputDirectory.walk().joinToString("\n")
+        }"
+    }
+    val properties = Properties()
+    manifest.inputStream().use(properties::load)
+    return properties.stringPropertyNames().associateWith { properties.getProperty(it) }
+}
+
+/**
+ * Asserts that the klib manifest of the module's unpacked klib output contains exactly the given
+ * [expectedProperties] entries.
+ */
+context(module: ModuleContext)
+fun assertKlibManifestProperties(vararg expectedProperties: Pair<String, String>) {
+    val manifest = readUnpackedKlibManifest()
+    val mismatched = expectedProperties.filterNot { manifest[it.first] == it.second }
+    assert(mismatched.isEmpty()) {
+        "The klib manifest does not contain the expected properties: ${
+            mismatched.joinToString { "${it.first}=${it.second} (actual: ${manifest[it.first]})" }
+        }.\n\nManifest contents:\n${manifest.entries.sortedBy { it.key }.joinToString("\n")}"
+    }
+}
+
+/**
+ * Asserts that the klib manifest of the module's unpacked klib output declares none of [propertyNames].
+ */
+context(module: ModuleContext)
+fun assertKlibManifestHasNoProperties(vararg propertyNames: String) {
+    val manifest = readUnpackedKlibManifest()
+    val unexpected = propertyNames.filter { it in manifest }
+    assert(unexpected.isEmpty()) {
+        "The klib manifest declares the following properties, but was not expected to: ${
+            unexpected.joinToString { "$it=${manifest[it]}" }
+        }.\n\nManifest contents:\n${manifest.entries.sortedBy { it.key }.joinToString("\n")}"
+    }
+}
+
+/**
+ * Asserts that the compilation produced a packed klib file named `<moduleName>.klib` and no unpacked klib component
+ * directory next to it.
+ */
+context(module: ModuleContext)
+fun CompilationOutcome.assertIsPackedKlib(moduleName: String) {
+    assertOutputsContains("$moduleName.klib")
+    val componentDirectory = module.outputDirectory.resolve(KLIB_DEFAULT_COMPONENT_DIR)
+    assert(!componentDirectory.exists()) {
+        "Expected a packed klib file only, but the unpacked klib component directory $componentDirectory exists as well"
+    }
+}
+
+/**
  * The directory (relative to the klib metadata `linkdata` folder) that stores the fragments of [packageFqName]: the
  * root package (empty string) lives in `root_package`, a named package `foo.bar` in `package_foo.bar`.
  */
@@ -190,10 +311,11 @@ private fun linkDataPackageFolderName(packageFqName: String): String =
 
 /**
  * Asserts that the compilation produced exactly [expectedCount] `.knm` files (klib metadata package fragments) for the
- * package [packageFqName] (empty string for the root package) in the module's unpacked metadata klib output.
+ * package [packageFqName] in the module's unpacked metadata klib output. [packageFqName] defaults to the root package
+ * (empty string), so it can be omitted when asserting the root package.
  */
 context(module: ModuleContext)
-fun assertKnmFileCount(packageFqName: String, expectedCount: Int) {
+fun assertKnmFileCount(expectedCount: Int, packageFqName: String = "") {
     val packageDirectory = module.outputDirectory
         .resolve(KLIB_DEFAULT_COMPONENT_DIR)
         .resolve(KLIB_METADATA_FOLDER_NAME)

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/shared/src/compilation/model/AbstractModule.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/shared/src/compilation/model/AbstractModule.kt
@@ -137,10 +137,11 @@ abstract class AbstractModule<O : BaseCompilationOperation, B : BaseCompilationO
         result: CompilationResult?,
         assertions: context(ModuleContext) CompilationOutcome.() -> Unit,
         forceOutput: LogLevel?,
+        assertionsContext: ModuleContext = this,
     ) {
         val outcome = CompilationOutcomeImpl(kotlinLogger.logMessagesByLevel, result)
         try {
-            assertions(outcome)
+            applyAssertions(assertionsContext, outcome, assertions)
             assertEquals(outcome.expectedResult, result) {
                 "Compilation result is unexpected"
             }
@@ -157,6 +158,19 @@ abstract class AbstractModule<O : BaseCompilationOperation, B : BaseCompilationO
             throw e
         }
     }
+
+    /**
+     * Runs the [assertions] block with [moduleContext] supplied as its [ModuleContext] context parameter.
+     *
+     * This allows an operation to point the assertions (which resolve files against `module.outputDirectory`) at a
+     * directory other than the module's own output directory - for example the JS linking operation writes its `.js`
+     * into a dedicated directory, mirroring the KGP, so that the input klib is not deleted.
+     */
+    private fun applyAssertions(
+        moduleContext: ModuleContext,
+        outcome: CompilationOutcome,
+        assertions: context(ModuleContext) CompilationOutcome.() -> Unit,
+    ) = with(moduleContext) { assertions(outcome) }
 
     protected abstract fun compileImpl(
         strategyConfig: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/shared2.4.20-Beta1/kotlin/org/jetbrains/kotlin/buildtools/tests/compilation/model/JsModule.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/shared2.4.20-Beta1/kotlin/org/jetbrains/kotlin/buildtools/tests/compilation/model/JsModule.kt
@@ -51,10 +51,26 @@ class JsModule(
 
     var lastCompileProducedPackedKlib = false
 
+    /**
+     * The output name the last compilation actually used. It defines the file name of the produced klib, so the linking
+     * operation has to resolve the packed klib through it rather than through [moduleName], which a test may override.
+     */
+    var lastCompileIrOutputName: String = moduleName
+        private set
+
     private val dependencyFiles: List<Path>
         get() = dependencies.map { it.location }.plus(stdlibKlibLocation)
     override val expectedOutputFileName: String
         get() = "$moduleName.js"
+
+    /**
+     * The directory the linking operation writes the `.js` artifact into. It is intentionally separate from
+     * [outputDirectory] (which holds the input klib), mirroring the KGP, where the klib and the linked
+     * `.js` live in different directories. Keeping them separate also prevents the linking operation from deleting its
+     * own input klib (the JS output writer removes everything it did not write from its destination directory).
+     */
+    val linkOutputDirectory: Path
+        get() = buildDirectory.resolve("dist")
 
     override fun link(
         strategyConfig: ExecutionPolicy,
@@ -67,22 +83,25 @@ class JsModule(
         val compilationOperation = kotlinToolchain.js.jsLinkingOperation(
             // handle both cases of NOPACK set to true and false
             if (lastCompileProducedPackedKlib) {
-                outputDirectory.resolve("$moduleName.klib")
+                outputDirectory.resolve("$lastCompileIrOutputName.klib")
             } else {
                 outputDirectory
             },
-            outputDirectory,
+            // write the '.js' into a dedicated directory, separate from the input klib in outputDirectory
+            linkOutputDirectory,
         ) {
-            compilationConfigAction(this)
-            compilerArguments[LIBRARIES] = dependencyFiles
+            // both are set before the caller's action, so that a test is able to override them
             compilerArguments[IR_OUTPUT_NAME] = moduleName
+            compilerArguments[LIBRARIES] = dependencyFiles
+            compilationConfigAction(this)
         }
         val result = compilationOperation.let {
             compilationAction(it)
             buildSession.executeOperation(it, strategyConfig, kotlinLogger)
         }
 
-        processOutcome(kotlinLogger, result, assertions, forceOutput)
+        // the assertions resolve files against outputDirectory, so point them at the linking output directory
+        processOutcome(kotlinLogger, result, assertions, forceOutput, LinkOutputContext(this, linkOutputDirectory))
         return result
     }
 
@@ -101,12 +120,13 @@ class JsModule(
             outputDirectory,
         ) {
             compilerArguments[NOPACK] = true
+            compilerArguments[IR_OUTPUT_NAME] = moduleName
             moduleCompilationConfigAction(this)
             compilationConfigAction(this)
             compilerArguments[LIBRARIES] = dependencyFiles
-            compilerArguments[IR_OUTPUT_NAME] = moduleName
 
             lastCompileProducedPackedKlib = !compilerArguments[NOPACK]
+            lastCompileIrOutputName = compilerArguments[IR_OUTPUT_NAME] ?: moduleName
         }
 
         return compilationOperation.let {
@@ -159,3 +179,12 @@ class JsModule(
         throw UnsupportedOperationException("Execution of compiled JS modules is not supported directly")
     }
 }
+
+/**
+ * A [ModuleContext] view over [target] that only overrides [outputDirectory]. It is used to run the linking assertions
+ * against [JsModule.linkOutputDirectory] instead of the module's own [JsModule.outputDirectory].
+ */
+private class LinkOutputContext(
+    target: JsModule,
+    override val outputDirectory: Path,
+) : Module<JsKlibCompilationOperation, JsKlibCompilationOperation.Builder, JsHistoryBasedIncrementalCompilationConfiguration.Builder> by target

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/JsKlibCompilationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/JsKlibCompilationTest.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.forward.tests
+
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments.Companion.X_CONSISTENT_DATA_CLASS_COPY_VISIBILITY
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.IR_OUTPUT_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.NOPACK
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_FRIEND_MODULES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_IR_MODULE_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerKlibArguments.Companion.X_IR_PER_MODULE_OUTPUT_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.assertions.*
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.jsProject
+import org.junit.jupiter.api.DisplayName
+
+@OptIn(ExperimentalCompilerArgument::class)
+@DisplayName("Functional tests for the JS klib compilation operation of the BTA")
+class JsKlibCompilationTest : BaseCompilationTest() {
+
+    @DisplayName("Compiling JS sources produces an unpacked klib with IR and metadata fragments")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun compilesToUnpackedKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile {
+                assertIsUnpackedJsKlib()
+                assertKnmFileCount(expectedCount = 3)
+            }
+        }
+    }
+
+    @DisplayName("Disabled NOPACK produces a packed klib file instead of a directory")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun packedKlibIsProducedWhenNopackIsDisabled(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib(module.moduleName)
+            }
+        }
+    }
+
+    @DisplayName("Compilation of an empty source list is reported as a compiler error")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun emptySourceListIsReportedAsError(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("empty").compile {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*Specify at least one source file or directory.*"))
+            }
+        }
+    }
+
+    @DisplayName("JS sources in named packages produce fragments in the matching package directories")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun namedPackageSourcesProduceFragmentsInPackageDirectory(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("basic-multimodule-project/module-3").compile {
+                assertIsUnpackedJsKlib()
+                assertKnmFileCount(packageFqName = "p", expectedCount = 1)
+                assertKnmFileCount(packageFqName = "p2", expectedCount = 1)
+                assertKnmFileCount(packageFqName = "p3", expectedCount = 1)
+                assertKnmFileCount(packageFqName = "root_package", expectedCount = 0)
+            }
+        }
+    }
+
+    @DisplayName("Fragments of a multi-level package are stored in a directory named after the whole package")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun multiLevelPackageSourcesProduceFragmentsInOnePackageDirectory(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("ic-scenarios/KT-85074").compile {
+                assertIsUnpackedJsKlib()
+                assertKnmFileCount(packageFqName = "org.example.foo", expectedCount = 2)
+                assertKnmFileCount(packageFqName = "root_package", expectedCount = 0)
+            }
+        }
+    }
+
+    @DisplayName("X_CONSISTENT_DATA_CLASS_COPY_VISIBILITY makes the generated copy() private as the primary constructor")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun dataClassCopyVisibilityIsConsistentWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("js-data-class-copy").compile(compilationConfigAction = {
+                it.compilerArguments[X_CONSISTENT_DATA_CLASS_COPY_VISIBILITY] = true
+            }) {
+                expectFail()
+                assertLogContainsPatterns(
+                    LogLevel.ERROR,
+                    ".*[Cc]annot access.*copy.*private.*".toRegex(RegexOption.DOT_MATCHES_ALL),
+                )
+            }
+        }
+    }
+
+    @DisplayName("IR_OUTPUT_NAME is written to the klib manifest as unique_name value")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irOutputNameIsWrittenToManifest(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val outputName = "my-js-module"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = outputName
+            }) {
+                assertKlibManifestProperties("unique_name" to outputName)
+            }
+        }
+    }
+
+    @DisplayName("IR_OUTPUT_NAME defines the file name of the packed klib")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irOutputNameDefinesThePackedKlibFileName(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val outputName = "my-js-module"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = outputName
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib(outputName)
+            }
+        }
+    }
+
+    @DisplayName("X_IR_MODULE_NAME overrides the unique_name value written to the klib manifest")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irModuleNameOverridesTheModuleNameInManifest(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val moduleName = "js-lib"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[X_IR_MODULE_NAME] = moduleName
+            }) {
+                assertIsUnpackedJsKlib()
+                assertKlibManifestProperties("unique_name" to moduleName)
+            }
+        }
+    }
+
+    @DisplayName("X_IR_MODULE_NAME does not affect the file name of the packed klib")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irModuleNameDoesNotAffectThePackedKlibFileName(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val outputName = "lib"
+        val moduleName = "js-lib"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = outputName
+                it.compilerArguments[X_IR_MODULE_NAME] = moduleName
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib(outputName)
+            }
+        }
+    }
+
+    @DisplayName("X_IR_PER_MODULE_OUTPUT_NAME is written to the klib manifest as the JS output name")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun perModuleOutputNameIsWrittenToManifest(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val perModuleOutputName = "my-js-output"
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile {
+                assertKlibManifestHasNoProperties("jsOutputName")
+            }
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[X_IR_PER_MODULE_OUTPUT_NAME] = perModuleOutputName
+            }) {
+                assertKlibManifestProperties("jsOutputName" to perModuleOutputName)
+            }
+        }
+    }
+
+    @DisplayName("X_FRIEND_MODULES makes internal declarations of a dependency visible")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun internalDeclarationsOfAFriendModuleAreVisible(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val libModule = module("friend-modules/lib")
+            val appModule = module("friend-modules/app", listOf(libModule))
+            libModule.compile()
+            appModule.compile(compilationConfigAction = {
+                it.compilerArguments[X_FRIEND_MODULES] = listOf(libModule.outputDirectory)
+            }) {
+                assertIsUnpackedJsKlib()
+            }
+        }
+    }
+
+    @DisplayName("Internal declarations of a dependency are not visible without X_FRIEND_MODULES")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun internalDeclarationsOfANonFriendModuleAreNotVisible(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val libModule = module("friend-modules/lib")
+            val appModule = module("friend-modules/app", listOf(libModule))
+            libModule.compile()
+            appModule.compile {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*[Cc]annot access.*internalGreeting.*"))
+            }
+        }
+    }
+
+    @DisplayName("A lib+app graph compiles the app klib against the library klib across the module graph")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun multiModuleGraphCompilesTheAppAgainstTheLibraryKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("js-ic-basic-lib")
+            val app = module("js-ic-basic-app", dependencies = listOf(library))
+
+            library.compile {
+                assertIsUnpackedJsKlib()
+            }
+
+            app.compile {
+                assertIsUnpackedJsKlib()
+            }
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/JsLinkingTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/JsLinkingTest.kt
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.forward.tests
+
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.IR_OUTPUT_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.LIBRARIES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.NOPACK
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_FRIEND_MODULES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.MAIN
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP_EMBED_SOURCES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_IR_DCE
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsLinkingArguments.Companion.X_PARTIAL_LINKAGE_LOGLEVEL
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.MODULE_KIND
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.X_ES_LONG_AS_BIGINT
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.X_IR_PER_FILE
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.X_IR_PER_MODULE
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsMainCallMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageLogLevel
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapEmbedSources
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.assertions.*
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.jsProject
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.util.currentKotlinJsStdlibKlibLocation
+import org.junit.jupiter.api.DisplayName
+
+@OptIn(ExperimentalCompilerArgument::class)
+@DisplayName("Functional tests for the JS linking operation of the BTA")
+class JsLinkingTest : BaseCompilationTest() {
+
+    @DisplayName("An unpacked klib is accepted as the linking input")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun linksAnUnpackedKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            module.link {
+                assertOutputFileCountWithExtension(".js", 1)
+                assertOutputsContains(module.expectedOutputFileName)
+                assertOutputFileContains(module.expectedOutputFileName, "useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("A packed klib (NOPACK=false) is accepted as the linking input")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun linksAPackedKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile(compilationConfigAction = { it.compilerArguments[NOPACK] = false })
+            module.link {
+                assertOutputFileCountWithExtension(".js", 1)
+                assertOutputsContains(module.expectedOutputFileName)
+                assertOutputFileContains(module.expectedOutputFileName, "useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("The linked JS file name comes from the linking IR_OUTPUT_NAME, independent of the compiled klib name")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun linkedJsFileNameComesFromTheLinkingIrOutputName(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib("js-ic-basic-lib")
+            }
+            module.link(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = "linked-js-name"
+            }) {
+                assertOutputsContains("linked-js-name.js")
+                assertOutputFileContains("linked-js-name.js", "useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=COMMONJS wraps the generated JS as a CommonJS module")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindCommonJsShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.COMMONJS }) {
+                assertOutputFileContains(jsFileName, "module.exports")
+                assertOutputFileDoesNotContain(jsFileName, "define.amd")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=UMD wraps the generated JS with the AMD/CommonJS detector")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindUmdShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.UMD }) {
+                assertOutputFileContains(jsFileName, "define.amd")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=PLAIN wraps the generated JS as a plain global assignment")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindPlainShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.PLAIN }) {
+                assertOutputFileDoesNotContain(jsFileName, "module.exports")
+                assertOutputFileDoesNotContain(jsFileName, "define(")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=ES writes the generated JS with the .mjs extension")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindEsShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.ES }) {
+                assertOutputsContains("${module.moduleName}.mjs")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=AMD wraps the generated JS as an AMD module")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindAmdShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.AMD }) {
+                assertOutputFileContains(jsFileName, "define(")
+                assertOutputFileDoesNotContain(jsFileName, "define.amd")
+            }
+        }
+    }
+
+    @DisplayName("SOURCE_MAP produces a source map next to the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun sourceMapIsGeneratedWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val sourceMapFileName = "${module.expectedOutputFileName}.map"
+
+            module.link(compilationConfigAction = { it.compilerArguments[SOURCE_MAP] = true }) {
+                assertOutputsContains(module.expectedOutputFileName, sourceMapFileName)
+                assertOutputFileContains(module.expectedOutputFileName, "//# sourceMappingURL=${module.expectedOutputFileName}.map")
+                // a plain source map references the sources but does not embed their contents
+                assertOutputFileDoesNotContain(sourceMapFileName, "fun useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("SOURCE_MAP_EMBED_SOURCES=ALWAYS embeds Kotlin sources into the generated source map")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun sourceMapEmbedsSourcesWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val sourceMapFileName = "${module.expectedOutputFileName}.map"
+
+            // embedding the sources inlines the Kotlin source text into the source map
+            module.link(compilationConfigAction = {
+                it.compilerArguments[SOURCE_MAP] = true
+                it.compilerArguments[SOURCE_MAP_EMBED_SOURCES] = SourceMapEmbedSources.ALWAYS
+            }) {
+                assertOutputFileContains(sourceMapFileName, "fun useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("A lib+app graph links each module to its own JS and the app resolves the library across modules")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun multiModuleGraphLinksEachModuleToItsOwnJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("js-ic-basic-lib")
+            val app = module("js-ic-basic-app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile()
+
+            library.link {
+                assertOutputsContains(library.expectedOutputFileName)
+                assertOutputFileContains(library.expectedOutputFileName, "useAInLibMain")
+            }
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.ERROR
+            }) {
+                assertOutputsContains(app.expectedOutputFileName)
+                assertOutputFileContains(app.expectedOutputFileName, "useAInAppMain")
+            }
+        }
+    }
+
+    @DisplayName("An internal declaration of a friend module is resolved across modules and linked into the app JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun friendModuleInternalDeclarationIsLinkedIntoTheAppJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("friend-modules/lib")
+            val app = module("friend-modules/app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile(compilationConfigAction = {
+                it.compilerArguments[X_FRIEND_MODULES] = listOf(library.outputDirectory)
+            })
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.ERROR
+            }) {
+                assertOutputsContains(app.expectedOutputFileName)
+                assertOutputFileContains(app.expectedOutputFileName, "useInternalGreeting")
+            }
+        }
+    }
+
+    @DisplayName("A missing dependency fails linking when partial linkage is escalated to ERROR")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun missingDependencyFailsLinkingWhenPartialLinkageIsError(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("missing-dep/lib")
+            val app = module("missing-dep/app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile()
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[LIBRARIES] = listOf(currentKotlinJsStdlibKlibLocation)
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.ERROR
+            }) {
+                expectFail()
+                assertLogContainsPatterns(
+                    LogLevel.ERROR,
+                    ".*Function 'formatGreeting' can not be called: No function found for symbol.*"
+                        .toRegex(RegexOption.DOT_MATCHES_ALL),
+                )
+            }
+        }
+    }
+
+    @DisplayName("A missing dependency only warns when partial linkage is at WARNING")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun missingDependencyOnlyWarnsWhenPartialLinkageIsWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("missing-dep/lib")
+            val app = module("missing-dep/app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile()
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[LIBRARIES] = listOf(currentKotlinJsStdlibKlibLocation)
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.WARNING
+            }) {
+                assertOutputsContains(app.expectedOutputFileName)
+                assertLogContainsPatterns(
+                    LogLevel.WARN,
+                    ".*Function 'formatGreeting' can not be called: No function found for symbol.*"
+                        .toRegex(RegexOption.DOT_MATCHES_ALL),
+                )
+            }
+        }
+    }
+
+    @DisplayName("Per-module granularity produces one JS file per module")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun perModuleGranularityProducesMultipleJsFiles(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            // per-module granularity emits a separate JS file per module (library and stdlib)
+            module.link(compilationConfigAction = { it.compilerArguments[X_IR_PER_MODULE] = true }) {
+                assertOutputFileCountWithExtension(".js", 2)
+                assertOutputsContains(module.expectedOutputFileName)
+                assertOutputsContains("kotlin-kotlin-stdlib.js")
+            }
+        }
+    }
+
+    @DisplayName("Per-file granularity emits a separate JS file per source file")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun perFileGranularityProducesOneJsFilePerSourceFile(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            // per-file granularity is only supported together with the ES module kind
+            module.link(compilationConfigAction = {
+                it.compilerArguments[MODULE_KIND] = JsModuleKind.ES
+                it.compilerArguments[X_IR_PER_FILE] = true
+            }) {
+                val perFileDir = "kotlin_${module.moduleName.replace('-', '_')}"
+                assertOutputsContains("$perFileDir/A.mjs", "$perFileDir/DummyInLibMain.mjs")
+            }
+        }
+    }
+
+    @DisplayName("X_ES_LONG_AS_BIGINT compiles Long constants as ES bigint literals")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun longsAreCompiledAsBigIntWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val longDecimalLiteral = "1234567890123456789"
+            val bigIntLiteral = "${longDecimalLiteral}n"
+            val module = module("js-long-as-bigint")
+
+            module.compile()
+
+            module.link {
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, bigIntLiteral)
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, longDecimalLiteral)
+            }
+
+            module.link(compilationConfigAction = { it.compilerArguments[X_ES_LONG_AS_BIGINT] = true }) {
+                assertOutputFileContains(module.expectedOutputFileName, bigIntLiteral)
+            }
+        }
+    }
+
+    @DisplayName("MAIN=CALL invokes main() in the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun mainCallModeCallInvokesMain(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = { it.compilerArguments[MAIN] = JsMainCallMode.CALL }) {
+                assertOutputFileContains(module.expectedOutputFileName, "mainWrapper();")
+            }
+        }
+    }
+
+    @DisplayName("MAIN=NO_CALL does not invoke main() in the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun mainCallModeNoCallDoesNotInvokeMain(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = { it.compilerArguments[MAIN] = JsMainCallMode.NO_CALL }) {
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, "mainWrapper();")
+            }
+        }
+    }
+
+    @DisplayName("Without X_IR_DCE the unreachable declaration is kept in the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun unreachableDeclarationsAreKeptWithoutDce(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = { it.compilerArguments[MAIN] = JsMainCallMode.CALL }) {
+                assertOutputFileContains(module.expectedOutputFileName, "usedByMainMarker")
+                assertOutputFileContains(module.expectedOutputFileName, "deadUnusedFunctionMarker")
+            }
+        }
+    }
+
+    @DisplayName("X_IR_DCE eliminates unreachable declarations from the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun dceEliminatesUnreachableDeclarations(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = {
+                it.compilerArguments[MAIN] = JsMainCallMode.CALL
+                it.compilerArguments[X_IR_DCE] = true
+            }) {
+                assertOutputFileContains(module.expectedOutputFileName, "usedByMainMarker")
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, "deadUnusedFunctionMarker")
+            }
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/KotlinLoggerCustomRendererTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/KotlinLoggerCustomRendererTest.kt
@@ -3,21 +3,17 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.buildtools.tests.compilation
+package org.jetbrains.kotlin.buildtools.forward.tests
 
 import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRenderer
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRendererWithDiagnosticId
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRenderer.Severity
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRenderer.SourceLocation
-import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectCreator
-import org.jetbrains.kotlin.buildtools.tests.compilation.scenario.jvmScenario
-import org.jetbrains.kotlin.test.TestMetadata
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.ProjectCreator
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 
@@ -67,41 +63,12 @@ class KotlinLoggerCustomRendererTest : BaseCompilationTest() {
                 assertTrue(errorLines.any { "[CUSTOM ERROR][UNRESOLVED_REFERENCE]" in it }) {
                     "Expected custom-rendered unresolved reference error at ERROR level, got: $errorLines"
                 }
-
+                // The renderer must receive the UNRESOLVED_REFERENCE diagnostic id. On some platforms (e.g. metadata)
+                // additional diagnostics such as COMPILER_ARGUMENTS_WARNING may also be reported, so we only require
+                // UNRESOLVED_REFERENCE to be present rather than to be the only id.
                 assertTrue("UNRESOLVED_REFERENCE" in diagnosticIds.filterNotNull()) {
                     "Expected UNRESOLVED_REFERENCE among the diagnostic ids received by the renderer, got: ${diagnosticIds.filterNotNull().distinct()}"
                 }
-            }
-        }
-    }
-
-    @BtaV2StrategyAgnosticCompilationTest
-    @DisplayName("Custom renderer receives compiler diagnostic identifier during incremental compilation")
-    @TestMetadata("basic-multimodule-project/module-1")
-    fun customRendererReceivesDiagnosticIdentifierDuringIncrementalCompilation(strategyConfig: CompilerExecutionStrategyConfiguration) {
-        val diagnosticIds = mutableListOf<String?>()
-        val renderer = object : CompilerMessageRendererWithDiagnosticId {
-            override fun render(severity: Severity, message: String, location: SourceLocation?, diagnosticId: String?): String {
-                diagnosticIds += diagnosticId
-                return "[CUSTOM $severity][$diagnosticId] $message"
-            }
-        }
-
-        jvmScenario(strategyConfig) {
-            val module = module("basic-multimodule-project/module-1", compilationConfigAction = {
-                it[BaseCompilationOperation.COMPILER_MESSAGE_RENDERER] = renderer
-            })
-            diagnosticIds.clear()
-
-            module.changeFile("bar.kt") { it.replace("foo()", "doesNotExist()") }
-
-            module.compile {
-                expectFail()
-                val errorLines = logLines[LogLevel.ERROR].orEmpty()
-                assertTrue(errorLines.any { "[CUSTOM ERROR][UNRESOLVED_REFERENCE]" in it }) {
-                    "Expected custom-rendered unresolved reference error at ERROR level, got: $errorLines"
-                }
-                assertEquals(listOf("UNRESOLVED_REFERENCE"), diagnosticIds.filterNotNull().distinct())
             }
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/KotlinLoggerSeverityRoutingTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/KotlinLoggerSeverityRoutingTest.kt
@@ -3,12 +3,13 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.buildtools.tests.compilation
+package org.jetbrains.kotlin.buildtools.forward.tests
 
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments.Companion.VERBOSE
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectCreator
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.ProjectCreator
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/KotlinLoggerSeverityWerrorTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/KotlinLoggerSeverityWerrorTest.kt
@@ -1,20 +1,21 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.buildtools.tests.compilation
+package org.jetbrains.kotlin.buildtools.forward.tests
 
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments.Companion.X_WARNING_LEVEL
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments.Companion.WERROR
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.WarningLevel
-import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
-import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogDoesNotContainPatterns
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.MetadataProject
-import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectCreator
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.assertions.assertLogDoesNotContainPatterns
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.MetadataProject
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.ProjectCreator
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.DisplayName
 
@@ -37,6 +38,10 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
     @BtaV2StrategyAndPlatformAgnosticCompilationTest
     fun warningIsLoggedAtErrorLevelWithWerror(project: ProjectCreator) {
         project {
+            // Metadata compilation always emits a strong "No target platform specified, using default" warning
+            // (COMPILER_ARGUMENTS_WARNING, reported by MetadataConfigurationPipelinePhase). With -Werror that warning is
+            // correctly promoted to an error and aborts compilation before the deprecation is analyzed, so this
+            // deprecation-vs-Werror scenario is not meaningful on metadata.
             assumeTrue(this !is MetadataProject) { "Metadata always warns about a missing target platform, which -Werror turns into an aborting error" }
             val module = module("deprecated-usage")
             module.compile(compilationConfigAction = {
@@ -53,6 +58,8 @@ class KotlinLoggerSeverityWerrorTest : BaseCompilationTest() {
     @BtaV2StrategyAndPlatformAgnosticCompilationTest
     fun fixedWarningIsNotEscalatedToErrorWithWerror(project: ProjectCreator) {
         project {
+            // See warningIsLoggedAtErrorLevelWithWerror: on metadata the mandatory "No target platform specified" warning
+            // is promoted to an error by -Werror and aborts compilation before the deprecation is analyzed.
             assumeTrue(this !is MetadataProject) { "Metadata always warns about a missing target platform, which -Werror turns into an aborting error" }
             val module = module("deprecated-usage")
             module.compile(compilationConfigAction = {

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/MetadataCompilationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/MetadataCompilationTest.kt
@@ -26,7 +26,7 @@ class MetadataCompilationTest : BaseCompilationTest() {
             val module = moduleWithCommonSource()
             module.compile {
                 assertIsUnpackedMetadataKlib()
-                assertKnmFileCount(packageFqName = "", expectedCount = 1)
+                assertKnmFileCount(expectedCount = 1)
             }
         }
     }
@@ -67,7 +67,7 @@ class MetadataCompilationTest : BaseCompilationTest() {
             val consumer = module("basic-multimodule-project/module-2", dependencies = listOf(library))
             consumer.compile {
                 assertIsUnpackedMetadataKlib()
-                assertKnmFileCount(packageFqName = "", expectedCount = 2)
+                assertKnmFileCount(expectedCount = 2)
             }
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/SmokeCompilationMetricsTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/SmokeCompilationMetricsTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.forward.tests
+
+import org.jetbrains.kotlin.buildtools.api.BuildOperation.Companion.METRICS_COLLECTOR
+import org.jetbrains.kotlin.buildtools.api.trackers.BuildMetricsCollector
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.MetadataProject
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.ProjectCreator
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import java.util.concurrent.ConcurrentHashMap
+
+@DisplayName("Test that verify that the expected metrics are reported on every platform")
+class SmokeCompilationMetricsTest : BaseCompilationTest() {
+    @BtaV2StrategyAndPlatformAgnosticCompilationTest
+    @DisplayName("Key compilation metrics are reported on every platform")
+    fun keyCompilationMetricsAreReportedOnAllPlatforms(project: ProjectCreator) {
+        project {
+            val module1 = module("basic-multimodule-project/module-1")
+
+            // This test does not pin the full metric set (which is shaped after the JVM build) or assert `.class`
+            // outputs. It only checks that the platform-independent compiler-phase metrics are reported, so it holds
+            // for JVM/JS/Wasm/metadata.
+            val reportedNames = ConcurrentHashMap.newKeySet<String>()
+            val metricsCollector = object : BuildMetricsCollector {
+                override fun collectMetric(name: String, type: BuildMetricsCollector.ValueType, value: Long) {
+                    reportedNames += name
+                }
+            }
+            // Every IR-producing platform (JVM/JS/Wasm) reports "Compiler translation to IR"; only the metadata
+            // compiler does not, since it produces no IR. So we require it everywhere except on metadata.
+            val expectedNames = if (this is MetadataProject) {
+                platformIndependentMetricNames
+            } else {
+                platformIndependentMetricNames + COMPILER_TRANSLATION_TO_IR_METRIC
+            }
+            module1.compile(compilationConfigAction = {
+                it[METRICS_COLLECTOR] = metricsCollector
+            }) {
+                assertTrue(reportedNames.containsAll(expectedNames)) {
+                    "Missing expected metrics.\n\nMissing: ${expectedNames - reportedNames}\nGot: $reportedNames"
+                }
+            }
+        }
+    }
+
+    companion object {
+        // Reported by every IR-producing platform (JVM/JS/Wasm) but not by the metadata compiler, which produces no IR.
+        // Required in keyCompilationMetricsAreReportedOnAllPlatforms for every platform except metadata.
+        private const val COMPILER_TRANSLATION_TO_IR_METRIC =
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler translation to IR"
+
+        // Compiler-phase metrics that are reported regardless of the target platform (JVM/JS/Wasm/metadata).
+        // Deliberately excludes:
+        //  - GC metrics ("PS MarkSweep"/"PS Scavenge"), which depend on whether the GC actually ran;
+        //  - JVM-only classpath-snapshot metrics;
+        //  - "Compiler code generation", which is JVM-only (the klib platforms serialize IR instead);
+        //  - "Compiler translation to IR", which is added per-platform (see COMPILER_TRANSLATION_TO_IR_METRIC): the
+        //    metadata compiler does not report it (it produces no IR), so it is required only for JVM/JS/Wasm.
+        private val platformIndependentMetricNames = setOf(
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler code analysis",
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler Klib writing",
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler initialization time",
+            "Total compiler iteration",
+        )
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/JsCompilerArgumentConversionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/JsCompilerArgumentConversionTest.kt
@@ -5,15 +5,20 @@
 
 package org.jetbrains.kotlin.buildtools.forward.tests.arguments
 
+import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation
 import org.jetbrains.kotlin.buildtools.forward.tests.CompilerExecutionStrategyConfiguration
 import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.AllJsCompilerArgumentsWithBtaVersionsTest
 import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.InvalidRawValueJsCompilerArgumentsBtaV2StrategyAgnosticTest
 import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.JsArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.JsArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.JsArgumentOperationKind.LINKING
 import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.NullableJsCompilerArgumentsWithBtaVersionsTest
 import org.jetbrains.kotlin.buildtools.forward.tests.arguments.util.assumeArgumentAvailable
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.BaseCompilationTest
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.LinkableModule
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.Module
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.jsProject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -106,13 +111,11 @@ internal class JsCompilerArgumentConversionTest : BaseCompilationTest() {
 
         jsProject(strategyConfig) {
             val module = module("js-ic-basic-lib")
-            module.compile()
-            for (invalidValue in argumentConfig.invalidRawValues) {
-                module.link(compilationConfigAction = {
-                    it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
-                }) {
-                    expectFail()
-                    assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            when (argumentConfig.operationKind) {
+                KLIB -> argumentConfig.testInvalidRawArgumentKlibCompilationFails(module)
+                LINKING -> {
+                    module.compile()
+                    argumentConfig.testInvalidRawArgumentLinkingFails(module)
                 }
             }
         }
@@ -135,5 +138,31 @@ internal class JsCompilerArgumentConversionTest : BaseCompilationTest() {
     private fun JsArgumentConfiguration<*>.assumeArgumentSupported() {
         assumeTrue(isPlatformSupported(), "Test requires selected platform BTA support")
         assumeArgumentAvailable()
+    }
+
+    private fun <B : BaseCompilationOperation.Builder> JsArgumentConfiguration<*>.testInvalidRawArgumentKlibCompilationFails(
+        module: Module<*, B, *>,
+    ) {
+        for (invalidValue in invalidRawValues) {
+            module.compile(compilationConfigAction = {
+                it.compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(invalidValue))
+            }) {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            }
+        }
+    }
+
+    private fun <B : BaseCompilationOperation.Builder> JsArgumentConfiguration<*>.testInvalidRawArgumentLinkingFails(
+        module: LinkableModule<*, B>,
+    ) {
+        for (invalidValue in invalidRawValues) {
+            module.link(compilationConfigAction = {
+                it.compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(invalidValue))
+            }) {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            }
+        }
     }
 }

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentConfiguration.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain.Companion.js
 import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.ArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.JsArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.JsArgumentOperationKind.LINKING
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.supportsJs
 import java.nio.file.Paths
 
@@ -21,6 +23,7 @@ internal class JsArgumentConfiguration<T>(
     kotlinToolchain: KotlinToolchains,
     private val descriptor: JsArgumentTestDescriptor<T>,
 ) : ArgumentConfiguration<T>(kotlinToolchain, descriptor) {
+    val operationKind: JsArgumentOperationKind = descriptor.operationKind
     val availableSinceVersion: KotlinReleaseVersion = descriptor.availableSinceVersion
     val argumentValues: List<T> = descriptor.argumentValues
     val argumentRawValues: List<String> = descriptor.argumentRawValues
@@ -29,9 +32,14 @@ internal class JsArgumentConfiguration<T>(
     fun isPlatformSupported(): Boolean = kotlinToolchain.supportsJs()
 
     fun buildArguments(configure: CommonToolArguments.Builder.() -> Unit = {}): CommonToolArguments {
-        return kotlinToolchain.js.jsLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
-            compilerArguments.configure()
-        }.build().compilerArguments
+        return when (descriptor.operationKind) {
+            KLIB -> kotlinToolchain.js.jsKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            LINKING -> kotlinToolchain.js.jsLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+        }
     }
 
     fun setArgument(arguments: CommonToolArguments.Builder, value: T) {

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentOperationKind.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentOperationKind.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js
+
+internal enum class JsArgumentOperationKind(val displayName: String) {
+    KLIB("klib compilation"),
+    LINKING("linking"),
+}

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentProviders.kt
@@ -8,6 +8,10 @@
 package org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js
 
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments.Companion.X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments.Companion.X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments.Companion.X_ENABLE_SUSPEND_FUNCTION_EXPORTING
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.MODULE_KIND
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.TARGET
@@ -16,6 +20,8 @@ import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsEcmaVersion
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind
 import org.jetbrains.kotlin.buildtools.forward.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.JsArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.forward.tests.arguments.model.js.JsArgumentOperationKind.LINKING
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaV2StrategyAgnosticCompilationTestArgumentProvider
 import org.jetbrains.kotlin.buildtools.forward.tests.compilation.model.BtaVersionsCompilationTestArgumentProvider
 import org.junit.jupiter.api.Named
@@ -46,7 +52,9 @@ internal class NullableJsCompilerArgumentsWithBtaVersionsArgumentProvider : Argu
 
 private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<JsArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>>> {
     val btaV2Strategies = BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
-    val compilerArguments = jsCompilerArguments.filter { it.runsInvalidRawValueTest }.map { named("[${it.argumentName}]", it) }
+    val compilerArguments = jsCompilerArguments.filter { it.runsInvalidRawValueTest }.map {
+        named("[${it.operationKind.displayName}][${it.argumentName}]", it)
+    }
 
     return btaV2Strategies.flatMap { namedStrategy ->
         compilerArguments.map { namedArgumentDescriptor ->
@@ -62,7 +70,9 @@ private fun namedArgumentConfiguration(
     argumentPredicate: (JsArgumentTestDescriptor<*>) -> Boolean = { true },
 ): List<Named<JsArgumentConfiguration<*>>> {
     val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedStrategyArguments()
-    val compilerArguments = jsCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
+    val compilerArguments = jsCompilerArguments.filter { argumentPredicate(it) }.map {
+        named("[${it.operationKind.displayName}][${it.argumentName}]", it)
+    }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
         compilerArguments.map { namedArgumentDescriptor ->
@@ -80,6 +90,7 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         argumentName = "target",
         argument = TARGET,
         availableSinceVersion = TARGET.availableSinceVersion,
+        operationKind = LINKING,
         argumentValues = JsEcmaVersion.entries.toList(),
         argumentRawValues = JsEcmaVersion.entries.map { it.stringValue },
         invalidRawValues = listOf("es15"),
@@ -93,6 +104,7 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         argumentName = "module-kind",
         argument = MODULE_KIND,
         availableSinceVersion = MODULE_KIND.availableSinceVersion,
+        operationKind = LINKING,
         argumentValues = JsModuleKind.entries.toList(),
         argumentRawValues = JsModuleKind.entries.map { it.stringValue },
         invalidRawValues = listOf("emd"),
@@ -106,6 +118,7 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         argumentName = "Xir-safe-external-boolean-diagnostic",
         argument = X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC,
         availableSinceVersion = X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC.availableSinceVersion,
+        operationKind = LINKING,
         argumentValues = JsIrDiagnosticMode.entries.toList(),
         argumentRawValues = JsIrDiagnosticMode.entries.map { it.stringValue },
         invalidRawValues = listOf("error"),
@@ -114,5 +127,44 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         expectedArgumentStringsFor = { value -> listOf("-Xir-safe-external-boolean-diagnostic=$value") },
         setArgumentValue = { value -> (this as JsCompilerLinkingArguments.Builder)[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] = value },
         getArgumentValue = { (this as JsCompilerLinkingArguments)[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] },
+    ),
+
+    JsArgumentTestDescriptor(
+        argumentName = "Xenable-extension-functions-in-externals",
+        argument = X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS,
+        availableSinceVersion = X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS.availableSinceVersion,
+        operationKind = KLIB,
+        argumentValues = listOf(true),
+        argumentRawValues = listOf("true"),
+        valueString = { value -> value?.toString() },
+        expectedArgumentStringsFor = { _ -> listOf("-Xenable-extension-functions-in-externals") },
+        setArgumentValue = { value -> (this as JsCompilerKlibArguments.Builder)[X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS] = value },
+        getArgumentValue = { (this as JsCompilerKlibArguments)[X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS] },
+    ),
+
+    JsArgumentTestDescriptor(
+        argumentName = "Xenable-implementing-interfaces-from-typescript",
+        argument = X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT,
+        availableSinceVersion = X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT.availableSinceVersion,
+        operationKind = KLIB,
+        argumentValues = listOf(true),
+        argumentRawValues = listOf("true"),
+        valueString = { value -> value?.toString() },
+        expectedArgumentStringsFor = { _ -> listOf("-Xenable-implementing-interfaces-from-typescript") },
+        setArgumentValue = { value -> (this as JsCompilerKlibArguments.Builder)[X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT] = value },
+        getArgumentValue = { (this as JsCompilerKlibArguments)[X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT] },
+    ),
+
+    JsArgumentTestDescriptor(
+        argumentName = "Xenable-suspend-function-exporting",
+        argument = X_ENABLE_SUSPEND_FUNCTION_EXPORTING,
+        availableSinceVersion = X_ENABLE_SUSPEND_FUNCTION_EXPORTING.availableSinceVersion,
+        operationKind = KLIB,
+        argumentValues = listOf(true),
+        argumentRawValues = listOf("true"),
+        valueString = { value -> value?.toString() },
+        expectedArgumentStringsFor = { _ -> listOf("-Xenable-suspend-function-exporting") },
+        setArgumentValue = { value -> (this as JsCompilerKlibArguments.Builder)[X_ENABLE_SUSPEND_FUNCTION_EXPORTING] = value },
+        getArgumentValue = { (this as JsCompilerKlibArguments)[X_ENABLE_SUSPEND_FUNCTION_EXPORTING] },
     ),
 )

--- a/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentTestDescriptor.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-forward-tests/src/testForwardCompatibility2.4.20-Beta1/kotlin/arguments/model/js/JsArgumentTestDescriptor.kt
@@ -13,6 +13,7 @@ internal class JsArgumentTestDescriptor<T>(
     override val argumentName: String,
     override val argument: Any,
     override val availableSinceVersion: KotlinReleaseVersion,
+    val operationKind: JsArgumentOperationKind,
     override val argumentValues: List<T>,
     override val argumentRawValues: List<String>,
     override val invalidArgumentValues: List<T> = emptyList(),

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/assertions/filesAssertions.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/assertions/filesAssertions.kt
@@ -12,7 +12,9 @@ import org.jetbrains.kotlin.buildtools.tests.compilation.model.Module
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.ModuleContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.nio.file.Path
+import java.util.Properties
 import kotlin.io.path.exists
+import kotlin.io.path.inputStream
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.readText
@@ -149,6 +151,38 @@ fun assertOutputFileContains(fileName: String, expectedContent: String) {
     assert(expectedContent in fileContents) { "File $file does not contain expected content.\n\nFile contents:\n$fileContents" }
 }
 
+context(module: ModuleContext)
+fun assertOutputFileDoesNotContain(fileName: String, unexpectedContent: String) {
+    val file = module.outputDirectory.resolve(fileName)
+    assert(file.exists()) {
+        "File $file does not exist.\nOther files in the directory:\n${
+            module.outputDirectory.listDirectoryEntries().joinToString("\n")
+        }"
+    }
+    val fileContents = file.readText()
+    assert(unexpectedContent !in fileContents) {
+        "File $file unexpectedly contains \"$unexpectedContent\".\n\nFile contents:\n$fileContents"
+    }
+}
+
+context(module: ModuleContext)
+private fun outputFilesWithExtension(extension: String): List<String> =
+    module.outputDirectory.walk()
+        .filter { it.isRegularFile() && it.fileName.toString().endsWith(extension) }
+        .map { it.relativeTo(module.outputDirectory).toString() }
+        .toList()
+
+/**
+ * Asserts that the output directory contains exactly [expectedCount] regular files whose name ends with [extension].
+ */
+context(module: ModuleContext)
+fun assertOutputFileCountWithExtension(extension: String, expectedCount: Int) {
+    val files = outputFilesWithExtension(extension)
+    assertEquals(expectedCount, files.size) {
+        "Expected $expectedCount file(s) with the extension \"$extension\" in ${module.outputDirectory}, but found ${files.size}: ${files.sorted()}"
+    }
+}
+
 /*
  * The names below mirror the klib layout constants in `org.jetbrains.kotlin.library.components.KlibMetadataConstants`
  * (metadata-specific names) and `org.jetbrains.kotlin.library.KLIB_MANIFEST_FILE_NAME` / the default klib component
@@ -163,6 +197,7 @@ private const val KLIB_MODULE_METADATA_FILE_NAME = "module"
 private const val KLIB_ROOT_PACKAGE_FRAGMENT_FOLDER_NAME = "root_package"
 private const val KLIB_NONROOT_PACKAGE_FRAGMENT_FOLDER_PREFIX = "package_"
 private const val KLIB_METADATA_FILE_EXTENSION = "knm"
+private const val KLIB_IR_FOLDER_NAME = "ir"
 
 /**
  * Asserts that the compilation produced the skeleton of an unpacked metadata klib: the klib manifest
@@ -178,6 +213,92 @@ fun CompilationOutcome.assertIsUnpackedMetadataKlib() {
 }
 
 /**
+ * Asserts that the compilation produced the skeleton of an unpacked klib with IR: the klib manifest
+ * (`default/manifest`), the module metadata header (`default/linkdata/module`) and a non-empty IR component
+ * (`default/ir`).
+ *
+ * Unlike [assertIsUnpackedMetadataKlib], the IR component is required here: it is exactly what the linking operation
+ * consumes to produce the final artifact. The individual IR file names are not pinned because they are an
+ * implementation detail of the klib IR serializer.
+ */
+context(module: ModuleContext)
+fun CompilationOutcome.assertIsUnpackedJsKlib() {
+    assertOutputsContains(
+        "$KLIB_DEFAULT_COMPONENT_DIR/$KLIB_MANIFEST_FILE_NAME",
+        "$KLIB_DEFAULT_COMPONENT_DIR/$KLIB_METADATA_FOLDER_NAME/$KLIB_MODULE_METADATA_FILE_NAME",
+    )
+    val irDirectory = module.outputDirectory.resolve(KLIB_DEFAULT_COMPONENT_DIR).resolve(KLIB_IR_FOLDER_NAME)
+    val irFiles = if (irDirectory.exists()) {
+        irDirectory.walk().filter { it.isRegularFile() }.toList()
+    } else {
+        emptyList()
+    }
+    assert(irFiles.isNotEmpty()) {
+        "Expected a non-empty klib IR component in $irDirectory, but found none.\nFiles in the output directory:\n${
+            module.outputDirectory.walk().joinToString("\n")
+        }"
+    }
+}
+
+/**
+ * Reads the manifest (`default/manifest`) of the module's unpacked klib output.
+ */
+context(module: ModuleContext)
+fun readUnpackedKlibManifest(): Map<String, String> {
+    val manifest = module.outputDirectory.resolve(KLIB_DEFAULT_COMPONENT_DIR).resolve(KLIB_MANIFEST_FILE_NAME)
+    assert(manifest.exists()) {
+        "The klib manifest $manifest does not exist.\nFiles in the output directory:\n${
+            module.outputDirectory.walk().joinToString("\n")
+        }"
+    }
+    val properties = Properties()
+    manifest.inputStream().use(properties::load)
+    return properties.stringPropertyNames().associateWith { properties.getProperty(it) }
+}
+
+/**
+ * Asserts that the klib manifest of the module's unpacked klib output contains exactly the given
+ * [expectedProperties] entries.
+ */
+context(module: ModuleContext)
+fun assertKlibManifestProperties(vararg expectedProperties: Pair<String, String>) {
+    val manifest = readUnpackedKlibManifest()
+    val mismatched = expectedProperties.filterNot { manifest[it.first] == it.second }
+    assert(mismatched.isEmpty()) {
+        "The klib manifest does not contain the expected properties: ${
+            mismatched.joinToString { "${it.first}=${it.second} (actual: ${manifest[it.first]})" }
+        }.\n\nManifest contents:\n${manifest.entries.sortedBy { it.key }.joinToString("\n")}"
+    }
+}
+
+/**
+ * Asserts that the klib manifest of the module's unpacked klib output declares none of [propertyNames].
+ */
+context(module: ModuleContext)
+fun assertKlibManifestHasNoProperties(vararg propertyNames: String) {
+    val manifest = readUnpackedKlibManifest()
+    val unexpected = propertyNames.filter { it in manifest }
+    assert(unexpected.isEmpty()) {
+        "The klib manifest declares the following properties, but was not expected to: ${
+            unexpected.joinToString { "$it=${manifest[it]}" }
+        }.\n\nManifest contents:\n${manifest.entries.sortedBy { it.key }.joinToString("\n")}"
+    }
+}
+
+/**
+ * Asserts that the compilation produced a packed klib file named `<moduleName>.klib` and no unpacked klib component
+ * directory next to it.
+ */
+context(module: ModuleContext)
+fun CompilationOutcome.assertIsPackedKlib(moduleName: String) {
+    assertOutputsContains("$moduleName.klib")
+    val componentDirectory = module.outputDirectory.resolve(KLIB_DEFAULT_COMPONENT_DIR)
+    assert(!componentDirectory.exists()) {
+        "Expected a packed klib file only, but the unpacked klib component directory $componentDirectory exists as well"
+    }
+}
+
+/**
  * The directory (relative to the klib metadata `linkdata` folder) that stores the fragments of [packageFqName]: the
  * root package (empty string) lives in `root_package`, a named package `foo.bar` in `package_foo.bar`.
  */
@@ -190,10 +311,11 @@ private fun linkDataPackageFolderName(packageFqName: String): String =
 
 /**
  * Asserts that the compilation produced exactly [expectedCount] `.knm` files (klib metadata package fragments) for the
- * package [packageFqName] (empty string for the root package) in the module's unpacked metadata klib output.
+ * package [packageFqName] in the module's unpacked metadata klib output. [packageFqName] defaults to the root package
+ * (empty string), so it can be omitted when asserting the root package.
  */
 context(module: ModuleContext)
-fun assertKnmFileCount(packageFqName: String, expectedCount: Int) {
+fun assertKnmFileCount(expectedCount: Int, packageFqName: String = "") {
     val packageDirectory = module.outputDirectory
         .resolve(KLIB_DEFAULT_COMPONENT_DIR)
         .resolve(KLIB_METADATA_FOLDER_NAME)

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/AbstractModule.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/AbstractModule.kt
@@ -137,10 +137,11 @@ abstract class AbstractModule<O : BaseCompilationOperation, B : BaseCompilationO
         result: CompilationResult?,
         assertions: context(ModuleContext) CompilationOutcome.() -> Unit,
         forceOutput: LogLevel?,
+        assertionsContext: ModuleContext = this,
     ) {
         val outcome = CompilationOutcomeImpl(kotlinLogger.logMessagesByLevel, result)
         try {
-            assertions(outcome)
+            applyAssertions(assertionsContext, outcome, assertions)
             assertEquals(outcome.expectedResult, result) {
                 "Compilation result is unexpected"
             }
@@ -157,6 +158,19 @@ abstract class AbstractModule<O : BaseCompilationOperation, B : BaseCompilationO
             throw e
         }
     }
+
+    /**
+     * Runs the [assertions] block with [moduleContext] supplied as its [ModuleContext] context parameter.
+     *
+     * This allows an operation to point the assertions (which resolve files against `module.outputDirectory`) at a
+     * directory other than the module's own output directory - for example the JS linking operation writes its `.js`
+     * into a dedicated directory, mirroring the KGP, so that the input klib is not deleted.
+     */
+    private fun applyAssertions(
+        moduleContext: ModuleContext,
+        outcome: CompilationOutcome,
+        assertions: context(ModuleContext) CompilationOutcome.() -> Unit,
+    ) = with(moduleContext) { assertions(outcome) }
 
     protected abstract fun compileImpl(
         strategyConfig: ExecutionPolicy,

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/JsModule.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/kotlin/compilation/model/JsModule.kt
@@ -51,10 +51,26 @@ class JsModule(
 
     var lastCompileProducedPackedKlib = false
 
+    /**
+     * The output name the last compilation actually used. It defines the file name of the produced klib, so the linking
+     * operation has to resolve the packed klib through it rather than through [moduleName], which a test may override.
+     */
+    var lastCompileIrOutputName: String = moduleName
+        private set
+
     private val dependencyFiles: List<Path>
         get() = dependencies.map { it.location }.plus(stdlibKlibLocation)
     override val expectedOutputFileName: String
         get() = "$moduleName.js"
+
+    /**
+     * The directory the linking operation writes the `.js` artifact into. It is intentionally separate from
+     * [outputDirectory] (which holds the input klib), mirroring the KGP, where the klib and the linked
+     * `.js` live in different directories. Keeping them separate also prevents the linking operation from deleting its
+     * own input klib (the JS output writer removes everything it did not write from its destination directory).
+     */
+    val linkOutputDirectory: Path
+        get() = buildDirectory.resolve("dist")
 
     override fun link(
         strategyConfig: ExecutionPolicy,
@@ -67,22 +83,25 @@ class JsModule(
         val compilationOperation = kotlinToolchain.js.jsLinkingOperation(
             // handle both cases of NOPACK set to true and false
             if (lastCompileProducedPackedKlib) {
-                outputDirectory.resolve("$moduleName.klib")
+                outputDirectory.resolve("$lastCompileIrOutputName.klib")
             } else {
                 outputDirectory
             },
-            outputDirectory,
+            // write the '.js' into a dedicated directory, separate from the input klib in outputDirectory
+            linkOutputDirectory,
         ) {
-            compilationConfigAction(this)
-            compilerArguments[LIBRARIES] = dependencyFiles
+            // both are set before the caller's action, so that a test is able to override them
             compilerArguments[IR_OUTPUT_NAME] = moduleName
+            compilerArguments[LIBRARIES] = dependencyFiles
+            compilationConfigAction(this)
         }
         val result = compilationOperation.let {
             compilationAction(it)
             buildSession.executeOperation(it, strategyConfig, kotlinLogger)
         }
 
-        processOutcome(kotlinLogger, result, assertions, forceOutput)
+        // the assertions resolve files against outputDirectory, so point them at the linking output directory
+        processOutcome(kotlinLogger, result, assertions, forceOutput, LinkOutputContext(this, linkOutputDirectory))
         return result
     }
 
@@ -101,12 +120,13 @@ class JsModule(
             outputDirectory,
         ) {
             compilerArguments[NOPACK] = true
+            compilerArguments[IR_OUTPUT_NAME] = moduleName
             moduleCompilationConfigAction(this)
             compilationConfigAction(this)
             compilerArguments[LIBRARIES] = dependencyFiles
-            compilerArguments[IR_OUTPUT_NAME] = moduleName
 
             lastCompileProducedPackedKlib = !compilerArguments[NOPACK]
+            lastCompileIrOutputName = compilerArguments[IR_OUTPUT_NAME] ?: moduleName
         }
 
         return compilationOperation.let {
@@ -159,3 +179,12 @@ class JsModule(
         throw UnsupportedOperationException("Execution of compiled JS modules is not supported directly")
     }
 }
+
+/**
+ * A [ModuleContext] view over [target] that only overrides [outputDirectory]. It is used to run the linking assertions
+ * against [JsModule.linkOutputDirectory] instead of the module's own [JsModule.outputDirectory].
+ */
+private class LinkOutputContext(
+    target: JsModule,
+    override val outputDirectory: Path,
+) : Module<JsKlibCompilationOperation, JsKlibCompilationOperation.Builder, JsHistoryBasedIncrementalCompilationConfiguration.Builder> by target

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/friend-modules/app/UseInternalApi.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/friend-modules/app/UseInternalApi.kt
@@ -1,0 +1,3 @@
+package friends
+
+fun useInternalGreeting(): String = internalGreeting()

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/friend-modules/lib/InternalApi.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/friend-modules/lib/InternalApi.kt
@@ -1,0 +1,5 @@
+package friends
+
+internal fun internalGreeting(): String = "hello from the internal API"
+
+fun publicGreeting(): String = internalGreeting()

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/js-data-class-copy/DataCopy.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/js-data-class-copy/DataCopy.kt
@@ -1,0 +1,9 @@
+data class User private constructor(val name: String) {
+    companion object {
+        fun create(name: String): User = User(name)
+    }
+}
+
+fun copyFromOutside(user: User): User {
+    return user.copy(name = "test")
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/js-long-as-bigint/BigLong.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/js-long-as-bigint/BigLong.kt
@@ -1,0 +1,5 @@
+fun bigLongConstant(): Long = 1234567890123456789L
+
+fun main() {
+    println(bigLongConstant())
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/js-with-main/App.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/js-with-main/App.kt
@@ -1,0 +1,11 @@
+fun usedByMain() {
+    println("usedByMainMarker")
+}
+
+fun deadUnusedFunction() {
+    println("deadUnusedFunctionMarker")
+}
+
+fun main() {
+    usedByMain()
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/missing-dep/app/App.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/missing-dep/app/App.kt
@@ -1,0 +1,5 @@
+import greeting.formatGreeting
+
+fun main() {
+    println(formatGreeting("Kotlin"))
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/missing-dep/lib/Lib.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/main/resources/modules/missing-dep/lib/Lib.kt
@@ -1,0 +1,3 @@
+package greeting
+
+fun formatGreeting(name: String): String = "Hello, $name!"

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testBuildMetrics/kotlin/SmokeCompilationMetricsTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testBuildMetrics/kotlin/SmokeCompilationMetricsTest.kt
@@ -10,6 +10,9 @@ import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
 import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertCompiledSources
 import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertOutputs
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAndPlatformAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.MetadataProject
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.ProjectCreator
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.jvmProject
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.DisplayName
@@ -20,6 +23,28 @@ import kotlin.io.path.writeText
 
 @DisplayName("Test that verify that only all the expected metrics are reported without checking their values")
 class SmokeCompilationMetricsTest : BaseCompilationTest() {
+    @BtaV2StrategyAndPlatformAgnosticCompilationTest
+    @DisplayName("Key compilation metrics are reported on every platform")
+    @TestMetadata("basic-multimodule-project/module-1")
+    fun keyCompilationMetricsAreReportedOnAllPlatforms(project: ProjectCreator) {
+        project {
+            val module1 = module("basic-multimodule-project/module-1")
+
+            val expectedNames = if (this is MetadataProject) {
+                platformIndependentMetricNames
+            } else {
+                platformIndependentMetricNames + COMPILER_TRANSLATION_TO_IR_METRIC
+            }
+
+            module1.compileWithMetrics { metrics ->
+                val actualNames = metrics.all().map { it.name }.toSet()
+                assertTrue(actualNames.containsAll(expectedNames)) {
+                    "Missing expected metrics.\n\nMissing: ${expectedNames - actualNames}\nGot: $actualNames"
+                }
+            }
+        }
+    }
+
     @BtaV2StrategyAgnosticCompilationTest
     @DisplayName("Basic non-incremental compilation metrics test")
     @TestMetadata("basic-multimodule-project/module-1")
@@ -142,6 +167,22 @@ class SmokeCompilationMetricsTest : BaseCompilationTest() {
     }
 
     companion object {
+        // Reported by every IR-producing platform (JVM/JS/Wasm) but not by the metadata compiler, which produces no IR.
+        private const val COMPILER_TRANSLATION_TO_IR_METRIC =
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler translation to IR"
+
+        // Compiler-phase metrics that are reported regardless of the target platform (JVM/JS/Wasm/Metadata).
+        // Excludes:
+        //  - GC metrics ("PS MarkSweep"/"PS Scavenge"), which depend on whether the GC actually ran;
+        //  - JVM-only classpath-snapshot metrics;
+        //  - "Compiler code generation", which is JVM-only (the klib platforms serialize IR instead).
+        private val platformIndependentMetricNames = setOf(
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler code analysis",
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler Klib writing",
+            "Run compilation -> Sources compilation round -> Compiler time -> Compiler initialization time",
+            "Total compiler iteration",
+        )
+
         private val baseMetricNames = setOf(
             "PS MarkSweep",
             "PS Scavenge",

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/JsKlibCompilationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/JsKlibCompilationTest.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests
+
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments.Companion.X_CONSISTENT_DATA_CLASS_COPY_VISIBILITY
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.IR_OUTPUT_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.NOPACK
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_FRIEND_MODULES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_IR_MODULE_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerKlibArguments.Companion.X_IR_PER_MODULE_OUTPUT_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.*
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.jsProject
+import org.junit.jupiter.api.DisplayName
+
+@OptIn(ExperimentalCompilerArgument::class)
+@DisplayName("Functional tests for the JS klib compilation operation of the BTA")
+class JsKlibCompilationTest : BaseCompilationTest() {
+
+    @DisplayName("Compiling JS sources produces an unpacked klib with IR and metadata fragments")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun compilesToUnpackedKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile {
+                assertIsUnpackedJsKlib()
+                assertKnmFileCount(expectedCount = 3)
+            }
+        }
+    }
+
+    @DisplayName("Disabled NOPACK produces a packed klib file instead of a directory")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun packedKlibIsProducedWhenNopackIsDisabled(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib(module.moduleName)
+            }
+        }
+    }
+
+    @DisplayName("Compilation of an empty source list is reported as a compiler error")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun emptySourceListIsReportedAsError(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("empty").compile {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*Specify at least one source file or directory.*"))
+            }
+        }
+    }
+
+    @DisplayName("JS sources in named packages produce fragments in the matching package directories")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun namedPackageSourcesProduceFragmentsInPackageDirectory(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("basic-multimodule-project/module-3").compile {
+                assertIsUnpackedJsKlib()
+                assertKnmFileCount(packageFqName = "p", expectedCount = 1)
+                assertKnmFileCount(packageFqName = "p2", expectedCount = 1)
+                assertKnmFileCount(packageFqName = "p3", expectedCount = 1)
+                assertKnmFileCount(packageFqName = "root_package", expectedCount = 0)
+            }
+        }
+    }
+
+    @DisplayName("Fragments of a multi-level package are stored in a directory named after the whole package")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun multiLevelPackageSourcesProduceFragmentsInOnePackageDirectory(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("ic-scenarios/KT-85074").compile {
+                assertIsUnpackedJsKlib()
+                assertKnmFileCount(packageFqName = "org.example.foo", expectedCount = 2)
+                assertKnmFileCount(packageFqName = "root_package", expectedCount = 0)
+            }
+        }
+    }
+
+    @DisplayName("X_CONSISTENT_DATA_CLASS_COPY_VISIBILITY makes the generated copy() private as the primary constructor")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun dataClassCopyVisibilityIsConsistentWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            module("js-data-class-copy").compile(compilationConfigAction = {
+                it.compilerArguments[X_CONSISTENT_DATA_CLASS_COPY_VISIBILITY] = true
+            }) {
+                expectFail()
+                assertLogContainsPatterns(
+                    LogLevel.ERROR,
+                    ".*[Cc]annot access.*copy.*private.*".toRegex(RegexOption.DOT_MATCHES_ALL),
+                )
+            }
+        }
+    }
+
+    @DisplayName("IR_OUTPUT_NAME is written to the klib manifest as unique_name value")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irOutputNameIsWrittenToManifest(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val outputName = "my-js-module"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = outputName
+            }) {
+                assertKlibManifestProperties("unique_name" to outputName)
+            }
+        }
+    }
+
+    @DisplayName("IR_OUTPUT_NAME defines the file name of the packed klib")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irOutputNameDefinesThePackedKlibFileName(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val outputName = "my-js-module"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = outputName
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib(outputName)
+            }
+        }
+    }
+
+    @DisplayName("X_IR_MODULE_NAME overrides the unique_name value written to the klib manifest")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irModuleNameOverridesTheModuleNameInManifest(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val moduleName = "js-lib"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[X_IR_MODULE_NAME] = moduleName
+            }) {
+                assertIsUnpackedJsKlib()
+                assertKlibManifestProperties("unique_name" to moduleName)
+            }
+        }
+    }
+
+    @DisplayName("X_IR_MODULE_NAME does not affect the file name of the packed klib")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun irModuleNameDoesNotAffectThePackedKlibFileName(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val outputName = "lib"
+        val moduleName = "js-lib"
+        jsProject(strategyConfig) {
+            module("js-ic-basic-lib").compile(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = outputName
+                it.compilerArguments[X_IR_MODULE_NAME] = moduleName
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib(outputName)
+            }
+        }
+    }
+
+    @DisplayName("X_IR_PER_MODULE_OUTPUT_NAME is written to the klib manifest as the JS output name")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun perModuleOutputNameIsWrittenToManifest(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        val perModuleOutputName = "my-js-output"
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile {
+                assertKlibManifestHasNoProperties("jsOutputName")
+            }
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[X_IR_PER_MODULE_OUTPUT_NAME] = perModuleOutputName
+            }) {
+                assertKlibManifestProperties("jsOutputName" to perModuleOutputName)
+            }
+        }
+    }
+
+    @DisplayName("X_FRIEND_MODULES makes internal declarations of a dependency visible")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun internalDeclarationsOfAFriendModuleAreVisible(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val libModule = module("friend-modules/lib")
+            val appModule = module("friend-modules/app", listOf(libModule))
+            libModule.compile()
+            appModule.compile(compilationConfigAction = {
+                it.compilerArguments[X_FRIEND_MODULES] = listOf(libModule.outputDirectory)
+            }) {
+                assertIsUnpackedJsKlib()
+            }
+        }
+    }
+
+    @DisplayName("Internal declarations of a dependency are not visible without X_FRIEND_MODULES")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun internalDeclarationsOfANonFriendModuleAreNotVisible(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val libModule = module("friend-modules/lib")
+            val appModule = module("friend-modules/app", listOf(libModule))
+            libModule.compile()
+            appModule.compile {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*[Cc]annot access.*internalGreeting.*"))
+            }
+        }
+    }
+
+    @DisplayName("A lib+app graph compiles the app klib against the library klib across the module graph")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun multiModuleGraphCompilesTheAppAgainstTheLibraryKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("js-ic-basic-lib")
+            val app = module("js-ic-basic-app", dependencies = listOf(library))
+
+            library.compile {
+                assertIsUnpackedJsKlib()
+            }
+
+            app.compile {
+                assertIsUnpackedJsKlib()
+            }
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/JsLinkingTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/JsLinkingTest.kt
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests
+
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.IR_OUTPUT_NAME
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.LIBRARIES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.NOPACK
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmArguments.Companion.X_FRIEND_MODULES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.MAIN
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.SOURCE_MAP_EMBED_SOURCES
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonJsAndWasmCompilerLinkingArguments.Companion.X_IR_DCE
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonKlibBasedArgumentsLinkingArguments.Companion.X_PARTIAL_LINKAGE_LOGLEVEL
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.MODULE_KIND
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.X_ES_LONG_AS_BIGINT
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.X_IR_PER_FILE
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.X_IR_PER_MODULE
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsMainCallMode
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.PartialLinkageLogLevel
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.SourceMapEmbedSources
+import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.*
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTest
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.jsProject
+import org.jetbrains.kotlin.buildtools.tests.compilation.util.currentKotlinJsStdlibKlibLocation
+import org.junit.jupiter.api.DisplayName
+
+@OptIn(ExperimentalCompilerArgument::class)
+@DisplayName("Functional tests for the JS linking operation of the BTA")
+class JsLinkingTest : BaseCompilationTest() {
+
+    @DisplayName("An unpacked klib is accepted as the linking input")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun linksAnUnpackedKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            module.link {
+                assertOutputFileCountWithExtension(".js", 1)
+                assertOutputsContains(module.expectedOutputFileName)
+                assertOutputFileContains(module.expectedOutputFileName, "useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("A packed klib (NOPACK=false) is accepted as the linking input")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun linksAPackedKlib(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile(compilationConfigAction = { it.compilerArguments[NOPACK] = false })
+            module.link {
+                assertOutputFileCountWithExtension(".js", 1)
+                assertOutputsContains(module.expectedOutputFileName)
+                assertOutputFileContains(module.expectedOutputFileName, "useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("The linked JS file name comes from the linking IR_OUTPUT_NAME, independent of the compiled klib name")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun linkedJsFileNameComesFromTheLinkingIrOutputName(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile(compilationConfigAction = {
+                it.compilerArguments[NOPACK] = false
+            }) {
+                assertIsPackedKlib("js-ic-basic-lib")
+            }
+            module.link(compilationConfigAction = {
+                it.compilerArguments[IR_OUTPUT_NAME] = "linked-js-name"
+            }) {
+                assertOutputsContains("linked-js-name.js")
+                assertOutputFileContains("linked-js-name.js", "useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=COMMONJS wraps the generated JS as a CommonJS module")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindCommonJsShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.COMMONJS }) {
+                assertOutputFileContains(jsFileName, "module.exports")
+                assertOutputFileDoesNotContain(jsFileName, "define.amd")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=UMD wraps the generated JS with the AMD/CommonJS detector")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindUmdShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.UMD }) {
+                assertOutputFileContains(jsFileName, "define.amd")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=PLAIN wraps the generated JS as a plain global assignment")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindPlainShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.PLAIN }) {
+                assertOutputFileDoesNotContain(jsFileName, "module.exports")
+                assertOutputFileDoesNotContain(jsFileName, "define(")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=ES writes the generated JS with the .mjs extension")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindEsShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.ES }) {
+                assertOutputsContains("${module.moduleName}.mjs")
+            }
+        }
+    }
+
+    @DisplayName("MODULE_KIND=AMD wraps the generated JS as an AMD module")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun moduleKindAmdShapesTheGeneratedJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val jsFileName = module.expectedOutputFileName
+            module.link(compilationConfigAction = { it.compilerArguments[MODULE_KIND] = JsModuleKind.AMD }) {
+                assertOutputFileContains(jsFileName, "define(")
+                assertOutputFileDoesNotContain(jsFileName, "define.amd")
+            }
+        }
+    }
+
+    @DisplayName("SOURCE_MAP produces a source map next to the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun sourceMapIsGeneratedWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val sourceMapFileName = "${module.expectedOutputFileName}.map"
+
+            module.link(compilationConfigAction = { it.compilerArguments[SOURCE_MAP] = true }) {
+                assertOutputsContains(module.expectedOutputFileName, sourceMapFileName)
+                assertOutputFileContains(module.expectedOutputFileName, "//# sourceMappingURL=${module.expectedOutputFileName}.map")
+                // a plain source map references the sources but does not embed their contents
+                assertOutputFileDoesNotContain(sourceMapFileName, "fun useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("SOURCE_MAP_EMBED_SOURCES=ALWAYS embeds Kotlin sources into the generated source map")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun sourceMapEmbedsSourcesWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            val sourceMapFileName = "${module.expectedOutputFileName}.map"
+
+            // embedding the sources inlines the Kotlin source text into the source map
+            module.link(compilationConfigAction = {
+                it.compilerArguments[SOURCE_MAP] = true
+                it.compilerArguments[SOURCE_MAP_EMBED_SOURCES] = SourceMapEmbedSources.ALWAYS
+            }) {
+                assertOutputFileContains(sourceMapFileName, "fun useAInLibMain")
+            }
+        }
+    }
+
+    @DisplayName("A lib+app graph links each module to its own JS and the app resolves the library across modules")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun multiModuleGraphLinksEachModuleToItsOwnJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("js-ic-basic-lib")
+            val app = module("js-ic-basic-app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile()
+
+            library.link {
+                assertOutputsContains(library.expectedOutputFileName)
+                assertOutputFileContains(library.expectedOutputFileName, "useAInLibMain")
+            }
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.ERROR
+            }) {
+                assertOutputsContains(app.expectedOutputFileName)
+                assertOutputFileContains(app.expectedOutputFileName, "useAInAppMain")
+            }
+        }
+    }
+
+    @DisplayName("An internal declaration of a friend module is resolved across modules and linked into the app JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun friendModuleInternalDeclarationIsLinkedIntoTheAppJs(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("friend-modules/lib")
+            val app = module("friend-modules/app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile(compilationConfigAction = {
+                it.compilerArguments[X_FRIEND_MODULES] = listOf(library.outputDirectory)
+            })
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.ERROR
+            }) {
+                assertOutputsContains(app.expectedOutputFileName)
+                assertOutputFileContains(app.expectedOutputFileName, "useInternalGreeting")
+            }
+        }
+    }
+
+    @DisplayName("A missing dependency fails linking when partial linkage is escalated to ERROR")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun missingDependencyFailsLinkingWhenPartialLinkageIsError(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("missing-dep/lib")
+            val app = module("missing-dep/app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile()
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[LIBRARIES] = listOf(currentKotlinJsStdlibKlibLocation)
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.ERROR
+            }) {
+                expectFail()
+                assertLogContainsPatterns(
+                    LogLevel.ERROR,
+                    ".*Function 'formatGreeting' can not be called: No function found for symbol.*"
+                        .toRegex(RegexOption.DOT_MATCHES_ALL),
+                )
+            }
+        }
+    }
+
+    @DisplayName("A missing dependency only warns when partial linkage is at WARNING")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun missingDependencyOnlyWarnsWhenPartialLinkageIsWarning(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val library = module("missing-dep/lib")
+            val app = module("missing-dep/app", dependencies = listOf(library))
+
+            library.compile()
+            app.compile()
+
+            app.link(compilationConfigAction = {
+                it.compilerArguments[LIBRARIES] = listOf(currentKotlinJsStdlibKlibLocation)
+                it.compilerArguments[X_PARTIAL_LINKAGE_LOGLEVEL] = PartialLinkageLogLevel.WARNING
+            }) {
+                assertOutputsContains(app.expectedOutputFileName)
+                assertLogContainsPatterns(
+                    LogLevel.WARN,
+                    ".*Function 'formatGreeting' can not be called: No function found for symbol.*"
+                        .toRegex(RegexOption.DOT_MATCHES_ALL),
+                )
+            }
+        }
+    }
+
+    @DisplayName("Per-module granularity produces one JS file per module")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun perModuleGranularityProducesMultipleJsFiles(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            // per-module granularity emits a separate JS file per module (library and stdlib)
+            module.link(compilationConfigAction = { it.compilerArguments[X_IR_PER_MODULE] = true }) {
+                assertOutputFileCountWithExtension(".js", 2)
+                assertOutputsContains(module.expectedOutputFileName)
+                assertOutputsContains("kotlin-kotlin-stdlib.js")
+            }
+        }
+    }
+
+    @DisplayName("Per-file granularity emits a separate JS file per source file")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun perFileGranularityProducesOneJsFilePerSourceFile(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-ic-basic-lib")
+            module.compile()
+            // per-file granularity is only supported together with the ES module kind
+            module.link(compilationConfigAction = {
+                it.compilerArguments[MODULE_KIND] = JsModuleKind.ES
+                it.compilerArguments[X_IR_PER_FILE] = true
+            }) {
+                val perFileDir = "kotlin_${module.moduleName.replace('-', '_')}"
+                assertOutputsContains("$perFileDir/A.mjs", "$perFileDir/DummyInLibMain.mjs")
+            }
+        }
+    }
+
+    @DisplayName("X_ES_LONG_AS_BIGINT compiles Long constants as ES bigint literals")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun longsAreCompiledAsBigIntWhenRequested(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val longDecimalLiteral = "1234567890123456789"
+            val bigIntLiteral = "${longDecimalLiteral}n"
+            val module = module("js-long-as-bigint")
+
+            module.compile()
+
+            module.link {
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, bigIntLiteral)
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, longDecimalLiteral)
+            }
+
+            module.link(compilationConfigAction = { it.compilerArguments[X_ES_LONG_AS_BIGINT] = true }) {
+                assertOutputFileContains(module.expectedOutputFileName, bigIntLiteral)
+            }
+        }
+    }
+
+    @DisplayName("MAIN=CALL invokes main() in the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun mainCallModeCallInvokesMain(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = { it.compilerArguments[MAIN] = JsMainCallMode.CALL }) {
+                assertOutputFileContains(module.expectedOutputFileName, "mainWrapper();")
+            }
+        }
+    }
+
+    @DisplayName("MAIN=NO_CALL does not invoke main() in the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun mainCallModeNoCallDoesNotInvokeMain(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = { it.compilerArguments[MAIN] = JsMainCallMode.NO_CALL }) {
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, "mainWrapper();")
+            }
+        }
+    }
+
+    @DisplayName("Without X_IR_DCE the unreachable declaration is kept in the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun unreachableDeclarationsAreKeptWithoutDce(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = { it.compilerArguments[MAIN] = JsMainCallMode.CALL }) {
+                assertOutputFileContains(module.expectedOutputFileName, "usedByMainMarker")
+                assertOutputFileContains(module.expectedOutputFileName, "deadUnusedFunctionMarker")
+            }
+        }
+    }
+
+    @DisplayName("X_IR_DCE eliminates unreachable declarations from the generated JS")
+    @BtaV2StrategyAgnosticCompilationTest
+    fun dceEliminatesUnreachableDeclarations(strategyConfig: CompilerExecutionStrategyConfiguration) {
+        jsProject(strategyConfig) {
+            val module = module("js-with-main")
+            module.compile()
+
+            module.link(compilationConfigAction = {
+                it.compilerArguments[MAIN] = JsMainCallMode.CALL
+                it.compilerArguments[X_IR_DCE] = true
+            }) {
+                assertOutputFileContains(module.expectedOutputFileName, "usedByMainMarker")
+                assertOutputFileDoesNotContain(module.expectedOutputFileName, "deadUnusedFunctionMarker")
+            }
+        }
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/MetadataCompilationTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/MetadataCompilationTest.kt
@@ -26,7 +26,7 @@ class MetadataCompilationTest : BaseCompilationTest() {
             val module = moduleWithCommonSource()
             module.compile {
                 assertIsUnpackedMetadataKlib()
-                assertKnmFileCount(packageFqName = "", expectedCount = 1)
+                assertKnmFileCount(expectedCount = 1)
             }
         }
     }
@@ -67,7 +67,7 @@ class MetadataCompilationTest : BaseCompilationTest() {
             val consumer = module("basic-multimodule-project/module-2", dependencies = listOf(library))
             consumer.compile {
                 assertIsUnpackedMetadataKlib()
-                assertKnmFileCount(packageFqName = "", expectedCount = 2)
+                assertKnmFileCount(expectedCount = 2)
             }
         }
     }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/JsCompilerArgumentConversionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/JsCompilerArgumentConversionTest.kt
@@ -5,15 +5,20 @@
 
 package org.jetbrains.kotlin.buildtools.tests.arguments
 
+import org.jetbrains.kotlin.buildtools.api.BaseCompilationOperation
 import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
 import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.AllJsCompilerArgumentsWithBtaVersionsTest
 import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.InvalidRawValueJsCompilerArgumentsBtaV2StrategyAgnosticTest
 import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentOperationKind.LINKING
 import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.NullableJsCompilerArgumentsWithBtaVersionsTest
 import org.jetbrains.kotlin.buildtools.tests.arguments.util.assumeArgumentAvailable
 import org.jetbrains.kotlin.buildtools.tests.compilation.BaseCompilationTest
 import org.jetbrains.kotlin.buildtools.tests.compilation.assertions.assertLogContainsPatterns
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.LinkableModule
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.LogLevel
+import org.jetbrains.kotlin.buildtools.tests.compilation.model.Module
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.jsProject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -106,13 +111,11 @@ internal class JsCompilerArgumentConversionTest : BaseCompilationTest() {
 
         jsProject(strategyConfig) {
             val module = module("js-ic-basic-lib")
-            module.compile()
-            for (invalidValue in argumentConfig.invalidRawValues) {
-                module.link(compilationConfigAction = {
-                    it.compilerArguments.applyArgumentStrings(argumentConfig.expectedArgumentStringsFor(invalidValue))
-                }) {
-                    expectFail()
-                    assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            when (argumentConfig.operationKind) {
+                KLIB -> argumentConfig.testInvalidRawArgumentKlibCompilationFails(module)
+                LINKING -> {
+                    module.compile()
+                    argumentConfig.testInvalidRawArgumentLinkingFails(module)
                 }
             }
         }
@@ -135,5 +138,31 @@ internal class JsCompilerArgumentConversionTest : BaseCompilationTest() {
     private fun JsArgumentConfiguration<*>.assumeArgumentSupported() {
         assumeTrue(isPlatformSupported(), "Test requires selected platform BTA support")
         assumeArgumentAvailable()
+    }
+
+    private fun <B : BaseCompilationOperation.Builder> JsArgumentConfiguration<*>.testInvalidRawArgumentKlibCompilationFails(
+        module: Module<*, B, *>,
+    ) {
+        for (invalidValue in invalidRawValues) {
+            module.compile(compilationConfigAction = {
+                it.compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(invalidValue))
+            }) {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            }
+        }
+    }
+
+    private fun <B : BaseCompilationOperation.Builder> JsArgumentConfiguration<*>.testInvalidRawArgumentLinkingFails(
+        module: LinkableModule<*, B>,
+    ) {
+        for (invalidValue in invalidRawValues) {
+            module.link(compilationConfigAction = {
+                it.compilerArguments.applyArgumentStrings(expectedArgumentStringsFor(invalidValue))
+            }) {
+                expectFail()
+                assertLogContainsPatterns(LogLevel.ERROR, Regex(".*${Regex.escape(invalidValue)}.*"))
+            }
+        }
     }
 }

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentConfiguration.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentConfiguration.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CommonToolArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.js.JsPlatformToolchain.Companion.js
 import org.jetbrains.kotlin.buildtools.tests.arguments.model.ArgumentConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentOperationKind.LINKING
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.supportsJs
 import java.nio.file.Paths
 
@@ -21,6 +23,7 @@ internal class JsArgumentConfiguration<T>(
     kotlinToolchain: KotlinToolchains,
     private val descriptor: JsArgumentTestDescriptor<T>,
 ) : ArgumentConfiguration<T>(kotlinToolchain, descriptor) {
+    val operationKind: JsArgumentOperationKind = descriptor.operationKind
     val availableSinceVersion: KotlinReleaseVersion = descriptor.availableSinceVersion
     val argumentValues: List<T> = descriptor.argumentValues
     val argumentRawValues: List<String> = descriptor.argumentRawValues
@@ -29,9 +32,14 @@ internal class JsArgumentConfiguration<T>(
     fun isPlatformSupported(): Boolean = kotlinToolchain.supportsJs()
 
     fun buildArguments(configure: CommonToolArguments.Builder.() -> Unit = {}): CommonToolArguments {
-        return kotlinToolchain.js.jsLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
-            compilerArguments.configure()
-        }.build().compilerArguments
+        return when (descriptor.operationKind) {
+            KLIB -> kotlinToolchain.js.jsKlibCompilationOperationBuilder(emptyList(), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+            LINKING -> kotlinToolchain.js.jsLinkingOperationBuilder(Paths.get("input.klib"), Paths.get(".")).apply {
+                compilerArguments.configure()
+            }.build().compilerArguments
+        }
     }
 
     fun setArgument(arguments: CommonToolArguments.Builder, value: T) {

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentOperationKind.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentOperationKind.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.buildtools.tests.arguments.model.js
+
+internal enum class JsArgumentOperationKind(val displayName: String) {
+    KLIB("klib compilation"),
+    LINKING("linking"),
+}

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentProviders.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentProviders.kt
@@ -8,6 +8,10 @@
 package org.jetbrains.kotlin.buildtools.tests.arguments.model.js
 
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments.Companion.X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments.Companion.X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT
+import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerKlibArguments.Companion.X_ENABLE_SUSPEND_FUNCTION_EXPORTING
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.MODULE_KIND
 import org.jetbrains.kotlin.buildtools.api.arguments.JsCompilerLinkingArguments.Companion.TARGET
@@ -16,6 +20,8 @@ import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsEcmaVersion
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsIrDiagnosticMode
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JsModuleKind
 import org.jetbrains.kotlin.buildtools.tests.CompilerExecutionStrategyConfiguration
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentOperationKind.KLIB
+import org.jetbrains.kotlin.buildtools.tests.arguments.model.js.JsArgumentOperationKind.LINKING
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaV2StrategyAgnosticCompilationTestArgumentProvider
 import org.jetbrains.kotlin.buildtools.tests.compilation.model.BtaVersionsCompilationTestArgumentProvider
 import org.junit.jupiter.api.Named
@@ -46,7 +52,9 @@ internal class NullableJsCompilerArgumentsWithBtaVersionsArgumentProvider : Argu
 
 private fun namedInvalidRawValueBtaV2ArgumentConfigurations(): List<Named<Pair<JsArgumentConfiguration<*>, CompilerExecutionStrategyConfiguration>>> {
     val btaV2Strategies = BtaV2StrategyAgnosticCompilationTestArgumentProvider.namedStrategyArguments()
-    val compilerArguments = jsCompilerArguments.filter { it.runsInvalidRawValueTest }.map { named("[${it.argumentName}]", it) }
+    val compilerArguments = jsCompilerArguments.filter { it.runsInvalidRawValueTest }.map {
+        named("[${it.operationKind.displayName}][${it.argumentName}]", it)
+    }
 
     return btaV2Strategies.flatMap { namedStrategy ->
         compilerArguments.map { namedArgumentDescriptor ->
@@ -62,7 +70,9 @@ private fun namedArgumentConfiguration(
     argumentPredicate: (JsArgumentTestDescriptor<*>) -> Boolean = { true },
 ): List<Named<JsArgumentConfiguration<*>>> {
     val btaVersions = BtaVersionsCompilationTestArgumentProvider.namedToolchainProviders()
-    val compilerArguments = jsCompilerArguments.filter { argumentPredicate(it) }.map { named("[${it.argumentName}]", it) }
+    val compilerArguments = jsCompilerArguments.filter { argumentPredicate(it) }.map {
+        named("[${it.operationKind.displayName}][${it.argumentName}]", it)
+    }
 
     return btaVersions.flatMap { namedKotlinToolchains ->
         compilerArguments.map { namedArgumentDescriptor ->
@@ -80,6 +90,7 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         argumentName = "target",
         argument = TARGET,
         availableSinceVersion = TARGET.availableSinceVersion,
+        operationKind = LINKING,
         argumentValues = JsEcmaVersion.entries.toList(),
         argumentRawValues = JsEcmaVersion.entries.map { it.stringValue },
         invalidRawValues = listOf("es15"),
@@ -93,6 +104,7 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         argumentName = "module-kind",
         argument = MODULE_KIND,
         availableSinceVersion = MODULE_KIND.availableSinceVersion,
+        operationKind = LINKING,
         argumentValues = JsModuleKind.entries.toList(),
         argumentRawValues = JsModuleKind.entries.map { it.stringValue },
         invalidRawValues = listOf("emd"),
@@ -106,6 +118,7 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         argumentName = "Xir-safe-external-boolean-diagnostic",
         argument = X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC,
         availableSinceVersion = X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC.availableSinceVersion,
+        operationKind = LINKING,
         argumentValues = JsIrDiagnosticMode.entries.toList(),
         argumentRawValues = JsIrDiagnosticMode.entries.map { it.stringValue },
         invalidRawValues = listOf("error"),
@@ -114,5 +127,44 @@ private val jsCompilerArguments: List<JsArgumentTestDescriptor<*>> = listOf(
         expectedArgumentStringsFor = { value -> listOf("-Xir-safe-external-boolean-diagnostic=$value") },
         setArgumentValue = { value -> (this as JsCompilerLinkingArguments.Builder)[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] = value },
         getArgumentValue = { (this as JsCompilerLinkingArguments)[X_IR_SAFE_EXTERNAL_BOOLEAN_DIAGNOSTIC] },
+    ),
+
+    JsArgumentTestDescriptor(
+        argumentName = "Xenable-extension-functions-in-externals",
+        argument = X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS,
+        availableSinceVersion = X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS.availableSinceVersion,
+        operationKind = KLIB,
+        argumentValues = listOf(true),
+        argumentRawValues = listOf("true"),
+        valueString = { value -> value?.toString() },
+        expectedArgumentStringsFor = { _ -> listOf("-Xenable-extension-functions-in-externals") },
+        setArgumentValue = { value -> (this as JsCompilerKlibArguments.Builder)[X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS] = value },
+        getArgumentValue = { (this as JsCompilerKlibArguments)[X_ENABLE_EXTENSION_FUNCTIONS_IN_EXTERNALS] },
+    ),
+
+    JsArgumentTestDescriptor(
+        argumentName = "Xenable-implementing-interfaces-from-typescript",
+        argument = X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT,
+        availableSinceVersion = X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT.availableSinceVersion,
+        operationKind = KLIB,
+        argumentValues = listOf(true),
+        argumentRawValues = listOf("true"),
+        valueString = { value -> value?.toString() },
+        expectedArgumentStringsFor = { _ -> listOf("-Xenable-implementing-interfaces-from-typescript") },
+        setArgumentValue = { value -> (this as JsCompilerKlibArguments.Builder)[X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT] = value },
+        getArgumentValue = { (this as JsCompilerKlibArguments)[X_ENABLE_IMPLEMENTING_INTERFACES_FROM_TYPESCRIPT] },
+    ),
+
+    JsArgumentTestDescriptor(
+        argumentName = "Xenable-suspend-function-exporting",
+        argument = X_ENABLE_SUSPEND_FUNCTION_EXPORTING,
+        availableSinceVersion = X_ENABLE_SUSPEND_FUNCTION_EXPORTING.availableSinceVersion,
+        operationKind = KLIB,
+        argumentValues = listOf(true),
+        argumentRawValues = listOf("true"),
+        valueString = { value -> value?.toString() },
+        expectedArgumentStringsFor = { _ -> listOf("-Xenable-suspend-function-exporting") },
+        setArgumentValue = { value -> (this as JsCompilerKlibArguments.Builder)[X_ENABLE_SUSPEND_FUNCTION_EXPORTING] = value },
+        getArgumentValue = { (this as JsCompilerKlibArguments)[X_ENABLE_SUSPEND_FUNCTION_EXPORTING] },
     ),
 )

--- a/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentTestDescriptor.kt
+++ b/compiler/build-tools/kotlin-build-tools-api-tests/src/testCompatibility/kotlin/arguments/model/js/JsArgumentTestDescriptor.kt
@@ -13,6 +13,7 @@ internal class JsArgumentTestDescriptor<T>(
     override val argumentName: String,
     override val argument: Any,
     override val availableSinceVersion: KotlinReleaseVersion,
+    val operationKind: JsArgumentOperationKind,
     override val argumentValues: List<T>,
     override val argumentRawValues: List<String>,
     override val invalidArgumentValues: List<T> = emptyList(),


### PR DESCRIPTION
Cover the JS klib compilation and linking operations of BTA with functional tests in both the compatibility and forward-compat suites:
- JsKlibCompilationTest
- JsLinkingTest
- Split JS compiler arguments into klib/linking phases via JsArgumentOperationKind, aligned with the Wasm setup
- Extend logging and metrics coverage to JS/Wasm/Metadata via the platform-agnostic tests

^KT-78204
^KT-78205