### PR TITLE
Squash whitespaces before comparing LLDB output in tests

### DIFF
--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/TestDirectives.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/TestDirectives.kt
@@ -389,8 +389,14 @@ internal fun parseExpectedExitCode(registeredDirectives: RegisteredDirectives): 
     }
 }
 
-internal fun parseOutputDataFile(baseDir: File, registeredDirectives: RegisteredDirectives): OutputDataFile? =
-    parseFileBasedDirective(baseDir, OUTPUT_DATA_FILE, registeredDirectives)?.let { OutputDataFile(file = it) }
+internal fun parseOutputDataFile(
+    baseDir: File,
+    registeredDirectives: RegisteredDirectives,
+    sanitizer: (String) -> String = { it },
+): OutputDataFile? =
+    parseFileBasedDirective(baseDir, OUTPUT_DATA_FILE, registeredDirectives)?.let {
+        OutputDataFile(file = it, sanitizer = sanitizer)
+    }
 
 internal fun parseInputDataFile(baseDir: File, registeredDirectives: RegisteredDirectives): File? =
     parseFileBasedDirective(baseDir, INPUT_DATA_FILE, registeredDirectives)

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/ExtTestCaseGroupProvider.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/ExtTestCaseGroupProvider.kt
@@ -40,7 +40,6 @@ import org.jetbrains.kotlin.konan.test.blackbox.support.util.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.platform.konan.NativePlatforms
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
@@ -445,6 +444,13 @@ private class ExtTestDataFile(
             OutputMatcher { output -> lldbSpec.checkLLDBOutput(output, settings.get()) }
         } ?: parseOutputRegex(structure.directives)
 
+        // LLDB changes whitespace formatting across versions.
+        // Let's squash tab and space sequences to a single space while leaving newlines.
+        val outputDataSanitizer: (String) -> String = when (testKind) {
+            TestKind.STANDALONE_LLDB -> ::normalizeLldbWhitespacegs
+            else -> { s -> s }
+        }
+
         val expectedExitCode = if (testKind == TestKind.STANDALONE_NO_TR) parseExpectedExitCode(structure.directives)
         else ExitCode.Expected(0)
 
@@ -453,6 +459,7 @@ private class ExtTestDataFile(
         else ExecutionTimeout.ShouldNotExceed(settings.get<Timeouts>().executionTimeout)
 
         val fileCheckStage = retrieveFileCheckStage()
+
         val testCase = TestCase(
             id = TestCaseId.TestDataFile(testDataFile),
             kind = testKind,
@@ -465,7 +472,11 @@ private class ExtTestDataFile(
                 testFiltering = testFiltering,
                 exitCodeCheck = expectedExitCode,
                 outputMatcher = outputMatcher,
-                outputDataFile = parseOutputDataFile(testDataFile.parentFile, structure.directives),
+                outputDataFile = parseOutputDataFile(
+                    testDataFile.parentFile,
+                    structure.directives,
+                    sanitizer = outputDataSanitizer,
+                ),
                 fileCheckMatcher = fileCheckStage?.let { TestRunCheck.FileCheckMatcher(settings, testDataFile) },
             ),
             fileCheckStage = fileCheckStage,
@@ -899,3 +910,11 @@ fun Settings.isIgnoredTarget(testDataFile: File): Boolean {
         disposeRootInWriteAction(disposable)
     }
 }
+
+internal fun normalizeLldbWhitespace(text: String): String =
+    text.lineSequence()
+        .map { line ->
+            if (line.isBlank()) ""
+            else line.replace(Regex("""[\t ]+"""), " ").trim()
+        }
+        .joinToString("\n")

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/ExtTestCaseGroupProvider.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/group/ExtTestCaseGroupProvider.kt
@@ -447,7 +447,7 @@ private class ExtTestDataFile(
         // LLDB changes whitespace formatting across versions.
         // Let's squash tab and space sequences to a single space while leaving newlines.
         val outputDataSanitizer: (String) -> String = when (testKind) {
-            TestKind.STANDALONE_LLDB -> ::normalizeLldbWhitespacegs
+            TestKind.STANDALONE_LLDB -> ::normalizeLldbWhitespace
             else -> { s -> s }
         }
 

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
@@ -112,7 +112,7 @@ sealed interface TestRunCheck {
             val actualFilteredOutput = runResult.processOutputAsString(output)
             val match = JUnit5Assertions.doesEqualToFile(file, actualFilteredOutput, sanitizer)
             return if (!match) {
-                // Show the diff without the sanitizer applied to see the real diff in the failure
+                // Pass in both the output and the file unsanitized to see the real diff in the failure
                 Result.Failed("Tested process output mismatch.", expectedFile = file, actual = actualFilteredOutput)
             } else {
                 Result.Passed

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
@@ -112,6 +112,7 @@ sealed interface TestRunCheck {
             val actualFilteredOutput = runResult.processOutputAsString(output)
             val match = JUnit5Assertions.doesEqualToFile(file, actualFilteredOutput, sanitizer)
             return if (!match) {
+                // Show the diff without the sanitizer applied to see the real diff in the failure
                 Result.Failed("Tested process output mismatch.", expectedFile = file, actual = actualFilteredOutput)
             } else {
                 Result.Passed

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
@@ -103,10 +103,14 @@ sealed interface TestRunCheck {
         Output.ALL -> processOutput.stdOut.filteredOutput + processOutput.stdErr
     }
 
-    class OutputDataFile(val output: Output = Output.ALL, val file: File) : TestRunCheck {
+    class OutputDataFile(
+        val output: Output = Output.ALL,
+        val file: File,
+        val sanitizer: (String) -> String = { it },
+    ) : TestRunCheck {
         override fun apply(testRun: TestRun, runResult: RunResult): Result {
             val actualFilteredOutput = runResult.processOutputAsString(output)
-            val match = JUnit5Assertions.doesEqualToFile(file, actualFilteredOutput)
+            val match = JUnit5Assertions.doesEqualToFile(file, actualFilteredOutput, sanitizer)
             return if (!match)
                 Result.Failed("Tested process output mismatch.", expectedFile = file, actual = actualFilteredOutput)
             else Result.Passed

--- a/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
+++ b/native/native.tests/testFixtures/org/jetbrains/kotlin/konan/test/blackbox/support/runner/TestRunChecks.kt
@@ -111,9 +111,11 @@ sealed interface TestRunCheck {
         override fun apply(testRun: TestRun, runResult: RunResult): Result {
             val actualFilteredOutput = runResult.processOutputAsString(output)
             val match = JUnit5Assertions.doesEqualToFile(file, actualFilteredOutput, sanitizer)
-            return if (!match)
+            return if (!match) {
                 Result.Failed("Tested process output mismatch.", expectedFile = file, actual = actualFilteredOutput)
-            else Result.Passed
+            } else {
+                Result.Passed
+            }
         }
     }
 


### PR DESCRIPTION
LLDB changes whitespace formatting across versions. These changes squash horizontal whitespaces into a single space before comparison of the golden .out file with the LLDB output.

#[KT-84572](https://youtrack.jetbrains.com/issue/KT-84572)