### PR TITLE
KGP: Deserialize only a handful of classes from KAPT incremental cache

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzer.kt
@@ -126,8 +126,12 @@ private fun analyzeInputStream(input: InputStream, internalName: String, entryDa
 class ClasspathEntryData : Serializable {
 
     object ClasspathEntrySerializer {
+        // `output.bin` only ever holds a single `ClasspathEntryData` whose custom `readObject` reads primitives. Restrict
+        // deserialization to that class to prevent gadget-chain attacks via a tampered structure file (KT-88432).
+        private val ALLOWED_CLASSES = setOf(ClasspathEntryData::class.java.name)
+
         fun loadFrom(file: File): ClasspathEntryData {
-            ObjectInputStream(BufferedInputStream(file.inputStream())).use {
+            FilteringObjectInputStream(BufferedInputStream(file.inputStream()), ALLOWED_CLASSES).use {
                 return it.readObject() as ClasspathEntryData
             }
         }

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshot.kt
@@ -13,6 +13,24 @@ private const val CLASSPATH_ENTRIES_FILE = "classpath-entries.bin"
 private const val ANNOTATION_PROCESSOR_CLASSPATH_ENTRIES_FILE = "ap-classpath-entries.bin"
 private const val CLASSPATH_STRUCTURE_FILE = "classpath-structure.bin"
 
+// Whitelist of classes that may appear as class descriptors (i.e. reach `resolveClass`) when deserializing the classpath
+// entry files (`classpath-entries.bin` / `ap-classpath-entries.bin`), which contain a `List<File>`. `Iterable.toList()`
+// produces one of `EmptyList` / `Collections$SingletonList` / `ArrayList`. `String` (the `File.path`) is written as
+// `TC_STRING`, so it never reaches `resolveClass` and is intentionally not listed. See KT-88432.
+private val CLASSPATH_ENTRIES_ALLOWED_CLASSES = setOf(
+    "java.io.File",
+    "java.util.ArrayList",
+    "java.util.Collections\$SingletonList",
+    "kotlin.collections.EmptyList",
+)
+
+// Whitelist for `classpath-structure.bin`, which contains a `HashMap<File, ClasspathEntryData?>`.
+private val CLASSPATH_STRUCTURE_ALLOWED_CLASSES = setOf(
+    "java.io.File",
+    "java.util.HashMap",
+    ClasspathEntryData::class.java.name,
+)
+
 open class ClasspathSnapshot protected constructor(
     private val cacheDir: File,
     private val classpath: List<File>,
@@ -28,23 +46,30 @@ open class ClasspathSnapshot protected constructor(
                 return UnknownSnapshot
             }
 
-            val classpathFiles = ObjectInputStream(BufferedInputStream(classpathEntries.inputStream())).use {
+            // The cache files are deserialized with a whitelisting stream and any failure falls back to a full,
+            // non-incremental run. This guards against Java-deserialization gadget attacks via a tampered cache and
+            // against corrupt caches (KT-88432).
+            return try {
                 @Suppress("UNCHECKED_CAST")
-                it.readObject() as List<File>
+                val classpathFiles = FilteringObjectInputStream(
+                    BufferedInputStream(classpathEntries.inputStream()), CLASSPATH_ENTRIES_ALLOWED_CLASSES
+                ).use { it.readObject() as List<File> }
+
+                @Suppress("UNCHECKED_CAST")
+                val annotationProcessorClasspathFiles = FilteringObjectInputStream(
+                    BufferedInputStream(annotationProcessorClasspathEntries.inputStream()), CLASSPATH_ENTRIES_ALLOWED_CLASSES
+                ).use { it.readObject() as List<File> }
+
+                @Suppress("UNCHECKED_CAST")
+                val dataForFiles = FilteringObjectInputStream(
+                    BufferedInputStream(classpathStructureData.inputStream()), CLASSPATH_STRUCTURE_ALLOWED_CLASSES
+                ).use { it.readObject() as MutableMap<File, ClasspathEntryData?> }
+
+                ClasspathSnapshot(cacheDir, classpathFiles, annotationProcessorClasspathFiles, dataForFiles)
+            } catch (_: Exception) {
+                // Cache is corrupt, was rejected by the class whitelist, or has an unexpected shape.
+                UnknownSnapshot
             }
-
-            val annotationProcessorClasspathFiles =
-                ObjectInputStream(BufferedInputStream(annotationProcessorClasspathEntries.inputStream())).use {
-                    @Suppress("UNCHECKED_CAST")
-                    it.readObject() as List<File>
-                }
-
-            val dataForFiles =
-                ObjectInputStream(BufferedInputStream(classpathStructureData.inputStream())).use {
-                    @Suppress("UNCHECKED_CAST")
-                    it.readObject() as MutableMap<File, ClasspathEntryData?>
-                }
-            return ClasspathSnapshot(cacheDir, classpathFiles, annotationProcessorClasspathFiles, dataForFiles)
         }
 
         fun createCurrent(cacheDir: File, classpath: List<File>, annotationProcessorClasspath: List<File>, allStructureData: Set<File>): ClasspathSnapshot {

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/FilteringObjectInputStream.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/FilteringObjectInputStream.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.internal.kapt.incremental
+
+import java.io.InputStream
+import java.io.InvalidClassException
+import java.io.ObjectInputStream
+import java.io.ObjectStreamClass
+
+/**
+ * An [ObjectInputStream] that only deserializes classes present in [allowedClasses] (plus primitive types and arrays
+ * of allowed classes) and rejects all proxy classes. This prevents Java-deserialization gadget-chain attacks via the
+ * KAPT incremental cache files read by the Kotlin Gradle Plugin (see KT-88432).
+ *
+ * This mirrors the whitelisting `FilteringObjectInputStream` added in the kapt-base worker process
+ * (`org.jetbrains.kotlin.kapt.base.incremental`) as the fix for KT-86604 / CVE-2026-53914. Since `java.io.ObjectInputFilter`
+ * is a Java 17 API and KAPT still supports Java 8, we implement our own version.
+ */
+internal class FilteringObjectInputStream(
+    input: InputStream,
+    private val allowedClasses: Set<String>,
+) : ObjectInputStream(input) {
+    override fun resolveClass(desc: ObjectStreamClass): Class<*> {
+        if (!isWhitelistedClass(desc.name)) {
+            throw InvalidClassException(desc.name, "Class is not whitelisted in KAPT incremental cache")
+        }
+        return super.resolveClass(desc)
+    }
+
+    override fun resolveProxyClass(interfaces: Array<out String>): Class<*> {
+        throw InvalidClassException(interfaces.joinToString(), "Proxy classes are not allowed in KAPT incremental cache")
+    }
+
+    private fun isWhitelistedClass(name: String): Boolean {
+        if (name in PRIMITIVE_TYPES || name in allowedClasses) {
+            return true
+        }
+
+        if (!name.startsWith("[")) {
+            return false
+        }
+
+        val componentType = getNonPrimitiveArrayComponentType(name) ?: return true
+        return isWhitelistedClass(componentType)
+    }
+}
+
+private fun getNonPrimitiveArrayComponentType(name: String): String? {
+    var componentName = name
+    while (componentName.startsWith("[")) {
+        componentName = componentName.drop(1)
+    }
+
+    if (componentName.length == 1) {
+        return null
+    }
+
+    return componentName.takeIf { it.startsWith("L") && it.endsWith(";") }?.let {
+        it.substring(1, it.length - 1)
+    }
+}
+
+private val PRIMITIVE_TYPES = setOf(
+    "boolean",
+    "byte",
+    "char",
+    "double",
+    "float",
+    "int",
+    "long",
+    "short",
+    "void"
+)

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzerTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathAnalyzerTest.kt
@@ -12,13 +12,18 @@ import org.jetbrains.kotlin.gradle.testing.newTempFile
 import org.jetbrains.org.objectweb.asm.ClassWriter
 import org.jetbrains.org.objectweb.asm.Opcodes
 import org.junit.jupiter.api.io.TempDir
+import java.io.BufferedOutputStream
 import java.io.File
+import java.io.InvalidClassException
+import java.io.ObjectOutputStream
 import java.nio.file.Path
+import java.util.Hashtable
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ClasspathAnalyzerTest : WithTemporaryFolder {
@@ -154,6 +159,20 @@ class ClasspathAnalyzerTest : WithTemporaryFolder {
         val data = ClasspathEntryData.ClasspathEntrySerializer.loadFrom(outputs.createdOutputs.single())
         assertEquals(setOf("test/A", "test/B", "test/C"), data.classAbiHash.keys)
         assertEquals(setOf("test/A", "test/B", "test/C"), data.classDependencies.keys)
+    }
+
+    @Test
+    fun testTamperedStructureFileIsRejected() {
+        // A structure file referencing a class outside the whitelist stands in for a deserialization-gadget payload;
+        // loadFrom must reject it instead of deserializing it (KT-88432).
+        val tampered = newTempFile("output.bin").toFile()
+        ObjectOutputStream(BufferedOutputStream(tampered.outputStream())).use {
+            it.writeObject(Hashtable<String, String>().apply { put("payload", "value") })
+        }
+
+        assertFailsWith<InvalidClassException> {
+            ClasspathEntryData.ClasspathEntrySerializer.loadFrom(tampered)
+        }
     }
 
     private fun emptyClass(internalName: String, superClass: String = "java/lang/Object"): ByteArray {

--- a/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshotTest.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/test/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/incremental/ClasspathSnapshotTest.kt
@@ -9,8 +9,11 @@ import org.jetbrains.kotlin.gradle.testing.WithTemporaryFolder
 import org.jetbrains.kotlin.gradle.testing.newTempDirectory
 import org.jetbrains.kotlin.gradle.testing.newTempFile
 import org.junit.jupiter.api.io.TempDir
+import java.io.BufferedOutputStream
 import java.io.File
+import java.io.ObjectOutputStream
 import java.nio.file.Path
+import java.util.Hashtable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -34,6 +37,48 @@ class ClasspathSnapshotTest : WithTemporaryFolder {
 
         val diff = loadedSnapshot.diff(currentSnapshot, setOf(data)) as KaptClasspathChanges.Known
         assertEquals(emptySet<String>(), diff.names)
+    }
+
+    @Test
+    fun testSerializationWithNonEmptyClasspath() {
+        val data = generateStructureData(
+            ClassData("first/A"), ClassData("first/B")
+        )
+
+        // Build the lists exactly as production does (`FileCollection.files.toList()`): a Set.toList() yields ArrayList
+        // for >=2 elements and Collections$SingletonList for a single element - both must pass the whitelist (KT-88432).
+        val classpath = setOf(File("a.jar"), File("b.jar")).toList()
+        val annotationProcessorClasspath = setOf(File("ap.jar")).toList()
+
+        val snapshotDir = newTempDirectory().toFile()
+        val currentSnapshot = ClasspathSnapshot.ClasspathSnapshotFactory.createCurrent(
+            snapshotDir, classpath, annotationProcessorClasspath, setOf(data)
+        )
+        currentSnapshot.writeToCache()
+
+        val loadedSnapshot = ClasspathSnapshot.ClasspathSnapshotFactory.loadFrom(snapshotDir)
+
+        val diff = loadedSnapshot.diff(currentSnapshot, setOf(data)) as KaptClasspathChanges.Known
+        assertEquals(emptySet<String>(), diff.names)
+    }
+
+    @Test
+    fun testTamperedStructureFileIsRejected() {
+        val data = generateStructureData(ClassData("first/A"))
+        val snapshotDir = newTempDirectory().toFile()
+        val snapshot = ClasspathSnapshot.ClasspathSnapshotFactory.createCurrent(
+            snapshotDir, listOf(File("a.jar")), listOf(File("ap.jar")), setOf(data)
+        )
+        snapshot.writeToCache()
+
+        // Overwrite the structure file with a serialized instance of a class that is not on the whitelist, standing in
+        // for a deserialization-gadget payload. loadFrom must reject it and fall back to a non-incremental run (KT-88432).
+        val structureFile = snapshotDir.resolve("classpath-structure.bin")
+        ObjectOutputStream(BufferedOutputStream(structureFile.outputStream())).use {
+            it.writeObject(Hashtable<String, String>().apply { put("payload", "value") })
+        }
+
+        assertEquals(UnknownSnapshot, ClasspathSnapshot.ClasspathSnapshotFactory.loadFrom(snapshotDir))
     }
 
     @Test


### PR DESCRIPTION
It was already done on the KAPT side in
bf51df665b458fda7c3eaf436c4d88dc119d7ec6, this change adds the support to Gradle Plugin side as well.
 #KT-88432 Fixed