### PR TITLE
[KGP] Wire commonized cinterops without reading Task.project

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CommonizerIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CommonizerIT.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.native.internal.CInteropCommonizerDependent
-import org.jetbrains.kotlin.gradle.targets.native.internal.commonizeCInteropTask
 import org.jetbrains.kotlin.gradle.targets.native.internal.commonizedOutputLibraries
 import org.jetbrains.kotlin.gradle.targets.native.internal.from
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
@@ -36,6 +35,7 @@ import org.jetbrains.kotlin.gradle.uklibs.include
 import org.jetbrains.kotlin.gradle.util.replaceText
 import org.jetbrains.kotlin.gradle.util.reportSourceSetCommonizerDependencies
 import org.jetbrains.kotlin.gradle.util.resolveIdeDependencies
+import org.jetbrains.kotlin.gradle.util.resolveIdeDependenciesAsModel
 import org.jetbrains.kotlin.gradle.utils.future
 import org.jetbrains.kotlin.incremental.testingUtils.assertEqualDirectories
 import org.jetbrains.kotlin.konan.library.KONAN_DISTRIBUTION_COMMONIZED_LIBS_DIR
@@ -49,6 +49,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import java.nio.file.Path
 import kotlin.io.path.*
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 @OsCondition(
@@ -316,6 +317,43 @@ open class CommonizerIT : KGPBaseTest() {
                 assertNativeDistributionCommonizationCacheHit()
                 assertTasksUpToDate(":commonizeCInterop")
             }
+        }
+    }
+
+    @DisplayName("KT-76147 - commonized cinterops are wired without reading Task.project at execution time")
+    @GradleTest
+    // pinned to the newest Gradle: on 8.5 `CInteropProcess` separately reads `Task.project` at execution
+    // time and fails the configuration cache here, with or without this fix
+    @GradleTestVersions(minVersion = TestVersions.Gradle.MAX_SUPPORTED)
+    fun testCommonizedCInteropDependenciesAreConfigurationCacheSafe(gradleVersion: GradleVersion) {
+        nativeProject("commonizeInteropUsingPosixApis", gradleVersion) {
+            configureCommonizerTargets()
+
+            // a plain build does not reproduce KT-76147: `testCommonizeInteropUsingPosixAPIs` compiles
+            // `:compileNativeMainKotlinMetadata` on this fixture and stays green without the fix. Only an IDE
+            // import reaches `IdeCommonizedCinteropDependencyResolver`, and only while that task executes is
+            // the metadata compile classpath resolved late enough to reach back to `Task.project`
+            val nativeMainCInterops = resolveIdeDependenciesAsModel(
+                sourceSets = setOf("nativeMain"),
+                tasks = listOf(":compileNativeMainKotlinMetadata", ":prepareKotlinIdeaImport"),
+            )["nativeMain"]
+                .filterIsInstance<IdeaKotlinResolvedBinaryDependency>()
+                .filter { !it.isNativeDistribution && it.klibExtra?.isInterop == true }
+
+            val commonizedCInterop = nativeMainCInterops.singleOrNull()
+                ?: fail("Expected a single commonized cinterop dependency on 'nativeMain', but got: $nativeMainCInterops")
+
+            val commonizedKlib = commonizedCInterop.classpath.singleOrNull()
+                ?: fail("Expected a single klib for ${commonizedCInterop.coordinates}, but got: ${commonizedCInterop.classpath}")
+
+            val commonizerIdeOutput = projectPersistentCache.resolve("metadata").resolve("commonizer").toFile().canonicalFile
+            val commonizedKlibPath = commonizedKlib.canonicalFile
+
+            assertTrue(
+                commonizedKlibPath.startsWith(commonizerIdeOutput),
+                "Expected 'nativeMain' to resolve a commonized klib under $commonizerIdeOutput, but got $commonizedKlibPath"
+            )
+            assertEquals("commonizeInteropUsingPosixApis-cinterop-withPosix", commonizedKlibPath.name)
         }
     }
 
@@ -989,12 +1027,11 @@ open class CommonizerIT : KGPBaseTest() {
     private fun TestProject.nonPlatformCinteropsClasspath(sourceSetName: String): Set<java.io.File> {
         return buildScriptReturn {
             project.future {
-                val cinteropCommonizerTask = project.commonizeCInteropTask()
-                cinteropCommonizerTask!!.get().commonizedOutputLibraries(
+                project.commonizedOutputLibraries(
                     CInteropCommonizerDependent.from(
                         kotlinMultiplatform.sourceSets.getByName(sourceSetName)
                     )!!
-                ).files
+                )!!.files
             }.getOrThrow()
         }.buildAndReturn()
     }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/resolveIdeDependencies.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/util/resolveIdeDependencies.kt
@@ -76,8 +76,9 @@ private class ResolveIdeDependenciesModelImpl(
 internal fun TestProject.resolveIdeDependenciesAsModel(
     sourceSets: Set<String>,
     buildOptions: BuildOptions = this.buildOptions,
+    tasks: List<String> = listOf("prepareKotlinIdeaImport"),
 ): IdeaKotlinDependenciesContainer {
-    val model = buildModel<ResolveIdeDependenciesModel>("prepareKotlinIdeaImport", buildOptions = buildOptions) { project ->
+    val model = buildModel<ResolveIdeDependenciesModel>(*tasks.toTypedArray(), buildOptions = buildOptions) { project ->
         val deps = sourceSets.associateWith {
             @OptIn(ExternalKotlinTargetApi::class)
             project.kotlinIdeMultiplatformImport.resolveDependenciesSerialized(it)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/KotlinCompilationK2MultiplatformConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/compilationImpl/KotlinCompilationK2MultiplatformConfigurator.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.gradle.plugin.sources.isSharedSourceSet
 import org.jetbrains.kotlin.gradle.targets.metadata.isNativeSourceSet
 import org.jetbrains.kotlin.gradle.targets.metadata.retrieveExternalDependencies
 import org.jetbrains.kotlin.gradle.targets.native.internal.cinteropCommonizerDependencies
-import org.jetbrains.kotlin.gradle.targets.native.internal.commonizeCInteropTask
 import org.jetbrains.kotlin.gradle.targets.native.internal.commonizerTarget
 import org.jetbrains.kotlin.gradle.targets.native.internal.retrievePlatformDependenciesWithNativeDistribution
 import org.jetbrains.kotlin.gradle.tasks.K2MultiplatformCompilationTask
@@ -147,9 +146,7 @@ internal object KotlinCompilationK2MultiplatformConfigurator : KotlinCompilation
                             add(it.retrievePlatformDependenciesWithNativeDistribution(project))
                         }
 
-                        commonizeCInteropTask()?.let {
-                            add(cinteropCommonizerDependencies(sourceSet, it))
-                        }
+                        add(cinteropCommonizerDependencies(sourceSet))
                     }
                     // We do not need transitive dependencies defined on higher levels of the hierarchy here
                     add(sourceSet.retrieveExternalDependencies(transitive = false))

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/AbstractCInteropCommonizerTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/AbstractCInteropCommonizerTask.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle.targets.native.internal
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskProvider
@@ -23,7 +24,7 @@ import java.io.File
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 internal abstract class AbstractCInteropCommonizerTask : DefaultTask(), UsesBuildMetricsService {
     @get:OutputDirectory
-    abstract val outputDirectory: File
+    abstract val outputDirectory: DirectoryProperty
 }
 
 internal const val CINTEROP_COMMONIZER_OUTPUT_PATH = "classes/kotlin/commonizer"
@@ -37,7 +38,7 @@ internal val Project.copyCInteropCommonizerForIdeOutputRoot: File
         .resolve(path.removePrefix(":").replace(":", "/"))
 
 internal fun AbstractCInteropCommonizerTask.outputDirectory(group: CInteropCommonizerGroup): File =
-    outputDirectory.commonizerGroupDirectory(group)
+    outputDirectory.get().asFile.commonizerGroupDirectory(group)
 
 private fun File.commonizerGroupDirectory(group: CInteropCommonizerGroup): File {
     val interopsDirectoryName = group.interops.map { it.interopName }.toSet().joinToString("_")

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/AbstractCInteropCommonizerTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/AbstractCInteropCommonizerTask.kt
@@ -6,8 +6,10 @@
 package org.jetbrains.kotlin.gradle.targets.native.internal
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.commonizer.CommonizerOutputFileLayout
 import org.jetbrains.kotlin.commonizer.CommonizerOutputFileLayout.base64Hash
@@ -15,8 +17,7 @@ import org.jetbrains.kotlin.commonizer.CommonizerOutputFileLayout.ensureMaxFileN
 import org.jetbrains.kotlin.commonizer.identityString
 import org.jetbrains.kotlin.gradle.report.UsesBuildMetricsService
 import org.jetbrains.kotlin.gradle.utils.changing
-import org.jetbrains.kotlin.gradle.utils.future
-import org.jetbrains.kotlin.gradle.utils.outputFilesProvider
+import org.jetbrains.kotlin.gradle.utils.kotlinMetadataDir
 import java.io.File
 
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
@@ -25,28 +26,57 @@ internal abstract class AbstractCInteropCommonizerTask : DefaultTask(), UsesBuil
     abstract val outputDirectory: File
 }
 
-internal fun AbstractCInteropCommonizerTask.outputDirectory(group: CInteropCommonizerGroup): File {
+internal const val CINTEROP_COMMONIZER_OUTPUT_PATH = "classes/kotlin/commonizer"
+
+internal val Project.cInteropCommonizerOutputRoot: File
+    get() = layout.buildDirectory.get().asFile.resolve(CINTEROP_COMMONIZER_OUTPUT_PATH)
+
+internal val Project.copyCInteropCommonizerForIdeOutputRoot: File
+    get() = kotlinMetadataDir()
+        .resolve("commonizer")
+        .resolve(path.removePrefix(":").replace(":", "/"))
+
+internal fun AbstractCInteropCommonizerTask.outputDirectory(group: CInteropCommonizerGroup): File =
+    outputDirectory.commonizerGroupDirectory(group)
+
+private fun File.commonizerGroupDirectory(group: CInteropCommonizerGroup): File {
     val interopsDirectoryName = group.interops.map { it.interopName }.toSet().joinToString("_")
     val groupDisambiguation = group.targets.joinToString { it.identityString } +
             group.interops.joinToString { it.uniqueName }
 
-    return outputDirectory
-        .resolve(ensureMaxFileNameLength(interopsDirectoryName))
+    return resolve(ensureMaxFileNameLength(interopsDirectoryName))
         .resolve(base64Hash(groupDisambiguation))
 }
 
-internal fun AbstractCInteropCommonizerTask.commonizedOutputLibraries(dependent: CInteropCommonizerDependent): FileCollection {
-    return outputFilesProvider {
-        val outputDirectory = project.future { commonizedOutputDirectory(dependent) }.getOrThrow()
-            ?: return@outputFilesProvider emptySet<File>()
-        project.providers.changing {
-            outputDirectory.listFiles().orEmpty().toSet()
-        }
-    }
+internal suspend fun Project.commonizedOutputLibraries(dependent: CInteropCommonizerDependent): FileCollection? {
+    val commonizerTask = commonizeCInteropTask() ?: return null
+    return commonizedOutputLibraries(commonizerTask, cInteropCommonizerOutputRoot, dependent)
 }
 
-internal suspend fun AbstractCInteropCommonizerTask.commonizedOutputDirectory(dependent: CInteropCommonizerDependent): File? {
-    val group = project.findCInteropCommonizerGroup(dependent) ?: return null
+internal suspend fun Project.commonizedOutputLibrariesForIde(dependent: CInteropCommonizerDependent): FileCollection? {
+    val commonizerTask = copyCommonizeCInteropForIdeTask() ?: return null
+    return commonizedOutputLibraries(commonizerTask, copyCInteropCommonizerForIdeOutputRoot, dependent)
+}
+
+private suspend fun Project.commonizedOutputLibraries(
+    commonizerTask: TaskProvider<out AbstractCInteropCommonizerTask>,
+    outputRoot: File,
+    dependent: CInteropCommonizerDependent,
+): FileCollection {
+    val commonizedOutputLibraries = objects.fileCollection().builtBy(commonizerTask)
+    val outputDirectory = commonizedOutputDirectory(outputRoot, dependent) ?: return commonizedOutputLibraries
+    return commonizedOutputLibraries.from(
+        providers.changing { outputDirectory.listFiles().orEmpty().toSet() }
+    )
+}
+
+internal suspend fun Project.commonizedOutputDirectory(dependent: CInteropCommonizerDependent): File? {
+    if (commonizeCInteropTask() == null) return null
+    return commonizedOutputDirectory(cInteropCommonizerOutputRoot, dependent)
+}
+
+private suspend fun Project.commonizedOutputDirectory(outputRoot: File, dependent: CInteropCommonizerDependent): File? {
+    val group = findCInteropCommonizerGroup(dependent) ?: return null
     return CommonizerOutputFileLayout
-        .resolveCommonizedDirectory(outputDirectory(group), dependent.target)
+        .resolveCommonizedDirectory(outputRoot.commonizerGroupDirectory(group), dependent.target)
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerCompositeMetadataJarBundling.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerCompositeMetadataJarBundling.kt
@@ -21,9 +21,8 @@ internal fun Project.includeCommonizedCInteropMetadata(
 }
 
 internal suspend fun Project.includeCommonizedCInteropMetadata(metadataKlib: Zip, compilation: KotlinSharedNativeCompilation) {
-    val commonizerTask = commonizeCInteropTask()?.get() ?: return
     val commonizerDependencyToken = CInteropCommonizerDependent.from(compilation) ?: return
-    val outputDirectory = commonizerTask.commonizedOutputDirectory(commonizerDependencyToken) ?: return
+    val outputDirectory = commonizedOutputDirectory(commonizerDependencyToken) ?: return
 
     metadataKlib.from(outputDirectory) { spec ->
         spec.into(cinteropMetadataDirectoryPath(compilation.defaultSourceSet.name))

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerDependencies.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerDependencies.kt
@@ -7,14 +7,12 @@ package org.jetbrains.kotlin.gradle.targets.native.internal
 
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.dsl.multiplatformExtensionOrNull
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.launch
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinSharedNativeCompilation
 import org.jetbrains.kotlin.gradle.utils.filesProvider
 import org.jetbrains.kotlin.gradle.utils.future
-import java.io.File
 
 internal fun Project.setupCInteropCommonizerDependencies() {
     val kotlin = this.multiplatformExtensionOrNull ?: return
@@ -25,36 +23,24 @@ internal fun Project.setupCInteropCommonizerDependencies() {
 }
 
 private fun Project.setupCInteropCommonizerDependenciesForCompilation(compilation: KotlinSharedNativeCompilation) = launch {
-    val cinteropCommonizerTask = project.commonizeCInteropTask() ?: return@launch
-
-    compilation.compileDependencyFiles += filesProvider {
-        val cinteropCommonizerDependent = future { CInteropCommonizerDependent.from(compilation) }.getOrThrow()
-            ?: return@filesProvider emptySet<File>()
-        cinteropCommonizerTask.get().commonizedOutputLibraries(cinteropCommonizerDependent)
-    }
+    val cinteropCommonizerDependent = CInteropCommonizerDependent.from(compilation) ?: return@launch
+    val commonizedCInterops = commonizedOutputLibraries(cinteropCommonizerDependent) ?: return@launch
+    compilation.compileDependencyFiles += commonizedCInterops
 }
 
 internal fun Project.cinteropCommonizerDependenciesForIde(sourceSet: KotlinSourceSet): FileCollection {
     return filesProvider {
         future {
-            val cinteropCommonizerTask = project.copyCommonizeCInteropForIdeTask()
-            cinteropCommonizerDependencies(sourceSet, cinteropCommonizerTask)
+            files(cinteropCommonizerDependents(sourceSet).mapNotNull { commonizedOutputLibrariesForIde(it) })
         }.getOrThrow()
     }
 }
 
-internal suspend fun Project.cinteropCommonizerDependencies(
-    sourceSet: KotlinSourceSet,
-    cInteropCommonizerTask: TaskProvider<out AbstractCInteropCommonizerTask>? = null,
-): FileCollection {
-    if (cInteropCommonizerTask == null) return project.files()
+internal suspend fun Project.cinteropCommonizerDependencies(sourceSet: KotlinSourceSet): FileCollection =
+    files(cinteropCommonizerDependents(sourceSet).mapNotNull { commonizedOutputLibraries(it) })
 
-    val directlyDependent = CInteropCommonizerDependent.from(sourceSet)
-    val associateDependent = CInteropCommonizerDependent.fromAssociateCompilations(sourceSet)
-
-    return files(
-        listOfNotNull(directlyDependent, associateDependent).map { cinteropCommonizerDependent ->
-            cInteropCommonizerTask.get().commonizedOutputLibraries(cinteropCommonizerDependent)
-        }
+private suspend fun cinteropCommonizerDependents(sourceSet: KotlinSourceSet): List<CInteropCommonizerDependent> =
+    listOfNotNull(
+        CInteropCommonizerDependent.from(sourceSet),
+        CInteropCommonizerDependent.fromAssociateCompilations(sourceSet),
     )
-}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerTask.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.gradle.targets.native.internal
 
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -51,7 +50,6 @@ private typealias GroupedCommonizerDependencies = Map<CInteropCommonizerGroup, L
 internal abstract class CInteropCommonizerTask
 @Inject constructor(
     private val objectFactory: ObjectFactory,
-    private val projectLayout: ProjectLayout,
     providerFactory: ProviderFactory,
 ) : AbstractCInteropCommonizerTask(),
     UsesClassLoadersCachingBuildService,
@@ -100,8 +98,6 @@ internal abstract class CInteropCommonizerTask
         }
 
     }
-
-    override val outputDirectory: File get() = projectLayout.buildDirectory.get().asFile.resolve(CINTEROP_COMMONIZER_OUTPUT_PATH)
 
     @get:Nested
     internal val kotlinNativeProvider: Property<KotlinNativeProvider> =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CInteropCommonizerTask.kt
@@ -101,7 +101,7 @@ internal abstract class CInteropCommonizerTask
 
     }
 
-    override val outputDirectory: File get() = projectLayout.buildDirectory.get().asFile.resolve("classes/kotlin/commonizer")
+    override val outputDirectory: File get() = projectLayout.buildDirectory.get().asFile.resolve(CINTEROP_COMMONIZER_OUTPUT_PATH)
 
     @get:Nested
     internal val kotlinNativeProvider: Property<KotlinNativeProvider> =

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CommonizerTasks.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CommonizerTasks.kt
@@ -94,6 +94,7 @@ internal suspend fun Project.commonizeCInteropTask(): TaskProvider<CInteropCommo
     }
 
     val nativeDownloadTask = getOrRegisterDownloadKotlinNativeDistributionTask()
+    val outputRoot = cInteropCommonizerOutputRoot
 
     return locateOrRegisterTask(
         commonizeCInteropTaskName,
@@ -107,6 +108,7 @@ internal suspend fun Project.commonizeCInteropTask(): TaskProvider<CInteropCommo
         configureTask = {
             group = "interop"
             description = "Invokes the commonizer on c-interop bindings of the project"
+            outputDirectory.fileValue(outputRoot)
 
             commonizerClasspath.from(project.maybeCreateCommonizerClasspathConfiguration())
             customJvmArgs.set(PropertiesProvider(project).commonizerJvmArgs)
@@ -142,6 +144,7 @@ private suspend fun Project.isCommonizeCInteropTaskRegistrationEnabled(): Boolea
 internal suspend fun Project.copyCommonizeCInteropForIdeTask(): TaskProvider<CopyCommonizeCInteropForIdeTask>? {
     val commonizeCInteropTask = commonizeCInteropTask()
     if (commonizeCInteropTask != null) {
+        val outputRoot = copyCInteropCommonizerForIdeOutputRoot
         return locateOrRegisterTask(
             "copyCommonizeCInteropForIde",
             args = listOf(commonizeCInteropTask),
@@ -158,6 +161,7 @@ internal suspend fun Project.copyCommonizeCInteropForIdeTask(): TaskProvider<Cop
                 group = "interop"
                 description = "Copies the output of $commonizeCInteropTaskName into " +
                         "the root projects .gradle folder for the IDE"
+                outputDirectory.fileValue(outputRoot)
             }
         )
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CopyCInteropCommonizerTaskOutputForIdeTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CopyCInteropCommonizerTaskOutputForIdeTask.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.build.report.metrics.BuildTimeMetric
 import org.jetbrains.kotlin.compilerRunner.addBuildMetricsForTaskAction
 import org.jetbrains.kotlin.gradle.plugin.launch
 import org.jetbrains.kotlin.gradle.report.GradleBuildMetricsReporter
-import org.jetbrains.kotlin.gradle.utils.kotlinMetadataDir
 import org.jetbrains.kotlin.gradle.utils.property
 import java.io.File
 import javax.inject.Inject
@@ -34,9 +33,7 @@ internal abstract class CopyCommonizeCInteropForIdeTask @Inject constructor(
         commonizeCInteropTask.map { it.allOutputDirectories }
 
     @get:OutputDirectory
-    override val outputDirectory: File = project.kotlinMetadataDir()
-        .resolve("commonizer")
-        .resolve(project.path.removePrefix(":").replace(":", "/"))
+    override val outputDirectory: File = project.copyCInteropCommonizerForIdeOutputRoot
 
     @get:Internal
     val metrics: Property<BuildMetricsReporter<BuildTimeMetric, BuildPerformanceMetric>> = project.objects

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CopyCInteropCommonizerTaskOutputForIdeTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/internal/CopyCInteropCommonizerTaskOutputForIdeTask.kt
@@ -32,9 +32,6 @@ internal abstract class CopyCommonizeCInteropForIdeTask @Inject constructor(
     val cInteropCommonizerTaskOutputDirectories: Provider<Set<File>> =
         commonizeCInteropTask.map { it.allOutputDirectories }
 
-    @get:OutputDirectory
-    override val outputDirectory: File = project.copyCInteropCommonizerForIdeOutputRoot
-
     @get:Internal
     val metrics: Property<BuildMetricsReporter<BuildTimeMetric, BuildPerformanceMetric>> = project.objects
         .property(GradleBuildMetricsReporter())
@@ -56,7 +53,7 @@ internal abstract class CopyCommonizeCInteropForIdeTask @Inject constructor(
     protected fun copy() {
         val metricReporter = metrics.get()
         addBuildMetricsForTaskAction(metricsReporter = metricReporter, languageVersion = null) {
-            outputDirectory.mkdirs()
+            outputDirectory.get().asFile.mkdirs()
             for ((group, source) in allInteropGroups) {
                 if (!source.exists()) continue
                 val target = outputDirectory(group)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/providerApiUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/utils/providerApiUtils.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.gradle.utils
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -141,10 +140,6 @@ internal fun Project.filesProvider(
     provider: () -> Any?
 ): ConfigurableFileCollection {
     return project.files(provider).builtBy(*buildDependencies)
-}
-
-internal fun <T : Task> T.outputFilesProvider(provider: T.() -> Any): ConfigurableFileCollection {
-    return project.filesProvider(this) { provider() }
 }
 
 internal inline fun <reified T> Project.listProperty(noinline itemsProvider: () -> Iterable<T>): ListProperty<T> =


### PR DESCRIPTION
Fixes [KT-76147](https://youtrack.jetbrains.com/issue/KT-76147) Gradle Configuration Cache: `compile*KotlinMetadata` caused invocation of `Task.project` in `commonizeCInterop`.

## Problem

When a project declares its own cinterop and consumes it from an intermediate source set, the commonizer's output is added to the shared native compilation's compile classpath as a lazily evaluated file collection. That lazy block reached back to the commonizer task's `project` property. Gradle only runs the block when something actually resolves the classpath, which happens after the build has started executing, and reading `Task.project` at that point is not supported by the configuration cache. With Isolated Projects enabled it stops being a warning and becomes an outright build failure, so IDE sync broke for every affected module.

```
org.gradle.api.InvalidUserCodeException: Execution of task ':compilePosixMainKotlinMetadata'
caused invocation of 'Task.project' by task ':commonizeCInterop' at execution time which is unsupported.
    at org.jetbrains.kotlin.gradle.targets.native.internal.AbstractCInteropCommonizerTaskKt.commonizedOutputLibraries(AbstractCInteropCommonizerTask.kt:39)
    at org.jetbrains.kotlin.gradle.utils.ProviderApiUtilsKt.outputFilesProvider(providerApiUtils.kt:138)
    at org.jetbrains.kotlin.gradle.targets.native.internal.CInteropCommonizerDependenciesKt$setupCInteropCommonizerDependenciesForCompilation$1$1.invoke(CInteropCommonizerDependencies.kt:39)
```

The only workaround available to users was to mark the metadata compilation as incompatible with the configuration cache, which downgrades the error to a warning but gives up caching for that task.

## Fix

Both commonizer output locations are now derived from the project (`cInteropCommonizerOutputRoot` for `commonizeCInterop`, and `copyCInteropCommonizerForIdeOutputRoot` for the IDE copy task). Consumers resolve the commonizer group during the plugin's configuration lifecycle and build the file collection from those roots, so nothing needs to look up the task's project later.

The commonizer is retained only as a `TaskProvider` passed to `builtBy`. This preserves the task dependency without realizing `commonizeCInterop` during configuration. Listing the contents of the selected output directory remains lazy through the same configuration-cache-safe `changing { }` value source as before.

`AbstractCInteropCommonizerTask.outputDirectory` is now a `DirectoryProperty`, configured when each task is registered from the same project-level roots used by consumers. This keeps the task output and consumer view aligned while avoiding both eager task realization and deferred task-property reads. `CInteropCommonizerTask` no longer needs its injected `ProjectLayout`.

`Task.outputFilesProvider` had no other callers and has been removed.

## Testing

The regression test is `CommonizerIT.testCommonizedCInteropDependenciesAreConfigurationCacheSafe`.

The test performs an IDE sync rather than an ordinary build. The issue was reported against a command-line build, but it does not reproduce that way on the `commonizeInteropUsingPosixApis` fixture (`testCommonizeInteropUsingPosixAPIs` already compiles `:compileNativeMainKotlinMetadata` there with the configuration cache and Isolated Projects enabled, and passes without this fix).

An IDE sync does reproduce the failure. `IdeMultiplatformImportActionSetupAction` returns early unless `isInIdeaSync` is set, and only that path reaches `IdeCommonizedCinteropDependencyResolver`, which resolves `cinteropCommonizerDependencies` into real files and triggers the late `Task.project` read. The test therefore performs a Tooling API model build with `idea.sync.active`, the configuration cache, and Isolated Projects enabled.

The test is pinned to the newest supported Gradle version because Gradle 8.5 separately reads `Task.project` from `CInteropProcess` at execution time on this fixture, with or without this fix. _This is an unrelated Configuration Cache issue that's detailed [in this comment](https://github.com/JetBrains/kotlin/pull/7382#discussion_r3767519722)_.

To confirm the test genuinely covers the fix, I ran it against `master` with the production changes reverted and only the new test applied.

| Tree | Result |
|---|---|
| `master` plus the new test only | **Failed**, with `InvalidUserCodeException: ... invocation of 'Task.project' by task ':commonizeCInterop' at execution time` (reproducing the original issue) |
| This branch | Passed |
| Full `CommonizerIT` on this branch | 59 of 59 passed, on Gradle `7.6.3` and `9.7.0` |

## Checklist

- [x] Link to the related issue: [KT-76147](https://youtrack.jetbrains.com/issue/KT-76147)
- [x] Changes are limited to that issue
- [x] I can explain the changes made
- [x] Built locally and verified the new functionality
- [x] Ran related tests locally (`:kotlin-gradle-plugin-integration-tests:kgpNativeTests --tests "org.jetbrains.kotlin.gradle.CommonizerIT"`), 59 of 59 pass
- [x] No merge commits (two focused commits rebased onto the latest changes in `master`).