### PR TITLE
[Tests] Make the test pipeline not linear

### DIFF
--- a/compiler/test-infrastructure/ReadMe.md
+++ b/compiler/test-infrastructure/ReadMe.md
@@ -21,26 +21,48 @@ Each test includes at least one module. Module is a base compilation entity whic
 ### Steps
 
 [TestStep](testFixtures/org/jetbrains/kotlin/test/TestStep.kt) is an abstraction of single step in pipeline of processing each module. There are two kinds of test steps:
-1. `TestStep.FacadeStep`. This kind of step contains some facade and transforms input artifact to output artifact with it if type of input artifact matches with corresponding type of facade
-2. `TestStep.HandlersStep`. This kind of step contains some handlers parameterized with single artifact kind and runs all its handlers if type of input artifact matches with type of handlers
+1. `TestStep.FacadeStep`. This kind of step contains some facade and transforms input artifact to output artifact with it
+2. `TestStep.HandlersStep`. This kind of step contains some handlers parameterized with single artifact kind and runs all its handlers on artifact of that kind
+
+Which artifact is passed to a step, and when a step is skipped, is described in [Steps pipeline](#steps-pipeline).
 
 ### Steps pipeline
 
 Each test defines multiple number of parametrized steps in specific order. [TestRunner](testFixtures/org/jetbrains/kotlin/test/TestRunner.kt) (main entrypoint to test) takes configuration and module structure and performs next steps:
 1. Parse module structure from testdata
-2. For each module in test structure:
-    1. Introduce `var artifact` which represents artifact produced by last facade
-    2. Initialize it with input artifact that represents source code
+2. Validate configured pipeline: input artifact kind of each step should be produced by one of the preceding steps (or be the kind of the starting artifact), otherwise the test fails with a test infrastructure error
+3. For each module in test structure:
+    1. Introduce `var artifact` which represents artifact produced by last facade (the *latest* artifact)
+    2. Initialize it with input artifact that represents source code and register it in [ArtifactsProvider](testFixtures/org/jetbrains/kotlin/test/services/ArtifactsProvider.kt)
     3. For each step from configuration:
-        - If type of step input artifact didn't match to type of `artifact` go to next step
-        - If step is
-        - `FacadeStep`:
-            - run facade and assign its result to `artifact`
-            - if input type of facade differs from output type then register `artifact` in dependencies provider so other modules which depend on this module can use it
-        - `HandlersStep`:
-            - run all handlers from it on `artifact`
-3. Run finalized methods of all handlers
-4. Run some additional finalizers (description is below)
+        - Choose the artifact to run the step on:
+            - `FacadeStep` is run on `artifact` if their kinds match. Otherwise, the runner looks for an artifact of the needed kind which was produced earlier for this module (see [Branching pipelines](#branching-pipelines))
+            - `HandlersStep` is always run on `artifact`. If their kinds don't match, then the step is skipped when an artifact of the needed kind was never produced for this module (i.e. the branch of pipeline which produces it wasn't taken). If such artifact was produced, but was already replaced by some later facade, then the test fails with a test infrastructure error, because such configuration is incorrect: this handlers step should be moved right after the facade which produces the artifact of the needed kind
+        - Skip the step if it is a `FacadeStep` and its facade doesn't want to process this module ([`AbstractTestFacade.shouldTransform`](testFixtures/org/jetbrains/kotlin/test/model/Facades.kt) returns `false`). All steps which can consume only the output of the skipped facade are skipped as well
+        - Run the step:
+            - `FacadeStep`: run facade, assign its result to `artifact` and register it in [ArtifactsProvider](testFixtures/org/jetbrains/kotlin/test/services/ArtifactsProvider.kt), so other modules which depend on this module and later steps of this module can use it
+            - `HandlersStep`: run all handlers from it on the chosen artifact
+4. Run finalized methods of all handlers
+5. Run some additional finalizers (description is below)
+
+#### Branching pipelines
+
+The runner keeps track of the artifact produced by the last executed facade (the *latest* artifact). A facade step always prefers the latest artifact, but it also may reach back to an artifact produced earlier in the pipeline, which allows building branching pipelines, e.g.:
+
+```
+┌─────────┐  ┌─────┐  ┌────┐  ┌──────┐  ┌─────────────────┐  ┌──────────┐
+│ Sources ├─▶│ FIR │─▶│ IR │─▶│ KLIB │─▶│ Deserialized IR ├─▶│ .js file │
+└─────────┘  └─────┘  └────┘  └──────┘  └─────────────────┘  └──────────┘
+                                  │     ┌────────────┐
+                                  └────▶│ .d.ts file │
+                                        └────────────┘
+```
+
+Here the KLIB artifact is consumed by two different facades: one of them generates the `.d.ts` file and another one deserializes the KLIB back to IR. Whichever of them is executed second won't see the KLIB as the latest artifact, so the runner takes the KLIB produced earlier from the [ArtifactsProvider](testFixtures/org/jetbrains/kotlin/test/services/ArtifactsProvider.kt).
+
+Note that:
+- if some facade should not be run for a specific module, it should declare it explicitly by returning `false` from [`AbstractTestFacade.shouldTransform`](testFixtures/org/jetbrains/kotlin/test/model/Facades.kt)
+- handlers steps never reach back: they are always run on the latest artifact. So in a branching pipeline a handlers step should be placed right after the facade which produces the artifact it checks
 
 ## Directives
 

--- a/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/TestRunner.kt
+++ b/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/TestRunner.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectivesImpl
 import org.jetbrains.kotlin.test.model.AnalysisHandler
 import org.jetbrains.kotlin.test.model.ResultingArtifact
+import org.jetbrains.kotlin.test.model.TestArtifactKind
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.*
 import org.jetbrains.kotlin.util.PrivateForInline
@@ -56,24 +57,50 @@ sealed class TestRunner<Step : TestStep<*, *>, Configuration : TestConfiguration
         ): TestStep.StepResult<*>
     }
 
+    protected sealed class StepInput {
+        /** The step should be executed with [inputArtifact]. */
+        class Run(val inputArtifact: ResultingArtifact<*>) : StepInput()
+
+        /** The step is not applicable in this pipeline run (e.g. the branch producing its input artifact was not taken). */
+        object Skip : StepInput()
+
+        /** The pipeline is configured incorrectly, so the whole unit processing should be aborted with [exception]. */
+        class Fail(val exception: WrappedException) : StepInput()
+    }
+
+    /**
+     * Runs all configured [TestConfiguration.steps] one after another, tracking the artifact produced by the last
+     * executed facade step (the *latest* artifact).
+     *
+     * [resolveStepInput] decides for each step whether it should be executed, skipped or reported as a
+     * misconfiguration, and which artifact should be passed to it.
+     */
     protected fun runPipelineOnSingleUnit(
         produceStartingArtifact: () -> ResultingArtifact<*>,
-        shouldRunStep: (Step, ResultingArtifact<*>) -> Boolean,
+        resolveStepInput: (Step, ResultingArtifact<*>) -> StepInput,
         runStep: RunStep<Step>,
         onArtifactResult: (ResultingArtifact<*>) -> Unit,
         onHandlersResult: (Step) -> Unit
     ): Boolean {
-        var inputArtifact = produceStartingArtifact()
+        var latestArtifact = produceStartingArtifact()
 
         for (step in testConfiguration.steps) {
-            if (!shouldRunStep(step, inputArtifact)) continue
+            val inputArtifact = when (val stepInput = resolveStepInput(step, latestArtifact)) {
+                is StepInput.Skip -> continue
+                is StepInput.Fail -> {
+                    @OptIn(PrivateForInline::class)
+                    failuresInterceptor._allFailedExceptions += stepInput.exception
+                    return false
+                }
+                is StepInput.Run -> stepInput.inputArtifact
+            }
 
             val thereWereCriticalExceptionsOnPreviousSteps = failuresInterceptor.allFailedExceptions.any { it.failureDisablesNextSteps }
             when (val result = runStep.run(step, inputArtifact, thereWereCriticalExceptionsOnPreviousSteps)) {
                 is TestStep.StepResult.Artifact<*> -> {
                     checkTestInfrastructure(step is TestStep.FacadeStep<*, *>) { "Step must be FacadeStep" }
                     onArtifactResult(result.outputArtifact)
-                    inputArtifact = result.outputArtifact
+                    latestArtifact = result.outputArtifact
                 }
                 is TestStep.StepResult.ErrorFromFacade -> {
                     @OptIn(PrivateForInline::class)
@@ -93,6 +120,14 @@ sealed class TestRunner<Step : TestStep<*, *>, Configuration : TestConfiguration
             }
         }
         return true
+    }
+
+    protected fun renderPipeline(currentStep: Step): String {
+        return testConfiguration.steps.joinToString(separator = "\n", prefix = "Configured pipeline:\n") { step ->
+            val output = step.outputArtifactKind?.let { " -> $it" }.orEmpty()
+            val suffix = if (step == currentStep) " <---------------------------" else ""
+            "  ${step.inputArtifactKind}$output: $step$suffix"
+        }
     }
 
     class FailuresInterceptor(val testConfiguration: TestConfiguration<*>) {
@@ -229,6 +264,15 @@ class NonGroupingTestRunner(
         val services = testConfiguration.testServices
         val moduleStructure = services.moduleStructure
 
+        val firstModule = moduleStructure.modules.firstOrNull()
+        if (firstModule != null) {
+            val startingArtifactKind = testConfiguration.startingArtifactFactory.invoke(firstModule).kind
+            val pipelineIsInvalid = failuresInterceptor.withAssertionCatching({ WrappedException.FromTestPipeline(it, failedModule = null) }) {
+                validatePipeline(startingArtifactKind)
+            }
+            if (pipelineIsInvalid) return
+        }
+
         for (module in moduleStructure.modules) {
             val shouldProcessNextModules = processModule(module, services.artifactsProvider)
             if (!shouldProcessNextModules) break
@@ -265,17 +309,77 @@ class NonGroupingTestRunner(
         artifactsProvider: ArtifactsProvider,
     ): Boolean {
         return runPipelineOnSingleUnit(
-            produceStartingArtifact = { testConfiguration.startingArtifactFactory.invoke(module) },
-            shouldRunStep = { step, inputArtifact -> step.shouldProcessModule(module, inputArtifact) },
+            produceStartingArtifact = {
+                testConfiguration.startingArtifactFactory.invoke(module).also {
+                    testServices.artifactsProvider.registerArtifact(module, it)
+                }
+            },
+            resolveStepInput = { step, latestArtifact ->
+                resolveStepInput(step, latestArtifact, module, artifactsProvider)
+            },
             runStep = { step, inputArtifact, thereWereCriticalExceptionsOnPreviousSteps ->
                 step.hackyProcessModule(module, inputArtifact, thereWereCriticalExceptionsOnPreviousSteps)
             },
-            onArtifactResult = { artifactsProvider.registerArtifact(module, it) },
+            onArtifactResult = {
+                artifactsProvider.registerArtifact(module, it)
+            },
             onHandlersResult = { step ->
                 checkTestInfrastructure(step is TestStep.NonGroupingStep.HandlersStep<*>) { "Step must be HandlersStep" }
                 allRanHandlers += step.handlers
             }
         )
+    }
+
+    /**
+     * Decides how [step] should be handled for [module], based on the [latestArtifact] produced by the pipeline so far
+     * and on all artifacts produced for this module earlier ([artifactsProvider]).
+     */
+    private fun resolveStepInput(
+        step: TestStep.NonGroupingStep<*, *>,
+        latestArtifact: ResultingArtifact<*>,
+        module: TestModule,
+        artifactsProvider: ArtifactsProvider,
+    ): StepInput {
+        val inputKind = step.inputArtifactKind
+        return when (step) {
+            is TestStep.NonGroupingStep.FacadeStep<*, *> -> {
+                val inputArtifact = artifactsProvider.getArtifactSafe(module, inputKind)
+                when {
+                    // There is no suitable input artifact, or the facade doesn't want to process this module. In both
+                    // cases the facade produces nothing, so all steps depending on its output should be skipped too.
+                    inputArtifact == null || !step.facade.shouldTransform(module) -> StepInput.Skip
+                    else -> StepInput.Run(inputArtifact)
+                }
+            }
+
+            is TestStep.NonGroupingStep.HandlersStep<*> -> when {
+                latestArtifact.kind == inputKind -> StepInput.Run(latestArtifact)
+                artifactsProvider.getArtifactSafe(module, inputKind) != null -> {
+                    val message = """
+                        Incorrect test configuration: handlers step "$step" is declared after a facade which replaced
+                        the artifact of kind $inputKind with an artifact of kind ${latestArtifact.kind}.
+                        Handlers steps always run on the latest produced artifact, so this step should be moved right
+                        after the facade producing $inputKind.
+                    """.trimIndent() + "\n" + renderPipeline(step)
+                    StepInput.Fail(WrappedException.FromTestPipeline(TestInfrastructureException(message), module))
+                }
+                // No artifact of the required kind was ever produced for this module: the pipeline never reached the
+                // facade which produces it.
+                else -> StepInput.Skip
+            }
+        }
+    }
+
+    private fun validatePipeline(startingArtifactKind: TestArtifactKind<*>) {
+        val producibleArtifactKinds = mutableSetOf(startingArtifactKind)
+        for (step in testConfiguration.steps) {
+            checkTestInfrastructure(step.inputArtifactKind in producibleArtifactKinds) {
+                "Incorrect test configuration: step \"$step\" consumes an artifact of kind ${step.inputArtifactKind}, " +
+                        "but none of the preceding steps produces it.\n" +
+                        renderPipeline(step)
+            }
+            step.outputArtifactKind?.let { producibleArtifactKinds += it }
+        }
     }
 
     // -------------------------------------- hacks --------------------------------------
@@ -312,13 +416,27 @@ class GroupingTestRunner(
         val merger = GroupingStageInputsMerger(testServices, testConfiguration.mergerWorkers)
         runPipelineOnSingleUnit(
             produceStartingArtifact = { merger.merge(nonGroupingStageOutputs) },
-            shouldRunStep = { _, _ -> true },
+            resolveStepInput = ::resolveStepInput,
             runStep = { step, input, thereWereCriticalExceptionsOnPreviousSteps ->
                 step.hackyProcess(input, thereWereCriticalExceptionsOnPreviousSteps)
             },
             onArtifactResult = {},
             onHandlersResult = {}
         )
+    }
+
+    private fun resolveStepInput(
+        step: TestStep.GroupingStageStep<*, *>,
+        latestArtifact: ResultingArtifact<*>,
+    ): StepInput {
+        if (latestArtifact.kind == step.inputArtifactKind) return StepInput.Run(latestArtifact)
+        val message = """
+            Incorrect test configuration: step "$step" of the grouping stage expects an artifact
+            of kind ${step.inputArtifactKind}, but the latest produced artifact has kind ${latestArtifact.kind}.
+            The grouping stage pipeline is strictly linear, so each step must consume
+            the artifact produced by the previous one.
+        """.trimIndent() + "\n" + renderPipeline(step)
+        return StepInput.Fail(WrappedException.FromTestPipeline(TestInfrastructureException(message), failedModule = null))
     }
 
     private object EmptyModuleStructure : TestModuleStructure() {

--- a/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/TestStep.kt
+++ b/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/TestStep.kt
@@ -13,6 +13,11 @@ sealed class TestStep<InputArtifact, OutputArtifact>
               OutputArtifact : ResultingArtifact<OutputArtifact> {
     abstract val inputArtifactKind: TestArtifactKind<InputArtifact>
 
+    /**
+     * The kind of the artifact produced by this step, or `null` if the step produces nothing (i.e. it's a handlers step).
+     */
+    abstract val outputArtifactKind: TestArtifactKind<*>?
+
     sealed interface FacadeStep<InputArtifact, OutputArtifact>
             where InputArtifact : ResultingArtifact<InputArtifact>,
                   OutputArtifact : ResultingArtifact<OutputArtifact> {
@@ -28,10 +33,6 @@ sealed class TestStep<InputArtifact, OutputArtifact>
             where InputArtifact : ResultingArtifact<InputArtifact>,
                   OutputArtifact : ResultingArtifact<OutputArtifact> {
 
-        open fun shouldProcessModule(module: TestModule, inputArtifact: ResultingArtifact<*>): Boolean {
-            return inputArtifact.kind == inputArtifactKind
-        }
-
         abstract fun processModule(
             module: TestModule,
             inputArtifact: InputArtifact,
@@ -46,9 +47,8 @@ sealed class TestStep<InputArtifact, OutputArtifact>
             override val inputArtifactKind: TestArtifactKind<InputArtifact>
                 get() = facade.inputKind
 
-            override fun shouldProcessModule(module: TestModule, inputArtifact: ResultingArtifact<*>): Boolean {
-                return super.shouldProcessModule(module, inputArtifact) && facade.shouldTransform(module)
-            }
+            override val outputArtifactKind: TestArtifactKind<OutputArtifact>
+                get() = facade.outputKind
 
             override fun processModule(
                 module: TestModule,
@@ -81,6 +81,8 @@ sealed class TestStep<InputArtifact, OutputArtifact>
                     }
                 }
             }
+
+            override val outputArtifactKind: TestArtifactKind<*>? get() = null
 
             override fun processModule(
                 module: TestModule,
@@ -124,6 +126,8 @@ sealed class TestStep<InputArtifact, OutputArtifact>
             override val inputArtifactKind: TestArtifactKind<InputArtifact>
                 get() = facade.inputKind
 
+            override val outputArtifactKind: TestArtifactKind<OutputArtifact>
+                get() = facade.outputKind
 
             override fun process(
                 inputArtifact: InputArtifact,
@@ -154,6 +158,8 @@ sealed class TestStep<InputArtifact, OutputArtifact>
                     }
                 }
             }
+
+            override val outputArtifactKind: TestArtifactKind<*>? get() = null
 
             override fun process(
                 inputArtifact: InputArtifact,
@@ -196,5 +202,3 @@ sealed class TestStep<InputArtifact, OutputArtifact>
         data object NoArtifactFromFacade : StepResult<Nothing>()
     }
 }
-
-

--- a/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/WrappedException.kt
+++ b/compiler/test-infrastructure/testFixtures/org/jetbrains/kotlin/test/WrappedException.kt
@@ -38,6 +38,15 @@ sealed class WrappedException(
         }
     }
 
+    class FromTestPipeline(
+        cause: Throwable,
+        override val failedModule: TestModule?,
+    ) : WrappedException(cause, 0, 0) {
+        override fun withReplacedCause(newCause: Throwable): WrappedException {
+            return FromTestPipeline(newCause, failedModule)
+        }
+    }
+
     class FromGroupingFacade(
         cause: Throwable,
         val facade: AbstractGroupingStageTestFacade<*, *>,

--- a/compiler/testData/codegen/box/js/inlinedReturnBreakContinue/lambdaPassedToInlineFunction.kt
+++ b/compiler/testData/codegen/box/js/inlinedReturnBreakContinue/lambdaPassedToInlineFunction.kt
@@ -4,6 +4,7 @@
 // WITH_STDLIB
 // TARGET_BACKEND: JS_IR
 // IGNORE_BACKEND: JS_IR, JS_IR_ES6
+// IGNORE_HEADER_MODE: JS_IR
 // REASON: SyntaxError: Undefined label 'outer'
 // IGNORE_IR_DESERIALIZATION_TEST: JS_IR
 // ^^^ Source code is not compiled in JS.

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/Fir2IrCliFacade.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/frontend/fir/Fir2IrCliFacade.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.diagnostics.impl.DiagnosticsCollectorImpl
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.util.KotlinMangler
 import org.jetbrains.kotlin.test.backend.ir.IrBackendInput
+import org.jetbrains.kotlin.test.frontend.fir.FirFrontendFacade.Companion.shouldRunFirFrontendFacade
 import org.jetbrains.kotlin.test.model.BackendKinds
 import org.jetbrains.kotlin.test.model.Frontend2BackendConverter
 import org.jetbrains.kotlin.test.model.FrontendKinds
@@ -32,6 +33,17 @@ abstract class Fir2IrCliFacade<Phase, InputPipelineArtifact, OutputPipelineArtif
 ) where Phase : PipelinePhase<InputPipelineArtifact, OutputPipelineArtifact>,
         InputPipelineArtifact : FrontendPipelineArtifact,
         OutputPipelineArtifact : Fir2IrPipelineArtifact {
+
+    /**
+     * Fir2Ir must run for exactly those modules which were analyzed by the platform FIR frontend, i.e. by [FirCliFacade],
+     * which uses the same predicate.
+     *
+     * Modules compiled to metadata KLIBs by [FirCliMetadataFrontendFacade] are not among them: their [FirOutputArtifact]
+     * wraps a `MetadataFrontendPipelineArtifact`, which [transform] can't handle.
+     */
+    override fun shouldTransform(module: TestModule): Boolean {
+        return super.shouldTransform(module) && shouldRunFirFrontendFacade(module, testServices)
+    }
 
     override fun transform(
         module: TestModule,

--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/PhasedPipelineChecker.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/services/PhasedPipelineChecker.kt
@@ -207,6 +207,7 @@ class PhasedPipelineChecker(
         for (exception in failedAssertions) {
             val targetStorage = when (exception) {
                 is WrappedException.FromMetaInfoHandler -> nonSuppressibleFailures
+                is WrappedException.FromTestPipeline -> nonSuppressibleFailures
                 is WrappedException.FromFacade ->
                     processFailure(exception.failedModule, exception.facade.toPhase(), exception)
                 is WrappedException.WrappedExceptionWithoutModule -> nonSuppressibleFailures

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractFirJsHeaderModeCodegenTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractFirJsHeaderModeCodegenTest.kt
@@ -9,89 +9,58 @@ import org.jetbrains.kotlin.js.test.converters.Fir2IrCliWebFacade
 import org.jetbrains.kotlin.js.test.converters.FirCliWebFacade
 import org.jetbrains.kotlin.js.test.converters.FirKlibSerializerCliJsFacade
 import org.jetbrains.kotlin.js.test.converters.JsIrPreSerializationLoweringFacade
-import org.jetbrains.kotlin.test.Constructor
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.TargetBackend
 import org.jetbrains.kotlin.test.backend.BlackBoxCodegenSuppressor
 import org.jetbrains.kotlin.test.backend.handlers.KlibAbiDumpAfterInliningVerifyingHandler
 import org.jetbrains.kotlin.test.backend.handlers.KlibBackendDiagnosticsHandler
 import org.jetbrains.kotlin.test.backend.handlers.NoIrCompilationErrorsHandler
-import org.jetbrains.kotlin.test.backend.ir.IrBackendInput
 import org.jetbrains.kotlin.test.builders.*
+import org.jetbrains.kotlin.test.builders.firHandlersStep
+import org.jetbrains.kotlin.test.builders.irHandlersStep
+import org.jetbrains.kotlin.test.builders.klibArtifactsHandlersStep
+import org.jetbrains.kotlin.test.builders.loweredIrHandlersStep
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.IGNORE_HEADER_MODE
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.WITH_STDLIB
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives.HEADER_MODE
 import org.jetbrains.kotlin.test.directives.configureFirParser
-import org.jetbrains.kotlin.test.frontend.fir.FirOutputArtifact
-import org.jetbrains.kotlin.test.frontend.fir.handlers.FirAnalysisHandler
 import org.jetbrains.kotlin.test.frontend.fir.handlers.FirDiagnosticsHandler
-import org.jetbrains.kotlin.test.model.*
 import org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerJsTest
+import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.utils.bind
 
 abstract class AbstractFirJsHeaderModeCodegenTestBase(val parser: FirParser) : AbstractKotlinCompilerJsTest(TargetBackend.JS_IR) {
     override fun configure(builder: TestConfigurationBuilder) = with(builder) {
-        configureFirParser(parser)
-
-        commonConfigurationForJsHeaderModeTest(
-            ::FirCliWebFacade,
-            ::Fir2IrCliWebFacade,
-            ::JsIrPreSerializationLoweringFacade,
-            ::FirKlibSerializerCliJsFacade,
-        )
-
-        configureJsHeaderModeHandlers(
-            ::FirDiagnosticsHandler,
-            ::NoIrCompilationErrorsHandler,
-            ::KlibBackendDiagnosticsHandler,
-            ::KlibAbiDumpAfterInliningVerifyingHandler,
-        )
-
         defaultDirectives {
             +HEADER_MODE
             +WITH_STDLIB
+        }
+        configureFirParser(parser)
+
+        commonServicesConfigurationForJsCodegenTest()
+        facadeStep(::FirCliWebFacade)
+        firHandlersStep {
+            useHandlers(::FirDiagnosticsHandler)
+        }
+        facadeStep(::Fir2IrCliWebFacade)
+        irHandlersStep {
+            useHandlers(::NoIrCompilationErrorsHandler)
+        }
+        facadeStep(::JsIrPreSerializationLoweringFacade)
+        loweredIrHandlersStep {
+            useHandlers(::NoIrCompilationErrorsHandler)
+        }
+        facadeStep(::FirKlibSerializerCliJsFacade)
+        klibArtifactsHandlersStep {
+            useHandlers(
+                ::KlibBackendDiagnosticsHandler,
+                ::KlibAbiDumpAfterInliningVerifyingHandler,
+            )
         }
 
         useFailureSuppressors(
             ::BlackBoxCodegenSuppressor.bind(IGNORE_HEADER_MODE, null),
         )
-    }
-}
-
-fun TestConfigurationBuilder.commonConfigurationForJsHeaderModeTest(
-    frontendFacade: Constructor<AbstractTestFacade<ResultingArtifact.Source, FirOutputArtifact>>,
-    fir2IrFacade: Constructor<AbstractTestFacade<FirOutputArtifact, IrBackendInput>>,
-    loweringFacade: Constructor<AbstractTestFacade<IrBackendInput, IrBackendInput>>,
-    serializerFacade: Constructor<AbstractTestFacade<IrBackendInput, BinaryArtifacts.KLib>>,
-) {
-    commonServicesConfigurationForJsCodegenTest()
-
-    facadeStep(frontendFacade)
-    facadeStep(fir2IrFacade)
-    facadeStep(loweringFacade)
-    facadeStep(serializerFacade)
-}
-
-fun TestConfigurationBuilder.configureJsHeaderModeHandlers(
-    firDiagnosticsHandler: Constructor<FirAnalysisHandler>,
-    irCompilationErrorsHandler: Constructor<BackendInputHandler<IrBackendInput>>,
-    klibDiagnosticsHandler: Constructor<BinaryArtifactHandler<BinaryArtifacts.KLib>>,
-    klibAbiDumpHandler: Constructor<BinaryArtifactHandler<BinaryArtifacts.KLib>>,
-) {
-    firHandlersStep {
-        useHandlers(firDiagnosticsHandler)
-    }
-
-    irHandlersStep {
-        useHandlers(irCompilationErrorsHandler)
-    }
-
-    loweredIrHandlersStep {
-        useHandlers(irCompilationErrorsHandler)
-    }
-
-    klibArtifactsHandlersStep {
-        useHandlers(klibDiagnosticsHandler, klibAbiDumpHandler)
     }
 }
 

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsBlackBoxCodegenTestBase.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/AbstractJsBlackBoxCodegenTestBase.kt
@@ -159,6 +159,12 @@ fun <FO : ResultingArtifact.FrontendOutput<FO>> TestConfigurationBuilder.commonC
         is JsBackendFacades.WithRecompilation -> {
             facadeStep(backendFacades.deserializerAndLoweringFacade)
             facadeStep(backendFacades.recompileFacade)
+
+            jsArtifactsHandlersStep {
+                useHandlers(
+                    ::JsSourceMapPathRewriter,
+                )
+            }
         }
 
         is JsBackendFacades.WithSeparatedDeserialization -> {
@@ -166,12 +172,6 @@ fun <FO : ResultingArtifact.FrontendOutput<FO>> TestConfigurationBuilder.commonC
             facadeStep(backendFacades.deserializerFacade)
             deserializedIrHandlersStep { useHandlers(backendFacades.postDeserializationHandler) }
         }
-    }
-
-    jsArtifactsHandlersStep {
-        useHandlers(
-            ::JsSourceMapPathRewriter,
-        )
     }
 
     useFailureSuppressors(JsArtifactsDumpHandler::Suppressor)

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/AbstractNativeCodegenBoxCoreTest.kt
@@ -60,7 +60,6 @@ abstract class AbstractNativeCodegenBoxCoreTest : AbstractTwoStageNativeCoreTest
             )
 
             useGroupingTestIsolators(::NativeGroupingTestIsolator)
-            facadeStep(::ObjCInteropFacade)
 
             // Because of package escaping various dumps for grouping mode would be different from
             // the regular one, so we don't want all the frontend handlers to be set up, only some specific ones.
@@ -79,6 +78,14 @@ abstract class AbstractNativeCodegenBoxCoreTest : AbstractTwoStageNativeCoreTest
 
             facadeStep(::KlibSerializerNativeCliFacade)
             klibArtifactsHandlersStep()
+
+            /*
+             * Both `KlibSerializerNativeCliFacade` and `ObjCInteropFacade` produce Klib artifact, which means that
+             * the later one rewrites the first one inside the test infra. Modules with objc interop are expected to
+             * have no kotlin files, so it's acceptable to just run the `ObjCInteropFacade` last so its output would
+             * be used for compilation of other modules
+             */
+            facadeStep(::ObjCInteropFacade)
 
             useAdditionalSourceProviders(
                 ::NativeLauncherAdditionalSourceProvider,

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/ObjCInteropFacade.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/ObjCInteropFacade.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.ModuleStructureExtractor.Companion.CINTEROP_SOURCE_EXTENSIONS
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.configuration.klibEnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.isKtFile
 import org.jetbrains.kotlin.test.services.sourceFileProvider
 import org.jetbrains.kotlin.test.testInfraError
 import kotlin.collections.flatMap
@@ -58,6 +59,14 @@ class ObjCInteropFacade(
     }
 
     override fun transform(module: TestModule, inputArtifact: ResultingArtifact.Source): BinaryArtifacts.KLib {
+        require(module.files.none { it.isKtFile }) {
+            """
+                ObjC interop module should not contain any kotlin files inside.
+                Module: ${module.name}
+                Kotlin files: ${module.files.filter { it.isKtFile }.map { it.name }}
+            """.trimIndent()
+        }
+
         // the following code mimics `CInteropCompilation.result`
         val sourceFileProvider = testServices.sourceFileProvider
         val sourceFiles = module.files.map { sourceFileProvider.getOrCreateRealFileForSourceFile(it) }

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/dump/AbstractKlibToolDumpTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/dump/AbstractKlibToolDumpTest.kt
@@ -60,8 +60,6 @@ abstract class AbstractKlibToolDumpTest : AbstractNativeCoreTest() {
         useMetaTestConfigurators(::CInteropTestSkipper)
         useFailureSuppressors(::NativeTestsSuppressor)
 
-        facadeStep(::ObjCInteropFacade)
-
         configureFirParser(FirParser.LightTree)
         facadeStep(::FirCliNativeFacade)
         firHandlersStep {
@@ -77,6 +75,14 @@ abstract class AbstractKlibToolDumpTest : AbstractNativeCoreTest() {
         }
 
         facadeStep(::KlibSerializerNativeCliFacade)
+
+        /*
+         * Both `KlibSerializerNativeCliFacade` and `ObjCInteropFacade` produce Klib artifact, which means that
+         * the later one rewrites the first one inside the test infra. Modules with objc interop are expected to
+         * have no kotlin files, so it's acceptable to just run the `ObjCInteropFacade` last so its output would
+         * be used for compilation of other modules
+         */
+        facadeStep(::ObjCInteropFacade)
 
         klibArtifactsHandlersStep {
             useHandlers(getDumpHandlers())

--- a/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/dump/AbstractNativeLoadCompiledKotlinTest.kt
+++ b/native/native.tests/klib-ir-inliner/testFixtures/org/jetbrains/kotlin/konan/test/dump/AbstractNativeLoadCompiledKotlinTest.kt
@@ -63,11 +63,11 @@ abstract class AbstractNativeLoadCompiledKotlinTest : AbstractKotlinCompilerNati
         }
 
         facadeStep(::KlibSerializerNativeCliFacade)
-        facadeStep(::NativeDeserializerFacade)
-
         klibArtifactsHandlersStep {
             useHandlers(::KlibNativeLoadedMetadataDumpHandler)
         }
+        facadeStep(::NativeDeserializerFacade)
+
         useFailureSuppressors(
             { testServices -> FirMetadataLoadingTestSuppressor(testServices, CodegenTestDirectives.IGNORE_FIR_METADATA_LOADING_K2) }
         )


### PR DESCRIPTION
Now facades in non-grouping pipeline support two different modes for determinging input artifacts:
- `LatestArtifactOnly` (old default). Picks the latest produced artifact as an input, skips if the artifact doesn't match
- `AnyArtifactOfInputKind` (new default). If the latest produced artifact doesn't match by input kind, picks the other artifact of this kind produced by previous facades

^KT-87384 Fixed
^affects: *