### PR TITLE
[Swift Export] Make sure sealedType leaf functions have a default impl

### DIFF
--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirProtocolFromKtSymbol.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirProtocolFromKtSymbol.kt
@@ -282,7 +282,10 @@ internal class SirBridgedProtocolImplementationFromKtSymbol(
                     else -> {}
                 }
             }
-            targetProtocol.sealedTypeFunctions.forEach { add(SirRelocatedFunction(it)) }
+            targetProtocol.sealedTypeFunctions.forEach {
+                if (it !is SirSealedTypeFunction.Sealed) return@forEach
+                add(SirRelocatedFunction(it))
+            }
         }.onEach { it.parent = this@SirBridgedProtocolImplementationFromKtSymbol }
     }
 }
@@ -596,7 +599,12 @@ internal class SirAuxiliaryProtocolDeclarationsFromKtSymbol(
             }
         }
 
-        (typeAliases + defaultFunctions + defaultVariables).onEach { it.parent = this }.toMutableList()
+        val sealedTypeLeafFunctions = targetProtocol.sealedTypeFunctions.mapNotNull {
+            if (it !is SirSealedTypeFunction.Leaf) return@mapNotNull null
+            SirRelocatedFunction(it)
+        }
+
+        (typeAliases + defaultFunctions + defaultVariables + sealedTypeLeafFunctions).onEach { it.parent = this }.toMutableList()
     }
 }
 

--- a/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirSealedType.kt
+++ b/native/swift/sir-light-classes/src/org/jetbrains/sir/lightclasses/nodes/SirSealedType.kt
@@ -77,7 +77,7 @@ internal fun createSirSealedTypeFunctions(
     }
 }
 
-private class SirSealedTypeEnum(
+internal class SirSealedTypeEnum(
     override val ktSymbol: KaNamedClassSymbol,
     override val sirSession: SirSession,
 ) : SirEnum(), SirFromKtSymbol<KaNamedClassSymbol> {
@@ -165,7 +165,7 @@ private class SirSealedTypeEnum(
     }
 }
 
-private class SirSealedTypeStruct(
+internal class SirSealedTypeStruct(
     override val ktSymbol: KaNamedClassSymbol,
     override val sirSession: SirSession,
     private val declaration: SirScopeDefiningDeclaration,
@@ -204,7 +204,7 @@ private class SirSealedTypeStruct(
     }
 }
 
-private sealed class SirSealedTypeFunction : SirFunction(), SirFromKtSymbol<KaNamedClassSymbol> {
+internal sealed class SirSealedTypeFunction : SirFunction(), SirFromKtSymbol<KaNamedClassSymbol> {
 
     protected abstract val sealedType: SirSealedTypeEnum
     override val returnType: SirType get() = SirNominalType(sealedType)

--- a/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/flow_overrides/flow_overrides.swift
+++ b/native/swift/swift-export-standalone-integration-tests/coroutines/testData/generation/coroutines/golden_result/flow_overrides/flow_overrides.swift
@@ -33,11 +33,11 @@ extension ExportedKotlinPackages.namespace.I1 {
 }
 @_documentation(visibility: internal)
 extension flow_overrides._ExportedKotlinPackages_namespace_I1_I2 where Self : flow_overrides.___ExportedKotlinPackages_namespace_I1_I2 {
+}
+extension flow_overrides._ExportedKotlinPackages_namespace_I1_I2 {
     public func sealedType() -> ExportedKotlinPackages.namespace.I1_SealedType {
         .i2(.init(self))
     }
-}
-extension flow_overrides._ExportedKotlinPackages_namespace_I1_I2 {
 }
 @_documentation(visibility: internal)
 extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.namespace.I1, ExportedKotlinPackages.namespace.__I1 where Wrapped : ExportedKotlinPackages.namespace._I1 {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/main/main.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/protocols/golden_result/main/main.swift
@@ -496,12 +496,12 @@ extension main.SealedBazzable where Self : main.__SealedBazzable {
     public func sealedType() -> main.SealedBazzable_SealedType {
         fatalError("must implement sealedType in subclass")
     }
+}
+extension main.SealedBazzable {
     @_disfavoredOverload
     public func sealedType() -> main.SealedFoeble_SealedType {
         .sealedBazzable(sealedType())
     }
-}
-extension main.SealedBazzable {
 }
 @_documentation(visibility: internal)
 extension main.SealedFoeble where Self : main.__SealedFoeble {
@@ -630,12 +630,12 @@ extension main._SealedFoeble_SealedBarable where Self : main.___SealedFoeble_Sea
     public func sealedType() -> main.SealedBarable_SealedType {
         fatalError("must implement sealedType in subclass")
     }
+}
+extension main._SealedFoeble_SealedBarable {
     @_disfavoredOverload
     public func sealedType() -> main.SealedFoeble_SealedType {
         .sealedBarable(sealedType())
     }
-}
-extension main._SealedFoeble_SealedBarable {
 }
 extension ExportedKotlinPackages.packagewithprotocols {
     public enum ENUM_WITH_INTERFACE_INHERITANCE: KotlinRuntimeSupport._KotlinBridgeable, Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.RawRepresentable {

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/generation/sealedTypes/golden_result/common/common.swift
@@ -114,11 +114,11 @@ public final class _ExportedKotlinPackages_org_kotlin_foo_QueryResult_Value: Kot
 }
 @_documentation(visibility: internal)
 extension ExportedKotlinPackages.org.kotlin.foo.InterfaceC where Self : ExportedKotlinPackages.org.kotlin.foo.__InterfaceC {
+}
+extension ExportedKotlinPackages.org.kotlin.foo.InterfaceC {
     public func sealedType() -> ExportedKotlinPackages.org.kotlin.foo.SealedInterfaceA_SealedType {
         .interfaceC(.init(self))
     }
-}
-extension ExportedKotlinPackages.org.kotlin.foo.InterfaceC {
 }
 @_documentation(visibility: internal)
 extension ExportedKotlinPackages.org.kotlin.foo.QueryResult where Self : ExportedKotlinPackages.org.kotlin.foo.__QueryResult {
@@ -137,11 +137,11 @@ extension ExportedKotlinPackages.org.kotlin.foo.SealedInterfaceA {
 }
 @_documentation(visibility: internal)
 extension ExportedKotlinPackages.org.kotlin.foo.SealedInterfaceB where Self : ExportedKotlinPackages.org.kotlin.foo.__SealedInterfaceB {
+}
+extension ExportedKotlinPackages.org.kotlin.foo.SealedInterfaceB {
     public func sealedType() -> ExportedKotlinPackages.org.kotlin.foo.SealedInterfaceA_SealedType {
         .sealedInterfaceB(.init(self))
     }
-}
-extension ExportedKotlinPackages.org.kotlin.foo.SealedInterfaceB {
 }
 @_documentation(visibility: internal)
 extension KotlinRuntimeSupport._KotlinExistential: ExportedKotlinPackages.org.kotlin.foo.QueryResult, ExportedKotlinPackages.org.kotlin.foo.__QueryResult where Wrapped : ExportedKotlinPackages.org.kotlin.foo._QueryResult {


### PR DESCRIPTION
The SealedType value can't be constructed in user code, so we need to always add the default implementation, not just for Kotlin types implementing the sealed type.

^KT-88473 Fixed