### PR TITLE
[K/N] Fix NPE in C export with plugin-generated declarations

### DIFF
--- a/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/lower/serialization/ir/JsIrLinker.kt
+++ b/compiler/ir/serialization.js/src/org/jetbrains/kotlin/ir/backend/js/lower/serialization/ir/JsIrLinker.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isJsStdlib
 import org.jetbrains.kotlin.library.isWasmStdlib
 import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
-import org.jetbrains.kotlin.library.metadata.klibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.klibModuleOriginOrNull
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 import org.jetbrains.kotlin.utils.memoryOptimizedMap
 
@@ -66,7 +66,8 @@ class JsIrLinker(
     override val moduleDependencyTracker: IrModuleDependencyTracker = IrModuleDependencyTrackerImpl()
 
     override fun isBuiltInModule(moduleDescriptor: ModuleDescriptor): Boolean {
-        val klib = (moduleDescriptor.klibModuleOrigin as? DeserializedKlibModuleOrigin)?.library ?: return false
+        val origin: DeserializedKlibModuleOrigin? = moduleDescriptor.klibModuleOriginOrNull as? DeserializedKlibModuleOrigin
+        val klib: KotlinLibrary = origin?.library ?: return false
         return klib.isJsStdlib || klib.isWasmStdlib
     }
 

--- a/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
+++ b/compiler/ir/serialization.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrLinker.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.library.isNativeStdlib
 import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
 import org.jetbrains.kotlin.library.metadata.impl.KlibResolvedModuleDescriptorsFactoryImpl
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
-import org.jetbrains.kotlin.library.metadata.klibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.klibModuleOriginOrNull
 import java.nio.file.Path
 
 class KonanIrLinker(
@@ -42,7 +42,8 @@ class KonanIrLinker(
     externalOverridabilityConditions: List<IrExternalOverridabilityCondition>,
 ) : KotlinIrLinker(currentModule, configuration, symbolTable, exportedDependencies) {
     override fun isBuiltInModule(moduleDescriptor: ModuleDescriptor): Boolean {
-        val klib = (moduleDescriptor.klibModuleOrigin as? DeserializedKlibModuleOrigin)?.library ?: return false
+        val origin: DeserializedKlibModuleOrigin? = moduleDescriptor.klibModuleOriginOrNull as? DeserializedKlibModuleOrigin
+        val klib: KotlinLibrary = origin?.library ?: return false
         return klib.isNativeStdlib
     }
 

--- a/compiler/ir/serialization.native/test/org/jetbrains/kotlin/backend/konan/serialization/KlibModuleOriginContractTest.kt
+++ b/compiler/ir/serialization.native/test/org/jetbrains/kotlin/backend/konan/serialization/KlibModuleOriginContractTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.serialization
+
+import org.jetbrains.kotlin.builtins.DefaultBuiltIns
+import org.jetbrains.kotlin.descriptors.ModuleCapability
+import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.library.metadata.CurrentKlibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.KlibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.klibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.klibModuleOriginOrNull
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.storage.LockBasedStorageManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * KT-62984: under the K2 frontend, `FirModuleDescriptor.getCapability` returns null for every capability,
+ * so a module descriptor without [KlibModuleOrigin] must be survivable for nullable callers
+ * (e.g. `ModuleDescriptor.konanLibrary`, which treats a null origin as "part of the current module").
+ */
+class KlibModuleOriginContractTest {
+    @Test
+    fun testModuleWithoutCapabilityHasNullOrigin() {
+        assertNull(moduleDescriptor(capabilities = emptyMap()).klibModuleOriginOrNull)
+    }
+
+    @Test
+    fun testModuleWithoutCapabilityFailsWithNamedError() {
+        val module = moduleDescriptor(capabilities = emptyMap())
+        val exception = assertThrows<IllegalStateException> { module.klibModuleOrigin }
+        assertTrue(exception.message!!.contains(MODULE_NAME)) {
+            "Error message should name the module, got: ${exception.message}"
+        }
+    }
+
+    @Test
+    fun testModuleWithCapabilityKeepsItsOrigin() {
+        val module = moduleDescriptor(capabilities = mapOf(KlibModuleOrigin.CAPABILITY to CurrentKlibModuleOrigin))
+        assertEquals(CurrentKlibModuleOrigin, module.klibModuleOriginOrNull)
+        assertEquals(CurrentKlibModuleOrigin, module.klibModuleOrigin)
+    }
+
+    private fun moduleDescriptor(capabilities: Map<ModuleCapability<*>, Any?>): ModuleDescriptorImpl =
+        ModuleDescriptorImpl(
+            Name.special(MODULE_NAME),
+            LockBasedStorageManager.NO_LOCKS,
+            DefaultBuiltIns.Instance,
+            capabilities = capabilities,
+        )
+
+    companion object {
+        private const val MODULE_NAME = "<moduleWithoutKlibOrigin>"
+    }
+}

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibModuleOrigin.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibModuleOrigin.kt
@@ -29,7 +29,16 @@ internal fun KlibModuleOrigin.isCInteropLibrary(): Boolean = when (this) {
     CurrentKlibModuleOrigin, SyntheticModulesOrigin -> false
 }
 
-val ModuleDescriptor.klibModuleOrigin: KlibModuleOrigin get() = this.getCapability(KlibModuleOrigin.CAPABILITY)!!
+val ModuleDescriptor.klibModuleOriginOrNull: KlibModuleOrigin?
+    get() = this.getCapability(KlibModuleOrigin.CAPABILITY)
+
+val ModuleDescriptor.klibModuleOrigin: KlibModuleOrigin
+    get() = klibModuleOriginOrNull
+        ?: error(
+            "No KlibModuleOrigin capability in $this (${this::class.qualifiedName}). " +
+                    "Note that FirModuleDescriptor provides no capabilities; " +
+                    "use klibModuleOriginOrNull for modules that may not originate from a klib."
+        )
 
 val ModuleDescriptor.kotlinLibrary: KotlinLibrary
     get() = (this.klibModuleOrigin as DeserializedKlibModuleOrigin).library

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
@@ -42,11 +42,7 @@ private fun IrClass.getOverridingOf(function: IrFunction) = (function as? IrSimp
     it.allOverriddenFunctions.atMostOne { it.parent == this }
 }
 
-val ModuleDescriptor.konanLibrary: KotlinLibrary?
-    get() {
-        val origin: DeserializedKlibModuleOrigin? = this.klibModuleOriginOrNull as? DeserializedKlibModuleOrigin
-        return origin?.library
-    }
+val ModuleDescriptor.konanLibrary get() = (this.klibModuleOriginOrNull as? DeserializedKlibModuleOrigin)?.library
 
 val IrPackageFragment.konanLibrary: KotlinLibrary?
     get() {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.util.target
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.metadata.DeserializedKlibModuleOrigin
-import org.jetbrains.kotlin.library.metadata.klibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.klibModuleOriginOrNull
 import org.jetbrains.kotlin.utils.atMostOne
 
 internal fun IrFunction.isBoxOrUnbox(): Boolean =
@@ -42,7 +42,11 @@ private fun IrClass.getOverridingOf(function: IrFunction) = (function as? IrSimp
     it.allOverriddenFunctions.atMostOne { it.parent == this }
 }
 
-val ModuleDescriptor.konanLibrary get() = (this.klibModuleOrigin as? DeserializedKlibModuleOrigin)?.library
+val ModuleDescriptor.konanLibrary: KotlinLibrary?
+    get() {
+        val origin: DeserializedKlibModuleOrigin? = this.klibModuleOriginOrNull as? DeserializedKlibModuleOrigin
+        return origin?.library
+    }
 
 val IrPackageFragment.konanLibrary: KotlinLibrary?
     get() {


### PR DESCRIPTION
First ran into this on when I ran my [kotlin-native-nuget](https://github.com/xxfast/kotlin-native-nuget) plugin on https://github.com/joreilly/PeopleInSpace/pull/503

`ModuleDescriptor.klibModuleOrigin` asserts the `KlibModuleOrigin` capability with `!!`, but K2's `FirModuleDescriptor` returns null for every capability, so C export crashed with a bare NPE when a compiler plugin (Koin, Compose) contributed declarations through its own `IrFile`.

Splits the property into a nullable `klibModuleOriginOrNull`, keeps the strict one failing with a named error, and moves the callers that already have a null contract to the nullable accessor. On master the two-stage compilation keeps FIR descriptors away from the backend, so the CLI can't hit this anymore. This is still live on 2.x (verified on 2.4.10 with the reproducer on the issue), making this a contract fix and a backport candidate. 

#5375 was Compose-specific and wouldn't have fixed the Koin case (with which I ran into this issue)

^KT-62984 Fixed