### PR TITLE
[IC] Disable intra-module inliner in 3 JS klib IC tests

### DIFF
--- a/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalK1JsKlibMultiModuleCompilerRunnerTest.kt
+++ b/compiler/incremental-compilation-impl/testFixtures/org/jetbrains/kotlin/incremental/AbstractIncrementalK1JsKlibMultiModuleCompilerRunnerTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.build.report.ICReporter
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.codegen.forTestCompile.ForTestCompileRuntime
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.incremental.multiproject.ModulesApiHistoryJs
 import org.jetbrains.kotlin.incremental.testingUtils.BuildLogFinder
 import org.jetbrains.kotlin.library.KlibConstants.KLIB_FILE_EXTENSION
@@ -94,7 +95,7 @@ abstract class AbstractIncrementalK2JsKlibMultiModuleCompilerRunnerTest :
 
     override fun createCompilerArguments(destinationDir: File, testDir: File): K2JSCompilerArguments {
         return super.createCompilerArguments(destinationDir, testDir).apply {
-            languageVersion = "2.0"
+            languageVersion = LanguageVersion.LATEST_STABLE.versionString
         }
     }
 }

--- a/jps/jps-plugin/testData/incremental/multiModule/common/inlineFunctionInlined/args.txt
+++ b/jps/jps-plugin/testData/incremental/multiModule/common/inlineFunctionInlined/args.txt
@@ -1,0 +1,1 @@
+-XXLanguage:-IrIntraModuleInlinerBeforeKlibSerialization

--- a/jps/jps-plugin/testData/incremental/multiModule/common/inlineFunctionTwoPackageParts/args.txt
+++ b/jps/jps-plugin/testData/incremental/multiModule/common/inlineFunctionTwoPackageParts/args.txt
@@ -1,0 +1,1 @@
+-XXLanguage:-IrIntraModuleInlinerBeforeKlibSerialization

--- a/jps/jps-plugin/testData/incremental/multiModule/common/transitiveInlining/args.txt
+++ b/jps/jps-plugin/testData/incremental/multiModule/common/transitiveInlining/args.txt
@@ -1,0 +1,1 @@
+-XXLanguage:-IrIntraModuleInlinerBeforeKlibSerialization


### PR DESCRIPTION
Bumping the K2 JS klib multi-module runner to LV 2.4 enables IrIntraModuleInlinerBeforeKlibSerialization, under which three inlining tests produce a klib that differs from a clean rebuild. Disable the feature for them via the per-test args.txt hook until the issue is fixed.

^KT-88539