### PR TITLE
[KMP parser] Fix "string literal content is remapped to IDENTIFIER if it matches a soft keyword"

### DIFF
--- a/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/SourceStubsTestGenerated.java
+++ b/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/SourceStubsTestGenerated.java
@@ -1133,6 +1133,12 @@ public class SourceStubsTestGenerated extends AbstractSourceStubsTest {
   }
 
   @Test
+  @TestMetadata("SoftKeywordRemapOnRollback.kt")
+  public void testSoftKeywordRemapOnRollback() {
+    run("SoftKeywordRemapOnRollback.kt");
+  }
+
+  @Test
   @TestMetadata("SoftKeywords.kt")
   public void testSoftKeywords() {
     run("SoftKeywords.kt");

--- a/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/common/CompiledCommonStubsTestGenerated.java
+++ b/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/common/CompiledCommonStubsTestGenerated.java
@@ -1133,6 +1133,12 @@ public class CompiledCommonStubsTestGenerated extends AbstractCompiledCommonStub
   }
 
   @Test
+  @TestMetadata("SoftKeywordRemapOnRollback.kt")
+  public void testSoftKeywordRemapOnRollback() {
+    run("SoftKeywordRemapOnRollback.kt");
+  }
+
+  @Test
   @TestMetadata("SoftKeywords.kt")
   public void testSoftKeywords() {
     run("SoftKeywords.kt");

--- a/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/js/CompiledJsStubsTestGenerated.java
+++ b/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/js/CompiledJsStubsTestGenerated.java
@@ -1133,6 +1133,12 @@ public class CompiledJsStubsTestGenerated extends AbstractCompiledJsStubsTest {
   }
 
   @Test
+  @TestMetadata("SoftKeywordRemapOnRollback.kt")
+  public void testSoftKeywordRemapOnRollback() {
+    run("SoftKeywordRemapOnRollback.kt");
+  }
+
+  @Test
   @TestMetadata("SoftKeywords.kt")
   public void testSoftKeywords() {
     run("SoftKeywords.kt");

--- a/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/jvm/CompiledJvmStubsTestGenerated.java
+++ b/analysis/stubs/tests-gen/org/jetbrains/kotlin/analysis/stubs/jvm/CompiledJvmStubsTestGenerated.java
@@ -1133,6 +1133,12 @@ public class CompiledJvmStubsTestGenerated extends AbstractCompiledJvmStubsTest 
   }
 
   @Test
+  @TestMetadata("SoftKeywordRemapOnRollback.kt")
+  public void testSoftKeywordRemapOnRollback() {
+    run("SoftKeywordRemapOnRollback.kt");
+  }
+
+  @Test
   @TestMetadata("SoftKeywords.kt")
   public void testSoftKeywords() {
     run("SoftKeywords.kt");

--- a/compiler/multiplatform-parsing/build.gradle.kts
+++ b/compiler/multiplatform-parsing/build.gradle.kts
@@ -62,6 +62,7 @@ tasks.withType<Test> {
         project(":compiler:tests-spec").isolated.projectDirectory.dir("testData"),
         project(":compiler:fir:analysis-tests").isolated.projectDirectory.dir("testData"),
         project(":analysis:analysis-api").isolated.projectDirectory.dir("testData"),
+        project(":compiler:psi:psi-impl").isolated.projectDirectory.dir("testData"),
     ).joinToString(File.pathSeparator)
     systemProperty("test.data.dirs", testDataDirs)
 

--- a/compiler/multiplatform-parsing/common/src/org/jetbrains/kotlin/kmp/lexer/KtTokens.kt
+++ b/compiler/multiplatform-parsing/common/src/org/jetbrains/kotlin/kmp/lexer/KtTokens.kt
@@ -380,18 +380,12 @@ object KtTokens : SyntaxElementTypesWithIds() {
     val HARD_KEYWORDS_AND_MODIFIERS: SyntaxElementTypeSet = hardKeywordsAndModifiers.asSyntaxElementTypeSet()
     val MODIFIERS: SyntaxElementTypeSet = allModifiers.asSyntaxElementTypeSet()
 
-    private val HARD_KEYWORDS_AND_MODIFIERS_MAP: Map<String, SyntaxElementType> = HARD_KEYWORDS_AND_MODIFIERS.associateBy { it.toString() }
+    val HARD_KEYWORDS_AND_MODIFIERS_MAP: Map<String, SyntaxElementType> = HARD_KEYWORDS_AND_MODIFIERS.associateBy { it.toString() }
 
-    private val SOFT_KEYWORDS_AND_MODIFIERS_MAP: Map<String, SyntaxElementType> = SOFT_KEYWORDS_AND_MODIFIERS.associateBy { it.toString() }
+    val SOFT_KEYWORDS_AND_MODIFIERS_MAP: Map<String, SyntaxElementType> = SOFT_KEYWORDS_AND_MODIFIERS.associateBy { it.toString() }
 
     fun getHardKeywordOrModifier(elementText: String?): SyntaxElementType? {
         return elementText?.let { HARD_KEYWORDS_AND_MODIFIERS_MAP[it] }
-    }
-
-    fun isSoftKeywordOrModifier(elementText: String?): Boolean = getSoftKeywordOrModifier(elementText) != null
-
-    fun getSoftKeywordOrModifier(elementText: String?): SyntaxElementType? {
-        return elementText?.let { SOFT_KEYWORDS_AND_MODIFIERS_MAP[it] }
     }
 
     val TYPE_MODIFIER_KEYWORDS: SyntaxElementTypeSet = syntaxElementTypeSetOf(SUSPEND_MODIFIER)

--- a/compiler/multiplatform-parsing/common/src/org/jetbrains/kotlin/kmp/parser/utils/AbstractKotlinParsing.kt
+++ b/compiler/multiplatform-parsing/common/src/org/jetbrains/kotlin/kmp/parser/utils/AbstractKotlinParsing.kt
@@ -141,7 +141,8 @@ internal abstract class AbstractKotlinParsing(
      */
     protected fun atWithRemap(expectation: SyntaxElementType): Boolean {
         if (atInternal(expectation)) return true
-        if (tt() === KtTokens.IDENTIFIER) {
+        val tokenType = tt()
+        if (tokenType === KtTokens.IDENTIFIER) {
             if (DEBUG_MODE && expectation !in KtTokens.SOFT_KEYWORDS_AND_MODIFIERS) {
                 error("Expectation is '${expectation}' but should be '${KtTokens.IDENTIFIER}' or soft keyword(modifier). Use '${::at.name}' call instead.")
             }
@@ -152,7 +153,7 @@ internal abstract class AbstractKotlinParsing(
             }
         }
         if (expectation === KtTokens.IDENTIFIER) {
-            if (KtTokens.isSoftKeywordOrModifier(builder.tokenText)) {
+            if (tokenType in KtTokens.SOFT_KEYWORDS_AND_MODIFIERS) {
                 builder.remapCurrentToken(KtTokens.IDENTIFIER)
                 return true
             }
@@ -185,15 +186,16 @@ internal abstract class AbstractKotlinParsing(
 
     protected fun atSetWithRemap(set: SyntaxElementTypeSet): Boolean {
         if (atSet(set)) return true
-        if (tt() === KtTokens.IDENTIFIER) {
-            val softKeywordToken = KtTokens.getSoftKeywordOrModifier(builder.tokenText)
+        val tokenType = tt()
+        if (tokenType === KtTokens.IDENTIFIER) {
+            val softKeywordToken = builder.tokenText?.let { KtTokens.SOFT_KEYWORDS_AND_MODIFIERS_MAP[it] }
             if (softKeywordToken?.let { set.contains(it) } == true) {
                 builder.remapCurrentToken(softKeywordToken)
                 return true
             }
         } else {
             // We know at this point that `set` does not contain `token`
-            if (set.contains(KtTokens.IDENTIFIER) && KtTokens.isSoftKeywordOrModifier(builder.tokenText)) {
+            if (set.contains(KtTokens.IDENTIFIER) && tokenType in KtTokens.SOFT_KEYWORDS_AND_MODIFIERS) {
                 builder.remapCurrentToken(KtTokens.IDENTIFIER)
                 return true
             }

--- a/compiler/multiplatform-parsing/jvm/test/org/jetbrains/kotlin/kmp/AbstractRecognizerTests.kt
+++ b/compiler/multiplatform-parsing/jvm/test/org/jetbrains/kotlin/kmp/AbstractRecognizerTests.kt
@@ -115,8 +115,8 @@ abstract class AbstractRecognizerTests<OldT, NewT, OldSyntaxElement : TestSyntax
         }
 
         comparisonFailures.add {
-            val approximateNumberOfTestDataFiles = 33400
-            assertTrue(filesCounter > approximateNumberOfTestDataFiles, "Number of tested files (kt, kts) should be more than $approximateNumberOfTestDataFiles")
+            val minimalNumberOfKotlinTestDataFiles = 35600
+            assertTrue(filesCounter > minimalNumberOfKotlinTestDataFiles, "Number of tested files (kt, kts) should be more than $minimalNumberOfKotlinTestDataFiles")
         }
 
         assertAll(comparisonFailures)

--- a/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.compiled.stubs.txt
+++ b/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.compiled.stubs.txt
@@ -1,0 +1,14 @@
+FILE[kind=Facade[packageFqName=<root>, facadeFqName=SoftKeywordRemapOnRollbackKt]]
+  facadeFqName: SoftKeywordRemapOnRollbackKt
+  partSimpleName: "SoftKeywordRemapOnRollbackKt"
+  PACKAGE_DIRECTIVE
+  IMPORT_LIST
+  FUN[fqName=test, hasBody=true, hasNoExpressionBody=true, hasTypeParameterListBeforeFunctionName=false, isExtension=false, isTopLevel=true, mayHaveContract=false, name=test]
+    origin: Facade(className=SoftKeywordRemapOnRollbackKt, jvmClassName=null)
+    MODIFIER_LIST[public]
+    VALUE_PARAMETER_LIST
+    TYPE_REFERENCE
+      USER_TYPE
+        USER_TYPE
+          REFERENCE_EXPRESSION[referencedName=kotlin]
+        REFERENCE_EXPRESSION[referencedName=Unit]

--- a/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.decompiledText.txt
+++ b/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.decompiledText.txt
@@ -1,0 +1,4 @@
+// IntelliJ API Decompiler stub source generated from a class file
+// Implementation of methods is not available
+
+public fun test(): kotlin.Unit { /* compiled code */ }

--- a/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.knm.compiled.stubs.txt
+++ b/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.knm.compiled.stubs.txt
@@ -1,0 +1,11 @@
+FILE[kind=File[packageFqName=<root>]]
+  PACKAGE_DIRECTIVE
+  IMPORT_LIST
+  FUN[fqName=test, hasBody=true, hasNoExpressionBody=true, hasTypeParameterListBeforeFunctionName=false, isExtension=false, isTopLevel=true, mayHaveContract=false, name=test]
+    MODIFIER_LIST[public]
+    VALUE_PARAMETER_LIST
+    TYPE_REFERENCE
+      USER_TYPE
+        USER_TYPE
+          REFERENCE_EXPRESSION[referencedName=kotlin]
+        REFERENCE_EXPRESSION[referencedName=Unit]

--- a/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.kt
+++ b/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.kt
@@ -1,0 +1,6 @@
+fun test() {
+    context(1) {
+        context("inner") {
+        }
+    }
+}

--- a/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.stubs.txt
+++ b/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.stubs.txt
@@ -1,0 +1,7 @@
+FILE[kind=Facade[packageFqName=<root>, facadeFqName=SoftKeywordRemapOnRollbackKt]]
+  facadeFqName: SoftKeywordRemapOnRollbackKt
+  partSimpleName: "SoftKeywordRemapOnRollbackKt"
+  PACKAGE_DIRECTIVE
+  IMPORT_LIST
+  FUN[fqName=test, hasBody=true, hasNoExpressionBody=true, hasTypeParameterListBeforeFunctionName=false, isExtension=false, isTopLevel=true, mayHaveContract=false, name=test]
+    VALUE_PARAMETER_LIST

--- a/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.txt
+++ b/compiler/psi/psi-impl/testData/psi/SoftKeywordRemapOnRollback.txt
@@ -1,0 +1,57 @@
+KtFile: SoftKeywordRemapOnRollback.kt
+  PACKAGE_DIRECTIVE
+    <empty list>
+  IMPORT_LIST
+    <empty list>
+  FUN
+    PsiElement(fun)('fun')
+    PsiWhiteSpace(' ')
+    PsiElement(IDENTIFIER)('test')
+    VALUE_PARAMETER_LIST
+      PsiElement(LPAR)('(')
+      PsiElement(RPAR)(')')
+    PsiWhiteSpace(' ')
+    BLOCK
+      PsiElement(LBRACE)('{')
+      PsiWhiteSpace('\n    ')
+      CALL_EXPRESSION
+        REFERENCE_EXPRESSION
+          PsiElement(IDENTIFIER)('context')
+        VALUE_ARGUMENT_LIST
+          PsiElement(LPAR)('(')
+          VALUE_ARGUMENT
+            INTEGER_CONSTANT
+              PsiElement(INTEGER_LITERAL)('1')
+          PsiElement(RPAR)(')')
+        PsiWhiteSpace(' ')
+        LAMBDA_ARGUMENT
+          LAMBDA_EXPRESSION
+            FUNCTION_LITERAL
+              PsiElement(LBRACE)('{')
+              PsiWhiteSpace('\n        ')
+              BLOCK
+                CALL_EXPRESSION
+                  REFERENCE_EXPRESSION
+                    PsiElement(IDENTIFIER)('context')
+                  VALUE_ARGUMENT_LIST
+                    PsiElement(LPAR)('(')
+                    VALUE_ARGUMENT
+                      STRING_TEMPLATE
+                        PsiElement(OPEN_QUOTE)('"')
+                        LITERAL_STRING_TEMPLATE_ENTRY
+                          PsiElement(REGULAR_STRING_PART)('inner')
+                        PsiElement(CLOSING_QUOTE)('"')
+                    PsiElement(RPAR)(')')
+                  PsiWhiteSpace(' ')
+                  LAMBDA_ARGUMENT
+                    LAMBDA_EXPRESSION
+                      FUNCTION_LITERAL
+                        PsiElement(LBRACE)('{')
+                        PsiWhiteSpace('\n        ')
+                        BLOCK
+                          <empty list>
+                        PsiElement(RBRACE)('}')
+              PsiWhiteSpace('\n    ')
+              PsiElement(RBRACE)('}')
+      PsiWhiteSpace('\n')
+      PsiElement(RBRACE)('}')

--- a/compiler/psi/psi-impl/tests-gen/org/jetbrains/kotlin/psi/parsing/PsiParsingTestGenerated.java
+++ b/compiler/psi/psi-impl/tests-gen/org/jetbrains/kotlin/psi/parsing/PsiParsingTestGenerated.java
@@ -1133,6 +1133,12 @@ public class PsiParsingTestGenerated extends AbstractPsiParsingTest {
   }
 
   @Test
+  @TestMetadata("SoftKeywordRemapOnRollback.kt")
+  public void testSoftKeywordRemapOnRollback() {
+    run("SoftKeywordRemapOnRollback.kt");
+  }
+
+  @Test
   @TestMetadata("SoftKeywords.kt")
   public void testSoftKeywords() {
     run("SoftKeywords.kt");


### PR DESCRIPTION
I've recently found this during checking the parser on IntelliJ repo.