### PR TITLE
[Kapt] Use ClassLoadersCache service when available

### DIFF
--- a/plugins/kapt/kapt-base/src/org/jetbrains/kotlin/kapt/base/KaptOptions.kt
+++ b/plugins/kapt/kapt-base/src/org/jetbrains/kotlin/kapt/base/KaptOptions.kt
@@ -79,6 +79,9 @@ class KaptOptions(
         var processorsStatsReportFile: File? = null
         var fileReadHistoryReportFile: File? = null
 
+        var processingClassLoader: ClassLoader? = null
+        val separateClassloaderForProcessors: MutableSet<String> = mutableSetOf()
+
         fun build(): KaptOptions {
             val sourcesOutputDir = this.sourcesOutputDir ?: error("'sourcesOutputDir' must be set")
             val classesOutputDir = this.classesOutputDir ?: error("'classesOutputDir' must be set")
@@ -90,8 +93,8 @@ class KaptOptions(
                 sourcesOutputDir, classesOutputDir, stubsOutputDir, incrementalDataOutputDir,
                 processingClasspath, processors, processingOptions, javacOptions, KaptFlags.fromSet(flags),
                 mode, detectMemoryLeaks, stubGenerationScheme,
-                processingClassLoader = null,
-                separateClassloaderForProcessors = emptySet(),
+                processingClassLoader = processingClassLoader,
+                separateClassloaderForProcessors = separateClassloaderForProcessors.toSet(),
                 processorsStatsReportFile = processorsStatsReportFile,
                 fileReadHistoryReportFile = fileReadHistoryReportFile
             )

--- a/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/FirKaptAnalysisHandlerExtension.kt
+++ b/plugins/kapt/kapt-compiler/src/org/jetbrains/kotlin/kapt/FirKaptAnalysisHandlerExtension.kt
@@ -77,6 +77,7 @@ open class FirKaptAnalysisHandlerExtension(
             compileClasspath.addAll(contentRoots.filterIsInstance<JvmClasspathRoot>().map { it.file })
             javaSourceRoots.addAll(contentRoots.filterIsInstance<JavaSourceRoot>().map { it.file })
             classesOutputDir = classesOutputDir ?: configuration.outputDirectory
+            processingClassLoader = configuration.classloadersCache?.getForClassPath(processingClasspath)
         }
 
         optionsBuilder.checkOptions(logger, configuration)?.let { return it }
@@ -109,7 +110,7 @@ open class FirKaptAnalysisHandlerExtension(
         if (!options.mode.runAnnotationProcessing) return true
 
         createProcessorLoader().use { processorLoader ->
-            val processors = processorLoader.loadProcessors()
+            val processors = processorLoader.loadProcessors(FirKaptAnalysisHandlerExtension::class.java.classLoader)
             if (processors.processors.isEmpty()) return true
 
             val kaptContext = KaptContext(options, false, logger)


### PR DESCRIPTION
When running in "apt" mode as a compiler plugin, Kapt will check if the compiler has a ClassLoadersCache service installed, and use it for loading (and caching) the annotation processor classes.

^KT-78197