### PR TITLE
[Swift Export] Add cross-language inheritance execution tests. Part 1

### DIFF
--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/abstract_and_constructors/abstract_and_constructors.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/abstract_and_constructors/abstract_and_constructors.kt
@@ -1,0 +1,32 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: abstract_and_constructors.kt
+
+// Swift inheritance through abstract Kotlin ancestry.
+
+abstract class AbstractRoot {
+    abstract fun abstractValue(): String
+    open fun concreteValue(): String = "abstract-concrete"
+}
+
+open class ConcreteAbstractBranch : AbstractRoot() {
+    override open fun abstractValue(): String = "kotlin-abstract"
+}
+
+fun callAbstractValue(value: AbstractRoot): String = value.abstractValue()
+fun callAbstractConcrete(value: AbstractRoot): String = value.concreteValue()
+
+// Primary, secondary and default-argument constructor ancestry.
+
+open class ConstructorBase(val constructorOrigin: String = "primary-default") {
+    constructor(number: Int) : this("secondary:$number")
+
+    open fun constructorValue(): String = constructorOrigin
+}
+
+// Kotlin default arguments are not emitted as Swift default parameters. This branch consumes the
+// default on the Kotlin side and exposes a no-argument class that Swift can extend.
+open class DefaultConstructorBranch : ConstructorBase()
+
+fun callConstructorValue(value: ConstructorBase): String = value.constructorValue()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/abstract_and_constructors/abstract_and_constructors.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/abstract_and_constructors/abstract_and_constructors.swift
@@ -1,0 +1,46 @@
+import Inheritance
+import Testing
+
+@Test
+func swiftSubclassWorksThroughAbstractKotlinAncestry() throws {
+    class SwiftAbstractLeaf: ConcreteAbstractBranch {
+        override func abstractValue() -> String { "swift-abstract" }
+    }
+
+    let value = SwiftAbstractLeaf()
+    #expect(callAbstractValue(value: value) == "swift-abstract")
+    #expect(callAbstractConcrete(value: value) == "abstract-concrete")
+}
+
+@Test
+func swiftSubclassUsesPrimarySecondaryAndDefaultedConstructorAncestry() throws {
+    class SwiftConstructorLeaf: ConstructorBase {
+        override func constructorValue() -> String { "swift>" + super.constructorValue() }
+    }
+    class SwiftDefaultConstructorLeaf: DefaultConstructorBranch {
+        override func constructorValue() -> String { "swift>" + super.constructorValue() }
+    }
+
+    let primary = SwiftConstructorLeaf(constructorOrigin: "primary-explicit")
+    #expect(callConstructorValue(value: primary) == "swift>primary-explicit")
+
+    let secondary = SwiftConstructorLeaf(number: 7)
+    #expect(callConstructorValue(value: secondary) == "swift>secondary:7")
+
+    let defaulted = SwiftDefaultConstructorLeaf()
+    #expect(callConstructorValue(value: defaulted) == "swift>primary-default")
+}
+
+//  `.disabled(...)` cannot be used here, because a disabled test is still compiled and this body does not
+//  compile. Delete the `#if`/`#endif` (and add `import KotlinRuntime`) once KT-87947 is
+// fixed;
+#if KT87947_FIXED
+@Test(.disabled("KT-87947:can't inherit Kotlin abstract class"))
+func directSwiftSubclassOfAbstractKotlinClass() throws {
+    class DirectSwiftAbstractLeaf: AbstractRoot {
+        override func abstractValue() -> String { "swift-direct-abstract" }
+    }
+
+    #expect(callAbstractValue(value: DirectSwiftAbstractLeaf()) == "swift-direct-abstract")
+}
+#endif

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/class_delegation/class_delegation.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/class_delegation/class_delegation.kt
@@ -1,0 +1,29 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: class_delegation.kt
+
+interface DelegatedContract {
+    fun delegatedValue(): String
+}
+
+private class DelegatedImplementation : DelegatedContract {
+    override fun delegatedValue(): String = "delegated-implementation"
+}
+
+open class DelegatingBase : DelegatedContract by DelegatedImplementation() {
+    open fun localValue(): String = "delegating-base"
+}
+
+class DelegatingStorage {
+    private var stored: DelegatingBase? = null
+
+    fun store(value: DelegatingBase) {
+        stored = value
+    }
+
+    fun retrieve(): DelegatingBase? = stored
+}
+
+fun callDelegatedValue(value: DelegatedContract): String = value.delegatedValue()
+fun callDelegatingLocal(value: DelegatingBase): String = value.localValue()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/class_delegation/class_delegation.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/class_delegation/class_delegation.swift
@@ -1,0 +1,17 @@
+import Inheritance
+import Testing
+
+@Test
+func kotlinClassDelegationSurvivesSwiftSubclassing() throws {
+    class SwiftDelegatingLeaf: DelegatingBase {
+        override func localValue() -> String { "swift-local" }
+    }
+
+    let value = SwiftDelegatingLeaf()
+    let storage = DelegatingStorage()
+    storage.store(value: value)
+    let retrieved = try #require(storage.retrieve())
+    #expect(retrieved === value)
+    #expect(callDelegatedValue(value: value) == "delegated-implementation")
+    #expect(callDelegatingLocal(value: value) == "swift-local")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/covariant_return_override/covariant_return_override.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/covariant_return_override/covariant_return_override.kt
@@ -1,0 +1,24 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: covariant_return_override.kt
+
+// A Swift override may narrow the return type of a Kotlin member.
+
+open class ReturnBase {
+    open fun tag(): String = "kotlin-base"
+}
+
+class ReturnDerived : ReturnBase() {
+    override fun tag(): String = "kotlin-derived"
+}
+
+open class ReturnFactory {
+    open fun make(): ReturnBase = ReturnBase()
+}
+
+// Calls the (possibly overridden) factory through the base static type and dispatches on the result.
+fun callMakeTag(f: ReturnFactory): String = f.make().tag()
+
+// Hands the produced object back to Swift as the base type, so the caller can check what it really is.
+fun callMake(f: ReturnFactory): ReturnBase = f.make()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/covariant_return_override/covariant_return_override.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/covariant_return_override/covariant_return_override.swift
@@ -1,0 +1,35 @@
+import Inheritance
+import Testing
+
+// The narrowed type is declared in Kotlin
+@Test
+func swiftOverrideNarrowsReturnTypeToKotlinSubclass() throws {
+    class SwiftFactory: ReturnFactory {
+        override func make() -> ReturnDerived { ReturnDerived() }
+    }
+
+    let f = SwiftFactory()
+    #expect(callMakeTag(f: f) == "kotlin-derived")
+    #expect(callMake(f: f) is ReturnDerived)
+
+    // The plain Kotlin factory is unaffected.
+    #expect(callMakeTag(f: ReturnFactory()) == "kotlin-base")
+}
+
+// The narrowed type is declared in Swift
+@Test
+func swiftOverrideNarrowsReturnTypeToSwiftSubclass() throws {
+    final class SwiftMade: ReturnBase {
+        override func tag() -> String { "swift-made" }
+    }
+    class SwiftFactory: ReturnFactory {
+        override func make() -> SwiftMade { SwiftMade() }
+    }
+
+    let f = SwiftFactory()
+    #expect(callMakeTag(f: f) == "swift-made")
+
+    let returned = callMake(f: f)
+    #expect(returned is SwiftMade)
+    #expect(returned.tag() == "swift-made")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/cross_module_packages/cross_module_packages.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/cross_module_packages/cross_module_packages.kt
@@ -1,0 +1,31 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance(CrossModuleSupport)
+// FILE: cross_module_packages.kt
+
+// Swift subclass -> Kotlin class in module Inheritance (package middle.pkg)
+//                -> Kotlin class in module CrossModuleSupport (package base.pkg)
+
+package middle.pkg
+
+import base.pkg.CrossModuleBase
+
+open class CrossModuleMiddle : CrossModuleBase() {
+    open fun middleValue(): String = "kotlin-middle"
+}
+
+fun callMiddleValue(value: CrossModuleMiddle): String = value.middleValue()
+
+fun callBaseValueFromMiddle(value: CrossModuleBase): String = value.baseValue()
+
+// MODULE: CrossModuleSupport
+// EXPORT_TO_SWIFT
+// FILE: cross_module_support.kt
+
+package base.pkg
+
+open class CrossModuleBase {
+    open fun baseValue(): String = "kotlin-base"
+}
+
+fun callBaseValue(value: CrossModuleBase): String = value.baseValue()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/cross_module_packages/cross_module_packages.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/cross_module_packages/cross_module_packages.swift
@@ -1,0 +1,27 @@
+import Inheritance
+import CrossModuleSupport
+import Testing
+
+// Packaged Kotlin declarations are relocated under `ExportedKotlinPackages.<package>`; alias them so the test
+// body stays readable.
+private typealias Middle = ExportedKotlinPackages.middle.pkg.CrossModuleMiddle
+private typealias Base = ExportedKotlinPackages.base.pkg.CrossModuleBase
+
+// Overrides one member from each module
+private final class SwiftCrossModuleLeaf: Middle {
+    override func middleValue() -> Swift.String { "swift-middle" }
+    override func baseValue() -> Swift.String { "swift-base" }
+}
+
+@Test
+func kotlinReachesSwiftOverrideDeclaredInTheMiddleModule() throws {
+    let value = SwiftCrossModuleLeaf()
+    #expect(ExportedKotlinPackages.middle.pkg.callMiddleValue(value: value) == "swift-middle")
+}
+
+@Test
+func kotlinReachesSwiftOverrideDeclaredInTheBaseModule() throws {
+    let value = SwiftCrossModuleLeaf()
+    #expect(ExportedKotlinPackages.base.pkg.callBaseValue(value: value) == "swift-base")
+    #expect(ExportedKotlinPackages.middle.pkg.callBaseValueFromMiddle(value: value) == "swift-base")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/error_propagation/error_propagation.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/error_propagation/error_propagation.kt
@@ -48,3 +48,12 @@ open class Relayer {
 
 @Throws(Throwable::class)
 fun callRelay(r: Relayer): String = r.relay()
+
+// An exported Kotlin Throwable with an overridable member, so that a Swift subclass of it is a genuinely
+// Swift-backed object (dynamic Kotlin class, patched slot) rather than a bare wrapper.
+open class ThrowableBranch(val origin: String) : Exception("kotlin throwable: $origin") {
+    open fun throwableValue(): String = "kotlin-throwable:$origin"
+}
+
+@Throws(Throwable::class)
+fun throwProvided(value: ThrowableBranch): Unit = throw value

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/error_propagation/error_propagation.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/error_propagation/error_propagation.swift
@@ -82,3 +82,23 @@ func kotlinExceptionThrownBySwiftOverrideSurfacesToSwift() throws {
         Issue.record("expected MyKotlinException, got \(type(of: error)): \(error)")
     }
 }
+
+@Test
+func kotlinThrowsSwiftBackedExceptionSubclass() throws {
+    // The thrown object is a *Swift* subclass of an exported Kotlin
+    // `Exception`.
+    class SwiftThrowableLeaf: ThrowableBranch {
+        override func throwableValue() -> String { "swift>" + super.throwableValue() }
+    }
+
+    let value = SwiftThrowableLeaf(origin: "primary")
+
+    do {
+        try throwProvided(value: value)
+        Issue.record("expected throwProvided to throw")
+    } catch let error as SwiftThrowableLeaf {
+        #expect(error === value)
+    } catch {
+        Issue.record("expected the original SwiftThrowableLeaf, got \(type(of: error))")
+    }
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/identity_and_casts/identity_and_casts.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/identity_and_casts/identity_and_casts.kt
@@ -1,0 +1,78 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: identity_and_casts.kt
+
+interface ParentRequirement {
+    fun parentRequirement(): String
+}
+
+interface ChildRequirement : ParentRequirement {
+    fun childRequirement(): String
+}
+
+open class CompleteRequirementBase : ChildRequirement {
+    override fun parentRequirement(): String = "kotlin-parent"
+    override fun childRequirement(): String = "kotlin-child"
+}
+
+class RequirementStorage {
+    private var stored: CompleteRequirementBase? = null
+
+    fun store(value: CompleteRequirementBase) {
+        stored = value
+    }
+
+    fun retrieve(): CompleteRequirementBase? = stored
+}
+
+fun callParentRequirement(value: ParentRequirement): String = value.parentRequirement()
+fun callChildRequirement(value: ChildRequirement): String = value.childRequirement()
+
+interface CastParent {
+    fun parentToken(): String
+}
+
+interface CastChild : CastParent {
+    fun childToken(): String
+}
+
+open class CastBase : CastChild {
+    override open fun parentToken(): String = "kotlin-parent-token"
+    override open fun childToken(): String = "kotlin-child-token"
+}
+
+class CastStorage {
+    private var stored: CastParent? = null
+
+    fun store(value: CastParent) {
+        stored = value
+    }
+
+    fun retrieve(): CastParent? = stored
+}
+
+fun echoCastParent(value: CastParent): CastParent = value
+fun callCastParent(value: CastParent): String = value.parentToken()
+fun callCastChild(value: CastChild): String = value.childToken()
+
+class FieldPayload(val label: String)
+
+open class FieldOwnerBase(initial: FieldPayload) {
+    open var current: FieldPayload = initial
+    open fun selected(): FieldPayload = current
+
+    open fun replace(next: FieldPayload): FieldPayload {
+        val previous = current
+        current = next
+        return previous
+    }
+}
+
+fun readCurrentField(value: FieldOwnerBase): FieldPayload = value.current
+fun writeCurrentField(value: FieldOwnerBase, payload: FieldPayload) {
+    value.current = payload
+}
+
+fun callSelectedField(value: FieldOwnerBase): FieldPayload = value.selected()
+fun replaceCurrentField(value: FieldOwnerBase, payload: FieldPayload): FieldPayload = value.replace(payload)

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/identity_and_casts/identity_and_casts.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/identity_and_casts/identity_and_casts.swift
@@ -1,0 +1,89 @@
+import Inheritance
+import Testing
+
+// Regression probe: an inherited interface member that Swift does NOT override must not be patched
+// into a recursive reverse bridge.
+@Test
+func nonOverriddenParentInterfaceRequirementDoesNotRecurse() throws {
+    class PartialSwiftRequirement: CompleteRequirementBase {
+        override func childRequirement() -> String { "swift-child" }
+        // parentRequirement is intentionally inherited from Kotlin.
+    }
+
+    let value = PartialSwiftRequirement()
+    let storage = RequirementStorage()
+    storage.store(value: value)
+    let retrieved = try #require(storage.retrieve())
+    let parentView: any ParentRequirement = retrieved
+    let childView: any ChildRequirement = retrieved
+    #expect(retrieved === value)
+    #expect(parentView === value)
+    #expect(childView === value)
+    #expect(callChildRequirement(value: childView) == "swift-child")
+    #expect(callParentRequirement(value: parentView) == "kotlin-parent")
+}
+
+@Test
+func castsSurviveKotlinStorageAndRepeatedWrapperConversions() throws {
+    class SwiftCastLeaf: CastBase {
+        override func parentToken() -> String { "swift-parent-token" }
+        override func childToken() -> String { "swift-child-token" }
+    }
+
+    let value = SwiftCastLeaf()
+    let storage = CastStorage()
+    storage.store(value: value)
+
+    // Kotlin returns the object as the parent interface
+    let storedParent = try #require(storage.retrieve())
+    #expect(storedParent === value)
+    #expect(callCastParent(value: storedParent) == "swift-parent-token")
+
+    // Parent interface -> child interface -> exported Kotlin class.
+    let childView = try #require(storedParent as? any CastChild)
+    let classView = try #require(childView as? CastBase)
+    #expect(childView === value)
+    #expect(classView === value)
+    #expect(callCastChild(value: childView) == "swift-child-token")
+
+    // Repeated Kotlin round trips should not manufacture a different Swift wrapper.
+    let parentAgain = echoCastParent(value: storedParent)
+    let parentThird = echoCastParent(value: parentAgain)
+    let classAgain = try #require(parentThird as? CastBase)
+    #expect(parentAgain === value)
+    #expect(parentThird === value)
+    #expect(classAgain === value)
+}
+
+@Test
+func kotlinObjectsStoredInSwiftSubclassFieldsRoundTripByIdentity() throws {
+    class SwiftFieldOwner: FieldOwnerBase {
+        let swiftStoredField: FieldPayload
+
+        override init(initial: FieldPayload) {
+            swiftStoredField = FieldPayload(label: "swift-only")
+            super.init(initial: initial)
+        }
+
+        override func selected() -> FieldPayload { swiftStoredField }
+    }
+
+    let initial = FieldPayload(label: "initial")
+    let value = SwiftFieldOwner(initial: initial)
+    #expect(readCurrentField(value: value) === initial)
+
+    let writtenFromSwift = FieldPayload(label: "from-swift")
+    value.current = writtenFromSwift
+    #expect(readCurrentField(value: value) === writtenFromSwift)
+
+    let writtenFromKotlin = FieldPayload(label: "from-kotlin")
+    writeCurrentField(value: value, payload: writtenFromKotlin)
+    #expect(value.current === writtenFromKotlin)
+    #expect(callSelectedField(value: value) === value.swiftStoredField)
+    #expect(callSelectedField(value: value).label == "swift-only")
+
+    let replacement = FieldPayload(label: "replacement")
+    let previous = replaceCurrentField(value: value, payload: replacement)
+    #expect(previous === writtenFromKotlin)
+    #expect(readCurrentField(value: value) === replacement)
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/inner_class_dispatch/inner_class_dispatch.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/inner_class_dispatch/inner_class_dispatch.kt
@@ -1,0 +1,25 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: inner_class_dispatch.kt
+
+// A Kotlin `inner` class captures the outer instance, which for a Swift subclass is the dynamically created
+// wrapper. Both qualified forms have to behave correctly from inside it:
+//
+//   this@InnerOuter.value()   virtual  -> must reach the Swift override through the patched slot
+//   super@InnerOuter.value()  non-virtual -> must reach InnerOuterBase and never enter Swift
+open class InnerOuterBase {
+    open fun value(): String = "kotlin-base"
+}
+
+open class InnerOuter : InnerOuterBase() {
+    override fun value(): String = "kotlin-outer"
+
+    inner class Probe {
+        fun viaThis(): String = this@InnerOuter.value()
+        fun viaSuperOuter(): String = super@InnerOuter.value()
+    }
+}
+
+fun callInnerViaThis(o: InnerOuter): String = o.Probe().viaThis()
+fun callInnerViaSuperOuter(o: InnerOuter): String = o.Probe().viaSuperOuter()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/inner_class_dispatch/inner_class_dispatch.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/inner_class_dispatch/inner_class_dispatch.swift
@@ -1,0 +1,21 @@
+import Inheritance
+import Testing
+
+@Test
+func innerClassThisCallReachesSwiftOverride() throws {
+    class SwiftOuter: InnerOuter {
+        override func value() -> String { "swift-outer" }
+    }
+    #expect(callInnerViaThis(o: SwiftOuter()) == "swift-outer")
+    // The plain Kotlin instance is unaffected.
+    #expect(callInnerViaThis(o: InnerOuter()) == "kotlin-outer")
+}
+
+@Test
+func innerClassSuperOuterCallStaysInKotlin() throws {
+    class SwiftOuter: InnerOuter {
+        override func value() -> String { "swift-outer" }
+    }
+    #expect(callInnerViaSuperOuter(o: SwiftOuter()) == "kotlin-base")
+    #expect(callInnerViaSuperOuter(o: InnerOuter()) == "kotlin-base")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_level_swift_hierarchy/multi_level_swift_hierarchy.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_level_swift_hierarchy/multi_level_swift_hierarchy.kt
@@ -1,0 +1,17 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: multi_level_swift_hierarchy.kt
+
+open class BaseClass {
+    open fun baseFunction(): String = "base-class"
+}
+
+fun callFunBaseClass(value: BaseClass): String = value.baseFunction()
+
+open class SuperReentryBase {
+    open fun callback(): String = "kotlin-callback"
+    open fun operation(): String = "kotlin-operation>${callback()}"
+}
+
+fun callSuperReentry(value: SuperReentryBase): String = value.operation()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_level_swift_hierarchy/multi_level_swift_hierarchy.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_level_swift_hierarchy/multi_level_swift_hierarchy.swift
@@ -1,0 +1,33 @@
+import Inheritance
+import Testing
+
+@Test
+func twoSwiftSubclassLevelsPreserveSuperChainThroughKotlin() throws {
+    class SwiftMiddle: BaseClass {
+        override func baseFunction() -> String { "swift-middle>" + super.baseFunction() }
+    }
+    class SwiftLeaf: SwiftMiddle {
+        override func baseFunction() -> String { "swift-leaf>" + super.baseFunction() }
+    }
+
+    let value = SwiftLeaf()
+    #expect(value.baseFunction() == "swift-leaf>swift-middle>base-class")
+    #expect(callFunBaseClass(value: value) == "swift-leaf>swift-middle>base-class")
+}
+
+@Test
+func severalSwiftLevelsCallKotlinSuperWhichCallsBackToSwift() throws {
+    class SwiftMiddle: SuperReentryBase {
+        override func callback() -> String { "swift-middle-callback" }
+        override func operation() -> String { "swift-middle>" + super.operation() }
+    }
+
+    class SwiftLeaf: SwiftMiddle {
+        override func callback() -> String { "swift-leaf-callback" }
+        override func operation() -> String { "swift-leaf>" + super.operation() }
+    }
+
+    let value = SwiftLeaf()
+    #expect(value.operation() == "swift-leaf>swift-middle>kotlin-operation>swift-leaf-callback")
+    #expect(callSuperReentry(value: value) == "swift-leaf>swift-middle>kotlin-operation>swift-leaf-callback")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_slot_binding/multi_slot_binding.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_slot_binding/multi_slot_binding.kt
@@ -1,0 +1,39 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: multi_slot_binding.kt
+
+// Two shapes where a single member occupies two interface slots: two interfaces contributing the same
+// defaulted signature, and one property declared by two interfaces that the Kotlin class implements once.
+
+interface LeftDefault {
+    fun conflict(): String = "left"
+}
+
+interface RightDefault {
+    fun conflict(): String = "right"
+}
+
+open class ConflictAnchor
+
+fun callLeftDefault(value: LeftDefault): String = value.conflict()
+fun callRightDefault(value: RightDefault): String = value.conflict()
+
+data class DataPayload(val text: String, val number: Int)
+
+interface RichDataView {
+    val richData: DataPayload
+}
+
+interface RichDataMirrorView {
+    val richData: DataPayload
+}
+
+open class TypeRichSuperBase : RichDataView, RichDataMirrorView {
+    override open val richData: DataPayload = DataPayload("kotlin-super", 40)
+}
+
+fun readRichData(value: RichDataView): DataPayload = value.richData
+fun readMirroredRichData(value: RichDataMirrorView): DataPayload = value.richData
+fun richDataAsView(value: TypeRichSuperBase): RichDataView = value
+fun richDataAsMirrorView(value: TypeRichSuperBase): RichDataMirrorView = value

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_slot_binding/multi_slot_binding.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/multi_slot_binding/multi_slot_binding.swift
@@ -1,0 +1,37 @@
+import Inheritance
+import Testing
+
+// One Swift implementation that has to be installed into *two* itable places. Swift Export emits one
+// @BindReverseBridgeToMethod per slot and the annotation is @Repeatable precisely for this shape, so these
+// are the only tests that can drive the multi-binding path: everything else needs a single slot.
+
+@Test
+func swiftImplementationResolvesConflictingInterfaceDefaults() throws {
+    class SwiftConflict: ConflictAnchor, LeftDefault, RightDefault {
+        func conflict() -> String { "swift-conflict" }
+    }
+
+    let value = SwiftConflict()
+    #expect(callLeftDefault(value: value) == "swift-conflict")
+    #expect(callRightDefault(value: value) == "swift-conflict")
+}
+
+@Test
+func typeRichPropertySuperDispatchesThroughInterfaceView() throws {
+    class SwiftRichSuper: TypeRichSuperBase {
+        override var richData: DataPayload {
+            let inherited = super.richData
+            return DataPayload(text: "swift>\(inherited.text)", number: inherited.number + 2)
+        }
+    }
+
+    let value = SwiftRichSuper()
+    let interfaceView = richDataAsView(value: value)
+    let mirrorView = richDataAsMirrorView(value: value)
+    let result = readRichData(value: interfaceView)
+    #expect(interfaceView === value)
+    #expect(mirrorView === value)
+    #expect(result.text == "swift>kotlin-super")
+    #expect(result.number == 42)
+    #expect(readMirroredRichData(value: mirrorView).text == "swift>kotlin-super")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/nested_classes/nested_classes.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/nested_classes/nested_classes.kt
@@ -1,0 +1,34 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: nested_classes.kt
+
+// Nested declaration relocation: Swift subclasses a nested Kotlin open class.
+
+data class DataPayload(val text: String, val number: Int)
+
+enum class InheritanceMode {
+    kotlinMode,
+    swiftMode,
+}
+
+
+interface NestedRichView {
+    val nestedData: DataPayload
+    val nestedMode: InheritanceMode
+}
+
+class NestedInheritanceContainer {
+    open class NestedBase : NestedRichView {
+        override open val nestedData: DataPayload = DataPayload("kotlin-nested-data", 50)
+        override open val nestedMode: InheritanceMode = InheritanceMode.kotlinMode
+
+        open fun nestedValue(): String = "kotlin-nested"
+    }
+}
+
+
+fun callNestedValue(value: NestedInheritanceContainer.NestedBase): String = value.nestedValue()
+fun nestedAsRichView(value: NestedInheritanceContainer.NestedBase): NestedRichView = value
+fun readNestedData(value: NestedRichView): DataPayload = value.nestedData
+fun readNestedMode(value: NestedRichView): InheritanceMode = value.nestedMode

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/nested_classes/nested_classes.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/nested_classes/nested_classes.swift
@@ -1,0 +1,26 @@
+import Inheritance
+import Testing
+
+@Test
+func swiftCanSubclassNestedKotlinOpenClass() throws {
+    class SwiftNestedLeaf: NestedInheritanceContainer.NestedBase {
+        override func nestedValue() -> String { "swift-nested>" + super.nestedValue() }
+    }
+
+    #expect(callNestedValue(value: SwiftNestedLeaf()) == "swift-nested>kotlin-nested")
+}
+
+@Test
+func nestedPartialPropertyOverrideThroughInterfaceView() throws {
+    class SwiftNestedRichLeaf: NestedInheritanceContainer.NestedBase {
+        override var nestedData: DataPayload {
+            DataPayload(text: "swift>" + super.nestedData.text, number: super.nestedData.number + 1)
+        }
+        // nestedMode is intentionally inherited.
+    }
+
+    let interfaceView = nestedAsRichView(value: SwiftNestedRichLeaf())
+    #expect(readNestedData(value: interfaceView).text == "swift>kotlin-nested-data")
+    #expect(readNestedData(value: interfaceView).number == 51)
+    #expect(readNestedMode(value: interfaceView) == .kotlinMode)
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/second_swift_level_interface/second_swift_level_interface.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/second_swift_level_interface/second_swift_level_interface.kt
@@ -1,0 +1,22 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: second_swift_level_interface.kt
+
+// A Kotlin interface is first adopted by the *first* Swift class in the chain, and the object handed to Kotlin
+// is an instance of the *second* Swift class, which inherits both the conformance and the implementation.
+// Kotlin then dispatches through the interface, i.e. through an itable slot that only the Swift side populates:
+//
+//   itable slot -> Kotlin bridge -> @ImportedBridge -> @_cdecl ..._reverse_swift -> Swift override
+//
+// The reverse entry point rebuilds the receiver with `__createProtocolWrapper` / `__createClassWrapper` for the
+// class that *declared* the conformance (level 1), while the object is an instance of level 2 — which is where
+// the ClassCastException comes from.
+
+open class InterfaceAnchor
+
+interface SecondLevelContract {
+    fun token(): String
+}
+
+fun callToken(value: SecondLevelContract): String = value.token()

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/second_swift_level_interface/second_swift_level_interface.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/second_swift_level_interface/second_swift_level_interface.swift
@@ -1,0 +1,33 @@
+import Inheritance
+import Testing
+
+// Level 1 — the only place the Kotlin interface is adopted and implemented.
+class SwiftFirstLevel: InterfaceAnchor, SecondLevelContract {
+    func token() -> String { "swift-token" }
+}
+
+// Level 2 — adds nothing at all: both the conformance and the implementation are inherited from level 1.
+final class SwiftSecondLevel: SwiftFirstLevel {}
+
+// Control: with the instance at the same level that declares the conformance, the itable slot resolves.
+// If this one starts failing too, the problem is not specific to the second level.
+
+// Control: with the instance at the same level that declares the conformance, the itable slot resolves.
+// If this one starts failing too, the problem is not specific to the second level.
+@Test
+func kotlinCallsInterfaceMethodOnFirstSwiftLevel() throws {
+    let value = SwiftFirstLevel()
+    let contractView: any SecondLevelContract = value
+    #expect(contractView === value)
+    #expect(callToken(value: value) == "swift-token")
+}
+
+// The reproducer: identical call, one extra Swift inheritance level between the instance and the class that
+// adopted the Kotlin interface. Remove `.disabled(...)` to reproduce.
+@Test(.disabled("KT-88042: Kotlin cannot dispatch an itable slot to a Swift implementation inherited from the first Swift level"))
+func kotlinCallsInterfaceMethodOnSecondSwiftLevel() throws {
+    let value = SwiftSecondLevel()
+    let contractView: any SecondLevelContract = value
+    #expect(contractView === value)
+    #expect(callToken(value: value) == "swift-token")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/signatures/signatures.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/signatures/signatures.kt
@@ -36,3 +36,48 @@ open class OverloadedSpeakerBase : OverloadedSpeaker {
 
 fun callSay(s: OverloadedSpeaker): String = s.say()
 fun callSayTimes(s: OverloadedSpeaker, times: Int): String = s.say(times)
+
+// Rich signatures with Kotlin-consumed default arguments, and overload selection across reverse bridges.
+
+data class DataPayload(val text: String, val number: Int)
+
+enum class InheritanceMode {
+    kotlinMode,
+    swiftMode,
+}
+
+open class DefaultSignatureBase {
+    open fun format(
+        prefix: String,
+        payload: DataPayload = DataPayload("default-payload", 7),
+        mode: InheritanceMode = InheritanceMode.kotlinMode,
+        note: String? = null,
+        repeat: Int = 2,
+    ): String = "$prefix:${payload.text}:$mode:$note:$repeat"
+}
+
+fun callFormatWithKotlinDefaults(value: DefaultSignatureBase, prefix: String): String = value.format(prefix)
+
+fun callFormatExplicitly(
+    value: DefaultSignatureBase,
+    prefix: String,
+    payload: DataPayload,
+    mode: InheritanceMode,
+    note: String?,
+    repeat: Int,
+): String = value.format(prefix, payload, mode, note, repeat)
+
+open class OverloadedSignatureBase {
+    open fun choose(value: String): String = "kotlin-one:$value"
+    open fun choose(value: String, count: Int): String = "kotlin-two:$value:$count"
+    open fun choose(value: String, count: Int, mode: InheritanceMode): String = "kotlin-three:$value:$count:$mode"
+}
+
+fun callChooseOne(value: OverloadedSignatureBase, text: String): String = value.choose(text)
+fun callChooseTwo(value: OverloadedSignatureBase, text: String, count: Int): String = value.choose(text, count)
+fun callChooseThree(
+    value: OverloadedSignatureBase,
+    text: String,
+    count: Int,
+    mode: InheritanceMode,
+): String = value.choose(text, count, mode)

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/signatures/signatures.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/signatures/signatures.swift
@@ -59,3 +59,48 @@ func swiftOverridesEachKotlinInterfaceOverloadSeparately() throws {
     #expect(callSay(s: k) == "kotlin-say")
     #expect(callSayTimes(s: k, times: 3) == "kotlin-say(3)")
 }
+
+@Test
+func kotlinDefaultsReachSwiftOverrideWithRichSignature() throws {
+    class SwiftDefaultSignature: DefaultSignatureBase {
+        override func format(
+            prefix: String,
+            payload: DataPayload,
+            mode: InheritanceMode,
+            note: String?,
+            `repeat`: Int32
+        ) -> String {
+            let modeText = mode == .kotlinMode ? "K" : "S"
+            return "\(prefix)|\(payload.text)|\(payload.number)|\(modeText)|\(note ?? "nil")|\(`repeat`)"
+        }
+    }
+
+    let value = SwiftDefaultSignature()
+    #expect(callFormatWithKotlinDefaults(value: value, prefix: "defaults") == "defaults|default-payload|7|K|nil|2")
+
+    let explicit = callFormatExplicitly(
+        value: value,
+        prefix: "explicit",
+        payload: DataPayload(text: "payload", number: 9),
+        mode: .swiftMode,
+        note: "note",
+        repeat: 4
+    )
+    #expect(explicit == "explicit|payload|9|S|note|4")
+}
+
+@Test
+func overloadedReverseBridgesSelectTheSwiftImplementation() throws {
+    class SwiftOverloadedSignature: OverloadedSignatureBase {
+        override func choose(value: String) -> String { "swift-one:\(value)" }
+        override func choose(value: String, count: Int32) -> String { "swift-two:\(value):\(count)" }
+        override func choose(value: String, count: Int32, mode: InheritanceMode) -> String {
+            "swift-three:\(value):\(count):\(mode == .swiftMode ? "S" : "K")"
+        }
+    }
+
+    let value = SwiftOverloadedSignature()
+    #expect(callChooseOne(value: value, text: "a") == "swift-one:a")
+    #expect(callChooseTwo(value: value, text: "b", count: 2) == "swift-two:b:2")
+    #expect(callChooseThree(value: value, text: "c", count: 3, mode: .swiftMode) == "swift-three:c:3:S")
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/swift_adopted_interface/swift_adopted_interface.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/swift_adopted_interface/swift_adopted_interface.swift
@@ -1,5 +1,6 @@
 import Inheritance
 import Testing
+import KotlinRuntime
 
 @Test
 func swiftSubclassOfKotlinClassConformsToUnrelatedKotlinInterface() throws {
@@ -28,3 +29,27 @@ func swiftSubclassOfKotlinClassConformsToUnrelatedKotlinInterface() throws {
     #expect(callVolume(s: s) == 7)
     #expect(callGreet(base: s) == "Hello from Kotlin")
 }
+
+// KT-88251 — a Swift class that implements a Kotlin interface with no exported Kotlin class in its
+// hierarchy, written as `KotlinBase & <interface>`. It cannot be constructed today, because
+// `KotlinBase.init()` is NS_UNAVAILABLE:
+//
+//   error: 'init()' is unavailable
+//   KotlinRuntime/KotlinBase.h: note: 'init()' has been explicitly marked unavailable here
+//
+// `.disabled(...)` cannot be used here, because a disabled test is still compiled and this body does not
+// compile. Delete the `#if`/`#endif` (and add `import KotlinRuntime`) once KT-88251 is
+// fixed;
+#if KT88251_FIXED
+@Test(.disabled("KT-88251: cannot instantiate KotlinBase"))
+func swiftOnlyImplementationOfKotlinInterface() throws {
+    final class SwiftOnlySpeaker: KotlinBase & Speaker {
+        func speak() -> String { "swift-only speaks" }
+        func volume() -> Int32 { 3 }
+    }
+
+    let s = SwiftOnlySpeaker()
+    #expect(callSpeak(s: s) == "swift-only speaks")
+    #expect(callVolume(s: s) == 3)
+}
+#endif

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/swift_backed_parameter/swift_backed_parameter.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/swift_backed_parameter/swift_backed_parameter.kt
@@ -1,0 +1,30 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: swift_backed_parameter.kt
+
+// Reverse bridges are normally exercised with a Swift-backed *receiver* and plain Kotlin arguments. Here the
+// argument itself is Swift-backed, so the wrapper has to travel Swift -> Kotlin -> reverse bridge -> Swift in
+// contravariant position and arrive as the very same Swift instance, rather than as a fresh wrapper built
+// around the Kotlin half of it. It also has to stay usable once it gets there: a virtual call on the argument
+// from inside the reverse bridge must go back out through that argument's own patched slot.
+
+open class Cargo {
+    open fun label(): String = "kotlin-cargo"
+}
+
+open class Handler {
+    open fun handle(cargo: Cargo): String = "kotlin-handled:${cargo.label()}"
+}
+
+// Kotlin receives the argument and passes it on, so it crosses the bridge as a parameter, not as the receiver.
+fun callHandle(handler: Handler, cargo: Cargo): String = handler.handle(cargo)
+
+// The argument never came from Swift at all: Kotlin creates it and hands it to the override.
+fun callHandleWithKotlinCargo(handler: Handler): String = handler.handle(Cargo())
+
+// The Swift-backed instance is parked on the Kotlin side first, so reaching the override cannot be a plain
+// pass-through of a reference Swift supplied in the same call.
+class CargoBox(val cargo: Cargo)
+
+fun callHandleFromBox(handler: Handler, box: CargoBox): String = handler.handle(box.cargo)

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/swift_backed_parameter/swift_backed_parameter.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/swift_backed_parameter/swift_backed_parameter.swift
@@ -1,0 +1,67 @@
+import Inheritance
+import Testing
+
+@Test
+func kotlinPassesSwiftBackedObjectIntoSwiftOverride() throws {
+    final class SwiftCargo: Cargo {
+        override func label() -> String { "swift-cargo" }
+    }
+    class SwiftHandler: Handler {
+        var received: Cargo? = nil
+        override func handle(cargo: Cargo) -> String {
+            received = cargo
+            return "swift-handled"
+        }
+    }
+
+    let handler = SwiftHandler()
+    let cargo = SwiftCargo()
+
+    #expect(callHandle(handler: handler, cargo: cargo) == "swift-handled")
+    // The argument has to arrive as the same Swift instance, not as a fresh wrapper over its Kotlin half.
+    #expect(handler.received === cargo)
+    #expect(handler.received is SwiftCargo)
+
+    // A purely Kotlin argument reaches the same override with no identity to carry across.
+    #expect(callHandleWithKotlinCargo(handler: handler) == "swift-handled")
+    #expect((handler.received is SwiftCargo) == false)
+}
+
+@Test
+func swiftOverrideCallsBackIntoSwiftBackedParameter() throws {
+    final class SwiftCargo: Cargo {
+        override func label() -> String { "swift-cargo" }
+    }
+    class SwiftHandler: Handler {
+        override func handle(cargo: Cargo) -> String { "swift:\(cargo.label())" }
+    }
+
+    // A virtual call on the argument, made from inside the reverse bridge, must resolve to the argument's own
+    // Swift override and not to Cargo's Kotlin body.
+    #expect(callHandle(handler: SwiftHandler(), cargo: SwiftCargo()) == "swift:swift-cargo")
+    #expect(callHandle(handler: SwiftHandler(), cargo: Cargo()) == "swift:kotlin-cargo")
+    // Control: Kotlin's own body sees the very same argument the very same way.
+    #expect(callHandle(handler: Handler(), cargo: SwiftCargo()) == "kotlin-handled:swift-cargo")
+}
+
+@Test
+func swiftBackedParameterSurvivesKotlinStorageBeforeReachingOverride() throws {
+    final class SwiftCargo: Cargo {
+        override func label() -> String { "boxed-swift-cargo" }
+    }
+    class SwiftHandler: Handler {
+        var received: Cargo? = nil
+        override func handle(cargo: Cargo) -> String {
+            received = cargo
+            return "boxed:\(cargo.label())"
+        }
+    }
+
+    let handler = SwiftHandler()
+    let cargo = SwiftCargo()
+    let box = CargoBox(cargo: cargo)
+
+    #expect(callHandleFromBox(handler: handler, box: box) == "boxed:boxed-swift-cargo")
+    #expect(handler.received === cargo)
+    #expect(box.cargo === cargo)
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/ungrouped/ungrouped.kt
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/ungrouped/ungrouped.kt
@@ -1,0 +1,49 @@
+// KIND: STANDALONE
+// FREE_COMPILER_ARGS: -opt-in=kotlin.native.internal.InternalForKotlinNative
+// MODULE: Inheritance
+// FILE: ungrouped.kt
+
+open class FunctionMemberBase {
+    open val producer: () -> String = { "kotlin-producer" }
+    open fun transform(mapper: (String) -> String): String = mapper("kotlin")
+}
+
+fun callProducer(value: FunctionMemberBase): String = value.producer()
+fun callTransform(value: FunctionMemberBase, prefix: String): String = value.transform { "$prefix:$it" }
+
+open class SideEffectBase {
+
+    open val tag: String? = "kotlin-tag"
+}
+
+
+// Safe call on a value that a Swift override may have made null.
+fun tagLength(value: SideEffectBase): Int = value.tag?.length ?: -1
+
+fun tagOrDefault(value: SideEffectBase): String = value.tag ?: "kotlin-default"
+
+data class DataPayload(val text: String, val number: Int)
+
+enum class InheritanceMode {
+    kotlinMode,
+    swiftMode,
+}
+
+value class InlinePayload(val value: Int)
+
+open class TypeRichBase {
+    open fun mapData(value: DataPayload): DataPayload =
+        DataPayload("kotlin:${value.text}", value.number + 1)
+
+    open fun mapEnum(value: InheritanceMode): InheritanceMode = InheritanceMode.kotlinMode
+
+    open fun mapInline(value: InlinePayload): InlinePayload = InlinePayload(value.value + 1)
+}
+
+fun callMapData(value: TypeRichBase, payload: DataPayload): DataPayload = value.mapData(payload)
+fun callMapEnum(value: TypeRichBase, mode: InheritanceMode): InheritanceMode = value.mapEnum(mode)
+fun callMapInline(value: TypeRichBase, payload: InlinePayload): InlinePayload = value.mapInline(payload)
+
+fun callToString(value: FunctionMemberBase): String {
+    return value.toString()
+}

--- a/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/ungrouped/ungrouped.swift
+++ b/native/swift/swift-export-standalone-integration-tests/simple/testData/execution/inheritance/ungrouped/ungrouped.swift
@@ -1,0 +1,79 @@
+import Inheritance
+import Testing
+
+@Test(.disabled("KT-88499: can't override function with lambda return type"))
+func swiftOverridesFunctionTypedProperty() throws {
+    class SwiftProducer: FunctionMemberBase {
+        override var producer: () -> Swift.String { { "swift-producer" } }
+    }
+    #expect(callProducer(value: SwiftProducer()) == "swift-producer")
+}
+
+@Test(.disabled("KT-88277: function override with lambda parameter is ignored"))
+func swiftOverrideInvokesKotlinLambdaParameter() throws {
+    class SwiftTransformer: FunctionMemberBase {
+        override func transform(mapper: @escaping (Swift.String) -> Swift.String) -> Swift.String {
+            "swift[" + mapper("swift") + "]"
+        }
+    }
+    #expect(callTransform(value: SwiftTransformer(), prefix: "p") == "swift[p:swift]")
+}
+
+@Test
+func kotlinSafeCallsSeeSwiftNilOverride() throws {
+    class SwiftNilTag: SideEffectBase {
+        override var tag: Swift.String? { nil }
+    }
+
+    let value = SwiftNilTag()
+    #expect(tagLength(value: value) == -1)
+    #expect(tagOrDefault(value: value) == "kotlin-default")
+}
+
+@Test
+func swiftOverrideBridgesObjectReferenceParameterAndResult() throws {
+    class SwiftTypeRich: TypeRichBase {
+        override func mapData(value: DataPayload) -> DataPayload {
+            DataPayload(text: "swift:\(value.text)", number: value.number + 10)
+        }
+    }
+
+    let result = callMapData(
+        value: SwiftTypeRich(),
+        payload: DataPayload(text: "payload", number: 2)
+    )
+    #expect(result.text == "swift:payload")
+    #expect(result.number == 12)
+}
+
+@Test()
+func swiftOverrideBridgesEnumParametersAndResults() throws {
+    class SwiftTypeRich: TypeRichBase {
+        override func mapEnum(value: InheritanceMode) -> InheritanceMode {
+            value == .kotlinMode ? .swiftMode : .kotlinMode
+        }
+    }
+
+    #expect(callMapEnum(value: SwiftTypeRich(), mode: .kotlinMode) == .swiftMode)
+    #expect(callMapEnum(value: SwiftTypeRich(), mode: .swiftMode) == .kotlinMode)
+}
+
+@Test
+func swiftOverrideBridgesInlineValueClassParametersAndResults() throws {
+    class SwiftTypeRich: TypeRichBase {
+        override func mapInline(value: InlinePayload) -> InlinePayload {
+            InlinePayload(value: value.value + 100)
+        }
+    }
+
+    let result = callMapInline(value: SwiftTypeRich(), payload: InlinePayload(value: 3))
+    #expect(result.value == 103)
+}
+
+@Test(.disabled("KT-88259: toString/hashCode/equals cause EXC_BAD_ACCESS on Swift subclass"))
+func swiftSubclassToString() throws {
+    class SwiftSubclass: FunctionMemberBase {}
+    let subclass = SwiftSubclass()
+    #expect(String(describing: subclass).contains("SwiftSubclass"))
+    #expect(callToString(value: subclass).contains("SwiftSubclass"))
+}


### PR DESCRIPTION
Extend the inheritance execution suite with scenarios the existing tests did not cover
Add reproducers for [KT-88499](https://youtrack.jetbrains.com/issue/KT-88499), [KT-88277](https://youtrack.jetbrains.com/issue/KT-88277), [KT-88259](https://youtrack.jetbrains.com/issue/KT-88259), [KT-88251](https://youtrack.jetbrains.com/issue/KT-88251), [KT-88042](https://youtrack.jetbrains.com/issue/KT-88042), [KT-87947](https://youtrack.jetbrains.com/issue/KT-87947)