### PR TITLE
[JVM] Drop `containingFile` param from `MetadataSerializer.serialize` method

### DIFF
--- a/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataLegacySerializerPhase.kt
+++ b/compiler/cli/cli-metadata/src/org/jetbrains/kotlin/cli/pipeline/metadata/MetadataLegacySerializerPhase.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.fir.declarations.comparators.FirMemberDeclarationCom
 import org.jetbrains.kotlin.fir.declarations.utils.classId
 import org.jetbrains.kotlin.fir.pipeline.SingleModuleFrontendOutput
 import org.jetbrains.kotlin.fir.resolve.ScopeSession
-import org.jetbrains.kotlin.fir.resolve.providers.firProvider
 import org.jetbrains.kotlin.fir.serialization.FirAdditionalMetadataProvider
 import org.jetbrains.kotlin.fir.serialization.FirElementSerializer
 import org.jetbrains.kotlin.fir.serialization.FirSerializerExtensionBase
@@ -185,8 +184,7 @@ abstract class MetadataLegacySerializerPhaseBase(
                     serializeClasses(nestedClasses, classSerializer)
                 }
 
-                val file = session.firProvider.getFirClassifierContainerFileIfAny(klass.symbol)
-                val classProto = classSerializer.classProto(klass, file)
+                val classProto = classSerializer.classProto(klass)
                 proto.addClass_(classProto.build())
             }
         }

--- a/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
+++ b/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
@@ -151,13 +151,8 @@ class FirElementSerializer private constructor(
         return builder
     }
 
-    fun classProto(klass: FirClass, containingFile: FirFile?): ProtoBuf.Class.Builder {
-        return if (containingFile == null) {
-            // Containing file can be null for local classes, as well as synthetic ones like kotlin/Cloneable.
-            // Not using `processFile` means that we will not be able to use IR-based constant expression evaluator when serializing
-            // annotations in such classes, and will fall back to the FIR-based evaluator.
-            classProtoImpl(klass)
-        } else classProtoImpl(klass)
+    fun classProto(klass: FirClass): ProtoBuf.Class.Builder {
+        return classProtoImpl(klass)
     }
 
     private fun classProtoImpl(klass: FirClass): ProtoBuf.Class.Builder = whileAnalysing(session, klass) {

--- a/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
+++ b/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/FirElementSerializer.kt
@@ -151,11 +151,7 @@ class FirElementSerializer private constructor(
         return builder
     }
 
-    fun classProto(klass: FirClass): ProtoBuf.Class.Builder {
-        return classProtoImpl(klass)
-    }
-
-    private fun classProtoImpl(klass: FirClass): ProtoBuf.Class.Builder = whileAnalysing(session, klass) {
+    fun classProto(klass: FirClass): ProtoBuf.Class.Builder = whileAnalysing(session, klass) {
         val builder = ProtoBuf.Class.newBuilder()
 
         val regularClass = klass as? FirRegularClass
@@ -407,7 +403,7 @@ class FirElementSerializer private constructor(
     @OptIn(UnexpandedTypeCheck::class)
     fun snippetProto(snippet: FirReplSnippet): ProtoBuf.Class.Builder = whileAnalysing(session, snippet) {
         if (versionRequirementTable == null) error("Version requirements must be serialized for snippets: ${snippet.render()}")
-        val builder = classProtoImpl(snippet.snippetClass)
+        val builder = classProto(snippet.snippetClass)
         extension.serializeSnippet(snippet, builder, versionRequirementTable, this)
         return builder
     }

--- a/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/firKlibSerialization.kt
+++ b/compiler/fir/fir-serialization/src/org/jetbrains/kotlin/fir/serialization/firKlibSerialization.kt
@@ -50,7 +50,7 @@ fun serializeSingleFirFile(
         )
         val index = classSerializer.stringTable.getFqNameIndex(this)
 
-        classesProto += classSerializer.classProto(this, file).build() to index
+        classesProto += classSerializer.classProto(this).build() to index
 
         for (nestedClassifierSymbol in classSerializer.computeNestedClassifiersForClass(symbol)) {
             (nestedClassifierSymbol as? FirClassSymbol<*>)?.fir?.makeClassProtoWithNested(parentSerializer = classSerializer)

--- a/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirBuiltinsSerializer.kt
+++ b/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirBuiltinsSerializer.kt
@@ -105,8 +105,7 @@ class FirBuiltInsSerializer(val session: FirSession, val scopeSession: ScopeSess
                     serializeClasses(nestedClasses, nestedSerializer)
                 }
 
-                val file = session.firProvider.getFirClassifierContainerFileIfAny(klass.symbol)
-                val classProto = parentSerializer.classProto(klass, file)
+                val classProto = parentSerializer.classProto(klass)
                 proto.addClass_(classProto.build())
             }
         }

--- a/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirJvmBackendExtension.kt
+++ b/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirJvmBackendExtension.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.fir.backend.Fir2IrComponents
 import org.jetbrains.kotlin.fir.backend.FirMetadataSource
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
-import org.jetbrains.kotlin.fir.resolve.providers.firProvider
 import org.jetbrains.kotlin.fir.serialization.FirElementAwareStringTable
 import org.jetbrains.kotlin.fir.serialization.FirElementSerializer
 import org.jetbrains.kotlin.fir.serialization.TypeApproximatorForMetadataSerializer
@@ -105,8 +104,7 @@ class FirJvmBackendExtension(
                 typeApproximator,
                 context.config.languageVersionSettings
             )
-            val file = session.firProvider.getFirClassifierContainerFileIfAny(fir.symbol)
-            return serializer.classProto(fir, file).build()
+            return serializer.classProto(fir).build()
         }
     }
 

--- a/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirMetadataSerializer.kt
+++ b/compiler/fir/fir2ir/jvm-backend/src/org/jetbrains/kotlin/fir/backend/jvm/FirMetadataSerializer.kt
@@ -120,9 +120,9 @@ class FirMetadataSerializer(
     private val actualizedExpectDeclarations: Set<FirDeclaration>?
 ) : MetadataSerializer {
 
-    override fun serialize(metadata: MetadataSource, containingFile: MetadataSource.File?): Pair<MessageLite, JvmStringTable>? {
+    override fun serialize(metadata: MetadataSource): Pair<MessageLite, JvmStringTable>? {
         val message = when (metadata) {
-            is FirMetadataSource.Class -> serializer!!.classProto(metadata.fir, (containingFile as FirMetadataSource.File?)?.fir).build()
+            is FirMetadataSource.Class -> serializer!!.classProto(metadata.fir).build()
             is FirMetadataSource.File -> serializer!!.packagePartProto(metadata.fir, actualizedExpectDeclarations).build()
             is FirMetadataSource.Function -> {
                 val withTypeParameters = metadata.fir.copyToFreeAnonymousFunction(approximator)

--- a/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/incrementalFirCacheUtils.kt
+++ b/compiler/incremental-compilation-impl/src/org/jetbrains/kotlin/incremental/incrementalFirCacheUtils.kt
@@ -111,7 +111,7 @@ internal fun collectNewDirtySources(
                     val metadata = FirMetadataSource.Class(klass)
                     withMetadataSerializer(metadata, data) { serializer ->
                         klass.acceptChildren(this, data)
-                        serializer.serialize(metadata, FirMetadataSource.File(file))?.let { [classProto, nameTable] ->
+                        serializer.serialize(metadata)?.let { [classProto, nameTable] ->
                             caches.platformCache.saveFrontendClassToCache(
                                 klass.classId,
                                 classProto as ProtoBuf.Class,

--- a/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
+++ b/compiler/ir/backend.jvm/codegen/src/org/jetbrains/kotlin/backend/jvm/codegen/ClassCodegen.kt
@@ -365,12 +365,7 @@ class ClassCodegen private constructor(
 
         writeKotlinMetadata(visitor, context.config, kind, isPublicAbi, extraFlags) { av ->
             if (metadata != null) {
-                val containingFile = when (val containingFileMetadata = irClass.file.metadata) {
-                    is MetadataSource.File -> containingFileMetadata
-                    is MetadataSource.CodeFragment -> null
-                    else -> error("Cannot serialize class metadata without containing file: ${irClass.render()}")
-                }
-                metadataSerializer.serialize(metadata, containingFile)?.let { [proto, stringTable] ->
+                metadataSerializer.serialize(metadata)?.let { [proto, stringTable] ->
                     AsmUtil.writeAnnotationData(
                         av, JvmProtoBufUtil.writeData(proto, stringTable), ArrayUtil.toStringArray(stringTable.strings),
                     )

--- a/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/metadata/MetadataSerializer.kt
+++ b/compiler/ir/backend.jvm/src/org/jetbrains/kotlin/backend/jvm/metadata/MetadataSerializer.kt
@@ -13,7 +13,7 @@ import org.jetbrains.org.objectweb.asm.Type
 import org.jetbrains.org.objectweb.asm.commons.Method
 
 interface MetadataSerializer {
-    fun serialize(metadata: MetadataSource, containingFile: MetadataSource.File?): Pair<MessageLite, JvmStringTable>?
+    fun serialize(metadata: MetadataSource): Pair<MessageLite, JvmStringTable>?
 
     fun bindPropertyMetadata(metadata: MetadataSource.Property, signature: Method, origin: IrDeclarationOrigin)
 

--- a/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/K1JvmIrCodegenFactory.kt
+++ b/plugins/scripting/scripting-compiler/src/org/jetbrains/kotlin/scripting/compiler/plugin/impl/K1JvmIrCodegenFactory.kt
@@ -271,7 +271,7 @@ private class DescriptorMetadataSerializer(
         }
     }
 
-    override fun serialize(metadata: MetadataSource, containingFile: MetadataSource.File?): Pair<MessageLite, JvmStringTable>? {
+    override fun serialize(metadata: MetadataSource): Pair<MessageLite, JvmStringTable>? {
         val localDelegatedProperties = irClass.localDelegatedProperties
         if (localDelegatedProperties != null && localDelegatedProperties.isNotEmpty()) {
             serializerExtension.localDelegatedProperties.put(


### PR DESCRIPTION
It was used as a key to extract constants evaluated by IR interpreter. Now all the constants are evaluated on FIR level, and we don't need this parameter anymore.

#KT-87043