### PR TITLE
[Gradle] Add internal workaround for prototyping isolated project support in JS

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt
@@ -42,7 +42,9 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaTarget
 import org.jetbrains.kotlin.gradle.plugin.statistics.CompilerArgumentMetrics
 import org.jetbrains.kotlin.gradle.plugin.statistics.KotlinCompilerRefIndexMetrics
 import org.jetbrains.kotlin.gradle.tasks.*
-import org.jetbrains.kotlin.gradle.utils.*
+import org.jetbrains.kotlin.gradle.utils.IsolatedKotlinClasspathClassCastException
+import org.jetbrains.kotlin.gradle.utils.javaSourceSetsIfAvailable
+import org.jetbrains.kotlin.gradle.utils.newTmpFile
 import org.jetbrains.kotlin.incremental.IncrementalModuleEntry
 import org.jetbrains.kotlin.incremental.IncrementalModuleInfo
 import org.jetbrains.kotlin.statistics.metrics.StatisticsValuesConsumer
@@ -310,6 +312,7 @@ internal open class GradleCompilerRunner(
         @Volatile
         private var cachedModulesInfo: IncrementalModuleInfo? = null
 
+        // Note: this function is not compatible with Isolated Projects KT-80262
         @Synchronized
         internal fun buildModulesInfo(gradle: Gradle): IncrementalModuleInfo {
             if (cachedGradle.get() === gradle && cachedModulesInfo != null) return cachedModulesInfo!!

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt
@@ -762,6 +762,15 @@ internal class PropertiesProvider private constructor(private val project: Proje
     val playwrightBrowsersPath: Provider<String>
         get() = property(PropertyNames.KOTLIN_PLAYWRIGHT_BROWSERS_PATH)
 
+    /**
+     * Temporary untested workaround for Isolated Project support.
+     * Absolutely no stability guarantees. It will most likely not work, or ever work.
+     * The only intended purpose is to help prototype IP support in kotlin git KT-88136.
+     * Must be removed after KT-80311.
+     */
+    val npmSharedDependenciesProjectMode: Provider<String>
+        get() = property(PropertyNames.NPM_SHARED_DEPENDENCIES_PROJECT_MODE)
+
     private fun propertyWithDeprecatedVariant(propName: String, deprecatedPropName: String): String? {
         val deprecatedProperty = get(deprecatedPropName)
         if (deprecatedProperty != null) {
@@ -896,6 +905,7 @@ internal class PropertiesProvider private constructor(private val project: Proje
         val KOTLIN_CREATE_ARCHIVE_TASKS_FOR_CUSTOM_COMPILATIONS =
             property("$KOTLIN_INTERNAL_NAMESPACE.mpp.createArchiveTasksForCustomCompilations")
         val KOTLIN_COMPILER_ARGUMENTS_LOG_LEVEL = property("$KOTLIN_INTERNAL_NAMESPACE.compiler.arguments.log.level")
+
         /**
          * Replaced by the per-target properties below, kept only to report
          * [org.jetbrains.kotlin.gradle.plugin.diagnostics.KotlinToolingDiagnostics.DeprecatedErrorGradleProperties] on its usage.
@@ -924,6 +934,8 @@ internal class PropertiesProvider private constructor(private val project: Proje
         val KOTLIN_TASK_EXECUTION_CACHE_METRICS_FILE = property("$KOTLIN_INTERNAL_NAMESPACE.reportTaskExecutionCacheMetricsToFile")
 
         val FUNCTIONAL_TEST_MODE_PROPERTY = "$KOTLIN_INTERNAL_NAMESPACE.functionalTestMode"
+
+        val NPM_SHARED_DEPENDENCIES_PROJECT_MODE = property("$KOTLIN_INTERNAL_NAMESPACE.npm.sharedNpmDependenciesProjectMode")
     }
 
     companion object {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/internal/jsToolingProject.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/internal/jsToolingProject.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.targets.js.internal
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
+import org.jetbrains.kotlin.gradle.plugin.internal.isProjectIsolationEnabled
+
+/**
+ * Returns the project to use for JS and WasmJS tooling plugins.
+ *
+ * Temp workaround for supporting Isolated Projects.
+ * It will definitely break things!
+ * Only intended for internal use, to prototype Isolated Projects support.
+ */
+internal fun Project.jsToolingProject(): Project {
+    return if (npmSharedProjectsPerProject && isProjectIsolationEnabled) {
+        this
+    } else {
+        rootProject
+    }
+}
+
+private val Project.npmSharedProjectsPerProject: Boolean
+    get() = PropertiesProvider(project).npmSharedDependenciesProjectMode.orNull == "PER-PROJECT"
+
+/**
+ * Check if [project] is the project to use for JS and WasmJS tooling plugins.
+ *
+ * Incompatible with Isolated Projects.
+ *
+ * Does nothing if [Project.npmSharedProjectsPerProject] is enabled.
+ */
+internal fun checkIsJsToolingProject(
+    project: Project,
+    message: () -> String,
+) {
+    check(project == project.jsToolingProject(), message)
+}

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrCompilation.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrCompilation.kt
@@ -9,6 +9,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJsCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.compilationImpl.KotlinCompilationImpl
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.npm.npmProject
 import org.jetbrains.kotlin.gradle.targets.js.webTargetVariant
@@ -70,8 +71,8 @@ internal fun KotlinJsIrCompilation.npmToolingDir(): Provider<Directory> {
 
 internal fun KotlinJsIrCompilation.nodeJsRoot(): BaseNodeJsRootExtension {
     return webTargetVariant(
-        { NodeJsRootPlugin.apply(project.rootProject) },
-        { WasmNodeJsRootPlugin.apply(project.rootProject) },
+        { NodeJsRootPlugin.apply(project.jsToolingProject()) },
+        { WasmNodeJsRootPlugin.apply(project.jsToolingProject()) },
     )
 }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrNpmBasedSubTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrNpmBasedSubTarget.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle.targets.js.ir
 
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin.Companion.kotlinNodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.kotlinNodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.webTargetVariant
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsPlugin.Companion.kotlinNodeJsEnvSpec as wasmKotlinNodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin.Companion.kotlinNodeJsRootExtension as wasmKotlinNodeJsRootExtension
@@ -16,8 +17,8 @@ abstract class KotlinJsIrNpmBasedSubTarget(
     disambiguationClassifier: String,
 ) : KotlinJsIrSubTarget(target, disambiguationClassifier) {
     protected val nodeJsRoot = target.webTargetVariant(
-        { project.rootProject.kotlinNodeJsRootExtension },
-        { project.rootProject.wasmKotlinNodeJsRootExtension },
+        { project.jsToolingProject().kotlinNodeJsRootExtension },
+        { project.jsToolingProject().wasmKotlinNodeJsRootExtension },
     )
 
     protected val nodeJsEnvSpec = target.webTargetVariant(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -10,6 +10,7 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
@@ -18,6 +19,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.resources.publication.setUpResourcesVariant
 import org.jetbrains.kotlin.gradle.targets.js.*
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTargetConfigurator.Companion.configureJsDefaultOptions
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.kotlinNodeJsRootExtension
@@ -181,8 +183,8 @@ internal constructor(
         return project.registerTask(binary.validateGeneratedTsTaskName, listOf(compilation)) {
             it.versions.value(
                 compilation.webTargetVariant(
-                    { project.rootProject.kotlinNodeJsRootExtension.versions },
-                    { project.rootProject.wasmKotlinNodeJsRootExtension.versions },
+                    { project.jsToolingProject().kotlinNodeJsRootExtension.versions },
+                    { project.jsToolingProject().wasmKotlinNodeJsRootExtension.versions },
                 )
             ).disallowChanges()
             it.inputDir.set(linkTask.flatMap { it.destinationDirectory })
@@ -226,7 +228,7 @@ internal constructor(
             commonLazy
         } else {
             WasmNodeJsPlugin.apply(project)
-            WasmNodeJsRootPlugin.apply(project.rootProject)
+            WasmNodeJsRootPlugin.apply(project.jsToolingProject())
         }
 
         addSubTarget(KotlinNodeJsIr::class.java) {
@@ -248,8 +250,8 @@ internal constructor(
     @OptIn(ExperimentalWasmDsl::class)
     private val d8LazyDelegate = lazy {
         webTargetVariant(
-            { NodeJsRootPlugin.apply(project.rootProject) },
-            { WasmNodeJsRootPlugin.apply(project.rootProject) },
+            { NodeJsRootPlugin.apply(project.jsToolingProject()) },
+            { WasmNodeJsRootPlugin.apply(project.jsToolingProject()) },
         )
 
         addSubTarget(KotlinD8Ir::class.java) {
@@ -379,33 +381,52 @@ internal constructor(
     internal companion object {
         private val DECAMELIZE_REGEX = "([A-Z])".toRegex()
 
+        /** Check whether [Project.getIsolated] is available. */
+        private val isIsolatedProjectAvailable: Boolean
+            get() = GradleVersion.current() >= GradleVersion.version("8.8")
+
+        /** Check if this [Project] is the root project (in an isolated-project-friendly way, if possible). */
+        private fun Project.isRootProject(): Boolean =
+            if (isIsolatedProjectAvailable) {
+                isolated == isolated.rootProject
+            } else {
+                this == rootProject
+            }
+
+        /** Get the root project name (in an isolated-project-friendly way, if possible). */
+        private fun Project.rootProjectName(): String =
+            if (isIsolatedProjectAvailable) {
+                isolated.rootProject.name
+            } else {
+                rootProject.name
+            }
+
         internal fun buildNpmProjectName(
             project: Project,
             targetName: String,
             defaultTargetName: String,
         ): String {
-            val rootProjectName = project.rootProject.name
+            return buildString {
+                if (project.isRootProject()) {
+                    append(project.rootProjectName())
+                } else {
+                    append(project.rootProjectName().replace(":", "-"))
+                    append(project.path.replace(":", "-"))
+                }
 
-            val localName = if (project != project.rootProject) {
-                (rootProjectName + project.path).replace(":", "-")
-            } else rootProjectName
-
-            val targetPartName = if (targetName.isNotEmpty() && targetName != defaultTargetName) {
-                targetName
-                    .replace(DECAMELIZE_REGEX) {
-                        it.groupValues
-                            .drop(1)
-                            .joinToString(prefix = "-", separator = "-")
-                    }
-                    .toLowerCaseAsciiOnly()
-            } else null
-
-            return sequenceOf(
-                localName,
-                targetPartName
-            )
-                .filterNotNull()
-                .joinToString("-")
+                if (targetName.isNotEmpty() && targetName != defaultTargetName) {
+                    append("-")
+                    append(
+                        targetName
+                            .replace(DECAMELIZE_REGEX) {
+                                it.groupValues
+                                    .drop(1)
+                                    .joinToString(prefix = "-", separator = "-")
+                            }
+                            .toLowerCaseAsciiOnly()
+                    )
+                }
+            }
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/SwcConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/SwcConfigurator.kt
@@ -8,26 +8,28 @@ package org.jetbrains.kotlin.gradle.targets.js.ir
 import org.gradle.api.Action
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompilerOptions
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider
-import org.jetbrains.kotlin.gradle.targets.js.swc.SwcExec
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBinaryMode
-import org.jetbrains.kotlin.gradle.targets.js.webTargetVariant
-import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.Mode
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.kotlinNodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.swc.GenerateSwcConfig
+import org.jetbrains.kotlin.gradle.targets.js.swc.SwcExec
+import org.jetbrains.kotlin.gradle.targets.js.webTargetVariant
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.Mode
+import org.jetbrains.kotlin.gradle.targets.web.nodejs.BaseNodeJsRootExtension
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
-import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin.Companion.kotlinNodeJsRootExtension as wasmKotlinNodeJsRootExtension
 import org.jetbrains.kotlin.gradle.utils.withType
 import org.jetbrains.kotlin.platform.js.JsPlatforms
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin.Companion.kotlinNodeJsRootExtension as wasmKotlinNodeJsRootExtension
 
 internal class SwcConfigurator(private val subTarget: KotlinJsIrSubTarget) :
     SubTargetConfigurator<SwcExec, SwcExec> {
     private val project = subTarget.project
     private val propertiesProvider = PropertiesProvider(project)
 
-    private val nodeJsRoot = subTarget.target.webTargetVariant(
-        { project.rootProject.kotlinNodeJsRootExtension },
-        { project.rootProject.wasmKotlinNodeJsRootExtension },
+    private val nodeJsRoot: BaseNodeJsRootExtension = subTarget.target.webTargetVariant(
+        { project.jsToolingProject().kotlinNodeJsRootExtension },
+        { project.jsToolingProject().wasmKotlinNodeJsRootExtension },
     )
 
     internal val isWasm: Boolean = subTarget.target.webTargetVariant(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/WebpackConfigurator.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/WebpackConfigurator.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.gradle.dsl.JsModuleKind
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.mpp.isMain
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBinaryMode
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinBrowserJsIr.Companion.WEBPACK_TASK_NAME
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrSubTarget.Companion.DISTRIBUTION_TASK_NAME
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrSubTarget.Companion.RUN_TASK_NAME
@@ -28,6 +29,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.Mode
 import org.jetbrains.kotlin.gradle.targets.js.webpack.WebpackDevtool
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.web.nodejs.BaseNodeJsRootExtension
 import org.jetbrains.kotlin.gradle.tasks.dependsOn
 import org.jetbrains.kotlin.gradle.utils.archivesName
 import org.jetbrains.kotlin.gradle.utils.domainObjectSet
@@ -40,9 +42,9 @@ class WebpackConfigurator(private val subTarget: KotlinJsIrSubTarget) : SubTarge
 
     private val project = subTarget.project
 
-    private val nodeJsRoot = subTarget.target.webTargetVariant(
-        { project.rootProject.kotlinNodeJsRootExtension },
-        { project.rootProject.wasmKotlinNodeJsRootExtension },
+    private val nodeJsRoot: BaseNodeJsRootExtension = subTarget.target.webTargetVariant(
+        { project.jsToolingProject().kotlinNodeJsRootExtension },
+        { project.jsToolingProject().wasmKotlinNodeJsRootExtension },
     )
 
     internal val isWasm: Boolean = subTarget.target.webTargetVariant(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/NodeJsRootPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/nodejs/NodeJsRootPlugin.kt
@@ -8,6 +8,8 @@ package org.jetbrains.kotlin.gradle.targets.js.nodejs
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.NpmExtension
@@ -53,10 +55,14 @@ abstract class NodeJsRootPlugin internal constructor() : CommonNodeJsRootPlugin 
     companion object {
         const val TASKS_GROUP_NAME: String = "nodeJs"
 
-        fun apply(rootProject: Project): NodeJsRootExtension {
-            check(rootProject == rootProject.rootProject)
-            rootProject.plugins.apply(NodeJsRootPlugin::class.java)
-            return rootProject.extensions.getByName(NodeJsRootExtension.EXTENSION_NAME) as NodeJsRootExtension
+        fun apply(project: Project): NodeJsRootExtension {
+            checkIsJsToolingProject(project) {
+                "Cannot register ${NodeJsRootPlugin::class.simpleName} in ${project.displayName}. It can only be registered in ${project.jsToolingProject().displayName}."
+            }
+            val toolingProject = project.jsToolingProject()
+
+            toolingProject.plugins.apply(NodeJsRootPlugin::class.java)
+            return toolingProject.extensions.getByName(NodeJsRootExtension.EXTENSION_NAME) as NodeJsRootExtension
         }
 
         val Project.kotlinNodeJsRootExtension: NodeJsRootExtension

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/BaseNpmExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/BaseNpmExtension.kt
@@ -18,6 +18,8 @@ import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.internal.ConfigurationPhaseAware
 import org.jetbrains.kotlin.gradle.logging.kotlinInfo
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnv
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NpmApiExtension
 import org.jetbrains.kotlin.gradle.targets.web.nodejs.BaseNodeJsRootExtension
@@ -36,7 +38,9 @@ abstract class BaseNpmExtension internal constructor(
     private val execOps: ExecOperations,
 ) : ConfigurationPhaseAware<NpmEnv>(), NpmApiExtension<NpmEnvironment, Npm> {
     init {
-        check(project == project.rootProject)
+        checkIsJsToolingProject(project) {
+            "Cannot register ${BaseNpmExtension::class.simpleName} in ${project.displayName}. It can only be registered in ${project.jsToolingProject().displayName}."
+        }
         project.logger.kotlinInfo("Storing cached files in ${project.gradle.gradleUserHomeDir}")
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmExtension.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.gradle.targets.js.npm
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.process.ExecOperations
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.JsPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
@@ -38,7 +39,7 @@ abstract class NpmExtension internal constructor(
             get() = extensionName("npm")
 
         operator fun get(project: Project): NpmExtension {
-            val rootProject = project.rootProject
+            val rootProject = project.jsToolingProject()
             rootProject.plugins.apply(NodeJsRootPlugin::class.java)
             return rootProject.extensions.getByName(EXTENSION_NAME) as NpmExtension
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmProject.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmProject.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJsCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.disambiguateName
 import org.jetbrains.kotlin.gradle.plugin.mpp.fileExtension
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin.Companion.kotlinNodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.kotlinNodeJsRootExtension
@@ -47,8 +48,8 @@ open class NpmProject(@Transient val compilation: KotlinJsIrCompilation) : Seria
     @delegate:Transient
     val nodeJsRoot by lazy {
         compilation.webTargetVariant(
-            { project.rootProject.kotlinNodeJsRootExtension },
-            { project.rootProject.wasmKotlinNodeJsRootExtension },
+            { project.jsToolingProject().kotlinNodeJsRootExtension },
+            { project.jsToolingProject().wasmKotlinNodeJsRootExtension },
         )
     }
 

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmResolverPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/NpmResolverPlugin.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.js.npm
 
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.web.npm.CommonNpmResolverPlugin
@@ -25,7 +26,7 @@ class NpmResolverPlugin : CommonNpmResolverPlugin {
 
     override fun apply(project: Project) {
         val applier = NpmResolverPluginApplier(
-            { NodeJsRootPlugin.apply(project.rootProject) },
+            { NodeJsRootPlugin.apply(project.jsToolingProject()) },
             { NodeJsPlugin.apply(project) },
             { it.compilation.wasmTarget == null },
         )

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.gradle.plugin.sources.KotlinDependencyScope
 import org.jetbrains.kotlin.gradle.plugin.sources.compilationDependencyConfigurationByScope
 import org.jetbrains.kotlin.gradle.plugin.sources.sourceSetDependencyConfigurationByScope
 import org.jetbrains.kotlin.gradle.plugin.usesPlatformOf
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.kotlinNodeJsRootExtension
@@ -108,8 +109,8 @@ class KotlinCompilationNpmResolver(
         }
 
         val nodeJsRoot = compilation.webTargetVariant(
-            { project.rootProject.kotlinNodeJsRootExtension },
-            { project.rootProject.wasmKotlinNodeJsRootExtension },
+            { project.jsToolingProject().kotlinNodeJsRootExtension },
+            { project.jsToolingProject().wasmKotlinNodeJsRootExtension },
         )
 
         nodeJsRoot.packageJsonUmbrellaTaskProvider.configure {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinNpmInstallTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/KotlinNpmInstallTask.kt
@@ -13,6 +13,8 @@ import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.work.NormalizeLineEndings
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager
 import org.jetbrains.kotlin.gradle.targets.js.npm.NodeJsEnvironmentTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.PackageJsonFilesTask
@@ -26,7 +28,9 @@ abstract class KotlinNpmInstallTask :
     PackageJsonFilesTask,
     UsesKotlinNpmResolutionManager {
     init {
-        check(project == project.rootProject)
+        checkIsJsToolingProject(project) {
+            "Cannot register ${KotlinNpmInstallTask::class.simpleName} in ${project.displayName}. It can only be registered in ${project.jsToolingProject().displayName}."
+        }
     }
 
     @Input

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/RootPackageJsonTask.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/tasks/RootPackageJsonTask.kt
@@ -11,6 +11,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.npm.NodeJsEnvironmentTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.PackageJsonFilesTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.UsesKotlinNpmResolutionManager
@@ -22,7 +24,9 @@ abstract class RootPackageJsonTask :
     PackageJsonFilesTask,
     UsesKotlinNpmResolutionManager {
     init {
-        check(project == project.rootProject)
+        checkIsJsToolingProject(project) {
+            "Cannot register ${RootPackageJsonTask::class.java.simpleName} in ${project.displayName}. It can only be registered in ${project.jsToolingProject().displayName}."
+        }
     }
 
     @get:OutputFile

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/karma/KotlinKarma.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/karma/KotlinKarma.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.gradle.targets.js.NpmVersions
 import org.jetbrains.kotlin.gradle.targets.js.RequiredKotlinJsDependency
 import org.jetbrains.kotlin.gradle.targets.js.dsl.WebpackRulesDsl.Companion.webpackRulesContainer
 import org.jetbrains.kotlin.gradle.targets.js.internal.appendConfigsFromDir
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.internal.parseNodeJsStackTraceAsJvm
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.ir.npmToolingDir
@@ -65,8 +66,8 @@ class KotlinKarma internal constructor(
 
     @Transient
     private val nodeJsRoot: BaseNodeJsRootExtension = compilation.webTargetVariant(
-        { project.rootProject.kotlinNodeJsRootExtension },
-        { project.rootProject.wasmKotlinNodeJsRootExtension },
+        { project.jsToolingProject().kotlinNodeJsRootExtension },
+        { project.jsToolingProject().wasmKotlinNodeJsRootExtension },
     )
 
     private val versions: NpmVersions by lazy {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/mocha/KotlinMocha.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/mocha/KotlinMocha.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesClientSetti
 import org.jetbrains.kotlin.gradle.internal.testing.TCServiceMessagesTestExecutionSpec
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.targets.js.RequiredKotlinJsDependency
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.internal.parseNodeJsStackTraceAsJvm
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin.Companion.kotlinNodeJsEnvSpec
@@ -39,8 +40,8 @@ class KotlinMocha internal constructor(
 
     @Transient
     private val nodeJsRoot = compilation.webTargetVariant(
-        { project.rootProject.kotlinNodeJsRootExtension },
-        { project.rootProject.wasmKotlinNodeJsRootExtension },
+        { project.jsToolingProject().kotlinNodeJsRootExtension },
+        { project.jsToolingProject().wasmKotlinNodeJsRootExtension },
     )
 
     private val versions by lazy {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPlugin.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.gradle.targets.js.yarn
 
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.JsPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin.Companion.kotlinNodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
@@ -37,7 +38,7 @@ open class YarnPlugin : CommonYarnPlugin {
 
     companion object {
         fun apply(project: Project): YarnRootExtension {
-            val rootProject = project.rootProject
+            val rootProject = project.jsToolingProject()
             rootProject.plugins.apply(YarnPlugin::class.java)
             return rootProject.extensions.getByName(YarnRootExtension.YARN) as YarnRootExtension
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPluginApplier.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnPluginApplier.kt
@@ -7,6 +7,8 @@ package org.jetbrains.kotlin.gradle.targets.js.yarn
 
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionContainer
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask
 import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
@@ -53,8 +55,8 @@ internal class YarnPluginApplier(
 ) {
 
     fun apply(project: Project) {
-        check(project == project.rootProject) {
-            "${this::class.java.name} can be applied only to root project"
+        checkIsJsToolingProject(project) {
+            "Cannot register ${YarnPluginApplier::class.simpleName} in ${project.displayName}. It can only be registered in ${project.jsToolingProject().displayName}."
         }
 
         nodeJsRootApply(project)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnRootExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/yarn/YarnRootExtension.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.process.ExecOperations
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.JsPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.web.HasPlatformDisambiguator
@@ -38,7 +39,7 @@ internal constructor(
             get() = extensionName("yarn")
 
         operator fun get(project: Project): YarnRootExtension {
-            val rootProject = project.rootProject
+            val rootProject = project.jsToolingProject()
             rootProject.plugins.apply(YarnPlugin::class.java)
             return rootProject.extensions.getByName(YARN) as YarnRootExtension
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/d8/D8Plugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/d8/D8Plugin.kt
@@ -10,6 +10,7 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.ExtensionContainer
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.targets.web.HasPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.tasks.registerTask
@@ -31,7 +32,7 @@ abstract class D8Plugin internal constructor() : Plugin<Project> {
             )
         }
 
-        val d8RootExtension = applyRootProject(project.rootProject)
+        val d8RootExtension = applyRootProject(project)
 
         spec.initializeD8EnvSpec(d8RootExtension)
 
@@ -81,8 +82,8 @@ abstract class D8Plugin internal constructor() : Plugin<Project> {
 
         @Suppress("DEPRECATION")
         private fun applyRootProject(project: Project): D8RootExtension {
-            project.rootProject.plugins.apply(D8Plugin::class.java)
-            return project.rootProject.extensions.getByName(
+            project.jsToolingProject().plugins.apply(D8Plugin::class.java)
+            return project.jsToolingProject().extensions.getByName(
                 D8RootExtension.EXTENSION_NAME
             ) as D8RootExtension
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/nodejs/WasmNodeJsRootPlugin.kt
@@ -11,6 +11,8 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.targets.js.allDependenciesInternal
+import org.jetbrains.kotlin.gradle.targets.js.internal.checkIsJsToolingProject
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin.Companion.TASKS_GROUP_NAME
 import org.jetbrains.kotlin.gradle.targets.js.npm.KotlinNpmResolutionManager
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask
@@ -145,9 +147,12 @@ internal constructor(
 
     companion object : HasPlatformDisambiguator by WasmPlatformDisambiguator {
         fun apply(rootProject: Project): WasmNodeJsRootExtension {
-            check(rootProject == rootProject.rootProject)
-            rootProject.plugins.apply(WasmNodeJsRootPlugin::class.java)
-            return rootProject.extensions.getByName(WasmNodeJsRootExtension.EXTENSION_NAME) as WasmNodeJsRootExtension
+            checkIsJsToolingProject(rootProject) {
+                "Cannot register ${WasmNodeJsRootPlugin::class.simpleName} in ${rootProject.displayName}. It can only be registered in ${rootProject.jsToolingProject().displayName}."
+            }
+            val toolingProject = rootProject.jsToolingProject()
+            toolingProject.plugins.apply(WasmNodeJsRootPlugin::class.java)
+            return toolingProject.extensions.getByName(WasmNodeJsRootExtension.EXTENSION_NAME) as WasmNodeJsRootExtension
         }
 
         val Project.kotlinNodeJsRootExtension: WasmNodeJsRootExtension

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/npm/WasmNpmExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/npm/WasmNpmExtension.kt
@@ -8,11 +8,11 @@ package org.jetbrains.kotlin.gradle.targets.wasm.npm
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.process.ExecOperations
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.npm.BaseNpmExtension
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmPlatformDisambiguator
-import org.jetbrains.kotlin.gradle.targets.wasm.npm.WasmNpmExtension.Companion.EXTENSION_NAME
 import org.jetbrains.kotlin.gradle.targets.web.HasPlatformDisambiguator
 
 /**
@@ -40,7 +40,7 @@ abstract class WasmNpmExtension internal constructor(
             get() = extensionName("npm")
 
         operator fun get(project: Project): WasmNpmExtension {
-            val rootProject = project.rootProject
+            val rootProject = project.jsToolingProject()
             rootProject.plugins.apply(NodeJsRootPlugin::class.java)
             return rootProject.extensions.getByName(EXTENSION_NAME) as WasmNpmExtension
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/yarn/WasmYarnPlugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/yarn/WasmYarnPlugin.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.gradle.targets.wasm.yarn
 
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.js.npm.LockCopyTask
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPluginApplier
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsPlugin.Companion.kotlinNodeJsEnvSpec
@@ -44,7 +45,7 @@ abstract class WasmYarnPlugin internal constructor() : CommonYarnPlugin {
 
     companion object : HasPlatformDisambiguator by WasmPlatformDisambiguator {
         fun apply(project: Project): WasmYarnRootExtension {
-            val rootProject = project.rootProject
+            val rootProject = project.jsToolingProject()
             rootProject.plugins.apply(WasmYarnPlugin::class.java)
             return rootProject.extensions.getByName(WasmYarnRootExtension.YARN) as WasmYarnRootExtension
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/yarn/WasmYarnRootExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/wasm/yarn/WasmYarnRootExtension.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.process.ExecOperations
+import org.jetbrains.kotlin.gradle.targets.js.internal.jsToolingProject
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmPlatformDisambiguator
 import org.jetbrains.kotlin.gradle.targets.web.HasPlatformDisambiguator
@@ -34,7 +35,7 @@ abstract class WasmYarnRootExtension internal constructor(
             get() = extensionName("yarn")
 
         operator fun get(project: Project): WasmYarnRootExtension {
-            val rootProject = project.rootProject
+            val rootProject = project.jsToolingProject()
             rootProject.plugins.apply(WasmYarnPlugin::class.java)
             return rootProject.extensions.getByName(YARN) as WasmYarnRootExtension
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/Kotlin2JsCompileConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/configuration/Kotlin2JsCompileConfig.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilationInfo
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
+import org.jetbrains.kotlin.gradle.plugin.internal.isProjectIsolationEnabled
 import org.jetbrains.kotlin.gradle.plugin.tcs
 import org.jetbrains.kotlin.gradle.targets.js.KotlinWasmTargetType
 import org.jetbrains.kotlin.gradle.targets.js.internal.LibraryFilterCachingService
@@ -31,10 +32,17 @@ internal open class BaseKotlin2JsCompileConfig<TASK : Kotlin2JsCompile>(
     init {
         val libraryFilterCachingService = LibraryFilterCachingService.registerIfAbsent(project)
 
-        val incrementalModuleInfoProvider = IncrementalModuleInfoBuildService.registerIfAbsent(
-            project,
-            objectFactory.providerWithLazyConvention { GradleCompilerRunner.buildModulesInfo(project.gradle) },
-        )
+        val incrementalModuleInfoProvider =
+            if (project.isProjectIsolationEnabled) {
+                // Can't use if IP is enabled. As a temp workaround, disable the service.
+                // https://youtrack.jetbrains.com/issue/KT-80262/Update-JS-IC-implementation-to-support-Project-Isolation
+                null
+            } else {
+                IncrementalModuleInfoBuildService.registerIfAbsent(
+                    project,
+                    objectFactory.providerWithLazyConvention { GradleCompilerRunner.buildModulesInfo(project.gradle) },
+                )
+            }
 
         configureTask { task ->
             task.incremental = propertiesProvider.incrementalJs ?: true
@@ -43,8 +51,9 @@ internal open class BaseKotlin2JsCompileConfig<TASK : Kotlin2JsCompile>(
             configureAdditionalFreeCompilerArguments(task, compilation)
 
             task.libraryFilterCacheService.value(libraryFilterCachingService).disallowChanges()
-            task.incrementalModuleInfoProvider.value(incrementalModuleInfoProvider).disallowChanges()
-
+            if (incrementalModuleInfoProvider != null) {
+                task.incrementalModuleInfoProvider.value(incrementalModuleInfoProvider).disallowChanges()
+            }
 
             task.projectVersion.value(project.provider { project.version.toString() }).disallowChanges()
             if (!compilation.isMain && project.kotlinPropertiesProvider.enableKlibKt64115Workaround) {


### PR DESCRIPTION
If `kotlin.internal.npm.sharedNpmDependenciesProjectMode=PER-PROJECT` is set, then apply the following workarounds:
1. Apply JS/WasmJS 'root' plugins per-project, not to the root project.
2. Disable incremental JS compilation if IsolatedProjects is enabled.

Absolutely no stability guarantees. It will most likely not work, or ever work.
The only intended purpose is to help prototype IP support in kotlin git KT-88136.
Must be removed after KT-80311.

^KT-88136