### PR TITLE
[Native] Adjust volatile check to account for inlined intrinsics

### DIFF
--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/checkers/NativeVolatileCheck.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/checkers/NativeVolatileCheck.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.konan.checkers
 
 import org.jetbrains.kotlin.backend.common.checkers.CommonKlibDiagnosticContext
 import org.jetbrains.kotlin.backend.common.checkers.at
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrCall
@@ -29,10 +30,22 @@ object NativeVolatileCheck : NativeKlibExpressionsChecker<IrCall> {
         "ATOMIC_SET_FIELD",
     )
 
+    private val atomicFunctionNames = setOf(
+        "compareAndSetField",
+        "compareAndExchangeField",
+        "getAndSetField",
+        "getAndAddField",
+        "atomicGetField",
+        "atomicSetField",
+    )
+
     private val typedIntrinsicAnnotation = FqName("kotlin.native.internal.TypedIntrinsic")
 
     fun IrFunctionAccessExpression.isVolatileIntrinsic(): Boolean {
-        if (!symbol.isBound) return false
+        if (!symbol.isBound) {
+            val signature = symbol.signature?.asPublic() ?: return false
+            return signature.packageFqName() == StandardNames.CONCURRENT_PACKAGE_FQ_NAME && signature.declarationFqName in atomicFunctionNames
+        }
         val owner = symbol.owner
         val annotation = owner.annotations.findAnnotation(typedIntrinsicAnnotation)
         val value = annotation?.getConstArgument<String>("kind") ?: return false
@@ -40,7 +53,19 @@ object NativeVolatileCheck : NativeKlibExpressionsChecker<IrCall> {
     }
 
     override fun check(expression: IrCall, context: CommonKlibDiagnosticContext, reporter: IrDiagnosticReporter) {
+        fun report() {
+            val expressionToReportOn = if (context.inlineBlockStack.isNotEmpty()) context.inlineBlockStack.first() else expression
+            reporter
+                .at(expressionToReportOn, context)
+                .report(NativeKlibErrors.LEAKED_VOLATILE_FIELD, expression)
+        }
+
         if (!expression.isVolatileIntrinsic()) return
+
+        // Given call is volatile intrinsic, and it came from another module (because it is unbound)
+        if (!expression.symbol.isBound) {
+            return report()
+        }
 
         val extensionReceiverIndex = expression.symbol.owner.parameters.indexOfFirst { it.kind == IrParameterKind.ExtensionReceiver }
         require(extensionReceiverIndex != -1) { "Extension receiver index not found for call ${expression.render()}" }
@@ -51,10 +76,7 @@ object NativeVolatileCheck : NativeKlibExpressionsChecker<IrCall> {
         val declarationFile = property.getPackageFragment()
 
         if (declarationFile != context.containingFile) {
-            val expressionToReportOn = if (context.inlineBlockStack.isNotEmpty()) context.inlineBlockStack.first() else expression
-            reporter
-                .at(expressionToReportOn, context)
-                .report(NativeKlibErrors.LEAKED_VOLATILE_FIELD, expression)
+            report()
         }
     }
 }

--- a/compiler/testData/diagnostics/nativeTests/friendModuleAccessToInternalVolatileVal.kt
+++ b/compiler/testData/diagnostics/nativeTests/friendModuleAccessToInternalVolatileVal.kt
@@ -1,6 +1,7 @@
 // RUN_PIPELINE_TILL: BACKEND
 // DISABLE_IR_VISIBILITY_CHECKS: ANY
 // DIAGNOSTICS: -ERROR_SUPPRESSION -NOTHING_TO_INLINE
+// LANGUAGE: +IrIntraModuleInlinerBeforeKlibSerialization +IrCrossModuleInlinerBeforeKlibSerialization
 
 // MODULE: lib
 // FILE: lib.kt
@@ -42,13 +43,13 @@ fun box(): String {
       v
       ::v.<!LEAKED_VOLATILE_FIELD!>atomicGetField()<!>
       set(1)
-      compareAndSet(1, 2)
+      <!LEAKED_VOLATILE_FIELD!>compareAndSet(1, 2)<!>
 
       val c = C()
       c.v
       c::v.<!LEAKED_VOLATILE_FIELD!>compareAndExchangeField(0, 1)<!>
       c.getAndSet(2)
-      c.getAndAdd(3)
+      c.<!LEAKED_VOLATILE_FIELD!>getAndAdd(3)<!>
 
       return "OK"
 }

--- a/compiler/testData/diagnostics/nativeTests/friendModuleAccessToInternalVolatileVal.ll.kt
+++ b/compiler/testData/diagnostics/nativeTests/friendModuleAccessToInternalVolatileVal.ll.kt
@@ -4,6 +4,7 @@
 // RUN_PIPELINE_TILL: BACKEND
 // DISABLE_IR_VISIBILITY_CHECKS: ANY
 // DIAGNOSTICS: -ERROR_SUPPRESSION -NOTHING_TO_INLINE
+// LANGUAGE: +IrIntraModuleInlinerBeforeKlibSerialization +IrCrossModuleInlinerBeforeKlibSerialization
 
 // MODULE: lib
 // FILE: lib.kt

--- a/plugins/atomicfu/atomicfu-compiler/testData/backendDiagnostic/friendModuleAccessToInternalAtomicfuVal.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/backendDiagnostic/friendModuleAccessToInternalAtomicfuVal.kt
@@ -33,12 +33,12 @@ import kotlinx.atomicfu.*
 fun box(): String {
     <!LEAKED_VOLATILE_FIELD!>a<!>.value
     set()
-    compareAndSet(1, 2)
+    <!LEAKED_VOLATILE_FIELD!>compareAndSet(1, 2)<!>
 
     val c = C()
     c.<!LEAKED_VOLATILE_FIELD!>a<!>.value
     c.getAndSet(1)
-    c.getAndAdd(2)
+    c.<!LEAKED_VOLATILE_FIELD!>getAndAdd(2)<!>
 
     return "OK"
 }


### PR DESCRIPTION
Previously we implemented a check that reports an error on leaked atomic intrinsics. With enabled cross-module inliner we inline methods from other modules. Inside these methods some atomic intrinsics could be present. These intrinsics will be unbound on the first phase (because they are not inline), and the only way to distinguish them is to check signature.

#KT-87829