### PR TITLE
[FIR] Resolve error qualifiers using independent context

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/body/resolve/FirExpressionsResolveTransformer.kt
@@ -444,8 +444,8 @@ open class FirExpressionsResolveTransformer(transformer: FirAbstractBodyResolveT
         qualifiedErrorAccessExpression: FirQualifiedErrorAccessExpression,
         data: ResolutionMode,
     ): FirStatement {
-        qualifiedErrorAccessExpression.transformAnnotations(this, data)
-        qualifiedErrorAccessExpression.transformSelector(this, data)
+        qualifiedErrorAccessExpression.transformAnnotations(this, ContextIndependent)
+        qualifiedErrorAccessExpression.transformSelector(this, ContextIndependent)
         qualifiedErrorAccessExpression.replaceReceiver(
             qualifiedErrorAccessExpression.receiver.transformAsExplicitReceiver(
                 ResolutionMode.ReceiverResolution,

--- a/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.fail
+++ b/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.fail
@@ -1,0 +1,1 @@
+lambda is not analyzed

--- a/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.fail
+++ b/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.fail
@@ -1,1 +1,0 @@
-lambda is not analyzed

--- a/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.kt
+++ b/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.kt
@@ -4,7 +4,7 @@
 fun test(x: Any, cond: Boolean) {
     run {
         if (cond) return@run
-        x. { "" }
+        x. <!ILLEGAL_SELECTOR!>{ "" }<!>
     }
 }
 

--- a/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.kt
+++ b/compiler/testData/diagnostics/tests/incompleteCode/postponedLambdaInSelector.kt
@@ -1,0 +1,11 @@
+// RUN_PIPELINE_TILL: FRONTEND
+// ISSUE: KT-77549
+
+fun test(x: Any, cond: Boolean) {
+    run {
+        if (cond) return@run
+        x. { "" }
+    }
+}
+
+/* GENERATED_FIR_TAGS: functionDeclaration, ifExpression, lambdaLiteral, stringLiteral */


### PR DESCRIPTION
When resolving the selector and annotations for a qualified error access
expression, use `ContextIndependent` mode rather than the current
resolution mode. This avoids problems with lambdas in the selector
position during postponed lambda analysis, where the selector lambda may
not be completely resolved.

^[KT-77549](https://youtrack.jetbrains.com/issue/KT-77549) Fixed