### PR TITLE
[K/N] Ignore a fileckech test with opt&cache

### DIFF
--- a/native/native.tests/testData/codegen/fileCheck/kt85403.kt
+++ b/native/native.tests/testData/codegen/fileCheck/kt85403.kt
@@ -1,6 +1,8 @@
 // TARGET_BACKEND: NATIVE
 // FILECHECK_STAGE: CStubs
 // FREE_COMPILER_ARGS: -Xbinary=genericSafeCasts=true
+// IGNORE_NATIVE: optimizationMode=OPT && cacheMode=STATIC_ONLY_DIST
+// IGNORE_NATIVE: optimizationMode=OPT && cacheMode=STATIC_EVERYWHERE
 
 // KT-85403: reading a top-level val (a trivial getter) inside an `if (x is T)` branch dropped
 // the branch's path predicate in CastsOptimization, so the control flow merge after the `if`


### PR DESCRIPTION
The cecks expects a call to be inlined in opt and not inlined in debug mode. Currently opt&cache mode stands inbetwee these two. Most likely, lately opt&cache mode should start inlining these calls as expected and the test should be unignored.