### PR TITLE
[2.4.20]: Run tests against Gradle 9.7.0 release

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/build.gradle.kts
@@ -236,6 +236,7 @@ val gradleVersions = listOf(
     "9.4.1",
     "9.5.1",
     "9.6.1",
+    "9.7.0",
 )
 
 // Keep in sync with testTags.kt

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildScriptInjectionIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildScriptInjectionIT.kt
@@ -279,6 +279,11 @@ class BuildScriptInjectionIT : KGPBaseTest() {
     }
 
     @GradleTest
+    @GradleTestVersions(
+        // org.gradle.api.plugins.UnknownPluginException serialVersionUID has changed between 9.6.0 and 9.7.0 causing serialization exception
+        // Re-check this test on updating Gradle version in the repo to 9.7.0
+        maxVersion = TestVersions.Gradle.G_9_6
+    )
     fun buildscriptBlockInjection(version: GradleVersion) {
         testBuildscriptBlockInjection(
             "emptyKts",
@@ -287,6 +292,11 @@ class BuildScriptInjectionIT : KGPBaseTest() {
     }
 
     @GradleTest
+    @GradleTestVersions(
+        // org.gradle.api.plugins.UnknownPluginException serialVersionUID has changed between 9.6.0 and 9.7.0 causing serialization exception
+        // Re-check this test on updating Gradle version in the repo to 9.7.0
+        maxVersion = TestVersions.Gradle.G_9_6
+    )
     fun buildscriptBlockInjectionGroovy(version: GradleVersion) {
         testBuildscriptBlockInjection(
             "empty",

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ExecutionStrategyIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/ExecutionStrategyIT.kt
@@ -147,7 +147,8 @@ abstract class ExecutionStrategyIT : KGPDaemonsBaseTest() {
             projectName = "kotlinBuiltins",
             gradleVersion = gradleVersion,
             enableKotlinDaemonMemoryLimitInMb = null,
-            addHeapDumpOptions = false
+            addHeapDumpOptions = false,
+            buildOptions = defaultBuildOptions.copy(isolatedProjects = BuildOptions.IsolatedProjectsMode.DISABLED)
         ) {
             setupProject(this)
 

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/GradleCompatibilityIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/GradleCompatibilityIT.kt
@@ -58,6 +58,7 @@ class GradleCompatibilityIT : KGPBaseTest() {
         project("kotlinProject", gradleVersion) {
             build("help") {
                 val expectedVariant = when (gradleVersion) {
+                    GradleVersion.version(TestVersions.Gradle.G_9_7) -> "gradle96"
                     GradleVersion.version(TestVersions.Gradle.G_9_6) -> "gradle96"
                     GradleVersion.version(TestVersions.Gradle.G_9_5) -> "gradle813"
                     GradleVersion.version(TestVersions.Gradle.G_9_4) -> "gradle813"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/JvmDefaultIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/JvmDefaultIT.kt
@@ -60,6 +60,9 @@ internal class JvmDefaultIT : KGPBaseTest() {
 
     @DisplayName("Should override 'kotlin-dsl' plugin value")
     @GradleTest
+    @GradleTestVersions(
+        maxVersion = TestVersions.Gradle.G_9_6 // Gradle 9.7+ configures by default proper value
+    )
     fun overrideKotlinDslPlugin(
         gradleVersion: GradleVersion,
     ) {
@@ -87,6 +90,9 @@ internal class JvmDefaultIT : KGPBaseTest() {
     @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
     @DisplayName("Should not override 'kotlin-dsl' plugin value if using BTA with older Kotlin compiler version")
     @GradleTest
+    @GradleTestVersions(
+        maxVersion = TestVersions.Gradle.G_9_6 // Gradle 9.7+ releases using incompatible by metadata with Kotlin compiler 2.2.0 artifacts
+    )
     fun notOverrideKotlinDslPluginOnUsingBtaWithOlderCompilerVersion(
         gradleVersion: GradleVersion,
     ) {
@@ -102,7 +108,7 @@ internal class JvmDefaultIT : KGPBaseTest() {
                 """.trimIndent()
             )
             buildScriptInjection {
-                useCompilerVersion("2.2.0-RC")
+                useCompilerVersion("2.2.0")
             }
             overrideOldGradleBoundLanguageVersionsWith21()
             kotlinSourcesDir().also { it.createDirectories() }.writeMainFun()
@@ -116,6 +122,9 @@ internal class JvmDefaultIT : KGPBaseTest() {
 
     @DisplayName("Should override 'kotlin-dsl' plugin value if using BTA with current Kotlin compiler version")
     @GradleTest
+    @GradleTestVersions(
+        maxVersion = TestVersions.Gradle.G_9_6 // Gradle 9.7+ configures by default proper value
+    )
     fun overrideKotlinDslPluginOnUsingBtaWithCurrentCompilerVersion(
         gradleVersion: GradleVersion,
     ) {
@@ -148,6 +157,9 @@ internal class JvmDefaultIT : KGPBaseTest() {
 
     @DisplayName("Stable -jvm-default option is specified")
     @GradleTest
+    @GradleTestVersions(
+        maxVersion = TestVersions.Gradle.G_9_6 // Gradle 9.7+ configures by default proper value
+    )
     fun stableJvmDefaultOptionIsPresent(
         gradleVersion: GradleVersion,
     ) {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TaskExecutionDiagnosticsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/TaskExecutionDiagnosticsIT.kt
@@ -111,6 +111,9 @@ class TaskExecutionDiagnosticsIT : KGPBaseTest() {
     @DisplayName("KT-79851: emit unsupported language version kotlin-dsl diagnostic, custom compiler via BTA with deprecation")
     @JvmGradlePluginTests
     @GradleTest
+    @GradleTestVersions(
+        maxVersion = TestVersions.Gradle.G_9_6 // Gradle 9.7+ brings Kotlin runtime 2.4.0 which metadata is not compatible with Kotlin compiler 2.2.10
+    )
     fun emitDiagnosticOnUnsupportedVersionAlongKotlinDslCustomVersionDeprecation(gradleVersion: GradleVersion) =
         emitDiagnosticOnUnsupportedVersionAlongKotlinDsl(
             gradleVersion,

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
@@ -26,6 +26,9 @@ import kotlin.time.Duration.Companion.milliseconds
 @JsBrowserGradlePluginTests
 class JsBrowserTestsIT : KGPBaseTest() {
 
+    override val defaultBuildOptions: BuildOptions = super.defaultBuildOptions
+        .disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
+
     @GradleTest
     fun `verify custom custom KotlinJsTest environment variables are used to launch tests`(gradleVersion: GradleVersion) {
         project(
@@ -103,7 +106,7 @@ class JsBrowserTestsIT : KGPBaseTest() {
         project(
             "empty",
             gradleVersion = gradleVersion,
-            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
+            buildOptions = defaultBuildOptions
         ) {
             plugins {
                 kotlin("multiplatform")
@@ -289,7 +292,6 @@ class JsBrowserTestsIT : KGPBaseTest() {
             gradleVersion = gradleVersion,
             buildOptions = defaultBuildOptions
                 .copy(logLevel = LogLevel.DEBUG)
-                .disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
         ) {
             plugins {
                 kotlin("multiplatform") apply false

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/AggregatingKotlinTestReportIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/AggregatingKotlinTestReportIT.kt
@@ -21,6 +21,8 @@ class AggregatingKotlinTestReportIT : KGPBaseTest() {
             "new-mpp-lib-with-tests",
             gradleVersion,
             buildOptions = defaultBuildOptions.copy(freeArgs = listOf("-Pkotlin.tests.individualTaskReports=false"))
+                // KT-75899 Support Gradle Project Isolation in KGP JS & Wasm
+                .disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
         ) {
             // break all the test tasks
             kotlinSourcesDir("commonTest").resolve("TestCommonCode.kt").modify {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppDslWasmIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppDslWasmIT.kt
@@ -49,6 +49,8 @@ class MppDslWasmIT : KGPBaseTest() {
         project(
             projectName = "new-mpp-wasm-test",
             gradleVersion = gradleVersion,
+            // KT-75899 Support Gradle Project Isolation in KGP JS & Wasm
+            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
         ) {
             buildGradleKts.modify {
                 it.replace("<JsEngine>", engine)

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/SeparateKmpCompilationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/SeparateKmpCompilationIT.kt
@@ -225,7 +225,7 @@ class SeparateKmpCompilationIT : KGPBaseTest() {
 
             buildAndFail(
                 ":assemble",
-                buildOptions = defaultBuildOptions.copy(continueAfterFailure = true)
+                buildOptions = buildOptions.copy(continueAfterFailure = true)
             ) {
                 // ensures no unexpected task dependencies are added
                 val libraryTasks = setOf(

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/TestCancellationIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/TestCancellationIT.kt
@@ -32,7 +32,12 @@ class TestCancellationIT : KGPBaseTest() {
         gradleVersion: GradleVersion,
     ) {
 
-        project("kmp-test-timeout", gradleVersion) {
+        project(
+            projectName = "kmp-test-timeout",
+            gradleVersion = gradleVersion,
+            // KT-75899 Support Gradle Project Isolation in KGP JS & Wasm
+            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899(),
+        ) {
 
             val kmpTasksWithExternalTestProcesses =
                 fetchKmpTestTasksThatUseExecHandle()

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/GeneralNativeIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/native/GeneralNativeIT.kt
@@ -59,7 +59,7 @@ class GeneralNativeIT : KGPBaseTest() {
                 file.appendText(
                     """
                     run {
-                        val serviceProvider = gradle.sharedServices.registrations.getByName("service").getService()
+                        val serviceProvider = gradle.sharedServices.registrations.findByName("service")!!.getService()
                         tasks.getByPath("compileKotlinLinux").doFirst {
                             val service = serviceProvider.get()
                             val countDownLatch = service.parameters.javaClass.getMethod("getLatch").invoke(service.parameters) as CountDownLatch

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/BuildOptions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/BuildOptions.kt
@@ -214,7 +214,15 @@ data class BuildOptions(
         }
         // Isolated projects can't be enabled, if the configuration cache is disabled
         val isolatedProjectsFlag = isolatedProjects.toBooleanFlag(gradleVersion) && configurationCacheFlag == true
-        arguments.add("-Dorg.gradle.unsafe.isolated-projects=$isolatedProjectsFlag")
+        if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_7)) {
+            arguments.add("-Dorg.gradle.unsafe.isolated-projects=$isolatedProjectsFlag")
+        } else {
+            if (isolatedProjectsFlag) {
+                arguments.add("--isolated-projects")
+            } else {
+                arguments.add("--no-isolated-projects")
+            }
+        }
 
         if (parallel) {
             arguments.add("--parallel")

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/TestVersions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/TestVersions.kt
@@ -39,6 +39,7 @@ interface TestVersions {
         const val G_9_4 = "9.4.1"
         const val G_9_5 = "9.5.1"
         const val G_9_6 = "9.6.1"
+        const val G_9_7 = "9.7.0"
 
         /**
          * Check [org.jetbrains.kotlin.gradle.GradleCompatibilityIT.testIncompatibleGradleVersion]
@@ -47,7 +48,7 @@ interface TestVersions {
 
         // Should be the same as GradleCompatibilityCheck.minSupportedGradleVersion
         const val MIN_SUPPORTED = MINIMALLY_SUPPORTED_GRADLE_VERSION
-        const val MAX_SUPPORTED = G_9_6
+        const val MAX_SUPPORTED = G_9_7
     }
 
     object Kotlin {
@@ -71,7 +72,7 @@ interface TestVersions {
         const val AGP_90 = "9.0.1"
         const val AGP_91 = "9.1.1"
         const val AGP_92 = "9.2.1"
-        const val AGP_93 = "9.3.0-alpha12"
+        const val AGP_93 = "9.3.1"
 
         // Should be in sync with KotlinMultiplatformAndroidGradlePluginCompatibilityHealthCheck
         const val MIN_SUPPORTED = AGP_85 // AgpCompatibilityCheck.minimalSupportedAgpVersion
@@ -96,7 +97,7 @@ interface TestVersions {
         AGP_90(AGP.AGP_90, GradleVersion.version(Gradle.G_9_1), GradleVersion.version(Gradle.G_9_4), JavaVersion.VERSION_17),
         AGP_91(AGP.AGP_91, GradleVersion.version(Gradle.G_9_3), GradleVersion.version(Gradle.G_9_5), JavaVersion.VERSION_17),
         AGP_92(AGP.AGP_92, GradleVersion.version(Gradle.G_9_4), GradleVersion.version(Gradle.G_9_5), JavaVersion.VERSION_17),
-        AGP_93(AGP.AGP_93, GradleVersion.version(Gradle.G_9_4), GradleVersion.version(Gradle.G_9_6), JavaVersion.VERSION_17),
+        AGP_93(AGP.AGP_93, GradleVersion.version(Gradle.G_9_4), GradleVersion.version(Gradle.G_9_7), JavaVersion.VERSION_17),
         ;
 
         companion object {

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/app/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/app/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
+plugins {
+    id "com.android.application"
+    id "org.jetbrains.kotlin.android"
+    id "org.jetbrains.kotlin.kapt"
+}
 
 android {
     namespace = "org.example.inter.project.ic"
@@ -21,10 +23,7 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     implementation 'com.android.support:appcompat-v7:23.3.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation project(':lib-android')
     implementation project(':lib-jvm')
     implementation "org.jetbrains.kotlin:annotation-processor-example:$kotlin_version"

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/build.gradle
@@ -1,11 +1,5 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        maven { url = 'https://maven.google.com' }
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:$android_tools_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+plugins {
+    id "com.android.application" apply false
+    id "org.jetbrains.kotlin.android" apply false
+    id "org.jetbrains.kotlin.kapt" apply false
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/lib-android/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/lib-android/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    id "com.android.library"
+    id "org.jetbrains.kotlin.android"
+}
 
 android {
     namespace = "org.example.inter.project.ic.androidLib"
@@ -16,8 +18,4 @@ android {
     kotlin {
         jvmToolchain(8)
     }
-}
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/lib-jvm/build.gradle
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/resources/testProject/kapt2/android-inter-project-ic/lib-jvm/build.gradle
@@ -1,7 +1,5 @@
-apply plugin: 'kotlin'
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+plugins {
+    id "org.jetbrains.kotlin.jvm"
 }
 
 kotlin {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerWork.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerWork.kt
@@ -332,7 +332,7 @@ internal class GradleKotlinCompilerWork @Inject constructor(
         val stream = ByteArrayOutputStream()
         val out = PrintStream(stream)
         // todo: cache classloader?
-        val classLoader = URLClassLoader(config.compilerFullClasspath.map { it.toURI().toURL() }.toTypedArray())
+        val classLoader = URLClassLoader(config.compilerFullClasspath.map { it.toURI().toURL() }.toTypedArray(), null)
         val servicesClass = Class.forName(Services::class.java.canonicalName, true, classLoader)
         val emptyServices = servicesClass.getField("EMPTY").get(servicesClass)
         val compiler = Class.forName(config.compilerClassName, true, classLoader)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KaptConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KaptConfig.kt
@@ -61,9 +61,6 @@ internal open class KaptConfig<TASK : KaptTask>(
         ext: KaptExtensionConfig,
     ) : this(project, ext) {
         configureTask { task ->
-            task.classpath.from(
-                kaptGenerateStubsTask.map { it.libraries }
-            )
             task.compiledSources
                 .from(
                     kaptGenerateStubsTask.flatMap { it.kotlinCompileDestinationDirectory },
@@ -96,7 +93,11 @@ internal open class KaptConfig<TASK : KaptTask>(
             // the configuration is not extended (via extendsFrom, which normally happens when one configuration is _added_ into another)
             // but is instead included as the (lazily) resolved files. This is needed because the class structure configuration doesn't have
             // the attributes that are potentially needed to resolve dependencies on MPP modules, and the classpath configuration does.
-            classStructureConfiguration.dependencies.add(project.dependencies.create(project.files(project.provider { taskProvider.get().classpath })))
+            classStructureConfiguration.dependencies.addLater(
+                taskProvider.map { task ->
+                    project.dependencies.create(project.files({ task.classpath }))
+                }
+            )
             classStructureConfiguration.incoming.artifactView { viewConfig ->
                 viewConfig.attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, CLASS_STRUCTURE_ARTIFACT_TYPE)
             }.files

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KaptGenerateStubsConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/KaptGenerateStubsConfig.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.gradle.internal.kapt.KaptProperties
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilationInfo
+import org.jetbrains.kotlin.gradle.tasks.BaseKapt
 import org.jetbrains.kotlin.gradle.tasks.CompilerPluginOptions
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.tasks.withType
@@ -113,6 +114,12 @@ internal class KaptGenerateStubsConfig : BaseKotlinCompileConfig<KaptGenerateStu
                 project.tasks.withType<KaptGenerateStubsTask>().configureEach { task ->
                     if (task.name == kaptGenerateStubsTaskName) {
                         task.libraries.from(paths)
+                    }
+                }
+                val kaptTaskName = getKaptTaskName(kotlinCompileTask.name, KAPT_PREFIX)
+                project.tasks.withType<BaseKapt>().configureEach { task ->
+                    if (task.name == kaptTaskName) {
+                        task.classpath.from(paths)
                     }
                 }
             }


### PR DESCRIPTION
- **[Gradle] Fix Kapt task may produce deprecation warning**
- **[Gradle] Run Gradle integration tests against 9.7.0 release**
