### PR TITLE
[Gradle] Introduce new export extension with swift config block

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
+++ b/libraries/tools/kotlin-gradle-plugin/api/all/kotlin-gradle-plugin.api
@@ -322,6 +322,9 @@ public final class org/jetbrains/kotlin/gradle/execution/KotlinAggregatingExecut
 	public static fun configureAllExecutions (Lorg/jetbrains/kotlin/gradle/execution/KotlinAggregatingExecution;Lorg/gradle/api/Action;)V
 }
 
+public abstract interface annotation class org/jetbrains/kotlin/gradle/export/ExperimentalExportDsl : java/lang/annotation/Annotation {
+}
+
 public abstract class org/jetbrains/kotlin/gradle/incremental/IncrementalModuleInfoBuildService : org/gradle/api/services/BuildService, org/jetbrains/kotlin/gradle/incremental/IncrementalModuleInfoProvider {
 	public static final field Companion Lorg/jetbrains/kotlin/gradle/incremental/IncrementalModuleInfoBuildService$Companion;
 	public fun <init> ()V
@@ -1904,6 +1907,21 @@ public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/compilati
 	public abstract fun getPluginConfiguration ()Lorg/gradle/api/artifacts/Configuration;
 	public abstract fun getRuntimeDependencyConfiguration ()Lorg/gradle/api/artifacts/Configuration;
 	public abstract fun getRuntimeOnlyConfiguration ()Lorg/gradle/api/artifacts/Configuration;
+}
+
+public abstract class org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun swift (Lkotlin/jvm/functions/Function1;)V
+	public final fun swift (Lorg/gradle/api/Action;)V
+}
+
+public final class org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtensionKt {
+	public static final field EXPORT_EXTENSION_NAME Ljava/lang/String;
+}
+
+public abstract interface class org/jetbrains/kotlin/gradle/plugin/mpp/export/SwiftExportConfigurationDsl {
+	public abstract fun getModuleName ()Lorg/gradle/api/provider/Property;
+	public abstract fun getRootPackage ()Lorg/gradle/api/provider/Property;
 }
 
 public class org/jetbrains/kotlin/gradle/plugin/mpp/external/DecoratedExternalKotlinCompilation$Delegate {

--- a/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugin/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
                 "org.jetbrains.kotlin.gradle.ExternalKotlinTargetApi",
                 "org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi",
                 "org.jetbrains.kotlin.gradle.ComposeKotlinGradlePluginApi",
+                "org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl",
                 "org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl",
                 "org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation",
                 "org.jetbrains.kotlin.gradle.ExperimentalJsTestDsl",

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/apple/swiftexport/SetupSwiftExportDSL.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XcodeEnvironment
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.registerEmbedSwiftExportTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.swiftexport.internal.initSwiftExportClasspathConfigurations
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.EXPORT_EXTENSION_NAME
+import org.jetbrains.kotlin.gradle.plugin.mpp.export.ExportExtension
 import org.jetbrains.kotlin.gradle.plugin.variantImplementationFactoryProvider
 
 internal object SwiftExportDSLConstants {
@@ -31,6 +33,10 @@ internal val SetUpSwiftExportAction = KotlinProjectSetupCoroutine {
         SwiftExportDSLConstants.SWIFT_EXPORT_EXTENSION_NAME,
         swiftExportExtension
     )
+
+    // TODO: Move to a more generic SetUpExportAction.
+    val exportExtension = objects.ExportExtension()
+    multiplatformExtension.addExtension(EXPORT_EXTENSION_NAME, exportExtension)
 
     val appleTargets = project
         .multiplatformExtension

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExperimentalExportDsl.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExperimentalExportDsl.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+@file:Suppress("PackageDirectoryMismatch")
+
+package org.jetbrains.kotlin.gradle.export
+
+// We mention OptIn explicitly because IDEA doesn't suggest it.
+@RequiresOptIn(
+    "This API is experimental and can be unstable. Add @OptIn(org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl::class) annotation.",
+    level = RequiresOptIn.Level.WARNING
+)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+annotation class ExperimentalExportDsl

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export
+
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.jetbrains.kotlin.gradle.dsl.KotlinGradlePluginDsl
+import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import javax.inject.Inject
+
+const val EXPORT_EXTENSION_NAME = "export"
+
+/**
+ * An *experimental* plugin DSL extension to configure platform-specific export functionality.
+ *
+ * This extension is available inside the `kotlin {}` block in your build script:
+ *
+ * ```kotlin
+ * kotlin {
+ *     export {
+ *         // Platform-specific export configuration
+ *     }
+ * }
+ * ```
+ *
+ * Note that this DSL is experimental, and it will likely change in future versions until it is stable.
+ *
+ * @since 2.5.0
+ */
+/*
+We can't mark top level extensions with @ExperimentalExportDsl because
+in buildSrc Gradle always creates accessors for these extensions which cause the opt-in error,
+which cannot be suppressed.
+
+See Gradle issue https://github.com/gradle/gradle/issues/32019
+ */
+@KotlinGradlePluginDsl
+abstract class ExportExtension @Inject constructor(
+    objectFactory: ObjectFactory,
+) {
+    internal val swiftExportConfiguration: SwiftExportConfiguration = DefaultSwiftExportConfiguration(objectFactory)
+
+    /**
+     * Configure Swift Export.
+     */
+    @ExperimentalExportDsl
+    fun swift(configure: SwiftExportConfigurationDsl.() -> Unit) {
+        (swiftExportConfiguration as SwiftExportConfigurationDsl).configure()
+    }
+
+    /**
+     * Configure Swift Export.
+     */
+    @ExperimentalExportDsl
+    fun swift(configure: Action<SwiftExportConfigurationDsl>) = swift {
+        configure.execute(this)
+    }
+}
+
+/**
+ * An *experimental* plugin DSL to configure Swift Export for an exported module.
+ *
+ * This DSL is available inside the `kotlin.export {}` block in your build script:
+ *
+ * ```kotlin
+ * kotlin {
+ *     export {
+ *         swift {
+ *             // Swift-specific export configuration
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * Note that this DSL is experimental, and it will likely change in future versions until it is stable.
+ *
+ * @since 2.5.0
+ */
+@ExperimentalExportDsl
+interface SwiftExportConfigurationDsl {
+    /**
+     * Configure the name of this module that will be used in Swift Export.
+     */
+    val moduleName: Property<String>
+
+    /**
+     * Configure this module's root package. If provided, the root package will be used for package flattening in Swift Export.
+     */
+    val rootPackage: Property<String>
+}
+
+/**
+ * Represents Swift Export configuration for an exported module.
+ *
+ * This API is experimental and may change in future versions.
+ */
+@ExperimentalExportDsl
+internal interface SwiftExportConfiguration {
+    /**
+     * The name of this module that will be used in Swift Export.
+     */
+    val moduleName: Property<String>
+
+    /**
+     * This module's root package.
+     */
+    val rootPackage: Property<String>
+}
+
+private class DefaultSwiftExportConfiguration(objectFactory: ObjectFactory) : SwiftExportConfiguration, SwiftExportConfigurationDsl {
+    override val moduleName: Property<String> = objectFactory.property(String::class.java)
+    override val rootPackage: Property<String> = objectFactory.property(String::class.java)
+}
+
+internal fun ObjectFactory.ExportExtension(): ExportExtension = newInstance(ExportExtension::class.java)

--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/export/ExportExtension.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.mpp.export
+
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.jetbrains.kotlin.gradle.dsl.KotlinGradlePluginDsl
+import org.jetbrains.kotlin.gradle.export.ExperimentalExportDsl
+import org.jetbrains.kotlin.gradle.swiftexport.ExperimentalSwiftExportDsl
+import javax.inject.Inject
+
+const val EXPORT_EXTENSION_NAME = "export"
+
+/**
+ * An *experimental* plugin DSL extension to configure platform-specific export functionality.
+ *
+ * This extension is available inside the `kotlin {}` block in your build script:
+ *
+ * ```kotlin
+ * kotlin {
+ *     export {
+ *         // Platform-specific export configuration
+ *     }
+ * }
+ * ```
+ *
+ * Note that this DSL is experimental, and it will likely change in future versions until it is stable.
+ *
+ * @since 2.5.0
+ */
+/*
+We can't mark top level extensions with @ExperimentalExportDsl because
+in buildSrc Gradle always creates accessors for these extensions which cause the opt-in error,
+which cannot be suppressed.
+
+See Gradle issue https://github.com/gradle/gradle/issues/32019
+ */
+@KotlinGradlePluginDsl
+abstract class ExportExtension @Inject constructor(
+    objectFactory: ObjectFactory,
+) {
+    internal val swiftExportConfiguration: SwiftExportConfiguration = DefaultSwiftExportConfiguration(objectFactory)
+
+    /**
+     * Configure Swift Export.
+     */
+    @ExperimentalExportDsl
+    fun swift(configure: SwiftExportConfigurationDsl.() -> Unit) {
+        (swiftExportConfiguration as SwiftExportConfigurationDsl).configure()
+    }
+
+    /**
+     * Configure Swift Export.
+     */
+    @ExperimentalExportDsl
+    fun swift(configure: Action<SwiftExportConfigurationDsl>) = swift {
+        configure.execute(this)
+    }
+}
+
+/**
+ * An *experimental* plugin DSL to configure Swift Export for an exported module.
+ *
+ * This DSL is available inside the `kotlin.export {}` block in your build script:
+ *
+ * ```kotlin
+ * kotlin {
+ *     export {
+ *         swift {
+ *             // Swift-specific export configuration
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * Note that this DSL is experimental, and it will likely change in future versions until it is stable.
+ *
+ * @since 2.5.0
+ */
+@ExperimentalSwiftExportDsl
+interface SwiftExportConfigurationDsl {
+    /**
+     * Configure the name of this module that will be used in Swift Export.
+     */
+    val moduleName: Property<String>
+
+    /**
+     * Configure this module's root package. If provided, the root package will be used for package flattening in Swift Export.
+     */
+    val rootPackage: Property<String>
+}
+
+/**
+ * Represents Swift Export configuration for an exported module.
+ *
+ * This API is experimental and may change in future versions.
+ */
+@ExperimentalSwiftExportDsl
+internal interface SwiftExportConfiguration {
+    /**
+     * The name of this module that will be used in Swift Export.
+     */
+    val moduleName: Property<String>
+
+    /**
+     * This module's root package.
+     */
+    val rootPackage: Property<String>
+}
+
+private class DefaultSwiftExportConfiguration(objectFactory: ObjectFactory) : SwiftExportConfiguration, SwiftExportConfigurationDsl {
+    override val moduleName: Property<String> = objectFactory.property(String::class.java)
+    override val rootPackage: Property<String> = objectFactory.property(String::class.java)
+}
+
+internal fun ObjectFactory.ExportExtension(): ExportExtension = newInstance(ExportExtension::class.java)


### PR DESCRIPTION
This change adds the new export extension accessible via the kotlin {} block. The extension currently allows configuring the swift export target (though the configuration isn't yet hooked up to Swift Export).

^KT-88523 Fixed