### PR TITLE
[K/N] Avoid redundant filtering in DevirtualizationAnalysis

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DevirtualizationAnalysis.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DevirtualizationAnalysis.kt
@@ -846,8 +846,11 @@ internal object DevirtualizationAnalysis {
             val badEdges = mutableListOf<Pair<Node, Node.CastEdge>>()
             for (node in topologicalOrder) {
                 node.directCastEdges
-                        ?.filter { it.node.priority < node.priority } // Contradicts topological order.
-                        ?.forEach { badEdges += node to it }
+                        ?.forEach {
+                            if (it.node.priority < node.priority){ // Contradicts topological order.
+                                badEdges += node to it
+                            }
+                        }
             }
             badEdges.sortBy { it.second.node.priority } // Heuristic.
 
@@ -868,9 +871,10 @@ internal object DevirtualizationAnalysis {
                         node.types.or(constraintGraph.nodes[it].types)
                     }
                     node.reversedCastEdges
-                            ?.filter { it.node.priority < node.priority } // Doesn't contradict topological order.
                             ?.forEach {
-                                node.types.orWithFilterHasChanged(it.node.types, it.suitableTypes)
+                                if(it.node.priority < node.priority) { // Doesn't contradict topological order.
+                                    node.types.orWithFilterHasChanged(it.node.types, it.suitableTypes)
+                                }
                             }
                 }
                 if (iterations >= maxNumberOfIterations) break

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DevirtualizationAnalysis.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DevirtualizationAnalysis.kt
@@ -872,7 +872,7 @@ internal object DevirtualizationAnalysis {
                     }
                     node.reversedCastEdges
                             ?.forEach {
-                                if(it.node.priority < node.priority) { // Doesn't contradict topological order.
+                                if (it.node.priority < node.priority) { // Doesn't contradict topological order.
                                     node.types.orWithFilterHasChanged(it.node.types, it.suitableTypes)
                                 }
                             }


### PR DESCRIPTION
Fixes [KT-88435](https://youtrack.jetbrains.com/issue/KT-88435) Kotlin/Native: Avoid redundant filtering in DevirtualizationAnalysis