### PR TITLE
[Wasm, WASIp2] cabi_realloc stdlib export (^KT-88027)

### DIFF
--- a/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/BackendWasmSymbols.kt
+++ b/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm/BackendWasmSymbols.kt
@@ -435,6 +435,16 @@ class BackendWasmSymbols(
             else -> lazyOf(null)
         }
     }
+
+    // cabi_realloc is a @WasmExport'ed function defined in the Wasm/WASI standard library, and only referenced here in order to preserve it during IR Serialization/Deserialization
+    @Suppress("unused")
+    val cabiRealloc: IrSimpleFunctionSymbol? by run {
+        when (configuration.wasmTarget == WasmTarget.WASI) {
+            true -> CallableIds.cabiRealloc.functionSymbol()
+            else -> lazyOf(null)
+        }
+    }
+
 }
 
 private object ClassIds {
@@ -677,5 +687,6 @@ private object CallableIds {
     val registerRootSuiteBlock = CallableId(StandardClassIds.BASE_TEST_PACKAGE, Name.identifier("registerRootSuiteBlock"))
     val runRootSuites = CallableId(StandardClassIds.BASE_TEST_PACKAGE, Name.identifier("runRootSuites"))
     val checkStaticInitializationState = "checkStaticInitializationState".wasmCallableId
+    val cabiRealloc = "cabi_realloc".wasmCallableId
 }
 

--- a/libraries/stdlib/wasm/wasi/src/kotlin/wasm/internal/reallocExport.kt
+++ b/libraries/stdlib/wasm/wasi/src/kotlin/wasm/internal/reallocExport.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.wasm.internal
+
+import kotlin.internal.UsedFromCompilerGeneratedCode
+import kotlin.wasm.unsafe.ComponentModelInternalApi
+import kotlin.wasm.unsafe.componentModelRealloc
+
+// internal because it should not be directly callable, just needs to be exported for component model support
+@OptIn(ComponentModelInternalApi::class, ExperimentalWasmInterop::class)
+@Suppress("FunctionName", "unused")
+@UsedFromCompilerGeneratedCode
+@WasmExport
+internal fun cabi_realloc(ptr: Int, oldSize: Int, align: Int, newSize: Int): Int =
+    componentModelRealloc(ptr, oldSize, newSize)


### PR DESCRIPTION
For now, just hardcode cabi_realloc as an export root; until we decide on how to resolve KT-88068. We will also have to consider whether we should consider this new export as a part of the guaranteed ABI.

^KT-88027 Fixed
^KT-88068