### PR TITLE
[ai] Implement running auto-code-review in TeamCity jobs

### DIFF
--- a/repo/auto-code-review/README.md
+++ b/repo/auto-code-review/README.md
@@ -3,11 +3,11 @@
 This module implements a tool that automatically reviews code changes by running Claude Code
 and instructing it to check the changed files against rules defined in `code-rules.md` files.
 
-## Requirements
+## Requirements for running locally
 
 Install Claude Code CLI and log in: https://code.claude.com/docs/en/quickstart.
 
-## Usage
+## Run locally
 
 ```shell
 ../../gradlew -q reviewCode
@@ -27,6 +27,17 @@ The report includes rule violations (if any) and some meta-information.
 If you run the tool from IntelliJ IDEA, the printed report link is clickable and opens the report in the IDE.
 Viewing the report in IntelliJ IDEA with Markdown preview enabled is the intended way of reading it:
 all the links to code and code rules are clickable and open the destinations in the IDE.
+
+## Run on CI
+
+JetBrains employees can also run the tool on the CI.
+
+1. Go to [the build configuration](https://kotlinlang.teamcity.com/buildConfiguration/Kotlin_KotlinCloud_Dev_AutoCodeReview).
+2. Select the branch to review in the "Branch" area.
+3. Press "Run".
+4. In the opened dialog, make sure to enter the proper base branch name ("master" by default).
+5. Press "Run Build" in the dialog and navigate to the scheduled build.
+6. Wait until the build is finished, and read the review report in the "Review" tab of the build.
 
 ## Operation
 

--- a/repo/auto-code-review/build.gradle.kts
+++ b/repo/auto-code-review/build.gradle.kts
@@ -34,13 +34,20 @@ sourceSets {
 }
 
 abstract class CodeReviewTask : JavaExec() {
-    @set:Option(
+    @get:Option(
         "base",
         "The base git revision to compare the sources against. For example, origin/master (default) or HEAD~2"
     )
     @get:Input
     @get:Optional
-    var base: String? = null
+    abstract val base: Property<String>
+
+    @get:Option(
+        "output",
+        "The path to the output Markdown file"
+    )
+    @get:OutputFile
+    abstract val output: RegularFileProperty
 }
 
 tasks.register<CodeReviewTask>("reviewCode") {
@@ -50,17 +57,16 @@ tasks.register<CodeReviewTask>("reviewCode") {
     classpath(sourceSets.named("main").map { it.compileClasspath })
     mainClass.set("org.jetbrains.kotlin.code.review.LocalKt")
 
-    val output = layout.buildDirectory.file("review.md")
+    output.convention(layout.buildDirectory.file("review.md"))
     val rootDir = rootDir
 
-    outputs.file(output)
     outputs.upToDateWhen { false }
 
     argumentProviders.add {
         listOf(
-            output.get().asFile.path,
+            output.get().asFile.absolutePath,
             rootDir.absolutePath
-        ) + listOfNotNull(base)
+        ) + listOfNotNull(base.getOrNull())
     }
 }
 

--- a/repo/auto-code-review/build.gradle.kts
+++ b/repo/auto-code-review/build.gradle.kts
@@ -14,7 +14,14 @@ val jdkVersion = JdkMajorVersion.JDK_17_0
 configureJvmToolchain(jdkVersion)
 
 dependencies {
-    implementation(kotlinStdlib())
+    // The `reviewCode` task is used on TeamCity and might also be used locally in cold build scenarios
+    // (i.e. the reviewer switches to the branch and runs the task).
+    // So, it is important to make the cold build fast. Use the bootstrap stdlib instead of
+    // the snapshot one (`:kotlin-stdlib`), so that running the task doesn't require building the stdlib:
+    implementation(kotlin("stdlib"))
+    // Note: this won't help if there are other dependencies transitively depending on the snapshot stdlib.
+    // Keep this in mind when adding the dependencies below.
+
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.core.jvm)
     implementation(libs.kotlinx.serialization.json)

--- a/repo/auto-code-review/build.gradle.kts
+++ b/repo/auto-code-review/build.gradle.kts
@@ -62,7 +62,14 @@ tasks.register<CodeReviewTask>("reviewCode") {
 
     classpath(sourceSets.named("main").flatMap { it.kotlin.classesDirectory })
     classpath(sourceSets.named("main").map { it.compileClasspath })
-    mainClass.set("org.jetbrains.kotlin.code.review.LocalKt")
+
+    mainClass = kotlinBuildProperties.isTeamcityBuild.map {
+        if (it) {
+            "org.jetbrains.kotlin.code.review.TeamcityKt"
+        } else {
+            "org.jetbrains.kotlin.code.review.LocalKt"
+        }
+    }
 
     output.convention(layout.buildDirectory.file("review.md"))
     val rootDir = rootDir

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitCLI.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitCLI.kt
@@ -37,62 +37,11 @@ object GitCLI : LocalGit {
     override suspend fun getMergeBase(gitWorkingTree: GitWorkingTree, revision: GitRevision): GitSHA1 =
         GitSHA1(gitOutput(gitWorkingTree, "merge-base", "HEAD", revision.rev))
 
-
-    private const val DIFF_MINUS_MINUS_GIT = "diff --git "
-
     override suspend fun getDiff(from: GitSHA1, to: GitWorkingTree): GitDiff {
         val diffText = gitOutput(tree = to, "diff", "--default-prefix", from.sha1)
-        val diffLines = ArrayDeque(diffText.lines())
-
-        val changedFiles = mutableListOf<GitDiff.ChangedFile>()
-
-        while (diffLines.isNotEmpty()) {
-            val firstLine = diffLines.first()
-            check(firstLine.startsWith(DIFF_MINUS_MINUS_GIT)) {
-                """
-                    |In the `git diff` output,
-                    |expected a line starting with "$DIFF_MINUS_MINUS_GIT", but got:
-                    |$firstLine
-                """.trimMargin()
-            }
-
-            val changedFileLines = listOf(diffLines.removeFirst()) +
-                    diffLines.removeFirstUntil { it.startsWith(DIFF_MINUS_MINUS_GIT) }
-
-            changedFiles.add(parseChangedFile(changedFileLines))
-        }
+        val changedFiles = parseGitDiffText(diffText)
 
         return GitDiff(changedFiles, GitDiff.Origin.Local(from, to))
-    }
-
-    private const val DIFF_SRC_LINE_PREFIX = "--- "
-    private const val DIFF_DST_LINE_PREFIX = "+++ "
-
-    private fun parseChangedFile(lines: List<String>): GitDiff.ChangedFile {
-        // It starts with `diff --git`.
-        // Then goes an arbitrary number of header lines. Look for `---` and `+++`.
-        val oldFileLineIndex = lines.indexOfFirst { it.startsWith(DIFF_SRC_LINE_PREFIX) }
-        check(oldFileLineIndex != -1)
-        val oldFile = lines[oldFileLineIndex].removePrefix(DIFF_SRC_LINE_PREFIX)
-            .takeIf { it != "/dev/null" }?.removePrefix("a/")?.let(::ProjectFilePath)
-
-        val newFileLineIndex = oldFileLineIndex + 1
-        val newFileLine = lines.getOrNull(newFileLineIndex)
-        check(newFileLine?.startsWith(DIFF_DST_LINE_PREFIX) == true) {
-            """
-                |In the `git diff` output,
-                |expected a line starting with "$DIFF_DST_LINE_PREFIX", but got:
-                |$newFileLine
-            """.trimMargin()
-        }
-        val newFile = newFileLine.removePrefix(DIFF_DST_LINE_PREFIX)
-            .takeIf { it != "/dev/null" }?.removePrefix("b/")?.let(::ProjectFilePath)
-
-        return GitDiff.ChangedFile(
-            oldPath = oldFile,
-            newPath = newFile,
-            patchLines = lines,
-        )
     }
 
     override suspend fun lsFiles(tree: GitWorkingTree): List<ProjectFilePath> =

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitCLI.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitCLI.kt
@@ -12,6 +12,8 @@ interface LocalGit {
 
     suspend fun getDiff(from: GitSHA1, to: GitWorkingTree): GitDiff
 
+    suspend fun findHead(tree: GitWorkingTree): GitSHA1
+
     suspend fun lsFiles(tree: GitWorkingTree): List<ProjectFilePath>
 }
 
@@ -43,6 +45,10 @@ object GitCLI : LocalGit {
 
         return GitDiff(changedFiles, GitDiff.Origin.Local(from, to))
     }
+
+    override suspend fun findHead(tree: GitWorkingTree): GitSHA1 = GitSHA1(
+        gitOutput(tree, "rev-parse", "HEAD")
+    )
 
     override suspend fun lsFiles(tree: GitWorkingTree): List<ProjectFilePath> =
         gitOutput(tree, "ls-files").lines().map { ProjectFilePath(it) }

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitTree.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitTree.kt
@@ -13,6 +13,10 @@ class GitSHA1(val sha1: String) : GitRevision(sha1)
 class GitDiff(val changedFiles: List<ChangedFile>, val origin: Origin) {
     sealed class Origin {
         class Local(val from: GitSHA1, val to: GitWorkingTree) : Origin()
+        class GitHub(val repository: String, val base: GitRevision, val to: GitSHA1) : Origin() {
+            val rawDiffUrl: String
+                get() = "https://github.com/$repository/compare/${base.rev}...${to.sha1}.diff"
+        }
     }
 
     class ChangedFile(val oldPath: ProjectFilePath?, val newPath: ProjectFilePath?, val patchLines: List<String>) {

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitTree.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitTree.kt
@@ -34,27 +34,6 @@ interface GitTree {
     suspend fun getDiffFrom(revision: GitSHA1): GitDiff
 }
 
-suspend fun GitTree.getDiffFromMergeBase(revision: GitRevision): GitDiff {
-    val mergeBase = getMergeBase(revision)
-    if (revision.rev == "HEAD" || revision.rev.startsWith("HEAD~") || revision.rev.startsWith("HEAD^")) {
-        // The intention is clear, there is no room for mistake.
-    } else {
-        val numberOfCommits = countCommitsAfter(mergeBase)
-        if (numberOfCommits > 100) {
-            // Maybe the `revision` is the wrong branch. For example, it is `origin/master`,
-            // but the tree is branched off from a release branch.
-            error(
-                """
-                    Suspicious input: base=${revision.rev} effective base = ${mergeBase.sha1}.
-                    It is $numberOfCommits commits. Is it not too many?
-                    Run with base = HEAD~$numberOfCommits to indicate that it is intentional.
-                """.trimIndent()
-            )
-        }
-    }
-    return getDiffFrom(mergeBase)
-}
-
 class GitWorkingTree(val root: File, private val git: LocalGit) : GitTree {
     override val project = LocalProject(root)
 

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitTree.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/GitTree.kt
@@ -45,5 +45,7 @@ class GitWorkingTree(val root: File, private val git: LocalGit) : GitTree {
     override suspend fun countCommitsAfter(ancestor: GitRevision): Int = git.countCommitsUpTo(this, ancestor)
     override suspend fun getDiffFrom(revision: GitSHA1): GitDiff = git.getDiff(from = revision, to = this)
 
+    suspend fun findHead(): GitSHA1 = git.findHead(this)
+
     suspend fun lsFiles(): List<ProjectFilePath> = git.lsFiles(this)
 }

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/LocalClaudeAgent.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/LocalClaudeAgent.kt
@@ -143,6 +143,7 @@ class LocalClaudeAgent private constructor(
     ): AgentResult {
         val diffDescription = when (diffOrigin) {
             is GitDiff.Origin.Local -> "`git diff ${diffOrigin.from.sha1}` at `${diffOrigin.to.root}`"
+            is GitDiff.Origin.GitHub -> diffOrigin.rawDiffUrl
         }
 
         val input = buildString {

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/LocalClaudeAgent.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/LocalClaudeAgent.kt
@@ -104,14 +104,16 @@ class LocalClaudeAgent private constructor(
             }
 
             if (
+                authSettings.env?.anthropicAuthToken == null &&
+                System.getenv(ANTHROPIC_AUTH_TOKEN) == null &&
                 authSettings.apiKeyHelper == null &&
                 authSettings.env?.anthropicApiKey == null &&
                 System.getenv(ANTHROPIC_API_KEY) == null
             ) {
                 error(
                     """
-                        No Anthropic API key found in environment or ${allSettingsFile.toURI().toURL()}.
-                        Please make sure that either "$ANTHROPIC_API_KEY" or "apiKeyHelper" is defined.
+                        No Anthropic API key or auth token found in environment or ${allSettingsFile.toURI().toURL()}.
+                        Please make sure that either "$ANTHROPIC_API_KEY", "$ANTHROPIC_AUTH_TOKEN" or "apiKeyHelper" is defined.
                     """.trimIndent()
                 )
             }
@@ -120,6 +122,7 @@ class LocalClaudeAgent private constructor(
         }
 
         private const val ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
+        private const val ANTHROPIC_AUTH_TOKEN = "ANTHROPIC_AUTH_TOKEN"
     }
 
     @Serializable
@@ -133,6 +136,8 @@ class LocalClaudeAgent private constructor(
             val anthropicBaseUrl: String? = null,
             @SerialName(ANTHROPIC_API_KEY)
             val anthropicApiKey: String? = null,
+            @SerialName(ANTHROPIC_AUTH_TOKEN)
+            val anthropicAuthToken: String? = null,
         )
     }
 

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/local.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/local.kt
@@ -14,12 +14,14 @@ suspend fun main(args: Array<String>) {
 
     val output = File(args[0])
     val repoRoot = File(args[1])
-    val baseRefString = args.getOrNull(2) ?: "origin/master"
+    val baseRevString = args.getOrNull(2) ?: "origin/master"
 
     val gitTree = GitWorkingTree(repoRoot, GitCLI)
+    val baseRev = GitRevision(baseRevString)
     val agent = LocalClaudeAgent.create(gitTree.project)
 
-    val reviewResult = runReview(gitTree, GitRevision(baseRefString), agent)
+    val diff = gitTree.getDiffFromMergeBase(baseRev)
+    val reviewResult = runReview(gitTree.project, diff, agent)
 
     writeLocalReport(output, gitTree.project, reviewResult)
 
@@ -34,6 +36,27 @@ suspend fun main(args: Array<String>) {
 
     println("Review generated:")
     println(outputUrl)
+}
+
+private suspend fun GitTree.getDiffFromMergeBase(revision: GitRevision): GitDiff {
+    val mergeBase = getMergeBase(revision)
+    if (revision.rev == "HEAD" || revision.rev.startsWith("HEAD~") || revision.rev.startsWith("HEAD^")) {
+        // The intention is clear, there is no room for mistake.
+    } else {
+        val numberOfCommits = countCommitsAfter(mergeBase)
+        if (numberOfCommits > 100) {
+            // Maybe the `revision` is the wrong branch. For example, it is `origin/master`,
+            // but the tree is branched off from a release branch.
+            error(
+                """
+                    Suspicious input: base=${revision.rev} effective base = ${mergeBase.sha1}.
+                    It is $numberOfCommits commits. Is it not too many?
+                    Run with base = HEAD~$numberOfCommits to indicate that it is intentional.
+                """.trimIndent()
+            )
+        }
+    }
+    return getDiffFrom(mergeBase)
 }
 
 private fun writeLocalReport(output: File, project: LocalProject, reviewResult: ReviewResult) {

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/local.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/local.kt
@@ -87,6 +87,7 @@ private class LocalRenderingContext(output: File, project: LocalProject) : Rende
     override fun describeDiff(origin: GitDiff.Origin): String {
         return when (origin) {
             is GitDiff.Origin.Local -> "`git diff ${origin.from.sha1}` at `${origin.to.root}`"
+            is GitDiff.Origin.GitHub -> origin.compareMarkdownLink
         }
     }
 }

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/parseGitDiffText.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/parseGitDiffText.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.code.review
+
+private const val DIFF_MINUS_MINUS_GIT = "diff --git "
+
+fun parseGitDiffText(diffText: String): List<GitDiff.ChangedFile> {
+    val diffLines = ArrayDeque(diffText.lines())
+
+    val changedFiles = mutableListOf<GitDiff.ChangedFile>()
+
+    while (diffLines.isNotEmpty()) {
+        val firstLine = diffLines.first()
+        check(firstLine.startsWith(DIFF_MINUS_MINUS_GIT)) {
+            """
+                |In the `git diff` output,
+                |expected a line starting with "$DIFF_MINUS_MINUS_GIT", but got:
+                |$firstLine
+            """.trimMargin()
+        }
+
+        val changedFileLines = listOf(diffLines.removeFirst()) +
+                diffLines.removeFirstUntil { it.startsWith(DIFF_MINUS_MINUS_GIT) }
+
+        changedFiles.add(parseChangedFile(changedFileLines))
+    }
+
+    return changedFiles
+}
+
+private const val DIFF_SRC_LINE_PREFIX = "--- "
+private const val DIFF_DST_LINE_PREFIX = "+++ "
+
+private fun parseChangedFile(lines: List<String>): GitDiff.ChangedFile {
+    // It starts with `diff --git`.
+    // Then goes an arbitrary number of header lines. Look for `---` and `+++`.
+    val oldFileLineIndex = lines.indexOfFirst { it.startsWith(DIFF_SRC_LINE_PREFIX) }
+    check(oldFileLineIndex != -1)
+    val oldFile = lines[oldFileLineIndex].removePrefix(DIFF_SRC_LINE_PREFIX)
+        .takeIf { it != "/dev/null" }?.removePrefix("a/")?.let(::ProjectFilePath)
+
+    val newFileLineIndex = oldFileLineIndex + 1
+    val newFileLine = lines.getOrNull(newFileLineIndex)
+    check(newFileLine?.startsWith(DIFF_DST_LINE_PREFIX) == true) {
+        """
+            |In the `git diff` output,
+            |expected a line starting with "$DIFF_DST_LINE_PREFIX", but got:
+            |$newFileLine
+        """.trimMargin()
+    }
+    val newFile = newFileLine.removePrefix(DIFF_DST_LINE_PREFIX)
+        .takeIf { it != "/dev/null" }?.removePrefix("b/")?.let(::ProjectFilePath)
+
+    return GitDiff.ChangedFile(
+        oldPath = oldFile,
+        newPath = newFile,
+        patchLines = lines,
+    )
+}

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/renderReport.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/renderReport.kt
@@ -25,8 +25,14 @@ fun render(review: ReviewResult): String = buildString {
 
 context(renderingContext: RenderingContext)
 fun StringBuilder.appendOrigin(review: ReviewResult) {
-    appendLine("Reviewing ${renderingContext.describeDiff(review.diffOrigin)}")
-    appendLine()
+    val readme = ProjectFilePath("repo/auto-code-review/README.md")
+    appendLine(
+        """
+            ${renderingContext.markdownLink(readme, "Auto Code Review")} for
+            ${renderingContext.describeDiff(review.diffOrigin)}
+            
+        """.trimIndent()
+    )
 }
 
 context(renderingContext: RenderingContext)

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/renderReport.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/renderReport.kt
@@ -22,6 +22,9 @@ interface RenderingContext {
     fun ruleLink(rule: CodeRule): String = markdownLink(rule.source, rule.name)
 }
 
+val GitDiff.Origin.GitHub.compareMarkdownLink: String
+    get() = "[${base.rev}...${to.sha1}](https://github.com/${repository}/compare/${base.rev}...${to.rev})"
+
 private const val WARNING_EMOJI = "⚠\uFE0F"
 
 context(renderingContext: RenderingContext)

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/renderReport.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/renderReport.kt
@@ -8,6 +8,15 @@ package org.jetbrains.kotlin.code.review
 interface RenderingContext {
     fun codeLink(path: ProjectFilePath, line: Int): String
     fun markdownLink(path: ProjectFilePath, title: String): String
+
+    /**
+     * Returns a Markdown link to [title] in the report, or `null` if unsupported.
+     */
+    fun localLink(text: String, title: String): String? {
+        val anchor = slugifyMarkdownTitle(title)
+        return "[$text](#$anchor)"
+    }
+
     fun describeDiff(origin: GitDiff.Origin): String
 
     fun ruleLink(rule: CodeRule): String = markdownLink(rule.source, rule.name)
@@ -130,10 +139,11 @@ private fun StringBuilder.appendMeta(review: ReviewResult) = appendCollapsed("Me
             is AgentResult.Failure -> WARNING_EMOJI
             is AgentResult.Success -> {
                 val count = result.reviewResult.comments.size
+                val countString = count.toString()
                 if (count == 0) {
-                    "0"
+                    countString
                 } else {
-                    "[$count](#${slugifyMarkdownTitle(rule.name)})"
+                    renderingContext.localLink(countString, rule.name) ?: countString
                 }
             }
         }

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/review.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/review.kt
@@ -12,15 +12,6 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 
-suspend fun runReview(
-    gitTree: GitTree,
-    base: GitRevision,
-    agent: Agent,
-): ReviewResult {
-    val diff = gitTree.getDiffFromMergeBase(base)
-    return runReview(gitTree.project, diff, agent)
-}
-
 private suspend fun CodeRuleRepository.getRules(file: GitDiff.ChangedFile): Set<CodeRule> =
     file.oldPath?.let { getRules(it) }.orEmpty() +
             file.newPath?.let { getRules(it) }.orEmpty()

--- a/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/teamcity.kt
+++ b/repo/auto-code-review/src/org/jetbrains/kotlin/code/review/teamcity.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.code.review
+
+import kotlinx.coroutines.future.asDeferred
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+suspend fun main(args: Array<String>) {
+    check(args.size <= 3) {
+        "Too many arguments. Expected <output> <repoRoot> <baseRev>"
+    }
+
+    val output = File(args[0])
+    val repoRoot = File(args[1])
+    val baseRevString = args[2]
+
+    val gitTree = GitWorkingTree(repoRoot, GitCLI)
+    val agent = LocalClaudeAgent.create(gitTree.project)
+
+    val headSha1 = gitTree.findHead()
+    val baseRev = GitRevision(baseRevString)
+
+    // Could probably be inferred from TeamCity parameters or `git remote get-url`,
+    // but this isn't worth the hassle.
+    val gitHubRepository = "JetBrains/kotlin"
+
+    /*
+    TeamCity uses the shallow clone by default, so computing the diff locally is not possible.
+
+    Using full clone instead is undesirable for performance reasons.
+
+    Potential trade-off: set specific clone depth with `teamcity.git.agent.shallowCloneDepth`.
+    But it is clumsy, as it would limit the number of commits between the base branch and HEAD;
+    also, that approach would still require to fetch the base branch locally or find the merge base in
+    another way.
+
+    Instead, let's trivially fetch the diff from GitHub:
+    */
+    val diff = fetchDiffFromGitHub(gitHubRepository, baseRev, headSha1)
+
+    val reviewResult = runReview(gitTree.project, diff, agent)
+
+    val text = with(GitHubRenderingContext(gitHubRepository, headSha1)) {
+        render(reviewResult)
+    }
+    output.writeText(text)
+
+    reviewResult.firstException?.let { exception ->
+        throw Exception(
+            "Review (partially) failed. See more details in the generated report",
+            exception
+        )
+    }
+}
+
+suspend fun fetchDiffFromGitHub(repository: String, base: GitRevision, to: GitSHA1): GitDiff {
+    val origin = GitDiff.Origin.GitHub(repository, base, to)
+    val text = fetchDiffTextFromGitHub(origin)
+    return GitDiff(parseGitDiffText(text), origin)
+}
+
+private suspend fun fetchDiffTextFromGitHub(origin: GitDiff.Origin.GitHub): String {
+    val rawDiffUrl = origin.rawDiffUrl
+
+    val request = HttpRequest.newBuilder()
+        .uri(URI.create(rawDiffUrl))
+        .GET()
+        .build()
+
+    val response = HttpClient.newHttpClient().sendAsync(
+        request,
+        HttpResponse.BodyHandlers.ofString()
+    ).asDeferred().await()
+
+    if (response.statusCode() !in 200..299) {
+        throw Exception("Failed to fetch the diff from $rawDiffUrl: ${response.statusCode()} ${response.body()}")
+    }
+
+    return response.body()
+}
+
+private class GitHubRenderingContext(val repository: String, val sha1: GitSHA1) : RenderingContext {
+    override fun codeLink(path: ProjectFilePath, line: Int): String {
+        // Use plain=1 just in case it is a file with a custom rendering like Markdown.
+        // Otherwise, a link to the line won't work.
+        return "[${path.fileName}:$line](https://github.com/$repository/blob/${sha1.sha1}/$path?plain=1#L$line)"
+    }
+
+    override fun markdownLink(path: ProjectFilePath, title: String): String {
+        return "[$title](https://github.com/$repository/blob/${sha1.sha1}/$path#${slugifyMarkdownTitle(title)})"
+    }
+
+    override fun localLink(text: String, title: String): String? {
+        // When posting Markdown as a GitHub comment, it is tricky to have a link to a title in the same comment.
+        // Let's keep it unsupported for now.
+        return null
+    }
+
+    override fun describeDiff(origin: GitDiff.Origin): String = when (origin) {
+        is GitDiff.Origin.Local ->
+            GitDiff.Origin.GitHub(repository, origin.from, sha1).compareMarkdownLink
+        is GitDiff.Origin.GitHub ->
+            origin.compareMarkdownLink
+    }
+}


### PR DESCRIPTION
Make `:repo:auto-code-review:reviewCode` behave a bit differently when running on TeamCity to address CI constraints and differences. This allows implementing a TeamCity job for running the tool in the scope of KT-87721.

Also add the documentation for the TeamCity job.

See more details in the commit messages.
