### PR TITLE
[Native] Introduce Split-Compilation Scheme

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -16445,6 +16445,51 @@
                                         "deprecatedMessage": null
                                     },
                                     {
+                                        "name": "Xcompilation-scheme",
+                                        "shortName": null,
+                                        "deprecatedName": null,
+                                        "description": {
+                                            "current": "Compilation scheme used by the compiler to produce final binaries. \n1. 'closed': default compilation scheme. It produces one single artifact containing all the Kotlin code.\n2. 'split': hot-reload enable artifacts. It produces one single executable (the host) and a bootstrap object (loaded by host) containing Kotlin code.",
+                                            "valueInVersions": []
+                                        },
+                                        "delimiter": "None",
+                                        "affectsCompilationOutcome": true,
+                                        "restrictedToCompilerPhase": null,
+                                        "valueType": {
+                                            "type": "org.jetbrains.kotlin.arguments.dsl.types.StringType",
+                                            "isNullable": {
+                                                "current": true,
+                                                "valueInVersions": []
+                                            },
+                                            "defaultValue": {
+                                                "current": null,
+                                                "valueInVersions": []
+                                            }
+                                        },
+                                        "valueDescription": {
+                                            "current": "<closed|split>",
+                                            "valueInVersions": []
+                                        },
+                                        "releaseVersionsMetadata": {
+                                            "introducedVersion": "2.5.0",
+                                            "stabilizedVersion": null,
+                                            "deprecatedVersion": null,
+                                            "removedVersion": null
+                                        },
+                                        "argumentType": {
+                                            "type": "org.jetbrains.kotlin.arguments.dsl.types.StringType",
+                                            "isNullable": {
+                                                "current": true,
+                                                "valueInVersions": []
+                                            },
+                                            "defaultValue": {
+                                                "current": null,
+                                                "valueInVersions": []
+                                            }
+                                        },
+                                        "deprecatedMessage": null
+                                    },
+                                    {
                                         "name": "Xcompile-from-bitcode",
                                         "shortName": null,
                                         "deprecatedName": null,

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/NativeCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/NativeCompilerArguments.kt
@@ -404,6 +404,22 @@ By default caches will be placed into the kotlin-native system cache directory."
     }
 
     compilerArgument {
+        name = "Xcompilation-scheme"
+        compilerName = "compilationScheme"
+        description = """
+            Compilation scheme used by the compiler to produce final binaries. 
+            1. 'closed': default compilation scheme. It produces one single artifact containing all the Kotlin code.
+            2. 'split': hot-reload enable artifacts. It produces one single executable (the host) and a bootstrap object (loaded by host) containing Kotlin code.
+        """.trimIndent().asReleaseDependent()
+        valueType = StringType.defaultNull
+        valueDescription = "<closed|split>".asReleaseDependent()
+        delimiter = KotlinCompilerArgument.Delimiter.None
+        lifecycle(
+            introducedVersion = KotlinReleaseVersion.v2_5_0
+        )
+    }
+
+    compilerArgument {
         name = "Xcheck-dependencies"
         deprecatedName = "-check_dependencies"
         description = "Check dependencies and download the missing ones.".asReleaseDependent()

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
@@ -143,6 +143,20 @@ The default value is 1.""",
         }
 
     @Argument(
+        value = "-Xcompilation-scheme",
+        valueDescription = "<closed|split>",
+        description = """Compilation scheme used by the compiler to produce final binaries. 
+1. 'closed': default compilation scheme. It produces one single artifact containing all the Kotlin code.
+2. 'split': hot-reload enable artifacts. It produces one single executable (the host) and a bootstrap object (loaded by host) containing Kotlin code.""",
+        delimiter = Argument.Delimiters.none,
+    )
+    var compilationScheme: String? = null
+        set(value) {
+            checkFrozen()
+            field = if (value.isNullOrEmpty()) null else value
+        }
+
+    @Argument(
         value = "-Xcompile-from-bitcode",
         valueDescription = "<path>",
         description = "Continue compilation from the given bitcode file.",

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArgumentsCopyGenerated.kt
@@ -20,6 +20,7 @@ fun copyK2NativeCompilerArguments(from: K2NativeCompilerArguments, to: K2NativeC
     to.checkDependencies = from.checkDependencies
     to.checkExternalCalls = from.checkExternalCalls
     to.clangOptions = from.clangOptions.copyOf()
+    to.compilationScheme = from.compilationScheme
     to.compileFromBitcode = from.compileFromBitcode
     to.debug = from.debug
     to.debugInfoFormatVersion = from.debugInfoFormatVersion

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.config.keys.generator
 
 import org.jetbrains.kotlin.backend.konan.AllocationMode
+import org.jetbrains.kotlin.backend.konan.CompilationScheme
 import org.jetbrains.kotlin.backend.konan.LlvmVariant
 import org.jetbrains.kotlin.backend.konan.TestRunnerKind
 import org.jetbrains.kotlin.config.keys.generator.model.KeysContainer
@@ -27,6 +28,7 @@ object NativeConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.ko
     val AUTO_CACHE_DIR by key<String>("Path to the directory where to put caches for auto-cacheable dependencies.")
     val INCREMENTAL_CACHE_DIR by key<String>("Path to the directory where to put incremental build caches.")
     val DUMP_BUILT_CACHES_TO by key<String>("Path to a file where the list of all cache archives produced by this build should be written.")
+    val COMPILATION_SCHEME by key<CompilationScheme>("Compilation scheme used by the compiler, 'split-host' is used to have hot-reload enabled binaries.")
     val CACHED_LIBRARIES by key<Map<String, String>>("Mapping from library paths to cache paths.")
     val FILES_TO_CACHE by key<List<String>>("Which files should be compiled to cache.")
     val MAKE_PER_FILE_CACHE by key<Boolean>()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BitcodeCompiler.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BitcodeCompiler.kt
@@ -6,11 +6,12 @@
 package org.jetbrains.kotlin.backend.konan
 
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
+import org.jetbrains.kotlin.backend.konan.util.absoluteNormalizedPathString
 import org.jetbrains.kotlin.config.nativeBinaryOptions.BinaryOptions
 import org.jetbrains.kotlin.konan.config.overrideClangOptions
 import org.jetbrains.kotlin.konan.exec.Command
 import org.jetbrains.kotlin.konan.target.*
-import java.io.File
+import java.nio.file.Path
 
 typealias ObjectFile = String
 
@@ -45,7 +46,7 @@ internal class BitcodeCompiler(
         runTool(absoluteToolName, *arg)
     }
 
-    private fun clang(configurables: ClangFlags, bitcodeFile: File, objectFile: File) {
+    private fun clang(configurables: ClangFlags, bitcodePath: Path, objectPath: Path) {
         val targetTriple = if (configurables is AppleConfigurables) {
             platform.targetTriple.withOSVersion(configurables.osVersionMin)
         } else {
@@ -62,12 +63,12 @@ internal class BitcodeCompiler(
                     })
                     addNonEmpty(configurables.currentRelocationMode(context).translateToClangCc1Flag())
                 }
-        val bitcodePath = bitcodeFile.absoluteFile.normalize().path
-        val objectPath = objectFile.absoluteFile.normalize().path
-        if (configurables is AppleConfigurables && config.configuration.get(BinaryOptions.compileBitcodeWithXcodeLlvm) == true) {
-            targetTool("clang++", *flags.toTypedArray(), bitcodePath, "-o", objectPath)
+        val bitcodePathString = bitcodePath.absoluteNormalizedPathString()
+        val objectPathString = objectPath.absoluteNormalizedPathString()
+        if (configurables is AppleConfigurables && config.configuration[BinaryOptions.compileBitcodeWithXcodeLlvm] == true) {
+            targetTool("clang++", *flags.toTypedArray(), bitcodePathString, "-o", objectPathString)
         } else {
-            hostLlvmTool("clang++", *flags.toTypedArray(), bitcodePath, "-o", objectPath)
+            hostLlvmTool("clang++", *flags.toTypedArray(), bitcodePathString, "-o", objectPathString)
         }
     }
 
@@ -78,11 +79,11 @@ internal class BitcodeCompiler(
     }
 
     /**
-     * Compile [bitcodeFile] to [objectFile].
+     * Compile the bitcode at [bitcodePath] to an object file at [objectPath] using `clang`.
      */
-    fun makeObjectFile(bitcodeFile: File, objectFile: File) =
+    fun makeObjectFile(bitcodePath: Path, objectPath: Path) =
             when (val configurables = platform.configurables) {
-                is ClangFlags -> clang(configurables, bitcodeFile, objectFile)
+                is ClangFlags -> clang(configurables, bitcodePath, objectPath)
                 else -> error("Unsupported configurables kind: ${configurables::class.simpleName}!")
             }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -70,7 +70,7 @@ class CacheBuilder(
 
     fun needToBuild() = config.ignoreCacheReason == null
             && (config.isFinalBinary || config.produce.isFullCache)
-            && (autoCacheableFrom.isNotEmpty() || icEnabled || config.compilationScheme == CompilationScheme.SPLIT_HOST)
+            && (autoCacheableFrom.isNotEmpty() || icEnabled)
 
     // Note: The order of libraries is not important here.
     private val allLibraries by lazy { config.resolvedLibraries.getFullList() }
@@ -590,7 +590,7 @@ class CacheBuilder(
             val fileContent = if (lastRebuiltArchives.isEmpty())
                 ""
             else
-                lastRebuiltArchives.joinToString("\n") { it.absolutePathString() } + "\n"
+                lastRebuiltArchives.joinToString("\n") { it.normalize().absolutePathString() } + "\n"
             rebuiltArchivesFile.writeText(fileContent)
         }
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -70,7 +70,7 @@ class CacheBuilder(
 
     fun needToBuild() = config.ignoreCacheReason == null
             && (config.isFinalBinary || config.produce.isFullCache)
-            && (autoCacheableFrom.isNotEmpty() || icEnabled)
+            && (autoCacheableFrom.isNotEmpty() || icEnabled || config.compilationScheme == CompilationScheme.SPLIT_HOST)
 
     // Note: The order of libraries is not important here.
     private val allLibraries by lazy { config.resolvedLibraries.getFullList() }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.cli.CliDiagnostics
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.konan.config.NativeConfigurationKeys
-import org.jetbrains.kotlin.konan.config.compilationScheme
 import org.jetbrains.kotlin.konan.config.filesToCache
 import org.jetbrains.kotlin.konan.config.konanLibraryToAddToCache
 import org.jetbrains.kotlin.konan.config.preLinkCaches
@@ -87,8 +86,8 @@ class CacheSupport(
             add(Path(directoryPathString).takeIf { it.isDirectory() }
                     ?: configuration.reportCompilationErrorAndThrow("cache directory $directoryPathString is not found or is not a directory"))
         }
-        systemCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() || incrementalCacheDirectory != null || configuration.compilationScheme == CompilationScheme.SPLIT_HOST }?.let { add(it) }
-        autoCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() || configuration.compilationScheme == CompilationScheme.SPLIT_HOST }?.let { add(it) }
+        systemCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() || incrementalCacheDirectory != null }?.let { add(it) }
+        autoCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() }?.let { add(it) }
         incrementalCacheDirectory?.let { add(it) }
     }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.cli.CliDiagnostics
 import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.konan.config.NativeConfigurationKeys
+import org.jetbrains.kotlin.konan.config.compilationScheme
 import org.jetbrains.kotlin.konan.config.filesToCache
 import org.jetbrains.kotlin.konan.config.konanLibraryToAddToCache
 import org.jetbrains.kotlin.konan.config.preLinkCaches
@@ -82,12 +83,12 @@ class CacheSupport(
             }
 
     private val implicitCacheDirectories = buildList {
-        configuration[NativeConfigurationKeys.CACHE_DIRECTORIES]!!.forEach {
-            add(Path(it).takeIf { it.isDirectory() }
-                    ?: configuration.reportCompilationErrorAndThrow("cache directory $it is not found or is not a directory"))
+        configuration[NativeConfigurationKeys.CACHE_DIRECTORIES]!!.forEach { directoryPathString ->
+            add(Path(directoryPathString).takeIf { it.isDirectory() }
+                    ?: configuration.reportCompilationErrorAndThrow("cache directory $directoryPathString is not found or is not a directory"))
         }
-        systemCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() || incrementalCacheDirectory != null }?.let { add(it) }
-        autoCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() }?.let { add(it) }
+        systemCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() || incrementalCacheDirectory != null || configuration.compilationScheme == CompilationScheme.SPLIT_HOST }?.let { add(it) }
+        autoCacheDirectory.takeIf { autoCacheableFrom.isNotEmpty() || configuration.compilationScheme == CompilationScheme.SPLIT_HOST }?.let { add(it) }
         incrementalCacheDirectory?.let { add(it) }
     }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CheckExternalCalls.kt
@@ -62,7 +62,7 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
                 LLVMIsAFunction(value) != null -> {
                     val valueOrSpecial = value.takeIf { !it.isLLVMBuiltin }
                             ?: LLVMConstIntToPtr(llvm.int64(CALLED_LLVM_BUILTIN), llvm.pointerType)!!
-                    ExternalCallInfo(value.valueName!!, valueOrSpecial).takeIf { value.isExternalFunction() }
+                    ExternalCallInfo(value.valueName!!, valueOrSpecial).takeIf { value.isExternalFunction }
                 }
                 LLVMIsACastInst(value) != null -> cleanCalledFunction(LLVMGetOperand(value, 0)!!)
                 isIndirectCallArgument(value) -> ExternalCallInfo(null, value) // this is a callback call
@@ -85,7 +85,7 @@ private class CallsChecker(generationState: NativeGenerationState, goodFunctions
 
     private fun processBasicBlock(functionName: String, block: LLVMBasicBlockRef) {
         val calls = getInstructions(block)
-                .filter { it.isFunctionCall() }
+                .filter { it.isFunctionCall }
                 .toList()
         val builder = LLVMCreateBuilderInContext(llvm.llvmContext)!!
 
@@ -205,7 +205,7 @@ internal fun checkLlvmModuleExternalCalls(generationState: NativeGenerationState
 
     val checker = CallsChecker(generationState, goodFunctions)
     getFunctions(llvm.module)
-            .filter { !it.isExternalFunction() && it !in ignoredFunctions }
+            .filter { !it.isExternalFunction && it !in ignoredFunctions }
             .forEach(checker::processFunction)
     verifyModule(llvm.module)
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 package org.jetbrains.kotlin.backend.konan
@@ -244,7 +244,7 @@ internal fun linkBitcodeDependencies(generationState: NativeGenerationState,
     linkAllDependencies(generationState, generatedBitcodePaths.map { it.absoluteNormalizedPathString() })
 }
 
-private fun parseAndLinkBitcodeFile(generationState: NativeGenerationState, llvmModule: LLVMModuleRef, path: String) {
+internal fun parseAndLinkBitcodeFile(generationState: NativeGenerationState, llvmModule: LLVMModuleRef, path: String) {
     val parsedModule = parseBitcodeFile(generationState, generationState.diagnosticReporter, generationState.llvmContext, path)
     if (!generationState.shouldUseDebugInfoFromNativeLibs()) {
         LLVMStripModuleDebugInfo(parsedModule)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
@@ -130,6 +130,8 @@ private fun collectLlvmModules(generationState: NativeGenerationState, generated
 
     val runtimeBitcodeFiles = buildList<String> {
         if (runtimeModulesConfig.containsDebuggingRuntime) add(RuntimeModule.DEBUG)
+        if (runtimeModulesConfig.isCompilingWithSplitScheme) add(RuntimeModule.HOT_RELOAD)
+
         add(RuntimeModule.RUNTIME)
 
         if (config.target.family == Family.OSX && config.minidumpLocation != null) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.objc.patchObjCRuntimeModule
 import org.jetbrains.kotlin.backend.konan.llvm.runtime.RuntimeModule
 import org.jetbrains.kotlin.backend.konan.llvm.runtime.linkRuntimeModules
 import org.jetbrains.kotlin.backend.konan.serialization.CacheDeserializationStrategy
+import org.jetbrains.kotlin.backend.konan.util.absoluteNormalizedPathString
 import org.jetbrains.kotlin.config.nativeBinaryOptions.CCallMode
 import org.jetbrains.kotlin.config.nativeBinaryOptions.CInterfaceGenerationMode
 import org.jetbrains.kotlin.config.nativeBinaryOptions.GC
@@ -24,7 +25,7 @@ import org.jetbrains.kotlin.konan.target.supportsLibBacktrace
 import org.jetbrains.kotlin.library.isNativeStdlib
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
-import java.io.File
+import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.pathString
 
@@ -228,7 +229,7 @@ internal fun insertAliasToEntryPoint(module: LLVMModuleRef, entryPointName: Stri
 }
 
 internal fun linkBitcodeDependencies(generationState: NativeGenerationState,
-                                     generatedBitcodeFiles: List<File>) {
+                                     generatedBitcodePaths: List<Path>) {
     val config = generationState.config
     val produce = config.produce
 
@@ -238,8 +239,7 @@ internal fun linkBitcodeDependencies(generationState: NativeGenerationState,
     if (staticFramework || swiftExport) {
         embedAppleLinkerOptionsToBitcode(generationState.llvm, config)
     }
-    linkAllDependencies(generationState, generatedBitcodeFiles.map { it.absoluteFile.normalize().path })
-
+    linkAllDependencies(generationState, generatedBitcodePaths.map { it.absoluteNormalizedPathString() })
 }
 
 private fun parseAndLinkBitcodeFile(generationState: NativeGenerationState, llvmModule: LLVMModuleRef, path: String) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
@@ -120,20 +120,24 @@ internal class Linker(
                 Family.OSX -> "Versions/A/$dylibName"
                 else -> error("Unsupported target family for Framework: $target")
             }
-
+            val flags = buildList {
+                if (!config.isUsingSplitCompilationScheme) add("-dead_strip")
+                add("-install_name")
+                add( "@rpath/${framework.name}/$dylibRelativePath")
+            }
             ExecutableTarget(
                     path = framework.resolve(dylibRelativePath).absolutePathString(),
-                    flags = listOf("-dead_strip", "-install_name", "@rpath/${framework.name}/$dylibRelativePath")
+                    flags = flags
             )
         }
         else -> {
             val flags = if (target.family.isAppleFamily) {
                 when (config.produce) {
                     CompilerOutputKind.DYNAMIC_CACHE -> listOf("-install_name", outputFiles.dynamicCacheInstallName)
+                    CompilerOutputKind.PROGRAM if config.isUsingSplitCompilationScheme -> []
                     else -> listOf("-dead_strip")
                 }
             } else emptyList()
-
             ExecutableTarget(outputFiles.nativeBinaryFile, flags)
         }
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
@@ -102,6 +102,7 @@ internal class NativeGenerationState(
     lateinit var objCExport: ObjCExport
 
     fun hasDebugInfo() = debugInfoDelegate.isInitialized()
+    fun hasObjCExport() = ::objCExport.isInitialized
 
     private var isDisposed = false
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -597,6 +597,8 @@ class NativeSecondStageCompilationConfig(
             append("-with_crash_dumps")
         if (runtimeLogsEnabled)
             append("-runtime_logs_enabled")
+        if (isUsingSplitCompilationScheme)
+            append("-hot_reload_enabled")
     }
 
     private val userCacheFlavorString = buildString {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -623,6 +623,10 @@ class NativeSecondStageCompilationConfig(
     internal val incrementalCacheDirectory = incrementalCacheRootDirectory?.resolve(userCacheFlavorString)
     internal val dumpBuiltCachesTo = configuration.dumpBuiltCachesTo
 
+    internal val compilationScheme: CompilationScheme = configuration.compilationScheme ?: CompilationScheme.DEFAULT
+    internal val isUsingSplitCompilationScheme: Boolean
+        get() = compilationScheme == CompilationScheme.SPLIT_HOST
+
     internal val ignoreCacheReason = when {
         optimizationsEnabled && !enableReleaseBinaryCache -> "with global optimizations"
         forceNativeThreadStateForFunctions != defaultForceNativeThreadStateForFunctions -> "with non-default forceNativeThreadStateForFunctions"

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.backend.konan
 
 import kotlinx.cinterop.*
 import llvm.*
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.config.LoggingContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.llvm.*
@@ -54,6 +53,7 @@ data class LlvmPipelineConfig(
         val saveIrDirectory: java.io.File? = null,
         val runLLVMPassesInCompiler: Boolean,
         val shouldInlineSafepoints: Boolean = false,
+        val isUsingSplitCompilationScheme: Boolean = false
 ) {
     /**
      * Create a copy of [LlvmPipelineConfig] setting up options to dump IR
@@ -150,10 +150,10 @@ internal fun createLTOPipelineConfigForRuntime(generationState: NativeGeneration
  * but for release binaries we rely on "closed" world and enable a lot of optimizations.
  */
 internal fun createLTOFinalPipelineConfig(
-    context: NativeBackendPhaseContext,
-    targetTriple: String,
-    closedWorld: Boolean,
-    timePasses: Boolean = false,
+        context: NativeBackendPhaseContext,
+        targetTriple: String,
+        closedWorld: Boolean,
+        timePasses: Boolean = false,
 ): LlvmPipelineConfig {
     val config = context.config
     val target = config.target
@@ -186,7 +186,8 @@ internal fun createLTOFinalPipelineConfig(
     // similar to DCE enabled by internalize but later:
     //
     // Important for binary size, workarounds references to undefined symbols from interop libraries.
-    val makeDeclarationsHidden = config.produce == CompilerOutputKind.STATIC_CACHE
+    // In the context of split compilation we want declarations to be visible, so the host runtime can resolve symbols easily.
+    val makeDeclarationsHidden = config.produce == CompilerOutputKind.STATIC_CACHE && !config.isUsingSplitCompilationScheme
     val objcPasses = configurables is AppleConfigurables
 
     // Null value means that LLVM should use default inliner params
@@ -217,6 +218,7 @@ internal fun createLTOFinalPipelineConfig(
             sspMode = config.stackProtectorMode,
             runLLVMPassesInCompiler = config.runLLVMPassesInCompiler,
             shouldInlineSafepoints = context.shouldInlineSafepoints(),
+            isUsingSplitCompilationScheme = config.isUsingSplitCompilationScheme
     )
 }
 
@@ -338,8 +340,13 @@ class MandatoryOptimizationPipeline(config: LlvmPipelineConfig, performanceManag
     }
 
     override fun executeCustomPreprocessing(config: LlvmPipelineConfig, module: LLVMModuleRef) {
-        if (config.runLLVMPassesInCompiler && config.makeDeclarationsHidden) {
-            makeVisibilityHiddenLikeLlvmInternalizePass(module)
+        when {
+            config.isUsingSplitCompilationScheme -> {
+                module.makeSymbolsVisibilityDefault()
+            }
+            config.runLLVMPassesInCompiler && config.makeDeclarationsHidden -> {
+                module.makeSymbolsVisibilityHiddenLikeLlvmInternalizePass()
+            }
         }
     }
 }
@@ -356,11 +363,11 @@ class LTOOptimizationPipeline(config: LlvmPipelineConfig, performanceManager: Pe
     override val passes =
             if (config.ltoPasses != null) listOf(config.ltoPasses)
             else buildList {
-                if (config.internalize) {
+                if (config.internalize && !config.isUsingSplitCompilationScheme) {
                     add("internalize")
                 }
 
-                if (config.globalDce) {
+                if (config.globalDce && !config.isUsingSplitCompilationScheme) {
                     add("globaldce")
                 }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
@@ -391,7 +391,7 @@ class ThreadSanitizerPipeline(config: LlvmPipelineConfig, performanceManager: Pe
         if (!config.runLLVMPassesInCompiler)
             return
         getFunctions(module)
-                .filter { LLVMIsDeclaration(it) == 0 }
+                .filter { it.isDefinition }
                 .forEach { addLlvmFunctionEnumAttribute(it, LlvmFunctionAttribute.SanitizeThread) }
     }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeLogging.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeLogging.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 package org.jetbrains.kotlin.backend.konan
@@ -33,6 +33,7 @@ enum class LoggingTag(val ord: Int) {
     GCMark(9),
     GCScheduler(10),
     MemoryDump(11),
+    HotReload(12)
     ;
 
     companion object {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/SetupConfiguration.kt
@@ -216,6 +216,49 @@ fun CompilerConfiguration.setupFromArguments(arguments: K2NativeCompilerArgument
         }
     })
 
+    val compilationScheme = when (arguments.compilationScheme) {
+        null, "closed" -> CompilationScheme.CLOSED
+        "split" -> CompilationScheme.SPLIT_HOST
+        else -> {
+            report(KONAN_ARGUMENT_ERROR, "Expected 'closed' or 'split' as compilation scheme. The default will be used.")
+            CompilationScheme.CLOSED
+        }
+    }
+    if (compilationScheme != CompilationScheme.CLOSED) {
+        // Split-Compilation requires debug enabled (to disable some aggressive optimizations, and for symbol resolution).
+        // In addition to that, symbol names should be stable across the host's bootstrap object and cached objects.
+        // To do so, we need incremental cache enabled in split-compilation.
+        report(KONAN_ARGUMENT_WARNING, "Split compilation is an experimental feature, available only on Darwin platforms, the final artifact may not work as expected.")
+        if (!getBoolean(NativeConfigurationKeys.DEBUG)) {
+            report(KONAN_ARGUMENT_ERROR, "Split compilation requires debugging information enabled. Please compile by passing '-g' as argument.")
+        }
+
+        if (outputKind != CompilerOutputKind.PROGRAM && outputKind != CompilerOutputKind.FRAMEWORK) {
+            report(
+                    KONAN_ARGUMENT_ERROR,
+                    "Split compilation only supports '-produce program' and '-produce framework'. " +
+                            "Got: '${outputKind.name.lowercase()}'."
+            )
+        }
+
+        get(BinaryOptions.perFileCacheForStdlib).let { perFileCacheForStdlib ->
+            if (perFileCacheForStdlib == null || perFileCacheForStdlib) {
+                report(KONAN_ARGUMENT_ERROR, "Split compilation requires the Standard Library compiled as monolithic cache." +
+                        "Please pass '-Xbinary=perFileCacheForStdlib=false' as argument.")
+            }
+        }
+
+        if (incrementalCacheDir.isNullOrEmpty()) {
+            report(
+                    KONAN_ARGUMENT_ERROR,
+                    "Split compilation requires incremental compilation. " +
+                            "Please pass '${K2NativeCompilerArguments::incrementalCompilation.cliArgument}' " +
+                            "and '${K2NativeCompilerArguments::incrementalCacheDir.cliArgument}=<directory>'."
+            )
+        }
+    }
+    put(COMPILATION_SCHEME, compilationScheme)
+
     arguments.externalDependencies?.let { put(EXTERNAL_DEPENDENCIES, it) }
     putIfNotNull(LLVM_VARIANT, when (val variant = arguments.llvmVariant) {
         "user" -> LlvmVariant.User
@@ -260,6 +303,7 @@ private fun String.absoluteNormalizedFile() = java.io.File(this).absoluteFile.no
 internal fun CompilerConfiguration.setupCommonOptionsForCaches(config: NativeSecondStageCompilationConfig) = with(NativeConfigurationKeys) {
     konanTarget = config.target.toString()
     put(DEBUG, config.debug)
+    put(COMPILATION_SCHEME, config.compilationScheme)
     setupPartialLinkageConfig(config.partialLinkageConfig)
     putIfNotNull(EXTERNAL_DEPENDENCIES, config.externalDependenciesFile?.absolutePathString())
     put(PROPERTY_LAZY_INITIALIZATION, config.propertyLazyInitialization)
@@ -276,6 +320,7 @@ internal fun CompilerConfiguration.setupCommonOptionsForCaches(config: NativeSec
     putIfNotNull(BinaryOptions.macabi, config.macabi)
     putIfNotNull(BinaryOptions.cCallMode, config.cCallMode)
     putIfNotNull(RUNTIME_LOGS, config.configuration.runtimeLogs)
+    putIfNotNull(COMPILATION_SCHEME, config.configuration.compilationScheme)
 }
 
 private fun Array<String>?.toNonNullList() = this?.asList().orEmpty()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterApiExporter.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterApiExporter.kt
@@ -15,8 +15,10 @@ import org.jetbrains.kotlin.types.typeUtil.isNothing
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 import org.jetbrains.kotlin.types.typeUtil.makeNullable
 import java.io.PrintWriter
-import java.io.File
 import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.backend.konan.util.printWriter
+import java.nio.file.Path
+import kotlin.io.path.forEachLine
 
 /**
  * Third phase of C export:
@@ -24,15 +26,15 @@ import org.jetbrains.kotlin.K1Deprecation
  *  2. Create a header file with API
  *  3. (MinGW only) create EXPORTS def file.
  *
- *  @param headerFile C header file that will be populated with the exported C API.
- *  @param defFile DLL module definition file
- *  @param cppAdapterFile C++ source that will be populated with glue code between K/N runtime and exported API.
+ *  @param headerPath C header file that will be populated with the exported C API.
+ *  @param defPath DLL module definition file
+ *  @param cppAdapterPath C++ source that will be populated with glue code between K/N runtime and exported API.
  */
 internal class CAdapterApiExporter(
         private val elements: CAdapterExportedElements,
-        private val headerFile: File,
-        private val defFile: File?,
-        private val cppAdapterFile: File,
+        private val headerPath: Path,
+        private val defPath: Path?,
+        private val cppAdapterPath: Path,
         private val target: KonanTarget,
 ) {
     private val typeTranslator = elements.typeTranslator
@@ -51,7 +53,7 @@ internal class CAdapterApiExporter(
             builtIns.floatType, builtIns.doubleType,
             builtIns.charType, builtIns.booleanType,
             builtIns.unitType
-    ) + UnsignedType.values().map {
+    ) + UnsignedType.entries.map {
         // Unfortunately, `context.symbols` and `context.irBuiltins` are not initialized, so `context.symbols.ubyte`, etc, are unreachable.
         builtIns.builtInsModule.findClassAcrossModuleDependencies(it.classId)!!.defaultType
     }
@@ -167,7 +169,7 @@ internal class CAdapterApiExporter(
     // TODO: Pass temp and output files explicitly and untie from `NativeGenerationState`.
     fun makeGlobalStruct() {
         val top = elements.scopes.first()
-        outputStreamWriter = headerFile.printWriter()
+        outputStreamWriter = headerPath.printWriter()
 
         val exportedSymbol = "${prefix}_symbols"
         exportedSymbols += exportedSymbol
@@ -250,10 +252,10 @@ internal class CAdapterApiExporter(
 
         outputStreamWriter.close()
 
-        outputStreamWriter = cppAdapterFile.printWriter()
+        outputStreamWriter = cppAdapterPath.printWriter()
 
         // Include header into C++ source.
-        headerFile.forEachLine { it -> output(it) }
+        headerPath.forEachLine { output(it) }
 
         output("""
     |struct KObjHeader;
@@ -390,8 +392,8 @@ internal class CAdapterApiExporter(
         output("RUNTIME_EXPORT ${prefix}_ExportedSymbols* $exportedSymbol(void) { return &__konan_symbols;}")
         outputStreamWriter.close()
 
-        if (defFile != null) {
-            outputStreamWriter = defFile.printWriter()
+        if (defPath != null) {
+            outputStreamWriter = defPath.printWriter()
             output("EXPORTS")
             exportedSymbols.forEach { output(it) }
             outputStreamWriter.close()
@@ -407,7 +409,7 @@ private val KotlinType.createGetNonNullValueOfPredefinedType
 
 private operator fun String.times(count: Int): String {
     val builder = StringBuilder()
-    repeat(count, { builder.append(this) })
+    repeat(count) { builder.append(this) }
     return builder.toString()
 }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterCompile.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cexport/CAdapterCompile.kt
@@ -5,19 +5,20 @@
 
 package org.jetbrains.kotlin.backend.konan.cexport
 
+import org.jetbrains.kotlin.backend.konan.util.absoluteNormalizedPathString
 import org.jetbrains.kotlin.konan.exec.*
 import org.jetbrains.kotlin.konan.target.*
-import java.io.File
+import java.nio.file.Path
 
 /**
  * Fourth phase of C export: compile runtime bindings to bitcode.
  */
-fun produceCAdapterBitcode(clang: ClangArgs, cppFile: File, bitcodeFile: File) {
+fun produceCAdapterBitcode(clang: ClangArgs, cppFile: Path, bitcodeFile: Path) {
     val clangCommand = clang.clangCXX(
             "-std=c++17",
-            cppFile.absoluteFile.normalize().path,
+            cppFile.absoluteNormalizedPathString(),
             "-emit-llvm", "-c",
-            "-o", bitcodeFile.absoluteFile.normalize().path
+            "-o", bitcodeFile.absoluteNormalizedPathString()
     )
     Command(clangCommand).execute()
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
@@ -28,14 +28,15 @@ import org.jetbrains.kotlin.backend.konan.llvm.valueName
 import org.jetbrains.kotlin.backend.konan.llvm.verifyModule
 import org.jetbrains.kotlin.backend.konan.optimizations.RemoveRedundantSafepointsPass
 import org.jetbrains.kotlin.config.nativeBinaryOptions.SanitizerKind
+import org.jetbrains.kotlin.io.canonicalPathString
 import org.jetbrains.kotlin.util.PerformanceManager
-import java.io.File
+import java.nio.file.Path
 import kotlin.sequences.forEach
 
 
 internal data class WriteBitcodeFileInput(
         override val llvmModule: LLVMModuleRef,
-        val outputFile: File,
+        val outputFile: Path,
 ) : LlvmIrHolder
 
 internal data class InsertEntryPointAliasInput(
@@ -57,7 +58,7 @@ internal val WriteBitcodeFilePhase = createSimpleNamedCompilerPhase<NativeBacken
         "WriteBitcodeFile",
         postactions = getDefaultLlvmModuleActions(),
 ) { _, (llvmModule, outputFile) ->
-    LLVMWriteBitcodeToFile(llvmModule, outputFile.canonicalPath)
+    LLVMWriteBitcodeToFile(llvmModule, outputFile.canonicalPathString())
 }
 
 internal val CheckExternalCallsPhase = createSimpleNamedCompilerPhase<NativeGenerationState, Unit>(
@@ -153,7 +154,7 @@ internal val CStubsPhase = createSimpleNamedCompilerPhase<NativeGenerationState,
         op = { context, _ -> produceCStubs(context) }
 )
 
-internal val LinkBitcodeDependenciesPhase = createSimpleNamedCompilerPhase<NativeGenerationState, List<File>>(
+internal val LinkBitcodeDependenciesPhase = createSimpleNamedCompilerPhase<NativeGenerationState, List<Path>>(
         name = "LinkBitcodeDependencies",
         postactions = getDefaultLlvmModuleActions(),
         op = { context, input -> linkBitcodeDependencies(context, input) }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Bitcode.kt
@@ -1,12 +1,11 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
 package org.jetbrains.kotlin.backend.konan.driver.phases
 
 import llvm.LLVMDumpModule
-import llvm.LLVMIsDeclaration
 import llvm.LLVMModuleRef
 import llvm.LLVMWriteBitcodeToFile
 import org.jetbrains.kotlin.config.LoggingContext
@@ -24,6 +23,7 @@ import org.jetbrains.kotlin.backend.konan.driver.utilities.getDefaultLlvmModuleA
 import org.jetbrains.kotlin.backend.konan.llvm.LlvmFunctionAttribute
 import org.jetbrains.kotlin.backend.konan.llvm.addLlvmFunctionEnumAttribute
 import org.jetbrains.kotlin.backend.konan.llvm.getFunctions
+import org.jetbrains.kotlin.backend.konan.llvm.isDefinition
 import org.jetbrains.kotlin.backend.konan.llvm.valueName
 import org.jetbrains.kotlin.backend.konan.llvm.verifyModule
 import org.jetbrains.kotlin.backend.konan.optimizations.RemoveRedundantSafepointsPass
@@ -121,7 +121,7 @@ internal val StackProtectorPhaseInCompiler = createSimpleNamedCompilerPhase<Opti
             }
             attribute?.let { sspAttribute ->
                 getFunctions(module)
-                        .filter { LLVMIsDeclaration(it) == 0 && it.valueName != "__clang_call_terminate" }
+                        .filter { it.isDefinition && it.valueName != "__clang_call_terminate" }
                         .forEach { addLlvmFunctionEnumAttribute(it, sspAttribute) }
             }
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/CExport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/CExport.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.backend.konan.cexport.CAdapterExportedElements
 import org.jetbrains.kotlin.backend.konan.cexport.CAdapterGenerator
 import org.jetbrains.kotlin.backend.konan.cexport.CAdapterTypeTranslator
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
-import java.io.File
+import java.nio.file.Path
 
 internal val BuildCExports = createSimpleNamedCompilerPhase<LinkKlibsContext, FrontendPhaseOutput.Full, CAdapterExportedElements>(
         "BuildCExports",
@@ -29,9 +29,9 @@ internal val BuildCExports = createSimpleNamedCompilerPhase<LinkKlibsContext, Fr
 
 internal data class CExportGenerateApiInput(
         val elements: CAdapterExportedElements,
-        val headerFile: File,
-        val defFile: File?,
-        val cppAdapterFile: File,
+        val headerPath: Path,
+        val defPath: Path?,
+        val cppAdapterPath: Path,
 )
 
 internal val CExportGenerateApiPhase = createSimpleNamedCompilerPhase<NativeBackendPhaseContext, CExportGenerateApiInput>(
@@ -39,20 +39,20 @@ internal val CExportGenerateApiPhase = createSimpleNamedCompilerPhase<NativeBack
 ) { context, input ->
     CAdapterApiExporter(
             elements = input.elements,
-            headerFile = input.headerFile,
-            defFile = input.defFile,
-            cppAdapterFile = input.cppAdapterFile,
+            headerPath = input.headerPath,
+            defPath = input.defPath,
+            cppAdapterPath = input.cppAdapterPath,
             target = context.config.target,
     ).makeGlobalStruct()
 }
 
 internal class CExportCompileAdapterInput(
-        val cppAdapterFile: File,
-        val bitcodeAdapterFile: File,
+        val cppAdapterPath: Path,
+        val bitcodeAdapterPath: Path,
 )
 
 internal val CExportCompileAdapterPhase = createSimpleNamedCompilerPhase<NativeBackendPhaseContext, CExportCompileAdapterInput>(
         name = "CExportCompileAdapter",
 ) { context, input ->
-    produceCAdapterBitcode(context.config.clang, input.cppAdapterFile, input.bitcodeAdapterFile)
+    produceCAdapterBitcode(context.config.clang, input.cppAdapterPath, input.bitcodeAdapterPath)
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Linker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Linker.kt
@@ -9,9 +9,10 @@ import org.jetbrains.kotlin.backend.common.phaser.createSimpleNamedCompilerPhase
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.Linker
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
+import org.jetbrains.kotlin.backend.konan.util.absoluteNormalizedPathString
 import org.jetbrains.kotlin.konan.TempFiles
 import org.jetbrains.kotlin.konan.target.LinkerOutputKind
-import java.io.File
+import java.nio.file.Path
 
 internal data class LinkerPhaseInput(
         val outputFile: String,
@@ -44,15 +45,15 @@ internal val LinkerPhase = createSimpleNamedCompilerPhase<NativeBackendPhaseCont
 }
 
 internal data class PreLinkCachesInput(
-        val objectFiles: List<File>,
+        val objectPaths: List<Path>,
         val caches: ResolvedCacheBinaries,
-        val outputObjectFile: File,
+        val outputObjectPath: Path,
 )
 
 internal val PreLinkCachesPhase = createSimpleNamedCompilerPhase<NativeBackendPhaseContext, PreLinkCachesInput>(
         name = "PreLinkCaches",
 ) { context, input ->
-    val inputFiles = input.objectFiles.map { it.absoluteFile.normalize().path } + input.caches.static
-    val commands = context.config.platform.linker.preLinkCommands(inputFiles, input.outputObjectFile.absoluteFile.normalize().path)
+    val inputFiles = input.objectPaths.map { it.absoluteNormalizedPathString() } + input.caches.static
+    val commands = context.config.platform.linker.preLinkCommands(inputFiles, input.outputObjectPath.absoluteNormalizedPathString())
     runLinkerCommands(context, commands, cachingInvolved = true)
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/ObjectFiles.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/ObjectFiles.kt
@@ -8,11 +8,11 @@ package org.jetbrains.kotlin.backend.konan.driver.phases
 import org.jetbrains.kotlin.backend.common.phaser.createSimpleNamedCompilerPhase
 import org.jetbrains.kotlin.backend.konan.BitcodeCompiler
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
-import java.io.File
+import java.nio.file.Path
 
 internal data class ObjectFilesPhaseInput(
-        val bitcodeFile: File,
-        val objectFile: File,
+        val bitcodeFile: Path,
+        val objectFile: Path,
 )
 
 internal val ObjectFilesPhase = createSimpleNamedCompilerPhase<NativeBackendPhaseContext, ObjectFilesPhaseInput>(

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -10,6 +10,11 @@ import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.PerformanceManagerContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
+import org.jetbrains.kotlin.backend.konan.driver.phases.split.HostModuleSplitCompilationOutput
+import org.jetbrains.kotlin.backend.konan.driver.phases.split.compileAndLinkForSplitHost
+import org.jetbrains.kotlin.backend.konan.driver.phases.split.compileAndLinkSplitFramework
+import org.jetbrains.kotlin.backend.konan.driver.phases.split.generateGuestBitcode
+import org.jetbrains.kotlin.backend.konan.driver.phases.split.generateHostBitcode
 import org.jetbrains.kotlin.backend.konan.driver.utilities.CExportPaths
 import org.jetbrains.kotlin.backend.konan.driver.utilities.createTempFiles
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
@@ -49,7 +54,9 @@ import kotlin.io.path.createFile
 import kotlin.io.path.name
 import kotlin.io.path.writeLines
 
-fun TempFiles.createBitcodeFile(fileName: String) = create(fileName, ".bc")
+internal data class BackendCodegenOutput(val generatedBitcodePaths: List<Path>)
+
+internal fun TempFiles.createBitcodeFile(fileName: String) = create(fileName, ".bc")
 
 internal fun PhaseEngine<NativeBackendPhaseContext>.runFrontend(config: NativeSecondStageCompilationConfig, environment: KotlinCoreEnvironment): FrontendPhaseOutput.Full? {
     val languageVersion = config.languageVersionSettings.languageVersion
@@ -199,7 +206,59 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
             try {
                 fragment.performanceManager?.notifyPhaseStarted(PhaseType.Backend)
                 backendEngine.useContext(generationState, copyState = true) { generationStateEngine ->
-                    val bitcodeFile = tempFiles.createBitcodeFile(generationState.llvmModuleName)
+
+                    fun PhaseEngine<NativeGenerationState>.runSplitHostBackendForProgram(cExportPaths: CExportPaths?) {
+                        val hostBitcodePath = tempFiles.createBitcodeFile("host")
+                        val bootstrapBitcodePath = tempFiles.createBitcodeFile("bootstrap")
+
+                        // Here the guest code is the bootstrap object
+                        generationStateEngine.generateGuestBitcode(fragment.irModule, backendContext.irBuiltIns, bootstrapBitcodePath, cExportPaths)
+                        generationStateEngine.generateHostBitcode(hostBitcodePath)
+
+                        // Collect dependencies after split compilation
+                        val dependenciesTrackingResult = collectAndMaybeSerializeDependencies()
+                        val hotReloadOutput = HostModuleSplitCompilationOutput(
+                                hostBitcodePath,
+                                bootstrapBitcodePath,
+                                dependenciesTrackingResult
+                        )
+                        generationStateEngine.compileAndLinkForSplitHost(hotReloadOutput, outputFiles, tempFiles)
+                    }
+
+                    fun PhaseEngine<NativeGenerationState>.runSplitHostBackendForFramework(cExportPaths: CExportPaths?) {
+                        // Framework compilation is harder to split at the moment, because we would need to modify the
+                        // Objective-C part quite heavily. So, in we decided to embed the user code within the final
+                        // framework plus the bootstrap (to fix linking issues with Swift compilation).
+                        // At runtime, the code actually used is the bootstrap's one.
+                        val bitcodePath = tempFiles.createBitcodeFile(generationState.llvmModuleName)
+                        generationStateEngine.compileModule(fragment.irModule, backendContext.irBuiltIns, bitcodePath, cExportPaths)
+
+                        val dependenciesTrackingResult = collectAndMaybeSerializeDependencies()
+                        val moduleCompilationOutput = ModuleCompilationOutput(bitcodePath, dependenciesTrackingResult)
+                        generationStateEngine.compileAndLinkSplitFramework(
+                                moduleCompilationOutput,
+                                outputFiles,
+                                tempFiles,
+                        )
+                    }
+
+                    fun PhaseEngine<NativeGenerationState>.runClosedBackend(cExportPaths: CExportPaths?) {
+                        val bitcodePath = tempFiles.createBitcodeFile(generationState.llvmModuleName)
+
+                        // TODO: Make this work if we first compile all the fragments and only after that run the link phases.
+                        generationStateEngine.compileModule(fragment.irModule, backendContext.irBuiltIns, bitcodePath, cExportPaths)
+
+                        val dependenciesTrackingResult = collectAndMaybeSerializeDependencies()
+                        // Split here
+                        val moduleCompilationOutput = ModuleCompilationOutput(bitcodePath, dependenciesTrackingResult)
+                        generationStateEngine.compileAndLink(
+                                moduleCompilationOutput,
+                                outputFiles.mainFileName,
+                                outputFiles,
+                                tempFiles,
+                        )
+                    }
+
                     val cExportPaths = if (config.produceCInterface) {
                         CExportPaths(
                                 cppAdapter = tempFiles.create("api", ".cpp"),
@@ -208,17 +267,14 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
                                 def = if (config.target.family == Family.MINGW) outputFiles.cAdapterDef else null,
                         )
                     } else null
-                    // TODO: Make this work if we first compile all the fragments and only after that run the link phases.
-                    generationStateEngine.compileModule(fragment.irModule, backendContext.irBuiltIns, bitcodeFile, cExportPaths)
-                    // Split here
-                    val dependenciesTrackingResult = generationStateEngine.collectAndMaybeSerializeDependencies()
-                    val moduleCompilationOutput = ModuleCompilationOutput(bitcodeFile, dependenciesTrackingResult)
-                    generationStateEngine.compileAndLink(
-                            moduleCompilationOutput,
-                            outputFiles.mainFileName,
-                            outputFiles,
-                            tempFiles,
-                    )
+
+                    when (config.compilationScheme) {
+                        CompilationScheme.SPLIT_HOST if config.produce == CompilerOutputKind.PROGRAM ->
+                            generationStateEngine.runSplitHostBackendForProgram(cExportPaths)
+                        CompilationScheme.SPLIT_HOST if config.produce == CompilerOutputKind.FRAMEWORK ->
+                            generationStateEngine.runSplitHostBackendForFramework(cExportPaths)
+                        else -> generationStateEngine.runClosedBackend(cExportPaths)
+                    }
                 }
             } finally {
                 tempFiles.dispose()
@@ -278,13 +334,13 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBitcodeBackend(
 ) {
     useContext(context) { bitcodeEngine ->
         val tempFiles = createTempFiles(context.config, null)
-        val bitcodeFile = tempFiles.createBitcodeFile(context.config.shortModuleName ?: "out")
+        val bitcodePath = tempFiles.createBitcodeFile(context.config.shortModuleName ?: "out")
         val outputPath = context.config.outputPath
         val outputFiles = OutputFiles(outputPath, context.config.target, context.config.produce)
         bitcodeEngine.runBitcodePostProcessing()
         runInsertEntryPointAliasPhaseIfNeededTo(context.llvm.module)
-        runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(context.llvm.module, bitcodeFile))
-        val moduleCompilationOutput = ModuleCompilationOutput(bitcodeFile, dependencies)
+        runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(context.llvm.module, bitcodePath))
+        val moduleCompilationOutput = ModuleCompilationOutput(bitcodePath, dependencies)
         compileAndLink(moduleCompilationOutput, outputFiles.mainFileName, outputFiles, tempFiles)
     }
 }
@@ -384,7 +440,7 @@ private fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runInsertEntryPointAl
 }
 
 internal data class ModuleCompilationOutput(
-        val bitcodeFile: Path,
+        val bitcodePath: Path,
         val dependenciesTrackingResult: DependenciesTrackingResult,
 )
 
@@ -425,7 +481,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.compileAndLink(
         temporaryFiles: TempFiles,
 ) {
     val compilationResult = temporaryFiles.create(Path(outputFiles.nativeBinaryFile).name, ".o")
-    runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(moduleCompilationOutput.bitcodeFile, compilationResult))
+    runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(moduleCompilationOutput.bitcodePath, compilationResult))
     val linkerOutputKind = determineLinkerOutput(context)
     val [linkerInput, cacheBinaries] = run {
         val resolvedCacheBinaries by lazy { resolveCacheBinaries(context.config.cachedLibraries, moduleCompilationOutput.dependenciesTrackingResult) }
@@ -485,7 +541,11 @@ internal fun PhaseEngine<NativeGenerationState>.partiallyLowerModuleWithDependen
     runModuleWisePhase(lowering, allModulesToLower, performanceManager)
 }
 
-internal fun PhaseEngine<NativeGenerationState>.runBackendCodegen(module: IrModuleFragment, irBuiltIns: IrBuiltIns, cExportPaths: CExportPaths?) {
+internal fun PhaseEngine<NativeGenerationState>.runBackendCodegen(
+        module: IrModuleFragment,
+        irBuiltIns: IrBuiltIns,
+        cExportPaths: CExportPaths?
+): BackendCodegenOutput {
     runCodegen(module, irBuiltIns)
     val generatedBitcodePaths = if (context.config.produceCInterface) {
         require(cExportPaths != null)
@@ -513,6 +573,7 @@ internal fun PhaseEngine<NativeGenerationState>.runBackendCodegen(module: IrModu
         runAndMeasurePhase(PrintBitcodePhase, llvmModule)
     }
     runAndMeasurePhase(LinkBitcodeDependenciesPhase, generatedBitcodePaths)
+    return BackendCodegenOutput(generatedBitcodePaths)
 }
 
 internal fun <Context, Input, Output, P> PhaseEngine<Context>.runAndMeasurePhase(phase: P, input: Input, disable: Boolean = false): Output

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.PerformanceManagerContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
-import org.jetbrains.kotlin.backend.konan.driver.utilities.CExportFiles
+import org.jetbrains.kotlin.backend.konan.driver.utilities.CExportPaths
 import org.jetbrains.kotlin.backend.konan.driver.utilities.createTempFiles
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.serialization.CacheDeserializationStrategy
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.LoggingContext
 import org.jetbrains.kotlin.config.phaser.NamedCompilerPhase
+import org.jetbrains.kotlin.io.canonicalPathString
 import org.jetbrains.kotlin.ir.IrBasedFunctionFactory.Companion.isFunctionInterfaceFile
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -38,6 +39,7 @@ import org.jetbrains.kotlin.util.PerformanceManagerImpl
 import org.jetbrains.kotlin.util.PhaseType
 import org.jetbrains.kotlin.util.tryMeasureDynamicPhaseTime
 import org.jetbrains.kotlin.util.tryMeasurePhaseTime
+import java.nio.file.Path
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -47,7 +49,7 @@ import kotlin.io.path.createFile
 import kotlin.io.path.name
 import kotlin.io.path.writeLines
 
-private fun TempFiles.createBitcodeFile(fileName: String) = create(fileName, ".bc").toFile()
+fun TempFiles.createBitcodeFile(fileName: String) = create(fileName, ".bc")
 
 internal fun PhaseEngine<NativeBackendPhaseContext>.runFrontend(config: NativeSecondStageCompilationConfig, environment: KotlinCoreEnvironment): FrontendPhaseOutput.Full? {
     val languageVersion = config.languageVersionSettings.languageVersion
@@ -62,7 +64,7 @@ internal fun PhaseEngine<NativeBackendPhaseContext>.runFrontend(config: NativeSe
 
 internal fun PhaseEngine<NativeBackendPhaseContext>.linkKlibs(
         frontendOutput: FrontendPhaseOutput.Full,
-): LinkKlibsOutput = linkKlibs(frontendOutput, {}).first
+): LinkKlibsOutput = linkKlibs(frontendOutput) {}.first
 
 internal fun <T> PhaseEngine<NativeBackendPhaseContext>.linkKlibs(
         frontendOutput: FrontendPhaseOutput.Full,
@@ -198,16 +200,16 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
                 fragment.performanceManager?.notifyPhaseStarted(PhaseType.Backend)
                 backendEngine.useContext(generationState, copyState = true) { generationStateEngine ->
                     val bitcodeFile = tempFiles.createBitcodeFile(generationState.llvmModuleName)
-                    val cExportFiles = if (config.produceCInterface) {
-                        CExportFiles(
-                                cppAdapter = tempFiles.create("api", ".cpp").toFile(),
+                    val cExportPaths = if (config.produceCInterface) {
+                        CExportPaths(
+                                cppAdapter = tempFiles.create("api", ".cpp"),
                                 bitcodeAdapter = tempFiles.createBitcodeFile("api"),
-                                header = outputFiles.cAdapterHeader.toFile(),
-                                def = if (config.target.family == Family.MINGW) outputFiles.cAdapterDef.toFile() else null,
+                                header = outputFiles.cAdapterHeader,
+                                def = if (config.target.family == Family.MINGW) outputFiles.cAdapterDef else null,
                         )
                     } else null
                     // TODO: Make this work if we first compile all the fragments and only after that run the link phases.
-                    generationStateEngine.compileModule(fragment.irModule, backendContext.irBuiltIns, bitcodeFile, cExportFiles)
+                    generationStateEngine.compileModule(fragment.irModule, backendContext.irBuiltIns, bitcodeFile, cExportPaths)
                     // Split here
                     val dependenciesTrackingResult = generationStateEngine.collectAndMaybeSerializeDependencies()
                     val moduleCompilationOutput = ModuleCompilationOutput(bitcodeFile, dependenciesTrackingResult)
@@ -382,7 +384,7 @@ private fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runInsertEntryPointAl
 }
 
 internal data class ModuleCompilationOutput(
-        val bitcodeFile: java.io.File,
+        val bitcodeFile: Path,
         val dependenciesTrackingResult: DependenciesTrackingResult,
 )
 
@@ -396,13 +398,13 @@ internal data class ModuleCompilationOutput(
 internal fun PhaseEngine<NativeGenerationState>.compileModule(
         module: IrModuleFragment,
         irBuiltIns: IrBuiltIns,
-        bitcodeFile: java.io.File,
-        cExportFiles: CExportFiles?,
+        bitcodePath: Path,
+        cExportPaths: CExportPaths?,
 ) {
-    runBackendCodegen(module, irBuiltIns, cExportFiles)
+    runBackendCodegen(module, irBuiltIns, cExportPaths)
     runPostCodegen()
     runInsertEntryPointAliasPhaseIfNeededTo(context.llvm.module)
-    runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(context.llvm.module, bitcodeFile))
+    runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(context.llvm.module, bitcodePath))
 }
 
 internal fun PhaseEngine<NativeGenerationState>.runPostCodegen() {
@@ -422,7 +424,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.compileAndLink(
         outputFiles: OutputFiles,
         temporaryFiles: TempFiles,
 ) {
-    val compilationResult = temporaryFiles.create(Path(outputFiles.nativeBinaryFile).name, ".o").toFile()
+    val compilationResult = temporaryFiles.create(Path(outputFiles.nativeBinaryFile).name, ".o")
     runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(moduleCompilationOutput.bitcodeFile, compilationResult))
     val linkerOutputKind = determineLinkerOutput(context)
     val [linkerInput, cacheBinaries] = run {
@@ -432,7 +434,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.compileAndLink(
                 compilationResult to ResolvedCacheBinaries(emptyList(), emptyList())
             }
             shouldPerformPreLink(context.config, resolvedCacheBinaries, linkerOutputKind) -> {
-                val prelinkResult = temporaryFiles.create("withStaticCaches", ".o").toFile()
+                val prelinkResult = temporaryFiles.create("withStaticCaches", ".o")
                 runAndMeasurePhase(PreLinkCachesPhase, PreLinkCachesInput(listOf(compilationResult), resolvedCacheBinaries, prelinkResult))
                 // Static caches are linked into binary, so we don't need to pass them.
                 prelinkResult to ResolvedCacheBinaries(emptyList(), resolvedCacheBinaries.dynamic)
@@ -445,7 +447,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.compileAndLink(
     val linkerPhaseInput = LinkerPhaseInput(
             linkerOutputFile,
             linkerOutputKind,
-            listOf(linkerInput.canonicalPath),
+            listOf(linkerInput.canonicalPathString()),
             moduleCompilationOutput.dependenciesTrackingResult,
             outputFiles,
             temporaryFiles,
@@ -483,19 +485,19 @@ internal fun PhaseEngine<NativeGenerationState>.partiallyLowerModuleWithDependen
     runModuleWisePhase(lowering, allModulesToLower, performanceManager)
 }
 
-internal fun PhaseEngine<NativeGenerationState>.runBackendCodegen(module: IrModuleFragment, irBuiltIns: IrBuiltIns, cExportFiles: CExportFiles?) {
+internal fun PhaseEngine<NativeGenerationState>.runBackendCodegen(module: IrModuleFragment, irBuiltIns: IrBuiltIns, cExportPaths: CExportPaths?) {
     runCodegen(module, irBuiltIns)
-    val generatedBitcodeFiles = if (context.config.produceCInterface) {
-        require(cExportFiles != null)
+    val generatedBitcodePaths = if (context.config.produceCInterface) {
+        require(cExportPaths != null)
         val input = CExportGenerateApiInput(
                 context.context.cAdapterExportedElements!!,
-                headerFile = cExportFiles.header,
-                defFile = cExportFiles.def,
-                cppAdapterFile = cExportFiles.cppAdapter
+                headerPath = cExportPaths.header,
+                defPath = cExportPaths.def,
+                cppAdapterPath = cExportPaths.cppAdapter
         )
         runAndMeasurePhase(CExportGenerateApiPhase, input)
-        runAndMeasurePhase(CExportCompileAdapterPhase, CExportCompileAdapterInput(cExportFiles.cppAdapter, cExportFiles.bitcodeAdapter))
-        listOf(cExportFiles.bitcodeAdapter)
+        runAndMeasurePhase(CExportCompileAdapterPhase, CExportCompileAdapterInput(cExportPaths.cppAdapter, cExportPaths.bitcodeAdapter))
+        listOf(cExportPaths.bitcodeAdapter)
     } else {
         emptyList()
     }
@@ -510,7 +512,7 @@ internal fun PhaseEngine<NativeGenerationState>.runBackendCodegen(module: IrModu
     if (context.shouldPrintBitCode()) {
         runAndMeasurePhase(PrintBitcodePhase, llvmModule)
     }
-    runAndMeasurePhase(LinkBitcodeDependenciesPhase, generatedBitcodeFiles)
+    runAndMeasurePhase(LinkBitcodeDependenciesPhase, generatedBitcodePaths)
 }
 
 internal fun <Context, Input, Output, P> PhaseEngine<Context>.runAndMeasurePhase(phase: P, input: Input, disable: Boolean = false): Output

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/BootstrapMetadata.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/BootstrapMetadata.kt
@@ -14,6 +14,9 @@ import org.jetbrains.kotlin.backend.konan.ResolvedCacheBinaries
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.driver.phases.*
 import org.jetbrains.kotlin.backend.konan.resolveCacheBinaries
+import org.jetbrains.kotlin.cli.CliDiagnostics
+import org.jetbrains.kotlin.cli.report
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.konan.TempFiles
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -30,6 +33,7 @@ private const val MANIFEST_ENTRY_SIZE: Long = 1L + Long.SIZE_BYTES + Long.SIZE_B
 
 private val FORCE_LOADED_CACHES_FQN = setOf(
         "kotlin.native.internal", // This points to the Runtime code
+        "org.jetbrains.kotlin.native.platform.",
         "skiko",
         "libkotlin",
         "libstdlib-cache"
@@ -43,7 +47,7 @@ private val String.isForceLoadCache: Boolean
 
 internal data class BootstrapCompilationMetadata(
         val forceLoadCaches: List<String>,
-        val cachesToLoadAtRuntime: List<String>,
+        val payloadsToLoadAtRuntime: List<String>,
         val resolvedCaches: ResolvedCacheBinaries
 )
 
@@ -76,16 +80,25 @@ private data class Manifest(
         val entries: List<ManifestEntry>
 )
 
-private fun BootstrapCompilationMetadata.toManifest(): Manifest {
-    val cachesToSize = cachesToLoadAtRuntime
+private fun BootstrapCompilationMetadata.toManifest(configuration: CompilerConfiguration): Manifest {
+    val [existingPayloads, missingPayloads] = payloadsToLoadAtRuntime
             .map { Path(it) }
-            .filter { it.exists() }
-            .associateWith { it.fileSize() }
-    val bundleSize = cachesToSize.values.sum()
-    val manifestSize = MANIFEST_HEADER_SIZE + MANIFEST_ENTRY_SIZE * cachesToSize.size + bundleSize
+            .partition { it.exists() }
+
+    for (missingPayload in missingPayloads) {
+        configuration.report(
+                CliDiagnostics.KONAN_ARGUMENT_STRONG_WARNING,
+                "Bootstrap payload does not exist and will be omitted from the embedded manifest: $missingPayload." +
+                        "Please report this issue in our tracker."
+        )
+    }
+
+    val payloadsToSize = existingPayloads.associateWith { it.fileSize() }
+    val bundleSize = payloadsToSize.values.sum()
+    val manifestSize = MANIFEST_HEADER_SIZE + MANIFEST_ENTRY_SIZE * payloadsToSize.size + bundleSize
 
     var offset = 0L
-    val entries = cachesToSize.map { [path, size] ->
+    val entries = payloadsToSize.map { [path, size] ->
         ManifestEntry(
                 path = path,
                 kind = path.toPayloadKind(),
@@ -125,8 +138,12 @@ private fun Manifest.toByteArray(byteOrder: ByteOrder): ByteArray {
  *
  * At the time of writing, this function works mainly for Darwin (i.e., macOS, iOS, ...).
  */
-private fun LLVMModuleRef.embedBootstrapManifest(context: LLVMContextRef, metadata: BootstrapCompilationMetadata) {
-    val manifest = metadata.toManifest()
+private fun LLVMModuleRef.embedBootstrapManifest(
+        context: LLVMContextRef,
+        configuration: CompilerConfiguration,
+        metadata: BootstrapCompilationMetadata,
+) {
+    val manifest = metadata.toManifest(configuration)
     val targetByteOrder = if (LLVMByteOrder(LLVMGetModuleDataLayout(this)) == LLVMByteOrdering.LLVMBigEndian) {
         ByteOrder.BIG_ENDIAN
     } else {
@@ -151,15 +168,20 @@ private fun LLVMModuleRef.embedBootstrapManifest(context: LLVMContextRef, metada
 
 internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.resolveBootstrapMetadata(
         dependenciesTrackingResult: DependenciesTrackingResult,
+        bootstrapObjectPath: Path,
 ): BootstrapCompilationMetadata {
     // Resolve cache binaries (stdlib, platform libs, etc.) that the host must link against
     val resolvedCaches = resolveCacheBinaries(context.config.cachedLibraries, dependenciesTrackingResult)
     val [forceLoadCaches, jitCaches] = resolvedCaches.static.partition { it.isForceLoadCache }
-    return BootstrapCompilationMetadata(forceLoadCaches, jitCaches, resolvedCaches)
+    return BootstrapCompilationMetadata(
+            forceLoadCaches,
+            listOf(bootstrapObjectPath.absolutePathString()) + jitCaches,
+            resolvedCaches,
+    )
 }
 
 /**
- * The split-compilation manifest defines with objects from the cache should be loaded
+ * The split-compilation manifest defines which object and archive payloads should be loaded
  * at the start of the host.
  */
 internal fun PhaseEngine<NativeGenerationState>.generateManifestObject(
@@ -170,7 +192,7 @@ internal fun PhaseEngine<NativeGenerationState>.generateManifestObject(
     val manifestBitcodePath = temporaryFiles.createBitcodeFile(MANIFEST_MODULE_NAME)
     val manifestModule = LLVMModuleCreateWithNameInContext(MANIFEST_MODULE_NAME, context.llvmContext)!!.apply {
         LLVMSetDataLayout(this, context.runtime.dataLayout)
-        embedBootstrapManifest(context.llvmContext, manifest)
+        embedBootstrapManifest(context.llvmContext, context.config.configuration, manifest)
     }
     runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(manifestModule, manifestBitcodePath))
     runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(manifestBitcodePath, manifestObjectPath))

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/BootstrapMetadata.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/BootstrapMetadata.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.driver.phases.split
+
+import kotlinx.cinterop.toCValues
+import llvm.*
+import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
+import org.jetbrains.kotlin.backend.konan.DependenciesTrackingResult
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.ResolvedCacheBinaries
+import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
+import org.jetbrains.kotlin.backend.konan.driver.phases.*
+import org.jetbrains.kotlin.backend.konan.resolveCacheBinaries
+import org.jetbrains.kotlin.konan.TempFiles
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Path
+import kotlin.io.path.*
+
+private const val MANIFEST_MODULE_NAME: String = "manifest"
+private const val SECTION_NAME: String = "__TEXT,__kaldo_boot"
+private const val BOOTSTRAP_START_MANIFEST_DATA_NAME: String = "bootStartManifestData"
+private const val BOOTSTRAP_START_MANIFEST_NAME: String = "bootStartManifest"
+private const val FORMAT_IDENTIFIER: String = "KALD0"
+private const val MANIFEST_HEADER_SIZE: Long = 5L + Long.SIZE_BYTES + Long.SIZE_BYTES + Int.SIZE_BYTES
+private const val MANIFEST_ENTRY_SIZE: Long = 1L + Long.SIZE_BYTES + Long.SIZE_BYTES
+
+private val FORCE_LOADED_CACHES_FQN = setOf(
+        "kotlin.native.internal", // This points to the Runtime code
+        "skiko",
+        "libkotlin",
+        "libstdlib-cache"
+)
+
+/**
+ * Does this library need to be force-loaded into the host executable?
+ */
+private val String.isForceLoadCache: Boolean
+    get() = FORCE_LOADED_CACHES_FQN.any { this@isForceLoadCache.contains(it) }
+
+internal data class BootstrapCompilationMetadata(
+        val forceLoadCaches: List<String>,
+        val cachesToLoadAtRuntime: List<String>,
+        val resolvedCaches: ResolvedCacheBinaries
+)
+
+private enum class PayloadKind(val raw: Int) {
+    OBJECT(0), ARCHIVE(1)
+}
+
+private fun Path.toPayloadKind() = when (this.extension) {
+    "o" -> PayloadKind.OBJECT
+    "a" -> PayloadKind.ARCHIVE
+    else -> error("Unsupported payload kind for ${this.extension}.")
+}
+
+private data class ManifestHeader(
+        val formatIdentifier: String,
+        val manifestSize: Long,
+        val bundleSize: Long,
+        val entries: Int,
+)
+
+private data class ManifestEntry(
+        val path: Path,
+        val kind: PayloadKind,
+        val offset: Long,
+        val size: Long,
+)
+
+private data class Manifest(
+        val header: ManifestHeader,
+        val entries: List<ManifestEntry>
+)
+
+private fun BootstrapCompilationMetadata.toManifest(): Manifest {
+    val cachesToSize = cachesToLoadAtRuntime
+            .map { Path(it) }
+            .filter { it.exists() }
+            .associateWith { it.fileSize() }
+    val bundleSize = cachesToSize.values.sum()
+    val manifestSize = MANIFEST_HEADER_SIZE + MANIFEST_ENTRY_SIZE * cachesToSize.size + bundleSize
+
+    var offset = 0L
+    val entries = cachesToSize.map { [path, size] ->
+        ManifestEntry(
+                path = path,
+                kind = path.toPayloadKind(),
+                offset = offset,
+                size = size,
+        ).also { offset += size }
+    }
+
+    val header = ManifestHeader(FORMAT_IDENTIFIER, manifestSize, bundleSize, entries.size)
+
+    return Manifest(header, entries)
+}
+
+private fun Manifest.toByteArray(byteOrder: ByteOrder): ByteArray {
+    require(header.manifestSize <= Int.MAX_VALUE) {
+        "The bootstrap manifest is too large: ${header.manifestSize} bytes."
+    }
+
+    return ByteBuffer.allocate(header.manifestSize.toInt()).order(byteOrder).apply {
+        put(header.formatIdentifier.toByteArray(Charsets.US_ASCII))
+        putLong(header.manifestSize)
+        putLong(header.bundleSize)
+        putInt(header.entries)
+
+        for ([_, kind, offset, size] in entries) {
+            put(kind.raw.toByte())
+            putLong(offset)
+            putLong(size)
+        }
+
+        entries.forEach { put(it.path.readBytes()) }
+    }.array()
+}
+
+/**
+ * Write the bootstrap manifest into the *read-only* data section of the given module.
+ *
+ * At the time of writing, this function works mainly for Darwin (i.e., macOS, iOS, ...).
+ */
+private fun LLVMModuleRef.embedBootstrapManifest(context: LLVMContextRef, metadata: BootstrapCompilationMetadata) {
+    val manifest = metadata.toManifest()
+    val targetByteOrder = if (LLVMByteOrder(LLVMGetModuleDataLayout(this)) == LLVMByteOrdering.LLVMBigEndian) {
+        ByteOrder.BIG_ENDIAN
+    } else {
+        ByteOrder.LITTLE_ENDIAN
+    }
+    val manifestBytes = manifest.toByteArray(targetByteOrder)
+    val dataInitializer = LLVMConstStringInContext(context, manifestBytes.toCValues(), manifestBytes.size, 1)
+    val dataGlobal = LLVMAddGlobal(this, LLVMTypeOf(dataInitializer), BOOTSTRAP_START_MANIFEST_DATA_NAME).apply {
+        LLVMSetInitializer(this, dataInitializer)
+        LLVMSetGlobalConstant(this, 1)
+        LLVMSetLinkage(this, LLVMLinkage.LLVMInternalLinkage)
+        LLVMSetAlignment(this, 8)
+        LLVMSetSection(this, SECTION_NAME)
+    }
+    val ptrType = LLVMPointerType(LLVMInt8TypeInContext(context), 0)
+    LLVMAddGlobal(this, ptrType, BOOTSTRAP_START_MANIFEST_NAME).apply {
+        LLVMSetInitializer(this, LLVMConstBitCast(dataGlobal, ptrType))
+        LLVMSetGlobalConstant(this, 1)
+        LLVMSetLinkage(this, LLVMLinkage.LLVMExternalLinkage)
+    }
+}
+
+internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.resolveBootstrapMetadata(
+        dependenciesTrackingResult: DependenciesTrackingResult,
+): BootstrapCompilationMetadata {
+    // Resolve cache binaries (stdlib, platform libs, etc.) that the host must link against
+    val resolvedCaches = resolveCacheBinaries(context.config.cachedLibraries, dependenciesTrackingResult)
+    val [forceLoadCaches, jitCaches] = resolvedCaches.static.partition { it.isForceLoadCache }
+    return BootstrapCompilationMetadata(forceLoadCaches, jitCaches, resolvedCaches)
+}
+
+/**
+ * The split-compilation manifest defines with objects from the cache should be loaded
+ * at the start of the host.
+ */
+internal fun PhaseEngine<NativeGenerationState>.generateManifestObject(
+        manifest: BootstrapCompilationMetadata,
+        temporaryFiles: TempFiles,
+): Path {
+    val manifestObjectPath = temporaryFiles.create(MANIFEST_MODULE_NAME, ".o")
+    val manifestBitcodePath = temporaryFiles.createBitcodeFile(MANIFEST_MODULE_NAME)
+    val manifestModule = LLVMModuleCreateWithNameInContext(MANIFEST_MODULE_NAME, context.llvmContext)!!.apply {
+        LLVMSetDataLayout(this, context.runtime.dataLayout)
+        embedBootstrapManifest(context.llvmContext, manifest)
+    }
+    runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(manifestModule, manifestBitcodePath))
+    runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(manifestBitcodePath, manifestObjectPath))
+    return manifestObjectPath
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/SplitCompilationSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/SplitCompilationSupport.kt
@@ -214,7 +214,13 @@ internal fun PhaseEngine<NativeGenerationState>.compileAndLinkForSplitHost(
     val hostObjectFile = temporaryFiles.create(outputFiles.outputName, ".host.o")
     runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(splitCompilationOutput.hostBitcodePath, hostObjectFile))
 
-    val manifest = resolveBootstrapMetadata(splitCompilationOutput.dependenciesTrackingResult)
+    val bootstrapObjectPath = temporaryFiles.create(outputFiles.outputName, ".bootstrap.o")
+    runAndMeasurePhase(
+            ObjectFilesPhase,
+            ObjectFilesPhaseInput(splitCompilationOutput.bootstrapBitcodePath, bootstrapObjectPath),
+    )
+
+    val manifest = resolveBootstrapMetadata(splitCompilationOutput.dependenciesTrackingResult, bootstrapObjectPath)
     val manifestObjectPath = generateManifestObject(manifest, temporaryFiles)
 
     val allLoadCaches = manifest.forceLoadCaches
@@ -252,7 +258,10 @@ internal fun PhaseEngine<NativeGenerationState>.compileAndLinkSplitFramework(
     // The user code in the binary is dead weight, live execution goes through HotReload runtime module.
     val configurables = context.config.platform.configurables
 
-    val manifest = resolveBootstrapMetadata(moduleOutput.dependenciesTrackingResult)
+    val bootstrapObjectPath = temporaryFiles.create(outputFiles.outputName, ".bootstrap.o")
+    runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(moduleOutput.bitcodePath, bootstrapObjectPath))
+
+    val manifest = resolveBootstrapMetadata(moduleOutput.dependenciesTrackingResult, bootstrapObjectPath)
     val manifestObjectPath = generateManifestObject(manifest, temporaryFiles)
 
     val resolvedCaches = resolveCacheBinaries(context.config.cachedLibraries, moduleOutput.dependenciesTrackingResult)
@@ -263,7 +272,7 @@ internal fun PhaseEngine<NativeGenerationState>.compileAndLinkSplitFramework(
     val linkerPhaseInput = LinkerPhaseInput(
             outputFiles.mainFileName,
             linkerOutputKind,
-            listOf(manifestObjectPath.absolutePathString()),
+            listOf(bootstrapObjectPath.absolutePathString(), manifestObjectPath.absolutePathString()),
             moduleOutput.dependenciesTrackingResult,
             outputFiles,
             temporaryFiles,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/SplitCompilationSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/split/SplitCompilationSupport.kt
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.driver.phases.split
+
+import com.intellij.openapi.util.io.toNioPathOrNull
+import llvm.*
+import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
+import org.jetbrains.kotlin.backend.konan.*
+import org.jetbrains.kotlin.backend.konan.driver.phases.*
+import org.jetbrains.kotlin.backend.konan.driver.utilities.CExportPaths
+import org.jetbrains.kotlin.backend.konan.llvm.getName
+import org.jetbrains.kotlin.backend.konan.llvm.objc.patchObjCRuntimeModule
+import org.jetbrains.kotlin.backend.konan.llvm.objcexport.split.createObjCExportConvertersModule
+import org.jetbrains.kotlin.backend.konan.llvm.parseBitcodeFile
+import org.jetbrains.kotlin.backend.konan.llvm.runtime.RuntimeModule
+import org.jetbrains.kotlin.backend.konan.llvm.runtime.RuntimeModulesConfig
+import org.jetbrains.kotlin.backend.konan.util.absoluteNormalizedPathString
+import org.jetbrains.kotlin.config.nativeBinaryOptions.CCallMode
+import org.jetbrains.kotlin.ir.IrBuiltIns
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.konan.TempFiles
+import org.jetbrains.kotlin.konan.file.isBitcode
+import org.jetbrains.kotlin.konan.library.components.bitcode
+import org.jetbrains.kotlin.konan.target.Configurables
+import org.jetbrains.kotlin.library.isNativeStdlib
+import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
+import java.nio.file.Path
+import kotlin.io.path.*
+
+private const val HOST_MODULE_NAME: String = "split_host"
+
+sealed interface SplitCompilationOutput {
+    val bootstrapBitcodePath: Path
+    val dependenciesTrackingResult: DependenciesTrackingResult
+}
+
+internal data class HostModuleSplitCompilationOutput(
+        val hostBitcodePath: Path,
+        override val bootstrapBitcodePath: Path,
+        override val dependenciesTrackingResult: DependenciesTrackingResult,
+) : SplitCompilationOutput
+
+private fun buildKaldoLinkerFlagsFrom(configurables: Configurables): List<String> = buildList {
+    add("-L${configurables.absoluteLlvmHome}/lib")
+    addAll(configurables.kaldoLinkerFlags)
+    add("-all_load") // We need to import all KN runtimes symbols
+    add("-export_dynamic")
+    addAll(listOf("-rpath", "${configurables.absoluteLlvmHome}/lib"))
+}
+
+/**
+ * Deduplicates an `.a` archive by extracting members and re-archiving unique ones.
+ * This is a hacky solution, duplicated objects **should not** exist within archives.
+ *
+ * If the archive has no duplicates, it returns the original path unchanged.
+ */
+private fun deduplicateArchive(
+        archiveFilename: String,
+        dedupDirPath: Path,
+        config: NativeSecondStageCompilationConfig,
+): String {
+    // TODO(Gabriele): this function is a temporary fix, it needs to be removed. Symbol duplication should not happen.
+    // TODO(Gabriele): Some cache archives (e.g. skiko) contain duplicate `.o` members which cause
+    // TODO(Gabriele): "duplicate symbol" errors when used with `-force_load`.
+
+    val archivePath = archiveFilename.toNioPathOrNull() ?: return archiveFilename
+
+    val ar = "${config.platform.configurables.absoluteLlvmHome}/bin/llvm-ar"
+
+    val listProcess = ProcessBuilder(ar, "t", archiveFilename)
+            .redirectErrorStream(true).start()
+
+    val members = listProcess.inputStream.bufferedReader().readLines()
+    require(listProcess.waitFor() == 0) {
+        "ar (listing) failed with exit code different from zero"
+    }
+
+    if (members.size == members.toSet().size) return archiveFilename
+
+    val name = archivePath.nameWithoutExtension
+    val extractDir = dedupDirPath.resolve(name).also { it.createDirectory() }
+    val arExtractProcess = ProcessBuilder(ar, "x", archiveFilename)
+            .directory(extractDir.toFile())
+            .redirectErrorStream(true)
+            .start()
+
+    require(arExtractProcess.waitFor() == 0) {
+        "ar (extraction) failed with exit code different from zero"
+    }
+
+    val dedupPath = dedupDirPath.resolve("${name}-dedup.a")
+    val objectFiles = extractDir.listDirectoryEntries("*.o").map { it.name }
+    val arCreateProcess = ProcessBuilder(listOf(ar, "rcs", dedupPath.absolutePathString()) + objectFiles)
+            .directory(extractDir.toFile())
+            .redirectErrorStream(true)
+            .start()
+
+    check(arCreateProcess.waitFor() == 0) {
+        "ar (creation) failed with exit code different from zero"
+    }
+
+    return dedupPath.absolutePathString()
+}
+
+/**
+ * Links library bitcode (interop stubs) into the bootstrap module for hot reload.
+ */
+private fun linkLibraryBitcodeForBootstrapObject(
+        generationState: NativeGenerationState,
+        generatedBitcodeFiles: List<Path>
+) {
+    // This function links only the library bitcode containing interop stubs (knifunptr_*, etc.)
+    // without the C++ runtime. The runtime object code comes from caches (specifically, `kotlin.native.internal`).
+    val config = generationState.config
+    val additionalProducedBitcodeFiles = generationState.llvm.additionalProducedBitcodeFiles
+
+    // This contains interop stubs (knifunptr_*) from platform libraries
+    val bitcodeLibraries = generationState.dependenciesTracker.bitcodeToLink
+            .filterNot { it.isCInteropLibrary() && config.cCallMode == CCallMode.Direct }
+            .filterNot { it.isNativeStdlib } // Skip stdlib bitcode (it's in stdlib-cache.a)
+            .flatMap { it.bitcode(config.target)?.bitcodeFilePaths.orEmpty() }
+            .filter { it.isBitcode }
+
+    val bitcodeFilesToLink = buildList {
+        addAll(generatedBitcodeFiles.map { it.absoluteNormalizedPathString() })
+        addAll(additionalProducedBitcodeFiles)
+        addAll(bitcodeLibraries)
+    }
+
+    if (bitcodeFilesToLink.isEmpty()) {
+        generationState.log { "No library bitcode to link into bootstrap" }
+        return
+    }
+
+    // Parse and link each bitcode file into the bootstrap module
+    val bootstrapModule = generationState.llvmModule
+    bitcodeFilesToLink.forEach { bitcodeFile ->
+        parseAndLinkBitcodeFile(generationState, bootstrapModule, bitcodeFile.toString())
+    }
+}
+
+/**
+ * Compile the module containing only user defined Kotlin program.
+ */
+internal fun PhaseEngine<NativeGenerationState>.generateGuestBitcode(
+        userModule: IrModuleFragment,
+        irBuiltIns: IrBuiltIns,
+        guestBitcodePath: Path,
+        cExportPaths: CExportPaths?,
+) {
+    val (generatedBitcodePaths) = runBackendCodegen(userModule, irBuiltIns, cExportPaths)
+    linkLibraryBitcodeForBootstrapObject(context, generatedBitcodePaths)
+    runPostCodegen()
+    runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(context.llvm.module, guestBitcodePath))
+}
+
+/**
+ * Generate the host bitcode file, containing the entry point to the program.
+ */
+internal fun PhaseEngine<NativeGenerationState>.generateHostBitcode(
+        hostBitcodePath: Path
+) {
+    // TODO(Gabriele): At the of writing of this function, it is not easy to decouple the functions
+    // TODO(Gabriele): needed to generate an isolated host-module. So, what we do is quite simple:
+    // TODO(Gabriele): we only compile the Obj-C patch for host, and the Runtime+Stdlib will come from caches.
+
+    // TODO(Gabriele): REMEMBER! The cache flavor should contain the hot-reload-enable runtime :)
+
+    fun LLVMModuleRef.linkOther(module: LLVMModuleRef): LLVMModuleRef {
+        val linkFailed = LLVMLinkModules2(this, module)
+        if (linkFailed != 0) {
+            error("failed to link module '${module.getName()}' into '${this.getName()}'")
+        }
+        return this
+    }
+
+    val runtimeModulesConfig = RuntimeModulesConfig(context.config)
+    val hotReloadLauncherModule = parseBitcodeFile(
+            context,
+            context.diagnosticReporter,
+            context.llvmContext,
+            runtimeModulesConfig.absolutePathFor(RuntimeModule.HOT_RELOAD_LAUNCHER)
+    )
+
+    var hostModule = LLVMModuleCreateWithNameInContext(HOST_MODULE_NAME, context.llvmContext)!!
+    hostModule = hostModule.linkOther(hotReloadLauncherModule)
+
+    if (context.config.target.family.isAppleFamily) {
+        val objcPatchModule = patchObjCRuntimeModule(context)!!
+        hostModule = hostModule.linkOther(objcPatchModule)
+
+        val convertersModule = createObjCExportConvertersModule(context.llvmContext).apply {
+            LLVMSetDataLayout(this, context.runtime.dataLayout)
+        }
+        hostModule = hostModule.linkOther(convertersModule)
+    }
+
+    runAndMeasurePhase(InsertEntryPointAliasPhase, InsertEntryPointAliasInput(hostModule, context.config.entryPointName))
+    runAndMeasurePhase(WriteBitcodeFilePhase, WriteBitcodeFileInput(hostModule, hostBitcodePath))
+}
+
+internal fun PhaseEngine<NativeGenerationState>.compileAndLinkForSplitHost(
+        splitCompilationOutput: HostModuleSplitCompilationOutput,
+        outputFiles: OutputFiles,
+        temporaryFiles: TempFiles,
+) {
+    // TODO(Gabriele): the linker use -filelist.
+    // TODO(Gabriele): but this is interesting, on theory since we're using cache we don't need to create
+    // TODO(Gabriele): an extra object for the bootstrap but we can load it directly from the cache.
+    val configurables = context.config.platform.configurables
+    val hostObjectFile = temporaryFiles.create(outputFiles.outputName, ".host.o")
+    runAndMeasurePhase(ObjectFilesPhase, ObjectFilesPhaseInput(splitCompilationOutput.hostBitcodePath, hostObjectFile))
+
+    val manifest = resolveBootstrapMetadata(splitCompilationOutput.dependenciesTrackingResult)
+    val manifestObjectPath = generateManifestObject(manifest, temporaryFiles)
+
+    val allLoadCaches = manifest.forceLoadCaches
+    val resolvedCaches = manifest.resolvedCaches
+
+    val dedupDir = temporaryFiles.create("dedup", "").also { it.createDirectory() }
+    val allLoadList = allLoadCaches.map { archivePath ->
+        deduplicateArchive(archivePath, dedupDir, context.config)
+    }
+
+    val kaldoLinkerFlags = buildKaldoLinkerFlagsFrom(configurables)
+
+    val linkerOutputKind = determineLinkerOutput(context)
+    val linkerPhaseInput = LinkerPhaseInput(
+            outputFiles.nativeBinaryFile,
+            linkerOutputKind,
+            listOf(hostObjectFile.absolutePathString(), manifestObjectPath.absolutePathString()),
+            splitCompilationOutput.dependenciesTrackingResult,
+            outputFiles,
+            temporaryFiles,
+            ResolvedCacheBinaries(allLoadList, resolvedCaches.dynamic),
+            kaldoLinkerFlags
+    )
+
+    runAndMeasurePhase(LinkerPhase, linkerPhaseInput)
+}
+
+internal fun PhaseEngine<NativeGenerationState>.compileAndLinkSplitFramework(
+        moduleOutput: ModuleCompilationOutput,
+        outputFiles: OutputFiles,
+        temporaryFiles: TempFiles,
+) {
+
+    // The framework binary contains the full module (runtime + user code + ObjC stubs + class metadata).
+    // The user code in the binary is dead weight, live execution goes through HotReload runtime module.
+    val configurables = context.config.platform.configurables
+
+    val manifest = resolveBootstrapMetadata(moduleOutput.dependenciesTrackingResult)
+    val manifestObjectPath = generateManifestObject(manifest, temporaryFiles)
+
+    val resolvedCaches = resolveCacheBinaries(context.config.cachedLibraries, moduleOutput.dependenciesTrackingResult)
+
+    val kaldoLinkerFlags = buildKaldoLinkerFlagsFrom(configurables)
+
+    val linkerOutputKind = determineLinkerOutput(context)
+    val linkerPhaseInput = LinkerPhaseInput(
+            outputFiles.mainFileName,
+            linkerOutputKind,
+            listOf(manifestObjectPath.absolutePathString()),
+            moduleOutput.dependenciesTrackingResult,
+            outputFiles,
+            temporaryFiles,
+            ResolvedCacheBinaries(resolvedCaches.static, resolvedCaches.dynamic),
+            kaldoLinkerFlags,
+    )
+    runAndMeasurePhase(LinkerPhase, linkerPhaseInput)
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/utilities/FileManagement.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/utilities/FileManagement.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.backend.konan.CacheSupport
 import org.jetbrains.kotlin.backend.konan.NativeSecondStageCompilationConfig
 import org.jetbrains.kotlin.konan.TempFiles
 import org.jetbrains.kotlin.konan.config.temporaryFilesDir
-import java.io.File
+import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.pathString
 
@@ -30,9 +30,9 @@ internal fun createTempFiles(config: NativeSecondStageCompilationConfig, cacheDe
  * TODO: At some point this class and it usages can be generalized to all possible compiler outputs,
  *  so instead of OutputFiles we will create a series of classes for each specific compiler output kit.
  */
-internal class CExportFiles(
-        val cppAdapter: File,
-        val bitcodeAdapter: File,
-        val header: File,
-        val def: File?,
+internal class CExportPaths(
+        val cppAdapter: Path,
+        val bitcodeAdapter: Path,
+        val header: Path,
+        val def: Path?,
 )

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -168,7 +168,7 @@ internal interface ContextUtils : RuntimeAware {
 
     fun linkageOf(irFunction: IrSimpleFunction): LLVMLinkage {
         // In split compilation builds (targeting native hot-reload), it is a good idea to have external linkage
-        // for Kotlin functions. The reason lies on possible passed made by LLVM (like internalize/DCE).
+        // for Kotlin functions. The reason lies on possible passes made by LLVM (like internalize/DCE).
         if (context.config.isUsingSplitCompilationScheme || isExternal(irFunction) || irFunction.isExported())
             return LLVMLinkage.LLVMExternalLinkage
         if (context.config.producePerFileCache) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -167,7 +167,9 @@ internal interface ContextUtils : RuntimeAware {
     }
 
     fun linkageOf(irFunction: IrSimpleFunction): LLVMLinkage {
-        if (isExternal(irFunction) || irFunction.isExported())
+        // In split compilation builds (targeting native hot-reload), it is a good idea to have external linkage
+        // for Kotlin functions. The reason lies on possible passed made by LLVM (like internalize/DCE).
+        if (context.config.isUsingSplitCompilationScheme || isExternal(irFunction) || irFunction.isExported())
             return LLVMLinkage.LLVMExternalLinkage
         if (context.config.producePerFileCache) {
             val originalFunction = irFunction.originalConstructor ?: irFunction

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -541,7 +541,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
         val elementSize = LLVMSizeOfTypeInBits(codegen.llvmTargetData, callSite.llvmReturnType).toInt()
         val vectorSize = LLVMSizeOfTypeInBits(codegen.llvmTargetData, vector.type).toInt()
 
-        assert(callSite.llvmReturnType.isVectorElementType()
+        assert(callSite.llvmReturnType.isVectorElementType
                 && vectorSize % elementSize == 0
         ) { "Invalid vector element type ${LLVMGetTypeKind(callSite.llvmReturnType)}"}
 
@@ -559,7 +559,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
 
     private fun FunctionGenerationContext.emitPlus(args: List<LLVMValueRef>): LLVMValueRef {
         val [first, second] = args
-        return if (first.type.isFloatingPoint()) {
+        return if (first.type.isFloatingPoint) {
             fadd(first, second)
         } else {
             add(first, second)
@@ -630,7 +630,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
 
     private fun FunctionGenerationContext.emitMinus(args: List<LLVMValueRef>): LLVMValueRef {
         val [first, second] = args
-        return if (first.type.isFloatingPoint()) {
+        return if (first.type.isFloatingPoint) {
             fsub(first, second)
         } else {
             sub(first, second)
@@ -639,7 +639,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
 
     private fun FunctionGenerationContext.emitTimes(args: List<LLVMValueRef>): LLVMValueRef {
         val [first, second] = args
-        return if (first.type.isFloatingPoint()) {
+        return if (first.type.isFloatingPoint) {
             LLVMBuildFMul(builder, first, second, "")
         } else {
             LLVMBuildMul(builder, first, second, "")
@@ -665,7 +665,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
     private fun FunctionGenerationContext.emitSignedDiv(args: List<LLVMValueRef>): LLVMValueRef {
         val [dividend, divisor] = args
         val divisorType = divisor.type
-        return if (!divisorType.isFloatingPoint()) {
+        return if (!divisorType.isFloatingPoint) {
             emitThrowIfZero(divisor)
             emitSignedDivisionWithOverflow(dividend, divisor, divisorType, retZeroOnOverflow = false) {
                 LLVMBuildSDiv(builder, dividend, divisor, "")!!
@@ -678,7 +678,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
     private fun FunctionGenerationContext.emitSignedRem(args: List<LLVMValueRef>): LLVMValueRef {
         val [dividend, divisor] = args
         val divisorType = divisor.type
-        return if (!divisorType.isFloatingPoint()) {
+        return if (!divisorType.isFloatingPoint) {
             emitThrowIfZero(divisor)
             emitSignedDivisionWithOverflow(dividend, divisor, divisorType, retZeroOnOverflow = true) {
                 LLVMBuildSRem(builder, dividend, divisor, "")!!
@@ -710,7 +710,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
     private fun FunctionGenerationContext.emitInc(args: List<LLVMValueRef>): LLVMValueRef {
         val first = args[0]
         val const1 = makeConstOfType(first.type, 1)
-        return if (first.type.isFloatingPoint()) {
+        return if (first.type.isFloatingPoint) {
             fadd(first, const1)
         } else {
             add(first, const1)
@@ -720,7 +720,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
     private fun FunctionGenerationContext.emitDec(args: List<LLVMValueRef>): LLVMValueRef {
         val first = args[0]
         val const1 = makeConstOfType(first.type, 1)
-        return if (first.type.isFloatingPoint()) {
+        return if (first.type.isFloatingPoint) {
             fsub(first, const1)
         } else {
             sub(first, const1)
@@ -733,7 +733,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
     private fun FunctionGenerationContext.emitUnaryMinus(args: List<LLVMValueRef>): LLVMValueRef {
         val first = args[0]
         val destTy = first.type
-        return if (destTy.isFloatingPoint()) {
+        return if (destTy.isFloatingPoint) {
             fneg(first)
         } else {
             val const0 = makeConstOfType(destTy, 0)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -2472,7 +2472,7 @@ internal class CodeGeneratorVisitor(
                 ib.eqeqeqSymbol -> icmpEq(args[0], args[1])
                 ib.booleanNotSymbol -> icmpNe(args[0], kTrue)
                 else -> {
-                    val isFloatingPoint = args[0].type.isFloatingPoint()
+                    val isFloatingPoint = args[0].type.isFloatingPoint
                     // LLVM does not distinguish between signed/unsigned integers, so we must check
                     // the parameter type.
                     val shouldUseUnsignedComparison = function.parameters[0].type.isChar()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.backend.konan.llvm
 
 import kotlinx.cinterop.cValuesOf
-import kotlinx.cinterop.toKString
 import llvm.*
 import org.jetbrains.kotlin.backend.common.compilationException
 import org.jetbrains.kotlin.backend.common.ir.isUnconditional

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -2904,6 +2904,7 @@ internal fun NativeGenerationState.generateRuntimeConstantsModule(): LLVMModuleR
         setRuntimeConstGlobal(NativeRuntimeConstants.GC_MARK_SINGLE_THREADED, config.gcMarkSingleThreaded.toLlvmConstInt32())
         setRuntimeConstGlobal(NativeRuntimeConstants.FIXED_BLOCK_PAGE_SIZE, config.fixedBlockPageSize.toInt().toLlvmConstInt32())
         setRuntimeConstGlobal(NativeRuntimeConstants.PAGED_ALLOCATOR, config.pagedAllocator.toLlvmConstInt32())
+        setRuntimeConstGlobal(NativeRuntimeConstants.HOT_RELOAD, config.isUsingSplitCompilationScheme.toLlvmConstInt32())
     }
 
     return llvmModule

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -186,6 +186,14 @@ private class DeclarationsGeneratorVisitor(override val generationState: NativeG
     }
 
     override fun visitClass(declaration: IrClass) {
+        if (generationState.config.isUsingSplitCompilationScheme && isExternal(declaration)) {
+            // TypeInfo identity is pointer identity, we only need one source of truth for
+            // TypeInfos when working with split compilation.
+            // Otherwise, we would have a double TypeInfo collision resulting in a conflict of identity.
+            super.visitClass(declaration)
+            return
+        }
+
         if (declaration.requiresRtti()) {
             val classLlvmDeclarations = createClassDeclarations(declaration)
             declaration.metadata = KonanMetadata.Class(declaration, classLlvmDeclarations, context.getLayoutBuilder(declaration))
@@ -392,6 +400,7 @@ private class DeclarationsGeneratorVisitor(override val generationState: NativeG
 
         val containingClass = declaration.parent as? IrClass
         if (containingClass != null && !declaration.isStatic) {
+            if (isExternal(containingClass)) return
             if (!containingClass.requiresRtti()) return
             val classDeclarations = (containingClass.metadata as? KonanMetadata.Class)?.llvm
                     ?: error(containingClass.render())

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
@@ -379,25 +379,27 @@ internal fun getInstructions(block: LLVMBasicBlockRef) =
 internal fun getGlobals(module: LLVMModuleRef) =
         generateSequence(LLVMGetFirstGlobal(module), { LLVMGetNextGlobal(it) })
 
-fun LLVMTypeRef.isFloatingPoint(): Boolean = when (llvm.LLVMGetTypeKind(this)) {
-    LLVMTypeKind.LLVMFloatTypeKind, LLVMTypeKind.LLVMDoubleTypeKind -> true
-    else -> false
-}
+val LLVMTypeRef.isFloatingPoint: Boolean
+    get() = when (LLVMGetTypeKind(this)) {
+        LLVMTypeKind.LLVMFloatTypeKind, LLVMTypeKind.LLVMDoubleTypeKind -> true
+        else -> false
+    }
 
-fun LLVMTypeRef.isVectorElementType(): Boolean = when (llvm.LLVMGetTypeKind(this)) {
-    LLVMTypeKind.LLVMIntegerTypeKind,
-    LLVMTypeKind.LLVMFloatTypeKind,
-    LLVMTypeKind.LLVMDoubleTypeKind -> true
-    else -> false
-}
+val LLVMTypeRef.isVectorElementType: Boolean
+    get() = when (LLVMGetTypeKind(this)) {
+        LLVMTypeKind.LLVMIntegerTypeKind,
+        LLVMTypeKind.LLVMFloatTypeKind,
+        LLVMTypeKind.LLVMDoubleTypeKind -> true
+        else -> false
+    }
 
 fun LLVMModuleRef.getName(): String = memScoped {
     val sizeVar = alloc<size_tVar>()
     LLVMGetModuleIdentifier(this@getName, sizeVar.ptr)!!.toKStringFromUtf8()
 }
 
-fun LLVMValueRef.isDefinition() = LLVMIsDeclaration(this) == 0
+val LLVMValueRef.isDefinition get() = LLVMIsDeclaration(this) == 0
 
-fun LLVMValueRef.isFunctionCall() = LLVMIsACallInst(this) != null || LLVMIsAInvokeInst(this) != null
+val LLVMValueRef.isFunctionCall get() = LLVMIsACallInst(this) != null || LLVMIsAInvokeInst(this) != null
 
-fun LLVMValueRef.isExternalFunction() = LLVMGetFirstBasicBlock(this) == null
+val LLVMValueRef.isExternalFunction get() = LLVMGetFirstBasicBlock(this) == null

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/NativeRuntimeConstants.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/NativeRuntimeConstants.kt
@@ -28,4 +28,5 @@ object NativeRuntimeConstants {
     const val GC_MARK_SINGLE_THREADED: String = "Kotlin_gcMarkSingleThreaded"
     const val FIXED_BLOCK_PAGE_SIZE: String = "Kotlin_fixedBlockPageSize"
     const val PAGED_ALLOCATOR: String = "Kotlin_pagedAllocator"
+    const val HOT_RELOAD: String = "Kotlin_hotReload"
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/linkObjC.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/linkObjC.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -17,6 +17,10 @@ import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExportNamer
 internal fun patchObjCRuntimeModule(generationState: NativeGenerationState): LLVMModuleRef? {
     val config = generationState.config
     if (!(config.isFinalBinary && config.target.family.isAppleFamily)) return null
+
+    // TODO(Gabriele): review if we actually need this line
+    // ObjCExport may not be initialized yet (e..g, during split-compilation)
+    if (!generationState.hasObjCExport()) return null
 
     val patchBuilder = PatchBuilder(generationState.objCExport.namer)
     patchBuilder.addObjCPatches()

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -735,35 +735,20 @@ private fun ObjCExportCodeGenerator.emitCollectionConverters() {
     fun importConverter(name: String): ConstPointer =
             llvm.externalNativeRuntimeFunction(name, kotlinToObjCFunctionType).toConstPointer()
 
-    bindObjCExportConvertToRetained(
-            irBuiltIns.listClass.owner,
-            importConverter("Kotlin_Interop_CreateRetainedNSArrayFromKList")
+    val collectionClasses = mapOf(
+            "kotlin.collections.List" to irBuiltIns.listClass.owner,
+            "kotlin.collections.MutableList" to irBuiltIns.mutableListClass.owner,
+            "kotlin.collections.Set" to irBuiltIns.setClass.owner,
+            "kotlin.collections.MutableSet" to irBuiltIns.mutableSetClass.owner,
+            "kotlin.collections.Map" to irBuiltIns.mapClass.owner,
+            "kotlin.collections.MutableMap" to irBuiltIns.mutableMapClass.owner,
     )
 
-    bindObjCExportConvertToRetained(
-            irBuiltIns.mutableListClass.owner,
-            importConverter("Kotlin_Interop_CreateRetainedNSMutableArrayFromKList")
-    )
-
-    bindObjCExportConvertToRetained(
-            irBuiltIns.setClass.owner,
-            importConverter("Kotlin_Interop_CreateRetainedNSSetFromKSet")
-    )
-
-    bindObjCExportConvertToRetained(
-            irBuiltIns.mutableSetClass.owner,
-            importConverter("Kotlin_Interop_CreateRetainedKotlinMutableSetFromKSet")
-    )
-
-    bindObjCExportConvertToRetained(
-            irBuiltIns.mapClass.owner,
-            importConverter("Kotlin_Interop_CreateRetainedNSDictionaryFromKMap")
-    )
-
-    bindObjCExportConvertToRetained(
-            irBuiltIns.mutableMapClass.owner,
-            importConverter("Kotlin_Interop_CreateRetainedKotlinMutableDictionaryFromKMap")
-    )
+    for ((kotlinFqName, converterFunctionName) in ObjCExportConverterConstants.standardConverters) {
+        val irClass = collectionClasses[kotlinFqName] ?: continue
+        val converter = importConverter(converterFunctionName)
+        bindObjCExportConvertToRetained(irClass, converter)
+    }
 }
 
 private fun ObjCExportFunctionGenerationContextBuilder.setupBridgeDebugInfo() {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportConverter.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportConverter.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.llvm.objcexport
+
+data class ObjCExportConverter(
+        val kotlinFqName: String,
+        val converterFunctionName: String
+)
+
+val ObjCExportConverter.writableTypeInfoSymbolName: String
+    get() = "ktypew:$kotlinFqName"
+
+internal object ObjCExportConverterConstants {
+    val standardConverters = [
+        ObjCExportConverter("kotlin.String", "Kotlin_ObjCExport_CreateRetainedNSStringFromKString"),
+        ObjCExportConverter("kotlin.collections.List", "Kotlin_Interop_CreateRetainedNSArrayFromKList"),
+        ObjCExportConverter("kotlin.collections.MutableList", "Kotlin_Interop_CreateRetainedNSMutableArrayFromKList"),
+        ObjCExportConverter("kotlin.collections.Set", "Kotlin_Interop_CreateRetainedNSSetFromKSet"),
+        ObjCExportConverter("kotlin.collections.MutableSet", "Kotlin_Interop_CreateRetainedKotlinMutableSetFromKSet"),
+        ObjCExportConverter("kotlin.collections.Map", "Kotlin_Interop_CreateRetainedNSDictionaryFromKMap"),
+        ObjCExportConverter("kotlin.collections.MutableMap", "Kotlin_Interop_CreateRetainedKotlinMutableDictionaryFromKMap"),
+    ]
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/WritableTypeInfo.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/WritableTypeInfo.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.llvm.objcexport
 
 import llvm.LLVMLinkage
+import llvm.LLVMTypeRef
 import org.jetbrains.kotlin.backend.konan.llvm.CodeGenerator
 import org.jetbrains.kotlin.backend.konan.llvm.ConstPointer
 import org.jetbrains.kotlin.backend.konan.llvm.ConstValue
@@ -129,28 +130,43 @@ private fun CodeGenerator.setWritableTypeInfo(
     }
 }
 
-private fun CodeGenerator.buildWritableTypeInfoValue(
+internal fun buildWritableTypeInfoValue(
+        writableTypeInfoType: LLVMTypeRef,
+        typeInfoObjCExportAddition: LLVMTypeRef,
         convertToRetained: ConstPointer?,
-        objCClass: ConstPointer?,
+        objCClass: ConstPointer? = null,
         swiftClass: ConstPointer? = null,
-        typeAdapter: ConstPointer?
+        typeAdapter: ConstPointer? = null,
+        llvmPointerType: LLVMTypeRef
 ): Struct {
     if (convertToRetained != null) {
-        val expectedType = llvm.pointerType
-        assert(convertToRetained.llvmType == expectedType) {
-            "Expected: ${expectedType.toTypeString()} " +
-                    "found: ${convertToRetained.llvmType.toTypeString()}"
+        assert(convertToRetained.llvmType == llvmPointerType) {
+            "Expected: ${llvmPointerType.toTypeString()}, found: ${convertToRetained.llvmType.toTypeString()}"
         }
     }
 
     val objCExportAddition = Struct(
-            runtime.typeInfoObjCExportAddition,
+            typeInfoObjCExportAddition,
             convertToRetained,
             objCClass,
             swiftClass,
             typeAdapter
     )
 
-    val writableTypeInfoType = runtime.writableTypeInfoType!!
     return Struct(writableTypeInfoType, objCExportAddition)
 }
+
+private fun CodeGenerator.buildWritableTypeInfoValue(
+        convertToRetained: ConstPointer?,
+        objCClass: ConstPointer?,
+        swiftClass: ConstPointer? = null,
+        typeAdapter: ConstPointer?
+): Struct = buildWritableTypeInfoValue(
+        writableTypeInfoType = runtime.writableTypeInfoType!!,
+        typeInfoObjCExportAddition = runtime.typeInfoObjCExportAddition,
+        convertToRetained = convertToRetained,
+        objCClass = objCClass,
+        swiftClass = swiftClass,
+        typeAdapter = typeAdapter,
+        llvmPointerType = llvm.pointerType
+)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/WritableTypeInfo.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/WritableTypeInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -110,6 +110,8 @@ private fun CodeGenerator.setWritableTypeInfo(
         writableTypeInfoValue: Struct,
 ) {
     if (isExternal(irClass)) {
+        if (context.config.isUsingSplitCompilationScheme) return
+
         // Note: this global replaces the external one with common linkage.
         replaceExternalWeakOrCommonGlobal(
                 irClass.writableTypeInfoSymbolName,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/split/SplitObjCSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/split/SplitObjCSupport.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.llvm.objcexport.split
+
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.memScoped
+import llvm.*
+import org.jetbrains.kotlin.backend.konan.llvm.constPointer
+import org.jetbrains.kotlin.backend.konan.llvm.objcexport.ObjCExportConverterConstants
+import org.jetbrains.kotlin.backend.konan.llvm.objcexport.buildWritableTypeInfoValue
+import org.jetbrains.kotlin.backend.konan.llvm.objcexport.writableTypeInfoSymbolName
+
+private const val OBJC_EXPORT_CONVERTERS_MODULE_NAME: String = "objc_export_converters"
+
+private fun LLVMContextRef.createNamedStructWithBody(name: String, vararg fieldTypes: LLVMTypeRef): LLVMTypeRef {
+    return LLVMStructCreateNamed(this, name)!!.also {
+        memScoped {
+            val fields = allocArrayOf(*fieldTypes)
+            LLVMStructSetBody(it, fields, fieldTypes.size, 0)
+        }
+    }
+}
+
+internal fun createObjCExportConvertersModule(llvmContext: LLVMContextRef): LLVMModuleRef {
+    // TODO(Gabriele): It'd be nice reusing [CodegenLlvmHelpers], however it is highly coupled with [NativeGenerationState].
+    // TODO(Gabriele): We should refactor this function when the split is complete.
+
+    // TODO(Gabriele): Since we're reusing the existing LLVMContext, wouldn't we have some clashes with
+    // TODO(Gabriele): `createdNamedStructWithBody`?
+
+    val module = LLVMModuleCreateWithNameInContext(OBJC_EXPORT_CONVERTERS_MODULE_NAME, llvmContext)!!
+    val pointerType = LLVMPointerTypeInContext(llvmContext, 0)!!
+
+    // Unfortunately, most of the ObjC-codegen module is coupled, so functions cannot be reused.
+    // We need to recreate structs manually.
+    val objCExportAdditionType = llvmContext.createNamedStructWithBody("struct.TypeInfoObjCExportAddition", pointerType, pointerType, pointerType, pointerType)
+    val writableTypeInfoType = llvmContext.createNamedStructWithBody("struct.WritableTypeInfo", objCExportAdditionType)
+
+    // Converters have this C-shape: char*(*)(char*)
+    val converterFunctionType = memScoped {
+        val paramTypes = allocArrayOf(pointerType)
+        LLVMFunctionType(pointerType, paramTypes, 1, 0)!!
+    }
+
+    for (entry in ObjCExportConverterConstants.standardConverters) {
+        val converterFunc = LLVMAddFunction(module, entry.converterFunctionName, converterFunctionType)!!
+        val converterPtr = constPointer(LLVMConstBitCast(converterFunc, pointerType)!!)
+
+        val value = buildWritableTypeInfoValue(writableTypeInfoType, objCExportAdditionType, convertToRetained = converterPtr, llvmPointerType = pointerType)
+
+        val global = LLVMAddGlobal(module, writableTypeInfoType, entry.writableTypeInfoSymbolName)!!
+        LLVMSetInitializer(global, value.llvm)
+        LLVMSetLinkage(global, LLVMLinkage.LLVMExternalLinkage)
+    }
+
+    return module
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/runtime/RuntimeModule.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/runtime/RuntimeModule.kt
@@ -31,4 +31,6 @@ enum class RuntimeModule(val filename: String) {
     BREAKPAD("breakpad.bc"),
     CRASH_HANDLER_IMPL("impl_crashHandler.bc"),
     CRASH_HANDLER_NOOP("noop_crashHandler.bc"),
+    HOT_RELOAD("hot_reload.bc"),
+    HOT_RELOAD_LAUNCHER("hot_reload_launcher.bc")
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/runtime/RuntimeModulesConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/runtime/RuntimeModulesConfig.kt
@@ -17,6 +17,9 @@ class RuntimeModulesConfig(private val config: NativeSecondStageCompilationConfi
     internal val containsDebuggingRuntime: Boolean
         get() = config.debug
 
+    internal val isCompilingWithSplitScheme: Boolean
+        get() = config.isUsingSplitCompilationScheme
+
     private val RuntimeModule.absolutePath: String
         get() = Path(config.distribution.defaultNatives(config.target)).resolve(filename).absolutePathString()
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/visibility.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/visibility.kt
@@ -8,29 +8,37 @@ package org.jetbrains.kotlin.backend.konan.llvm
 import llvm.*
 import org.jetbrains.kotlin.utils.DFS
 
+private fun Sequence<LLVMValueRef>.setVisibilityTo(viz: LLVMVisibility, preserved: Set<LLVMValueRef>, f: (LLVMValueRef) -> Boolean) {
+    this.filter(f).minus(preserved).forEach { LLVMSetVisibility(it, viz) }
+}
+
 /**
  * Applies hidden visibility to symbols similarly to LLVM's internalize pass:
  * it makes hidden the symbols that are made internal by internalize.
  */
-fun makeVisibilityHiddenLikeLlvmInternalizePass(module: LLVMModuleRef) {
+fun LLVMModuleRef.makeSymbolsVisibilityHiddenLikeLlvmInternalizePass() {
     // Note: the implementation below generally follows InternalizePass::internalizeModule,
     // but omits some details for simplicity.
 
     // TODO: LLVM handles some additional cases.
-    val alwaysPreserved = getLlvmUsed(module)
+    val alwaysPreserved = getLlvmUsed(this)
+    val gatheredValues = getFunctions(this) + getGlobals(this) + getGlobalAliases(this)
 
-    (getFunctions(module) + getGlobals(module) + getGlobalAliases(module))
-            .filter {
-                when (LLVMGetLinkage(it)) {
-                    LLVMLinkage.LLVMInternalLinkage, LLVMLinkage.LLVMPrivateLinkage -> false
-                    else -> true
-                }
-            }
-            .filter { LLVMIsDeclaration(it) == 0 }
-            .minus(alwaysPreserved)
-            .forEach {
-                LLVMSetVisibility(it, LLVMVisibility.LLVMHiddenVisibility)
-            }
+    gatheredValues.setVisibilityTo(LLVMVisibility.LLVMHiddenVisibility, alwaysPreserved) {
+        val hasTargetLinkage = when (LLVMGetLinkage(it)) {
+            LLVMLinkage.LLVMInternalLinkage, LLVMLinkage.LLVMPrivateLinkage -> false
+            else -> true
+        }
+        hasTargetLinkage && it.isDefinition
+    }
+}
+
+fun LLVMModuleRef.makeSymbolsVisibilityDefault() {
+    val alwaysPreserved = getLlvmUsed(this)
+    val gatheredValues = getFunctions(this) + getGlobals(this) + getGlobalAliases(this)
+    gatheredValues.setVisibilityTo(LLVMVisibility.LLVMDefaultVisibility, alwaysPreserved) {
+        it.isDefinition
+    }
 }
 
 private fun getLlvmUsed(module: LLVMModuleRef): Set<LLVMValueRef> {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/PerformanceInline.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/PerformanceInline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.setFunctionAlwaysInline
 private const val PERFORMANCE_INLINE_ANNOTATION = "performance_inline"
 
 internal fun handlePerformanceInlineAnnotation(config: NativeSecondStageCompilationConfig, llvm: BasicLlvmHelpers) {
-    if (config.inlineForPerformance) {
+    if (config.inlineForPerformance && !config.isUsingSplitCompilationScheme) {
         val toInline = llvm.runtimeAnnotationMap[PERFORMANCE_INLINE_ANNOTATION] ?: return
         toInline.filter { it.isDefinition() }.forEach { setFunctionAlwaysInline(it) }
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/PerformanceInline.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/PerformanceInline.kt
@@ -16,6 +16,6 @@ private const val PERFORMANCE_INLINE_ANNOTATION = "performance_inline"
 internal fun handlePerformanceInlineAnnotation(config: NativeSecondStageCompilationConfig, llvm: BasicLlvmHelpers) {
     if (config.inlineForPerformance && !config.isUsingSplitCompilationScheme) {
         val toInline = llvm.runtimeAnnotationMap[PERFORMANCE_INLINE_ANNOTATION] ?: return
-        toInline.filter { it.isDefinition() }.forEach { setFunctionAlwaysInline(it) }
+        toInline.filter { it.isDefinition }.forEach { setFunctionAlwaysInline(it) }
     }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/PathUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/PathUtils.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.util
+
+import java.io.PrintWriter
+import java.nio.file.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.pathString
+
+fun Path.absoluteNormalizedPathString(): String = absolute().normalize().pathString
+
+fun Path.printWriter(): PrintWriter = bufferedWriter().let(::PrintWriter)

--- a/kotlin-native/konan/konan.properties
+++ b/kotlin-native/konan/konan.properties
@@ -135,6 +135,8 @@ targetToolchain.macos_arm64 = target-toolchain-xcode_26.4_17E192
 libffiDir.macos_arm64 = libffi-3.3-1-macos-arm64
 additionalToolsDir.macos_arm64 = xcode-addon-xcode_26.4_17E192
 
+kaldoLinkerFlags.macos_arm64 = -lKaldo
+
 targetToolchain.macos_x64-macos_arm64 = target-toolchain-xcode_26.4_17E192
 targetTriple.macos_arm64 = arm64-apple-macos
 targetSysRoot.macos_arm64 = target-sysroot-xcode_26.4_17E192-macosx
@@ -218,6 +220,8 @@ osVersionMinFlagLd.ios_x64 = -ios_simulator_version_min
 
 targetToolchain.macos_x64-ios_simulator_arm64 = target-toolchain-xcode_26.4_17E192
 targetToolchain.macos_arm64-ios_simulator_arm64 = target-toolchain-xcode_26.4_17E192
+
+kaldoLinkerFlags.ios_simulator_arm64 = -lKaldo.iossim
 
 targetTriple.ios_simulator_arm64 = arm64-apple-ios-simulator
 targetSysRoot.ios_simulator_arm64 = target-sysroot-xcode_26.4_17E192-iphonesimulator

--- a/kotlin-native/runtime/build.gradle.kts
+++ b/kotlin-native/runtime/build.gradle.kts
@@ -132,6 +132,8 @@ bitcode {
                     "REPORT_BACKTRACE_TO_IOS_CRASH_LOG".takeIf { target.supportsIosCrashLog() },
                     "SUPPORTS_GRAND_CENTRAL_DISPATCH".takeIf { target.supportsGrandCentralDispatch },
                     "SUPPORTS_SIGNPOSTS".takeIf { target.supportsSignposts },
+                    "HOT_RELOAD".takeIf { target.family.isAppleFamily },
+
             ).map { "KONAN_$it=1" }
             val otherOptions = listOfNotNull(
                     "USE_ELF_SYMBOLS=1".takeIf { target.binaryFormat() == BinaryFormat.ELF },
@@ -286,6 +288,24 @@ bitcode {
             sourceSets {
                 main {}
             }
+        }
+
+        module("hot_reload_launcher") {
+            srcRoot.set(layout.projectDirectory.dir("src/hot_reload_launcher"))
+            headersDirs.from(files("src/externalCallsChecker/common/cpp", "src/objcExport/cpp", "src/main/cpp", "src/hot_reload/common/cpp"))
+            sourceSets {
+                main {}
+            }
+            onlyIf { it.family.isAppleFamily }
+        }
+
+        module("hot_reload") {
+            srcRoot.set(layout.projectDirectory.dir("src/hot_reload/impl"))
+            headersDirs.from("src/alloc/common/cpp", "src/gcScheduler/common/cpp", "src/gc/common/cpp", "src/mm/cpp", "src/externalCallsChecker/common/cpp", "src/hot_reload/common/cpp", "src/main/cpp")
+            sourceSets {
+                main { }
+            }
+            onlyIf { it.family.isAppleFamily }
         }
 
         module("debug") {

--- a/kotlin-native/runtime/src/hot_reload/common/cpp/HotReload.hpp
+++ b/kotlin-native/runtime/src/hot_reload/common/cpp/HotReload.hpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+*/
+
+#ifndef HOTRELOAD_HPP
+#define HOTRELOAD_HPP
+
+#include "Memory.h"
+#include "Natives.h"
+#include "Runtime.h"
+#include "Types.h"
+#include "Common.h"
+#include "Logging.hpp"
+
+#define HRLogInfo(format, ...) RuntimeLogInfo({kotlin::kTagHotReload}, format, ##__VA_ARGS__)
+#define HRLogDebug(format, ...) RuntimeLogDebug({kotlin::kTagHotReload}, format, ##__VA_ARGS__)
+#define HRLogWarning(format, ...) RuntimeLogWarning({kotlin::kTagHotReload}, format, ##__VA_ARGS__)
+#define HRLogError(format, ...) RuntimeLogError({kotlin::kTagHotReload}, format, ##__VA_ARGS__)
+
+#endif

--- a/kotlin-native/runtime/src/hot_reload/impl/cpp/HotReload.cpp
+++ b/kotlin-native/runtime/src/hot_reload/impl/cpp/HotReload.cpp
@@ -1,0 +1,6 @@
+/**
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+*/
+
+// Empty at the moment :)

--- a/kotlin-native/runtime/src/hot_reload_launcher/cpp/Launcher.cpp
+++ b/kotlin-native/runtime/src/hot_reload_launcher/cpp/Launcher.cpp
@@ -1,0 +1,114 @@
+#include "HotReload.hpp"
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+// Must be in synch with `BootstrapMetadata.kt`
+extern "C" RUNTIME_WEAK const uint8_t* bootStartManifest;
+
+enum class PayloadKind : uint8_t {
+    kObject = 0,
+    kArchive = 1,
+};
+
+struct ManifestEntryMetadata {
+    PayloadKind kind;
+    uint64_t offset;
+    uint64_t size;
+};
+
+struct ManifestMetadata {
+    uint64_t manifestSize;
+    uint64_t bundleSize;
+    std::vector<ManifestEntryMetadata> entries;
+};
+
+struct KaldoManifestReader {
+    /**
+    * Parses the content of [bootStartManifest] without copying any payload.
+    * Integer fields use the target's byte order, so they can be read directly
+    * on the host for which this launcher was compiled.
+    */
+    static std::optional<ManifestMetadata> parse(const uint8_t* ptr) {
+        if (!ptr || std::memcmp(ptr, kFormatIdentifier, kFormatIdentifierSize) != 0) {
+            return std::nullopt;
+        }
+        ptr += kFormatIdentifierSize;
+
+        const uint64_t manifestSize = read<uint64_t>(ptr);
+        const uint64_t bundleSize = read<uint64_t>(ptr);
+        const uint32_t entryCount = read<uint32_t>(ptr);
+
+        const uint64_t metadataSize = kHeaderSize + entryCount * kEntrySize;
+        if (manifestSize < metadataSize || manifestSize - metadataSize != bundleSize) {
+            return std::nullopt;
+        }
+
+        ManifestMetadata manifest{manifestSize, bundleSize, {}};
+        manifest.entries.reserve(entryCount);
+
+        for (uint32_t i = 0; i < entryCount; ++i) {
+            const auto kind = static_cast<PayloadKind>(*ptr++);
+            const uint64_t offset = read<uint64_t>(ptr);
+            const uint64_t size = read<uint64_t>(ptr);
+
+            if ((kind != PayloadKind::kObject && kind != PayloadKind::kArchive) ||
+                    offset > bundleSize || size > bundleSize - offset) {
+                return std::nullopt;
+            }
+            manifest.entries.push_back({kind, offset, size});
+        }
+
+        return manifest;
+    }
+
+private:
+    static constexpr char kFormatIdentifier[] = "KALD0";
+    static constexpr uint64_t kFormatIdentifierSize = sizeof(kFormatIdentifier) - 1;
+    static constexpr uint64_t kHeaderSize =
+            kFormatIdentifierSize + sizeof(uint64_t) + sizeof(uint64_t) + sizeof(uint32_t);
+    static constexpr uint64_t kEntrySize = sizeof(uint8_t) + sizeof(uint64_t) + sizeof(uint64_t);
+
+    template <typename T>
+    static T read(const uint8_t*& ptr) {
+        T value;
+        std::memcpy(&value, ptr, sizeof(value));
+        ptr += sizeof(value);
+        return value;
+    }
+};
+
+// TODO(Gabriele): This function will be renamed into future. Right now, it does nothing
+// TODO(Gabriele): since the hot-reload runtime is not implemented.
+extern "C" RUNTIME_EXPORT void* KNHR_LoadObjCStubAddress(void* arg) {
+    return nullptr;
+}
+
+extern "C" RUNTIME_EXPORT int Konan_main(const int argc, const char** argv) {
+
+    Kotlin_initRuntimeIfNeeded();
+
+    fprintf(stderr,
+        "[warning] :: hot-reload runtime is not implemented yet, thus this program does nothing "
+        "and will now terminate. Please use the 'closed' compilation scheme instead.\n");
+
+    auto manifest = KaldoManifestReader::parse(bootStartManifest);
+    if (!manifest) {
+        fprintf(stderr, "[error] :: invalid bootstrap manifest\n");
+        Kotlin_shutdownRuntime();
+        return 1;
+    }
+    for (const auto& entry : manifest->entries) {
+        fprintf(stderr, "[debug] :: embedded payload kind=%u offset=%llu size=%llu\n",
+                static_cast<unsigned>(entry.kind),
+                static_cast<unsigned long long>(entry.offset),
+                static_cast<unsigned long long>(entry.size));
+    }
+
+    Kotlin_shutdownRuntime();
+
+    return 0;
+}

--- a/kotlin-native/runtime/src/main/cpp/CompilerConstants.hpp
+++ b/kotlin-native/runtime/src/main/cpp/CompilerConstants.hpp
@@ -85,7 +85,7 @@ ALWAYS_INLINE inline bool pagedAllocator() noexcept {
     return Kotlin_pagedAllocator != 0;
 }
 
-ALWAYS_INLINE intline bool hotReloadEnabled() noexcept {
+ALWAYS_INLINE inline bool hotReloadEnabled() noexcept {
     return Kotlin_hotReload != 0;
 }
 

--- a/kotlin-native/runtime/src/main/cpp/CompilerConstants.hpp
+++ b/kotlin-native/runtime/src/main/cpp/CompilerConstants.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -30,6 +30,7 @@ extern "C" const int32_t Kotlin_concurrentWeakSweep;
 extern "C" const int32_t Kotlin_gcMarkSingleThreaded;
 extern "C" const int32_t Kotlin_fixedBlockPageSize;
 extern "C" const int32_t Kotlin_pagedAllocator;
+extern "C" const int32_t Kotlin_hotReload;
 
 class SourceInfo;
 
@@ -84,6 +85,9 @@ ALWAYS_INLINE inline bool pagedAllocator() noexcept {
     return Kotlin_pagedAllocator != 0;
 }
 
+ALWAYS_INLINE intline bool hotReloadEnabled() noexcept {
+    return Kotlin_hotReload != 0;
+}
 
 bool gcMutatorsCooperate() noexcept;
 uint32_t auxGCThreads() noexcept;

--- a/kotlin-native/runtime/src/main/cpp/Logging.hpp
+++ b/kotlin-native/runtime/src/main/cpp/Logging.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -41,8 +41,9 @@ enum class Tag : int32_t {
     kGCMark = 9,
     kGCScheduler = 10,
     kMemoryDump = 11,
+    kHotReload = 12,
 
-    kEnumSize = 12
+    kEnumSize = 13
 };
 
 namespace internal {
@@ -71,6 +72,7 @@ inline const char* name(Tag tag) {
         case Tag::kGCMark: return "gcMark";
         case Tag::kGCScheduler: return "gcScheduler";
         case Tag::kMemoryDump: return "memoryDump";
+        case Tag::kHotReload: return "hotReload";
 
         case Tag::kEnumSize: break;
     }

--- a/kotlin-native/runtime/src/main/cpp/Logging.hpp
+++ b/kotlin-native/runtime/src/main/cpp/Logging.hpp
@@ -143,6 +143,7 @@ inline constexpr auto kTagGC = logging::Tag::kGC;
 inline constexpr auto kTagMM = logging::Tag::kMM;
 inline constexpr auto kTagTLS = logging::Tag::kTLS;
 inline constexpr auto kTagBalancing = logging::Tag::kBalancing;
+inline constexpr auto kTagHotReload = logging::Tag::kHotReload;
 
 } // namespace kotlin
 

--- a/kotlin-native/runtime/src/test_support/cpp/CompilerGenerated.cpp
+++ b/kotlin-native/runtime/src/test_support/cpp/CompilerGenerated.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -78,6 +78,7 @@ extern const int32_t Kotlin_gcMarkSingleThreaded = 0;
 extern const int32_t Kotlin_fixedBlockPageSize = 128;
 extern const int32_t Kotlin_pagedAllocator = 1;
 extern const int32_t Kotlin_latin1Strings = 1;
+extern const int32_t Kotlin_hotReload = 0;
 
 extern const TypeInfo* theAnyTypeInfo = theAnyTypeInfoHolder.typeInfo();
 extern const TypeInfo* theArrayTypeInfo = theArrayTypeInfoHolder.typeInfo();

--- a/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
+++ b/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
@@ -13,6 +13,7 @@ package org.jetbrains.kotlin.konan.config
  */
 
 import org.jetbrains.kotlin.backend.konan.AllocationMode
+import org.jetbrains.kotlin.backend.konan.CompilationScheme
 import org.jetbrains.kotlin.backend.konan.LlvmVariant
 import org.jetbrains.kotlin.backend.konan.TestRunnerKind
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -67,6 +68,10 @@ object NativeConfigurationKeys {
     // Path to a file where the list of all cache archives produced by this build should be written.
     @JvmField
     val DUMP_BUILT_CACHES_TO = CompilerConfigurationKey.create<String>("DUMP_BUILT_CACHES_TO")
+
+    // Compilation scheme used by the compiler, 'split-host' is used to have hot-reload enabled binaries.
+    @JvmField
+    val COMPILATION_SCHEME = CompilerConfigurationKey.create<CompilationScheme>("COMPILATION_SCHEME")
 
     // Mapping from library paths to cache paths.
     @JvmField
@@ -325,6 +330,10 @@ var CompilerConfiguration.incrementalCacheDir: String?
 var CompilerConfiguration.dumpBuiltCachesTo: String?
     get() = get(NativeConfigurationKeys.DUMP_BUILT_CACHES_TO)
     set(value) { put(NativeConfigurationKeys.DUMP_BUILT_CACHES_TO, requireNotNull(value) { "nullable values are not allowed" }) }
+
+var CompilerConfiguration.compilationScheme: CompilationScheme?
+    get() = get(NativeConfigurationKeys.COMPILATION_SCHEME)
+    set(value) { put(NativeConfigurationKeys.COMPILATION_SCHEME, requireNotNull(value) { "nullable values are not allowed" }) }
 
 var CompilerConfiguration.cachedLibraries: Map<String, String>
     get() = getMap(NativeConfigurationKeys.CACHED_LIBRARIES)

--- a/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
+++ b/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
@@ -20,6 +20,10 @@ where advanced options include:
   -Xcheck-dependencies       Check dependencies and download the missing ones.
   -Xcheck-state-at-external-calls
                              Ensure that all calls of possibly long external functions are done in the native thread state.
+  -Xcompilation-scheme=<closed|split>
+                             Compilation scheme used by the compiler to produce final binaries.
+                             1. 'closed': default compilation scheme. It produces one single artifact containing all the Kotlin code.
+                             2. 'split': hot-reload enable artifacts. It produces one single executable (the host) and a bootstrap object (loaded by host) containing Kotlin code.
   -Xcompile-from-bitcode=<path> Continue compilation from the given bitcode file.
   -Xdebug-info-version       Generate debug info of the given version (1, 2).
   -Xdebug-prefix-map=<old1=new1,old2=new2,...>

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationScheme.kt
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationScheme.kt
@@ -1,0 +1,3 @@
+fun main() {
+    println("split")
+}

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeInvalidValue.args
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeInvalidValue.args
@@ -1,0 +1,4 @@
+$TESTDATA_DIR$/splitCompilationScheme.kt
+-o
+$TEMP_DIR$/splitCompilationSchemeInvalidValue
+-Xcompilation-scheme=whole-world

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeInvalidValue.out
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeInvalidValue.out
@@ -1,0 +1,2 @@
+error: expected 'closed' or 'split' as compilation scheme. The default will be used.
+COMPILATION_ERROR

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeUnsupportedProduce.args
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeUnsupportedProduce.args
@@ -1,0 +1,9 @@
+$TESTDATA_DIR$/splitCompilationScheme.kt
+-o
+$TEMP_DIR$/splitCompilationSchemeUnsupportedProduce
+-g
+-produce
+dynamic
+-Xcompilation-scheme=split
+-Xenable-incremental-compilation
+-Xic-cache-dir=$TEMP_DIR$/ic-cache

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeUnsupportedProduce.out
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeUnsupportedProduce.out
@@ -1,0 +1,2 @@
+error: split compilation only supports '-produce program' and '-produce framework'. Got: 'dynamic'.
+COMPILATION_ERROR

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutDebug.args
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutDebug.args
@@ -1,0 +1,6 @@
+$TESTDATA_DIR$/splitCompilationScheme.kt
+-o
+$TEMP_DIR$/splitCompilationSchemeWithoutDebug
+-Xcompilation-scheme=split
+-Xenable-incremental-compilation
+-Xic-cache-dir=$TEMP_DIR$/ic-cache

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutDebug.out
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutDebug.out
@@ -1,0 +1,2 @@
+error: split compilation requires debugging information enabled. Please compile by passing '-g' as argument.
+COMPILATION_ERROR

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutIc.args
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutIc.args
@@ -1,0 +1,5 @@
+$TESTDATA_DIR$/splitCompilationScheme.kt
+-o
+$TEMP_DIR$/splitCompilationSchemeWithoutIc
+-g
+-Xcompilation-scheme=split

--- a/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutIc.out
+++ b/native/native.tests/cli-tests/testData/cli/splitCompilationSchemeWithoutIc.out
@@ -1,0 +1,2 @@
+error: split compilation requires incremental compilation. Please pass '-Xenable-incremental-compilation' and '-Xic-cache-dir=<directory>'.
+COMPILATION_ERROR

--- a/native/native.tests/testData/caches/testSplitScheme/simple/main/main.kt
+++ b/native/native.tests/testData/caches/testSplitScheme/simple/main/main.kt
@@ -1,0 +1,1 @@
+fun main() = println("ok!")

--- a/native/native.tests/testData/splitScheme/symbolConsistency/lib/lib.kt
+++ b/native/native.tests/testData/splitScheme/symbolConsistency/lib/lib.kt
@@ -1,0 +1,11 @@
+class SplitSchemeProbe {
+    val label: String = "probe"
+
+    fun describe(): String = "SplitSchemeProbe($label)"
+
+    private fun internalHelper(): Int = label.length
+
+    fun compute(): Int = internalHelper() * 2
+}
+
+fun topLevelProbeEntry(): String = SplitSchemeProbe().describe()

--- a/native/native.tests/testData/splitScheme/symbolConsistency/main/main.kt
+++ b/native/native.tests/testData/splitScheme/symbolConsistency/main/main.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+
+@Test
+fun useProbeFromLibrary() {
+    val probe = SplitSchemeProbe()
+    println(probe.describe())
+    println(probe.compute())
+    println(topLevelProbeEntry())
+    assertTrue(true)
+}

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/compilation/NativeTestGroupingMessageCollector.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/compilation/NativeTestGroupingMessageCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -75,6 +75,7 @@ internal class NativeTestGroupingMessageCollector(
                     || isContextReceiversWarning(message)
                     || isK1LanguageVersionWarning(message)
                     || isArgumentPassedMultipleTimesWarning(message)
+                    || isSplitCompilationWarning(message)
                 -> {
                 // These warnings are known and should not be reported as errors.
                 severity
@@ -129,6 +130,8 @@ internal class NativeTestGroupingMessageCollector(
 
     private fun isArgumentPassedMultipleTimesWarning(message: String): Boolean = message.matches(ARGUMENT_PASSED_MULTIPLE_TIMES_WARNING_REGEX)
 
+    private fun isSplitCompilationWarning(message: String): Boolean = message.startsWith(SPLIT_COMPILATION_WARNING_PREFIX)
+
     override fun hasErrors() = hasWarningsWithRaisedSeverity || super.hasErrors()
 
     companion object {
@@ -139,6 +142,7 @@ internal class NativeTestGroupingMessageCollector(
         private const val K2_NATIVE_EXPERIMENTAL_WARNING_PREFIX = "Language version 2.0 is experimental"
         private const val KLIB_LOADER_WARNING_PREFIX = "KLIB loader: "
         private const val CONTEXT_RECEIVERS_WARNING_PREFIX = "Experimental context receivers are superseded by context parameters"
+        private const val SPLIT_COMPILATION_WARNING_PREFIX = "Split compilation is an experimental feature"
 
         private val K1_LANGUAGE_VERSIONS_WARNING_REGEX = Regex("Language version 1.[0-9.]+ is deprecated and its support will be removed in a future version of Kotlin")
         private val PARTIAL_LINKAGE_WARNING_REGEX = Regex("^<[^<>]+>( @ (?:(?!: ).)+)?: .*")

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CachesSplitSchemeBuildTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CachesSplitSchemeBuildTest.kt
@@ -59,7 +59,7 @@ class CachesSplitSchemeBuildTest : AbstractNativeSimpleTest() {
         ).executableFile
 
         assertTrue(main.exists())
-        // Since the dump cache list exist, we can be sure that caches were built in split mode!
+        // Since the dump cache list exists, we can be sure that caches were built in split mode!
         assertTrue(
             builtCachesDump.exists(),
             "expected the split scheme to trigger cache building (no dump file at $builtCachesDump)"

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CachesSplitSchemeBuildTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CachesSplitSchemeBuildTest.kt
@@ -42,6 +42,7 @@ class CachesSplitSchemeBuildTest : AbstractNativeSimpleTest() {
     fun testSplitSchemeBuildsCaches() {
         val rootDir = ForTestCompileRuntime.transformTestDataPath("$TEST_SUITE_PATH/simple")
         val builtCachesDump = buildDir.resolve("built_caches_split.txt")
+        val icCacheDir = buildDir.resolve("ic_cache").also { it.mkdirs() }
 
         val main = compileToExecutableInOneStage(
             rootDir.resolve("main"),
@@ -50,6 +51,8 @@ class CachesSplitSchemeBuildTest : AbstractNativeSimpleTest() {
                 [
                     "-Xcompilation-scheme=split",
                     "-g",
+                    "-Xenable-incremental-compilation",
+                    "-Xic-cache-dir=${icCacheDir.absolutePath}",
                     "-Xdump-built-caches-to=${builtCachesDump.absolutePath}",
                 ]
             ),

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CachesSplitSchemeBuildTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/CachesSplitSchemeBuildTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.konan.test.blackbox
+
+import com.intellij.testFramework.TestDataPath
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.test.blackbox.CachesSplitSchemeBuildTest.Companion.TEST_SUITE_PATH
+import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedHostTarget
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestCompilerArgs
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.CacheMode
+import org.jetbrains.kotlin.test.TestMetadata
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+
+@Tag("caches")
+@EnforcedHostTarget
+@TestMetadata(TEST_SUITE_PATH)
+@TestDataPath($$"$PROJECT_ROOT")
+class CachesSplitSchemeBuildTest : AbstractNativeSimpleTest() {
+
+    companion object {
+        const val TEST_SUITE_PATH = "native/native.tests/testData/caches/testSplitScheme"
+    }
+
+    @BeforeEach
+    fun assumeCachesAreEnabled() {
+        Assumptions.assumeFalse(testRunSettings.get<CacheMode>() == CacheMode.WithoutCache)
+        Assumptions.assumeFalse(targets.testTarget == KonanTarget.MINGW_X64)
+    }
+
+    @Test
+    @TestMetadata("simple")
+    fun testSplitSchemeBuildsCaches() {
+        val rootDir = ForTestCompileRuntime.transformTestDataPath("$TEST_SUITE_PATH/simple")
+        val builtCachesDump = buildDir.resolve("built_caches_split.txt")
+
+        val main = compileToExecutableInOneStage(
+            rootDir.resolve("main"),
+            tryPassSystemCacheDirectory = false,
+            freeCompilerArgs = TestCompilerArgs(
+                [
+                    "-Xcompilation-scheme=split",
+                    "-g",
+                    "-Xdump-built-caches-to=${builtCachesDump.absolutePath}",
+                ]
+            ),
+        ).executableFile
+
+        assertTrue(main.exists())
+        // Since the dump cache list exist, we can be sure that caches were built in split mode!
+        assertTrue(
+            builtCachesDump.exists(),
+            "expected the split scheme to trigger cache building (no dump file at $builtCachesDump)"
+        )
+    }
+
+    @Test
+    @TestMetadata("simple")
+    fun testClosedSchemeDoesNotBuildCaches() {
+        val rootDir = ForTestCompileRuntime.transformTestDataPath("$TEST_SUITE_PATH/simple")
+        val builtCachesDump = buildDir.resolve("built_caches_closed.txt")
+
+        val main = compileToExecutableInOneStage(
+            rootDir.resolve("main"),
+            tryPassSystemCacheDirectory = false,
+            freeCompilerArgs = TestCompilerArgs(
+                [
+                    "-g",
+                    "-Xdump-built-caches-to=${builtCachesDump.absolutePath}",
+                ]
+            ),
+        ).executableFile
+
+        assertTrue(main.exists())
+        assertFalse(
+            builtCachesDump.exists(),
+            "cache building must not be triggered without the split scheme"
+        )
+    }
+}

--- a/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/SplitSchemeHostArtifactTest.kt
+++ b/native/native.tests/tests/org/jetbrains/kotlin/konan/test/blackbox/SplitSchemeHostArtifactTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.konan.test.blackbox
+
+import com.intellij.testFramework.TestDataPath
+import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.test.blackbox.SplitSchemeHostArtifactTest.Companion.TEST_SUITE_PATH
+import org.jetbrains.kotlin.konan.test.blackbox.support.EnforcedHostTarget
+import org.jetbrains.kotlin.konan.test.blackbox.support.TestCompilerArgs
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.CacheMode
+import org.jetbrains.kotlin.konan.test.blackbox.support.settings.configurables
+import org.jetbrains.kotlin.test.TestMetadata
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.io.File
+
+@Tag("caches")
+@EnforcedHostTarget
+@TestMetadata(TEST_SUITE_PATH)
+@TestDataPath($$"$PROJECT_ROOT")
+class SplitSchemeHostArtifactTest : AbstractNativeSimpleTest() {
+
+    companion object {
+        const val TEST_SUITE_PATH = "native/native.tests/testData/splitScheme"
+
+        // Caches force-loaded straight into the host (see BootstrapMetadata.FORCE_LOADED_CACHES_FQN);
+        // they are linked directly, so their paths are NOT embedded in the runtime manifest.
+        private val FORCE_LOADED = listOf("kotlin.native.internal", "skiko", "libkotlin", "libstdlib-cache")
+
+        private val USER_SYMBOLS = listOf("SplitSchemeProbe", "topLevelProbeEntry")
+    }
+
+    @BeforeEach
+    fun assumeCachesAreEnabled() {
+        Assumptions.assumeFalse(testRunSettings.get<CacheMode>() == CacheMode.WithoutCache)
+        Assumptions.assumeFalse(targets.testTarget == KonanTarget.MINGW_X64)
+    }
+
+    @Test
+    @TestMetadata("symbolConsistency")
+    fun testHostExcludesUserCodeAndEmbedsRuntimeCachePaths() {
+        val rootDir = ForTestCompileRuntime.transformTestDataPath("$TEST_SUITE_PATH/symbolConsistency")
+        val icCacheDir = buildDir.resolve("ic_cache").also { it.mkdirs() }
+
+        val lib = compileToLibrary(rootDir.resolve("lib"))
+        val host = compileToExecutableInOneStage(
+            rootDir.resolve("main"),
+            tryPassSystemCacheDirectory = false,
+            freeCompilerArgs = TestCompilerArgs(
+                [
+                    "-Xverbose-phases=Linker",
+                    "-Xcompilation-scheme=split",
+                    "-g",
+                    "-Xbinary=perFileCacheForStdlib=false",
+                    "-Xenable-incremental-compilation",
+                    "-Xic-cache-dir=${icCacheDir.absolutePath}",
+                ]
+            ),
+            lib,
+        ).executableFile
+
+        val stringsDefinedInExecutable = strings(host)
+
+        // User code was split out into the bootstrap object, so the host binary must not contain it.
+        USER_SYMBOLS.forEach { symbol ->
+            assertFalse(stringsDefinedInExecutable.any { symbol in it }, "host binary must not contain user symbol '$symbol'")
+        }
+
+        // The runtime manifest embeds absolute paths to the caches the host loads at startup,
+        // exactly the ones that are not force-loaded.
+        val cachePaths = stringsDefinedInExecutable.filter { "/" in it && it.endsWith(".a") }
+        assertTrue(
+            cachePaths.any { path -> FORCE_LOADED.none { it in path } },
+            "expected a non-force-loaded cache path embedded in the host binary, found: $cachePaths"
+        )
+    }
+
+    private fun strings(file: File): List<String> {
+        val llvmStrings = "${testRunSettings.configurables.absoluteLlvmHome}/bin/llvm-strings"
+        val process = ProcessBuilder(llvmStrings, file.absolutePath).redirectErrorStream(true).start()
+        val lines = process.inputStream.bufferedReader().readLines()
+        check(process.waitFor() == 0) { "`$llvmStrings ${file.absolutePath}` exited with a non-zero code" }
+        return lines
+    }
+}

--- a/native/utils/src/org/jetbrains/kotlin/backend/konan/CompilationScheme.kt
+++ b/native/utils/src/org/jetbrains/kotlin/backend/konan/CompilationScheme.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan
+
+enum class CompilationScheme {
+    CLOSED,
+    SPLIT_HOST;
+
+    companion object {
+        /**
+         * By default, the compilation scheme is the classical one: [CLOSED].
+         */
+        val DEFAULT = CLOSED
+    }
+}

--- a/native/utils/src/org/jetbrains/kotlin/konan/target/Configurables.kt
+++ b/native/utils/src/org/jetbrains/kotlin/konan/target/Configurables.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 JetBrains s.r.o.
+ * Copyright 2010-2026 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,8 @@ interface Configurables : TargetableExternalStorage, RelocationModeFlags {
     val targetCpu get() = targetString("targetCpu")
     val targetCpuFeatures get() = targetString("targetCpuFeatures")
     val llvmInlineThreshold get() = targetString("llvmInlineThreshold")
+
+    val kaldoLinkerFlags get() = targetList("kaldoLinkerFlags")
 
     val runtimeDefinitions get() = targetList("runtimeDefinitions")
 }


### PR DESCRIPTION
^KT-87702

This draft PR introduces the experimental `-Xcompilation-scheme` compiler argument.

By default, Kotlin/Native uses a closed-world compilation scheme: all dependencies are known at compilation time, allowing the compiler to perform whole-program optimizations at the cost of longer compilation times.

The new `split` compilation scheme lays some foundations for faster development iterations and hot-reload. It re-uses incremental-cache artifacts so that updated code can be rebuilt without recompiling the entire executable.

This PR currently covers only the compiler-side changes. Integration with Kaldo, which will load the split artifacts and provide the hot-reload runtime capabilities, will follow separately.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>