### PR TITLE
[CLI] Restore custom IC search scope creation

### DIFF
--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/IncrementalCompilationContextUtils.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/IncrementalCompilationContextUtils.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.cli.jvm.compiler
 
+import org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.IncrementalCompilationComponentsWithCustomScope
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.fir.session.IncrementalCompilationContext
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope
@@ -17,7 +18,11 @@ private fun createIncrementalCompilationScope(
     incrementalExcludesScope: AbstractProjectFileSearchScope?
 ): AbstractProjectFileSearchScope? {
     if (configuration.modules.isEmpty()) return null
-    if (configuration.incrementalCompilationComponents == null) return null
+
+    val incrementalCompilationComponents = configuration.incrementalCompilationComponents ?: return null
+    if (incrementalCompilationComponents is IncrementalCompilationComponentsWithCustomScope) {
+        return incrementalCompilationComponents.createSearchScope(projectEnvironment)
+    }
 
     val dir = configuration.outputDirectory ?: return null
     return projectEnvironment.getSearchScopeByDirectories(setOf(dir)).let {

--- a/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/legacy/pipeline/IncrementalCompilationComponentsWithCustomScope.kt
+++ b/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/legacy/pipeline/IncrementalCompilationComponentsWithCustomScope.kt
@@ -7,7 +7,11 @@ package org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline
 
 import org.jetbrains.kotlin.cli.jvm.compiler.VfsBasedProjectEnvironment
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope
+import org.jetbrains.kotlin.load.kotlin.incremental.components.IncrementalCompilationComponents
 
-interface ProjectFileSearchScopeProvider {
+/*
+ * This interface is used by custom IC components implementation in IntelliJ.
+ */
+interface IncrementalCompilationComponentsWithCustomScope : IncrementalCompilationComponents {
     fun createSearchScope(projectEnvironment: VfsBasedProjectEnvironment): AbstractProjectFileSearchScope
 }


### PR DESCRIPTION
In the intellij there is a custom implementation of `IncrementalCompilationComponents` which relied on the ability to provide custom search scope for IC. This hook was removed 8e4f77cf because there were no usages of this functionality in the kotlin repo. Also nothing failed in the intellij repo.

So the fact it was actually needed for intellij was found only during migration of intellij to the 2.4.20.

^KT-88475 Fixed