### PR TITLE
[K/N] Fix samples compilation

### DIFF
--- a/kotlin-native/backend.native/tests/samples/echoServer/src/nativeMain/kotlin/EchoServer.kt
+++ b/kotlin-native/backend.native/tests/samples/echoServer/src/nativeMain/kotlin/EchoServer.kt
@@ -29,13 +29,13 @@ fun main(args: Array<String>) {
                 .ensureUnixCallResult("socket") { !it.isMinusOne() }
 
         with(serverAddr) {
-            memset(this.ptr, 0, sockaddr_in.size.convert())
+            memset(this.ptr, 0, sizeOf<sockaddr_in>().convert())
             @OptIn(UnsafeNumber::class)
             sin_family = AF_INET.convert()
             sin_port = posix_htons(port).convert()
         }
 
-        bind(listenFd, serverAddr.ptr.reinterpret(), sockaddr_in.size.convert())
+        bind(listenFd, serverAddr.ptr.reinterpret(), sizeOf<sockaddr_in>().convert())
                 .ensureUnixCallResult("bind") { it == 0 }
 
         listen(listenFd, 10)

--- a/kotlin-native/backend.native/tests/samples/nonBlockingEchoServer/src/nonBlockingEchoServerMain/kotlin/EchoServer.kt
+++ b/kotlin-native/backend.native/tests/samples/nonBlockingEchoServer/src/nonBlockingEchoServerMain/kotlin/EchoServer.kt
@@ -26,13 +26,13 @@ fun main(args: Array<String>) {
                 .ensureUnixCallResult { !it.isMinusOne() }
 
         with(serverAddr) {
-            memset(this.ptr, 0, sockaddr_in.size.convert())
+            memset(this.ptr, 0, sizeOf<sockaddr_in>().convert())
             sin_family = AF_INET.convert()
             sin_addr.s_addr = posix_htons(0).convert()
             sin_port = posix_htons(port).convert()
         }
 
-        bind(listenFd, serverAddr.ptr.reinterpret(), sockaddr_in.size.toUInt())
+        bind(listenFd, serverAddr.ptr.reinterpret(), sizeOf<sockaddr_in>().toUInt())
                 .ensureUnixCallResult { it == 0 }
 
         fcntl(listenFd, F_SETFL, O_NONBLOCK)

--- a/kotlin-native/backend.native/tests/samples/tensorflow/src/tensorflowMain/kotlin/HelloTensorflow.kt
+++ b/kotlin-native/backend.native/tests/samples/tensorflow/src/tensorflowMain/kotlin/HelloTensorflow.kt
@@ -47,14 +47,14 @@ fun scalarTensor(value: Int): Tensor {
             /* dims = */ null,
             /* num_dims = */ 0,
             /* data = */ data,
-            /* len = */ IntVar.size.convert(),
+            /* len = */ sizeOf<IntVar>().convert(),
             /* deallocator = */ staticCFunction { dataToFree, _, _ -> nativeHeap.free(dataToFree!!.reinterpret<IntVar>()) },
             /* deallocator_arg = */ null
     )!!
 }
 
 val Tensor.scalarIntValue: Int get() {
-    if (TF_INT32 != TF_TensorType(this) || IntVar.size.convert<size_t>() != TF_TensorByteSize(this)) {
+    if (TF_INT32 != TF_TensorType(this) || sizeOf<IntVar>().convert<size_t>() != TF_TensorByteSize(this)) {
         throw Error("Tensor is not of type int.")
     }
     if (0 != TF_NumDims(this)) {


### PR DESCRIPTION
After `CVariable.Type` deprecation raised to an error, samples compilation build started to fail.

This commit fixes samples by switching to `sizeOf<T>`.

^KT-88374