### PR TITLE
[Build] cache downloadSkeleton task

### DIFF
--- a/compiler/multiplatform-parsing/build.gradle.kts
+++ b/compiler/multiplatform-parsing/build.gradle.kts
@@ -98,6 +98,7 @@ val skeletonDownloadTask = tasks.register("downloadSkeleton") {
 
     inputs.property("skeletonVersion", skeletonVersion)
     outputs.file(skeletonFile)
+    outputs.cacheIf { true }
 
     doFirst {
         val skeletonFileOutput = skeletonFile.get().asFile


### PR DESCRIPTION
Enable build caching of `downloadSkeleton` to avoid hitting GitHub rate limits.