### PR TITLE
[Native] Deprecate and ignore `-Xpurge-user-libs` CLI argument

### DIFF
--- a/compiler/arguments/resources/kotlin-compiler-arguments.json
+++ b/compiler/arguments/resources/kotlin-compiler-arguments.json
@@ -17977,7 +17977,7 @@
                                             "introducedVersion": "1.5.20",
                                             "stabilizedVersion": null,
                                             "deprecatedVersion": null,
-                                            "removedVersion": null
+                                            "removedVersion": "2.5.0"
                                         },
                                         "argumentType": {
                                             "type": "org.jetbrains.kotlin.arguments.dsl.types.BooleanType",

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/NativeCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/NativeCompilerArguments.kt
@@ -606,17 +606,6 @@ The default value is 1.""".asReleaseDependent()
     }
 
     compilerArgument {
-        name = "Xpurge-user-libs"
-        deprecatedName = "-purge_user_libs"
-        description = "Don't link unused libraries even if explicitly specified.".asReleaseDependent()
-        valueType = BooleanType.defaultFalse
-
-        lifecycle(
-            introducedVersion = KotlinReleaseVersion.v1_5_20,
-        )
-    }
-
-    compilerArgument {
         name = "Xwrite-dependencies-of-produced-klib-to"
         description = "Write file containing the paths of dependencies used during klib compilation to the provided path".asReleaseDependent()
         valueType = StringType.defaultNull

--- a/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/removed/removedNativeCompilerArguments.kt
+++ b/compiler/arguments/src/org/jetbrains/kotlin/arguments/description/removed/removedNativeCompilerArguments.kt
@@ -126,4 +126,16 @@ val removedNativeArguments by compilerArgumentsLevel(CompilerArgumentsLevelNames
             removedVersion = KotlinReleaseVersion.v2_5_0,
         )
     }
+
+    compilerArgument {
+        name = "Xpurge-user-libs"
+        deprecatedName = "-purge_user_libs"
+        description = "Don't link unused libraries even if explicitly specified.".asReleaseDependent()
+        valueType = BooleanType.defaultFalse
+
+        lifecycle(
+            introducedVersion = KotlinReleaseVersion.v1_5_20,
+            removedVersion = KotlinReleaseVersion.v2_5_0,
+        )
+    }
 }

--- a/compiler/arguments/stableReleaseTests/org/jetbrains/kotlin/arguments/dsl/testUtils.kt
+++ b/compiler/arguments/stableReleaseTests/org/jetbrains/kotlin/arguments/dsl/testUtils.kt
@@ -27,6 +27,7 @@ private val temporaryExceptions: Set<String> = setOf(
     "Xsuppress-api-version-greater-than-language-version-error",
     "Xbundle-id",
     "Xfake-override-validator",
+    "Xpurge-user-libs",
 )
 
 internal fun Set<StableKotlinCompilerArgument>.filterNonDeprecated() = filter {

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArguments.kt
@@ -479,17 +479,6 @@ This library must be one of the ones passed with '-library'.""",
         }
 
     @Argument(
-        value = "-Xpurge-user-libs",
-        deprecatedName = "--purge_user_libs",
-        description = "Don't link unused libraries even if explicitly specified.",
-    )
-    var purgeUserLibs: Boolean = false
-        set(value) {
-            checkFrozen()
-            field = value
-        }
-
-    @Argument(
         value = "-Xread-dependencies-from",
         valueDescription = "<path>",
         description = "Serialized dependencies to use for linking.",

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArgumentsCopyGenerated.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/K2NativeCompilerArgumentsCopyGenerated.kt
@@ -74,7 +74,6 @@ fun copyK2NativeCompilerArguments(from: K2NativeCompilerArguments, to: K2NativeC
     to.printIr = from.printIr
     to.produce = from.produce
     to.propertyLazyInitialization = from.propertyLazyInitialization
-    to.purgeUserLibs = from.purgeUserLibs
     to.refinesPaths = from.refinesPaths.copyOf()
     to.runtimeFile = from.runtimeFile
     to.runtimeLogs = from.runtimeLogs

--- a/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/RemovedCompilerArguments.kt
+++ b/compiler/cli/cli-base/gen/org/jetbrains/kotlin/cli/common/arguments/RemovedCompilerArguments.kt
@@ -355,6 +355,21 @@ It has no effect when -language-version is 2.0 or higher.""",
         level = DeprecationLevel.ERROR,
     )
     @Argument(
+        value = "-Xpurge-user-libs",
+        deprecatedName = "--purge_user_libs",
+        description = "Don't link unused libraries even if explicitly specified.",
+        removedVersion = "2.5.0",
+    )
+    var purgeUserLibs: Boolean = false
+        set(value) {
+            field = value
+        }
+
+    @all:Deprecated(
+        message = "",
+        level = DeprecationLevel.ERROR,
+    )
+    @Argument(
         value = "-Xworker-exception-handling",
         valueDescription = "<mode>",
         description = "Unhandled exception processing in 'Worker.executeAfter'. Possible values: 'legacy' and 'use-hook'. The default value is 'legacy' and for '-memory-model experimental', the default value is 'use-hook'.",

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/FirNativeSerializer.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/FirNativeSerializer.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.pipeline.AllModulesFrontendOutput
 import org.jetbrains.kotlin.fir.pipeline.Fir2KlibMetadataSerializer
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
-import org.jetbrains.kotlin.konan.config.konanPurgeUserLibs
 import org.jetbrains.kotlin.konan.library.isExplicitlySpecifiedByUserInCLIArgument
 
 internal fun NativeFirstStagePhaseContext.firSerializerBase(
@@ -27,7 +26,7 @@ internal fun NativeFirstStagePhaseContext.firSerializerBase(
 ): SerializerOutput {
     val usedLibraries = fir2IrOutput?.let {
         config.loadedKlibs.all.filter { library ->
-            if (library.isExplicitlySpecifiedByUserInCLIArgument && !configuration.konanPurgeUserLibs) {
+            if (library.isExplicitlySpecifiedByUserInCLIArgument) {
                 // This is the dependency explicitly specified by the user in one of the compiler's CLI arguments: -library, -Xinclude.
                 //
                 // We assume such a library as "used" even if we cannot immediately prove there are declarations belonging to it

--- a/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
+++ b/compiler/cli/cli-native-klib/src/main/kotlin/org/jetbrains/kotlin/native/pipeline/NativeConfigurationPhase.kt
@@ -158,7 +158,6 @@ object NativeKlibConfigurationUpdater : ConfigurationUpdater<K2NativeCompilerArg
 
         konanNoDefaultLibs = arguments.nodefaultlibs || !konanLibraryToAddToCache.isNullOrEmpty()
         konanNoStdlib = arguments.nostdlib || !konanLibraryToAddToCache.isNullOrEmpty()
-        konanPurgeUserLibs = arguments.purgeUserLibs
 
         konanDontCompressKlib = arguments.nopack
         arguments.manifestFile?.let { konanManifestAddend = it }

--- a/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
+++ b/compiler/config/configuration-keys-generator/src/org/jetbrains/kotlin/config/keys/generator/NativeConfigurationKeysContainer.kt
@@ -57,7 +57,6 @@ object NativeConfigurationKeysContainer : KeysContainer("org.jetbrains.kotlin.ko
     val KONAN_PRINT_IR by key<Boolean>()
     val KONAN_PRINT_FILES by key<Boolean>()
     val KONAN_PRODUCED_ARTIFACT_KIND by key<CompilerOutputKind>()
-    val KONAN_PURGE_USER_LIBS by key<Boolean>()
     val RUNTIME_FILE by key<String>()
     val KONAN_INCLUDED_LIBRARIES by key<List<String>>("Klibs processed in the same manner as source files.")
     val KONAN_SHORT_MODULE_NAME by key<String>("Short module name for IDE and export.")

--- a/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
+++ b/kotlin-native/Interop/StubGenerator/src/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
@@ -59,8 +59,12 @@ open class CommonInteropArguments(val argParser: ArgParser) {
     val nodefaultlibsDeprecated by argParser.option(ArgType.Boolean, NODEFAULTLIBS_DEPRECATED,
             description = "don't link the libraries from dist/klib automatically",
             deprecatedWarning = "Old form of flag. Please, use $NODEFAULTLIBS.").default(false)
+
+    @Suppress("unused")
     val purgeUserLibs by argParser.option(ArgType.Boolean, PURGE_USER_LIBS,
-            description = "don't link unused libraries even explicitly specified").default(false)
+            description = "don't link unused libraries even explicitly specified",
+            deprecatedWarning = "The option is deprecated. It will be removed in one of the future releases.").default(false)
+
     val nopack by argParser.option(ArgType.Boolean, fullName = NOPACK,
             description = "Don't pack the produced library into a klib file").default(false)
     val tempDir by argParser.option(ArgType.String, TEMP_DIR,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/DependenciesTracker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/DependenciesTracker.kt
@@ -187,7 +187,7 @@ internal class DependenciesTrackerImpl(
 
         init {
             val immediateBitcodeDependencies = topSortedLibraries
-                    .filter { (it.isExplicitlySpecifiedByUserInCLIArgument && !context.config.purgeUserLibs) || bitcodeIsUsed(it) }
+                    .filter { it.isExplicitlySpecifiedByUserInCLIArgument || bitcodeIsUsed(it) }
             for (library in immediateBitcodeDependencies) {
                 if (library == context.config.libraryToCache?.klib) continue
                 val cache = context.config.cachedLibraries.getLibraryCache(library)
@@ -319,7 +319,7 @@ internal class DependenciesTrackerImpl(
             topSortedLibraries.mapNotNull { allBitcodeDependencies[it] }
         }
 
-        val nativeDependenciesToLink = topSortedLibraries.filter { (it.isExplicitlySpecifiedByUserInCLIArgument && !context.config.purgeUserLibs) || it in usedNativeDependencies }
+        val nativeDependenciesToLink = topSortedLibraries.filter { it.isExplicitlySpecifiedByUserInCLIArgument || it in usedNativeDependencies }
 
         val allNativeDependencies = (nativeDependenciesToLink +
                 allCachedBitcodeDependencies.map { it.library } // Native dependencies are per library
@@ -337,7 +337,7 @@ internal class DependenciesTrackerImpl(
             }
 
             // Apply some DCE:
-            return (library.isExplicitlySpecifiedByUserInCLIArgument && !context.config.purgeUserLibs) || bitcodeIsUsed(library)
+            return library.isExplicitlySpecifiedByUserInCLIArgument || bitcodeIsUsed(library)
         }
     }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -403,7 +403,7 @@ class NativeSecondStageCompilationConfig(
             // Later upon the subsequent `getFullList()` call, some of the implicit dependencies will be added. But only if they
             // are mentioned in `depends=` manifest property in root libraries. Which means only a small really required subset
             // of them will be added.
-            it.library.isExplicitlySpecifiedByUserInCLIArgument && !purgeUserLibs
+            it.library.isExplicitlySpecifiedByUserInCLIArgument
         }.getFullList()
     }
 
@@ -728,9 +728,6 @@ class NativeSecondStageCompilationConfig(
 
     val languageVersionSettings: LanguageVersionSettings
         get() = configuration.get(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS)!!
-
-    val purgeUserLibs: Boolean
-        get() = configuration.konanPurgeUserLibs
 
     val isInteropStubs: Boolean
         get() = manifestProperties?.getProperty("interop") == "true"

--- a/kotlin-native/platformLibs/build.gradle.kts
+++ b/kotlin-native/platformLibs/build.gradle.kts
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.platformLibs.*
 import org.jetbrains.kotlin.platformManager
 import org.jetbrains.kotlin.utils.capitalized
 import org.jetbrains.kotlin.utils.reproducibilityCompilerFlags
-import org.jetbrains.kotlin.utils.reproducibilityRootsMap
 
 plugins {
     id("common-configuration")
@@ -101,6 +100,8 @@ enabledTargets(platformManager).forEach { target ->
             )
             df.file?.let { this.defFile.set(it) }
             df.config.depends.forEach { defName ->
+                // Set explicit dependencies on other platform libs that should be built prior to the current one.
+                // `this.klibFiles` is transformed to a set of `-library ...` arguments later in `KonanInteropTask`.
                 this.klibFiles.from(tasks.named(interopTaskName(defFileToLibName(targetName, defName), targetName)))
             }
 
@@ -110,10 +111,9 @@ enabledTargets(platformManager).forEach { target ->
             }.toTypedArray()
 
             this.extraOpts.addAll(
-                    "-Xpurge-user-libs",
                     "-Xshort-module-name", df.name,
                     "-Xdisable-experimental-annotation",
-                    "-no-default-libs",
+                    "-no-default-libs", // We shall not try to (implicitly) load platform libs while they are being built to avoid seeing some "middle" state.
                     "-Xccall-mode", "indirect", // Default is `-Xccall-mode both`, but platform libs use `indirect` for now. See KT-82062.
                     *reproducibilityCompilerFlags,
             )

--- a/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
+++ b/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
@@ -279,7 +279,7 @@ private fun generateLibrary(
                 "-target", target.visibleName,
                 "-def", defFile.absolutePathString(),
                 "-compiler-option", "-fmodules-cache-path=${tmpDirectory.resolve("clangModulesCache").absolutePathString()}",
-                "-no-default-libs", "-Xpurge-user-libs", "-nopack",
+                "-no-default-libs", "-nopack",
                 "-Xdisable-experimental-annotation",
                 *cinteropOptions.additionalArguments.toTypedArray(),
                 "-$SHORT_MODULE_NAME", def.shortLibraryName,

--- a/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/InteropCompiler.kt
+++ b/kotlin-native/utilities/cli-runner/src/org/jetbrains/kotlin/cli/utilities/InteropCompiler.kt
@@ -30,7 +30,6 @@ fun invokeInterop(flavor: String, args: Array<String>, runFromDaemon: Boolean): 
     arguments.argParser.parse(args)
     val outputFileName = arguments.output
     val noDefaultLibs = arguments.nodefaultlibs || arguments.nodefaultlibsDeprecated
-    val purgeUserLibs = arguments.purgeUserLibs
     val nopack = arguments.nopack
     val temporaryFilesDir = arguments.tempDir
     val moduleName = arguments.moduleName
@@ -70,7 +69,6 @@ fun invokeInterop(flavor: String, args: Array<String>, runFromDaemon: Boolean): 
         cinteropArgsToCompiler +
         libraries.flatMap { listOf("-library", it) } +
         (if (noDefaultLibs) arrayOf("-$NODEFAULTLIBS") else emptyArray()) +
-        (if (purgeUserLibs) arrayOf("-$PURGE_USER_LIBS") else emptyArray()) +
         (if (nopack) arrayOf("-$NOPACK") else emptyArray()) +
         moduleName?.let { arrayOf("-module-name", it) }.orEmpty() +
         shortModuleName?.let { arrayOf("${K2NativeCompilerArguments::shortModuleName.cliArgument}=$it") }.orEmpty() +

--- a/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
+++ b/native/native.config/gen/org/jetbrains/kotlin/konan/config/NativeConfigurationKeys.kt
@@ -168,9 +168,6 @@ object NativeConfigurationKeys {
     val KONAN_PRODUCED_ARTIFACT_KIND = CompilerConfigurationKey.create<CompilerOutputKind>("KONAN_PRODUCED_ARTIFACT_KIND")
 
     @JvmField
-    val KONAN_PURGE_USER_LIBS = CompilerConfigurationKey.create<Boolean>("KONAN_PURGE_USER_LIBS")
-
-    @JvmField
     val RUNTIME_FILE = CompilerConfigurationKey.create<String>("RUNTIME_FILE")
 
     // Klibs processed in the same manner as source files.
@@ -448,10 +445,6 @@ var CompilerConfiguration.konanPrintFiles: Boolean
 var CompilerConfiguration.konanProducedArtifactKind: CompilerOutputKind?
     get() = get(NativeConfigurationKeys.KONAN_PRODUCED_ARTIFACT_KIND)
     set(value) { put(NativeConfigurationKeys.KONAN_PRODUCED_ARTIFACT_KIND, requireNotNull(value) { "nullable values are not allowed" }) }
-
-var CompilerConfiguration.konanPurgeUserLibs: Boolean
-    get() = getBoolean(NativeConfigurationKeys.KONAN_PURGE_USER_LIBS)
-    set(value) { put(NativeConfigurationKeys.KONAN_PURGE_USER_LIBS, value) }
 
 var CompilerConfiguration.runtimeFile: String?
     get() = get(NativeConfigurationKeys.RUNTIME_FILE)

--- a/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
+++ b/native/native.tests/cli-tests/testData/cli/nativeExtraHelp.out
@@ -60,7 +60,6 @@ where advanced options include:
   -Xprint-bitcode            Print LLVM bitcode.
   -Xprint-files              Print files.
   -Xprint-ir                 Print IR.
-  -Xpurge-user-libs          Don't link unused libraries even if explicitly specified.
   -Xread-dependencies-from=<path>
                              Serialized dependencies to use for linking.
   -Xrefines-paths=<path>     Paths to output directories for refined modules (modules whose 'expect' declarations this module can actualize).

--- a/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/UsedLibrariesComputationTest.kt
+++ b/native/native.tests/klib-ir-inliner/tests/org/jetbrains/kotlin/konan/test/UsedLibrariesComputationTest.kt
@@ -51,24 +51,12 @@ class UsedLibrariesComputationTest : AbstractNativeSimpleTest() {
             )
         }
 
-        // TODO (KT-60874): Need to clarify why used-specified libraries are forced to stay in the list of "used libraries"
-        //  even when they are not used. Note that the default value for `konanPurgeUserLibs` is always `false`.
         newSourceModules {
             addRegularModule("test")
         }.compileToKlibsViaCli(extraCliArgs = listOf("-l", additionalUnusedModulePath)) { _, successKlib ->
             successKlib.assertDependencyNames(
                 /* implicit unavoidable dependency */ "stdlib",
                 /* because it was passed explicitly via CLI, even if "test" doesn't use any API from "additional" */ "additional",
-            )
-        }
-
-        // TODO (KT-60874): Need to clarify why used-specified libraries are forced to stay in the list of "used libraries"
-        //  even when they are not used. Note that the default value for `konanPurgeUserLibs` is always `false`.
-        newSourceModules {
-            addRegularModule("test")
-        }.compileToKlibsViaCli(extraCliArgs = listOf("-l", additionalUnusedModulePath, "-Xpurge-user-libs")) { _, successKlib ->
-            successKlib.assertDependencyNames(
-                /* implicit unavoidable dependency */ "stdlib",
             )
         }
 


### PR DESCRIPTION
[KT-61096](https://youtrack.jetbrains.com/issue/KT-61096) [KLIB Resolve] Drop KLIB resolve inside the Kotlin/Native compiler
[KT-81624](https://youtrack.jetbrains.com/issue/KT-81624) [KLIB Resolve] Kotlin/Native: -no-default-libs may lead to the final binary depending on a lot of system frameworks

Pending merge of PR: https://github.com/JetBrains/kotlin/pull/7347