### PR TITLE
KT-88430 Kotlin compiler diagnostics are lost for identical errors from multiple compilation tasks with --warning-mode=all

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerDiagnosticsProblemsApiIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/CompilerDiagnosticsProblemsApiIT.kt
@@ -8,9 +8,9 @@ package org.jetbrains.kotlin.gradle
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.testbase.*
+import org.jetbrains.kotlin.gradle.uklibs.applyMultiplatform
 import org.junit.jupiter.api.DisplayName
 import org.jetbrains.kotlin.gradle.testbase.assertProblemsReportContainsDiagnostic
-import kotlin.io.path.writeText
 
 @DisplayName("Compiler Diagnostics Problems API tests")
 @GradleTestVersions(
@@ -119,6 +119,109 @@ class CompilerDiagnosticsProblemsApiIT : KGPBaseTest() {
                     "UNRESOLVED_REFERENCE",
                     "nresolved reference",
                     gradleVersion,
+                )
+            }
+        }
+    }
+
+    @GradleTest
+    @GradleTestVersions(
+        minVersion = TestVersions.Gradle.G_8_11,
+        additionalVersions = [
+            TestVersions.Gradle.G_8_13,
+            TestVersions.Gradle.G_9_3,
+            TestVersions.Gradle.G_9_5,
+        ],
+    )
+    @DisplayName("KT-88430: an identical compiler error is reported for every failed compilation task")
+    fun testIdenticalCompilerErrorReportedForEveryFailedCompilation(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion, buildOptions = defaultBuildOptions.disableIsolatedProjects()) {
+            plugins {
+                kotlin("multiplatform")
+            }
+
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    jvm()
+                    js { nodejs() }
+
+                    sourceSets.commonMain.get().compileSource(
+                        """
+                        fun broken(): String = nonExistentFunction()
+                        """.trimIndent()
+                    )
+                }
+            }
+
+            gradleProperties.append("\norg.gradle.warning.mode=all\n")
+
+            buildAndFail(
+                "compileCommonMainKotlinMetadata",
+                "compileKotlinJvm",
+                "compileKotlinJs",
+                "--continue",
+            ) {
+                assertTasksFailed(
+                    ":compileCommonMainKotlinMetadata",
+                    ":compileKotlinJvm",
+                    ":compileKotlinJs",
+                )
+
+                // Each of the three failed compilations must contribute its own diagnostic
+                assertProblemsReportContainsDiagnosticTimes(
+                    "UNRESOLVED_REFERENCE",
+                    "nonExistentFunction",
+                    gradleVersion,
+                    expectedCount = 3,
+                )
+            }
+        }
+    }
+
+    @GradleTest
+    @GradleTestVersions(
+        minVersion = TestVersions.Gradle.G_8_11,
+        additionalVersions = [
+            TestVersions.Gradle.G_8_13,
+            TestVersions.Gradle.G_9_3,
+            TestVersions.Gradle.G_9_5,
+        ],
+    )
+    @DisplayName("KT-88430: an identical compiler warning is reported for every compilation task")
+    fun testIdenticalCompilerWarningReportedForEveryCompilation(gradleVersion: GradleVersion) {
+        project("empty", gradleVersion, buildOptions = defaultBuildOptions.disableIsolatedProjects()) {
+            plugins {
+                kotlin("multiplatform")
+            }
+
+            buildScriptInjection {
+                project.applyMultiplatform {
+                    jvm()
+                    js { nodejs() }
+
+                    sourceSets.commonMain.get().compileSource(
+                        """
+                        @Deprecated("Use newFunction instead")
+                        fun oldFunction(): String = "old"
+        
+                        fun callerOfOldFunction(): String = oldFunction()
+                        """.trimIndent()
+                    )
+                }
+            }
+
+            gradleProperties.append("\norg.gradle.warning.mode=all\n")
+
+            build(
+                "compileCommonMainKotlinMetadata",
+                "compileKotlinJvm",
+                "compileKotlinJs",
+            ) {
+                assertProblemsReportContainsDiagnosticTimes(
+                    "DEPRECATION",
+                    "Use newFunction instead",
+                    gradleVersion,
+                    expectedCount = 3,
                 )
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/problemsApiTestUtils.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/problemsApiTestUtils.kt
@@ -11,6 +11,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
 import java.io.File
 import java.net.URI
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -52,28 +53,62 @@ internal object ProblemsApiTestUtils {
     }
 }
 
+internal fun BuildResult.problemsReport(gradleVersion: GradleVersion): ProblemReport<*> {
+    val reportUrl = ProblemsApiTestUtils.extractProblemReportUrl(output)
+    assertNotNull(reportUrl, "Problems API HTML report URL not found in build output")
+
+    val reportContent = ProblemsApiTestUtils.readProblemReportContent(reportUrl)
+    return ProblemsApiTestUtils.parseProblemReportFromScript(reportContent, gradleVersion)
+}
+
+internal fun ProblemReport<*>.diagnosticsMatching(
+    expectedProblemId: String,
+    expectedMessageSubstring: String,
+): List<ProblemDiagnostic> = diagnostics.filter { diagnostic ->
+    diagnostic.problemId.any { it.name == expectedProblemId } &&
+            (diagnostic.problemDetailsActual.contains(expectedMessageSubstring) ||
+                    diagnostic.contextualLabel.contains(expectedMessageSubstring))
+}
+
+private fun ProblemReport<*>.render(): String =
+    diagnostics.joinToString(prefix = "[", postfix = "]") { d ->
+        "${d.problemId.map { it.name }} -> tasks: ${d.locations.mapNotNull { it.taskPath }}, details: ${d.problemDetailsActual}"
+    }
+
 internal fun BuildResult.assertProblemsReportContainsDiagnostic(
     expectedProblemId: String,
     expectedMessageSubstring: String,
     gradleVersion: GradleVersion,
 ) {
-    val reportUrl = ProblemsApiTestUtils.extractProblemReportUrl(output)
-    assertNotNull(reportUrl, "Problems API HTML report URL not found in build output")
-
-    val reportContent = ProblemsApiTestUtils.readProblemReportContent(reportUrl)
-    val report = ProblemsApiTestUtils.parseProblemReportFromScript(reportContent, gradleVersion)
-
-    val matchingDiagnostics = report.diagnostics.filter { diagnostic ->
-        diagnostic.problemId.any { it.name == expectedProblemId } &&
-                (diagnostic.problemDetailsActual.contains(expectedMessageSubstring) ||
-                        diagnostic.contextualLabel.contains(expectedMessageSubstring))
-    }
+    val report = problemsReport(gradleVersion)
 
     assertTrue(
-        matchingDiagnostics.isNotEmpty(),
+        report.diagnosticsMatching(expectedProblemId, expectedMessageSubstring).isNotEmpty(),
         "Expected Problems API HTML report to contain a '$expectedProblemId' diagnostic " +
                 "with message containing '$expectedMessageSubstring', but none found.\n" +
-                "Report diagnostics: ${report.diagnostics.map { d -> "${d.problemId.map { it.name }} -> details: ${d.problemDetailsActual}}" }}"
+                "Report diagnostics: ${report.render()}"
+    )
+}
+
+/**
+ * Asserts the Problems API HTML report contains exactly [expectedCount] diagnostics
+ * matching [expectedProblemId] and [expectedMessageSubstring].
+ */
+internal fun BuildResult.assertProblemsReportContainsDiagnosticTimes(
+    expectedProblemId: String,
+    expectedMessageSubstring: String,
+    gradleVersion: GradleVersion,
+    expectedCount: Int,
+) {
+    val report = problemsReport(gradleVersion)
+    val matchingDiagnostics = report.diagnosticsMatching(expectedProblemId, expectedMessageSubstring)
+
+    assertEquals(
+        expectedCount,
+        matchingDiagnostics.size,
+        "Expected Problems API HTML report to contain $expectedCount '$expectedProblemId' diagnostics " +
+                "with message containing '$expectedMessageSubstring', but found ${matchingDiagnostics.size}.\n" +
+                "Report diagnostics: ${report.render()}"
     )
 }
 
@@ -133,7 +168,10 @@ internal data class ProblemsApiDiagnosticG94(
 internal data class TextWrapper(val text: String)
 
 @Serializable
-internal data class ProblemsApiLocation(val pluginId: String = "")
+internal data class ProblemsApiLocation(
+    val pluginId: String = "",
+    val taskPath: String? = null,
+)
 
 @Serializable
 internal data class ProblemIdentifier(

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/BuildToolsApiCompilationWork.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/btapi/BuildToolsApiCompilationWork.kt
@@ -75,7 +75,7 @@ internal abstract class BuildToolsApiCompilationWork @Inject constructor(
         get() = workArguments.taskPath
 
     private val compilerDiagnosticsProblemsReporter: CompilerDiagnosticsProblemsReporter
-        get() = parameters.compilerDiagnosticsProblemsReporterFactory.get().getInstance(objects)
+        get() = parameters.compilerDiagnosticsProblemsReporterFactory.get().getInstance(objects, taskPath)
 
     private val metrics = if (workArguments.reportingSettings.buildReportOutputs.isNotEmpty()) {
         BuildMetricsReporterImpl()

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporter.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporter.kt
@@ -26,7 +26,11 @@ internal interface CompilerDiagnosticsProblemsReporter {
     )
 
     interface Factory : VariantImplementationFactories.VariantImplementationFactory {
-        fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter
+        /**
+         * @param taskPath path of the task being reported for; used by variants that have to keep otherwise identical
+         * diagnostics apart, see `CompilerDiagnosticTaskData` in the `gradle813` variant.
+         */
+        fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter
     }
 }
 
@@ -51,6 +55,9 @@ internal abstract class DefaultCompilerDiagnosticsProblemsReporter @Inject const
         fun ProblemSpec.populateSpec() = contextualLabel(severity.toDisplayName())
             .details(message)
             .applySourceLocation(location)
+            // Attaching any typed additional data also defeats Gradle's content-hash deduplication of problems:
+            // `DefaultTypedAdditionalData` hashes a `SerializedPayload`, which has no `hashCode`. That is why identical
+            // diagnostics from different tasks survive here without the `CompilerDiagnosticTaskData` trick of `gradle813`.
             .additionalData(KotlinCompilerDiagnosticAdditionalData::class.java) { data ->
                 data.severity.value(severity).finalizeValue()
             }
@@ -74,7 +81,7 @@ internal abstract class DefaultCompilerDiagnosticsProblemsReporter @Inject const
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<DefaultCompilerDiagnosticsProblemsReporter>()
         }
     }
@@ -90,7 +97,7 @@ internal abstract class NoOpCompilerDiagnosticsProblemsReporter : CompilerDiagno
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<NoOpCompilerDiagnosticsProblemsReporter>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle80/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG80.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle80/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG80.kt
@@ -21,7 +21,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG80 : CompilerDiagnos
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG80>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle81/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG81.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle81/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG81.kt
@@ -21,7 +21,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG81 : CompilerDiagnos
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG81>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle811/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG811.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle811/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG811.kt
@@ -45,7 +45,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG811 @Inject construc
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG811>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle813/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG813.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle813/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG813.kt
@@ -8,14 +8,29 @@ package org.jetbrains.kotlin.gradle.plugin.diagnostics
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.problems.AdditionalData
 import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.Problems
 import org.jetbrains.kotlin.buildtools.api.CompilerMessageRenderer
 import org.jetbrains.kotlin.gradle.utils.newInstance
 import javax.inject.Inject
 
+/**
+ * Makes a diagnostic unique per task.
+ *
+ * Gradle 8.13 deduplicates problems by content hash and attaches the task location only after that check, so the same
+ * compiler message from the metadata, JVM and JS compilations of `commonMain` collapses into one entry (KT-88430).
+ *
+ * Keep this a JavaBean over `String`: 8.13 rejects `Property<T>` in additional data, which is why
+ * [KotlinCompilerDiagnosticAdditionalData] can't be reused here.
+ */
+internal interface CompilerDiagnosticTaskData : AdditionalData {
+    var taskPath: String?
+}
+
 internal abstract class CompilerDiagnosticsProblemsReporterG813 @Inject constructor(
     private val problems: Problems,
+    private val taskPath: String,
 ) : CompilerDiagnosticsProblemsReporter {
     private val logger: Logger = Logging.getLogger(this.javaClass)
 
@@ -40,6 +55,9 @@ internal abstract class CompilerDiagnosticsProblemsReporterG813 @Inject construc
                     .details(message)
                     .severity(gradleSeverity)
                     .applySourceLocation(location)
+                    .additionalData(CompilerDiagnosticTaskData::class.java) { data ->
+                        data.taskPath = taskPath
+                    }
             }
         } catch (e: NoSuchMethodError) {
             logger.error("Can't invoke reporter method:", e)
@@ -47,8 +65,8 @@ internal abstract class CompilerDiagnosticsProblemsReporterG813 @Inject construc
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
-            return objects.newInstance<CompilerDiagnosticsProblemsReporterG813>()
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
+            return objects.newInstance<CompilerDiagnosticsProblemsReporterG813>(taskPath)
         }
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle82/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG82.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle82/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG82.kt
@@ -21,7 +21,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG82 : CompilerDiagnos
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG82>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle85/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG85.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle85/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG85.kt
@@ -21,7 +21,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG85 : CompilerDiagnos
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG85>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle86/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG86.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle86/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG86.kt
@@ -43,7 +43,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG86 @Inject construct
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG86>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/gradle88/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG88.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/gradle88/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG88.kt
@@ -49,7 +49,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG88 @Inject construct
     private fun problemGroup(group: DiagnosticGroup): ProblemGroup = KgpProblemGroup(group)
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG88>()
         }
     }

--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG76.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/CompilerDiagnosticsProblemsReporterG76.kt
@@ -21,7 +21,7 @@ internal abstract class CompilerDiagnosticsProblemsReporterG76 : CompilerDiagnos
     }
 
     class Factory : CompilerDiagnosticsProblemsReporter.Factory {
-        override fun getInstance(objects: ObjectFactory): CompilerDiagnosticsProblemsReporter {
+        override fun getInstance(objects: ObjectFactory, taskPath: String): CompilerDiagnosticsProblemsReporter {
             return objects.newInstance<CompilerDiagnosticsProblemsReporterG76>()
         }
     }


### PR DESCRIPTION
Fix compiler diagnostics deduplication bug