### PR TITLE
fix(KT-86265): Target cortex-a7 for androidNativeArm32 instead of arm7tdmi

### DIFF
--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -628,9 +628,9 @@ dependencies.mingw_x64-android_arm32 = \
     target-toolchain-2-windows-android_ndk
 
 targetTriple.android_arm32 = arm-unknown-linux-androideabi
-targetCpu.android_arm32 = arm7tdmi
-targetCpuFeatures.android_arm32 = +armv4t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp
-clangFlags.android_arm32 = -cc1 -emit-obj -disable-llvm-optzns -x ir -femulated-tls -mrelocation-model pic
+targetCpu.android_arm32 = cortex-a7
+targetCpuFeatures.android_arm32 = +armv7-a,+d32,+dsp,+hwdiv,+hwdiv-arm,+neon,+vfp3,+vfp3d16,+vfp4,-thumb-mode
+clangFlags.android_arm32 = -cc1 -emit-obj -disable-llvm-optzns -x ir -femulated-tls -mrelocation-model pic -target-cpu cortex-a7 -mfloat-abi soft
 clangOptFlags.android_arm32 = -O3 -ffunction-sections
 linkerNoDebugFlags.android_arm32 = -Wl,-S
 clangNooptFlags.android_arm32 = -O1

--- a/kotlin-native/runtime/build.gradle.kts
+++ b/kotlin-native/runtime/build.gradle.kts
@@ -760,3 +760,11 @@ cacheableTargetNames.forEach { targetName ->
 }
 
 // endregion
+
+// KT-86265: Use ARMv7 baseline for android_arm32 to match NDK armeabi-v7a spec.
+// This ensures ALL runtime modules (including libbacktrace) are compiled with cortex-a7.
+tasks.withType<org.jetbrains.kotlin.cpp.ClangFrontend>().configureEach {
+    if (targetName.get() == "android_arm32") {
+        arguments.addAll("-mcpu=cortex-a7", "-mfloat-abi=softfp")
+    }
+}

--- a/kotlin-native/runtime/src/main/cpp/polyhash/PolyHash-arm.h
+++ b/kotlin-native/runtime/src/main/cpp/polyhash/PolyHash-arm.h
@@ -63,8 +63,8 @@ struct NeonTraits {
 #if defined(__aarch64__)
     const bool neonSupported = true; // AArch64 always supports Neon.
 #elif defined(__ANDROID__)
-    #include <cpu-features.h>
-    const bool neonSupported = android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_NEON;
+    // cortex-a7 baseline always has NEON; cpu-features.h unavailable in konan deps
+    const bool neonSupported = true;
 #elif defined(__APPLE__)
     const bool neonSupported = true; // It is supported starting from iPhone 3GS.
 #elif defined(__linux__) or defined(__unix__)

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -145,6 +145,8 @@ sealed class ClangArgs(
                     "-I$toolchainSysroot/usr/include",
                     "-I$toolchainSysroot/usr/include/$clangTarget"
             ) + when (target) {
+                // KT-86265: Use ARMv7 baseline for android_arm32 to match NDK armeabi-v7a spec
+                KonanTarget.ANDROID_ARM32 -> listOf("-mcpu=cortex-a7", "-mfloat-abi=softfp")
                 // KT-73559
                 KonanTarget.ANDROID_ARM64 -> listOf("-mno-outline-atomics")
                 else -> emptyList()


### PR DESCRIPTION
## Summary

The Kotlin/Native `android_arm32` target emits code for `arm7tdmi` (ARMv4T) which lacks VFP/NEON floating-point support. This causes **silent runtime failures** when Kotlin/Native compiled code interacts with NDK-built `armeabi-v7a` libraries that use hardware floating-point (VFPv3 calling convention).

**Symptoms:** Blank rendering, corrupted data, or hangs when calling into libraries like PDFium, OpenCV — without any crash.

## Changes

- `konan.properties`: Set `targetCpu=cortex-a7` with `+armv7-a,+neon,+vfp3` features and add `-target-cpu cortex-a7 -mfloat-abi soft` to clangFlags
- `ClangArgs.kt`: Pass `-mcpu=cortex-a7 -mfloat-abi=softfp` for `ANDROID_ARM32` C/C++ compilation
- `runtime/build.gradle.kts`: Ensure all C++ runtime modules use cortex-a7 via ClangFrontend task configuration
- `PolyHash-arm.h`: Remove `cpu-features.h` dependency and assume NEON on Android (guaranteed by cortex-a7 baseline)

## Why cortex-a7?

- Lowest ARMv7-A core matching Google's `armeabi-v7a` minimum spec
- Includes NEON, VFPv3, VFPv4, hardware divide
- Uses `softfp` float ABI — matches NDK convention
- Every Android device running armeabi-v7a has at minimum this capability

## Verification

1. Built Kotlin/Native dist with the patch
2. Compiled a real-world KMP PDF rendering library for `androidNativeArm32`
3. Verified output binary contains VFP/NEON instructions (9,378 VFP ops via objdump)
4. Tested on real arm32 device (Realme C11 2021, Android 11) — PDF rendering works correctly, previously showed blank pages

**Before:** `readelf -A` shows `Tag_CPU_arch: v4T`, rendering blank
**After:** Binary uses VFP/NEON, rendering works on arm32 device