### PR TITLE
[IR] Report a proper error if `IrDeclarationBase.parent` was not set

### DIFF
--- a/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/RenderIrElement.kt
+++ b/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/RenderIrElement.kt
@@ -872,7 +872,9 @@ private fun IrSimpleFunction.renderSimpleFunctionFlags(renderer: FlagsRenderer):
         "fake_override".takeIf { isFakeOverride },
         "operator".takeIf { isOperator },
         "infix".takeIf { isInfix },
-        "companion".takeIf { isStatic },
+        // `_parent` check is required to avoid StackOverflowError if `IrDeclarationBase` report an error.
+        // This happens in case when `parent` was accessed, but not yet set. See KT-87456 for details.
+        "companion".takeIf { _parent != null && isStatic },
     )
 
 private fun IrConstructor.renderConstructorFlags(renderer: FlagsRenderer) =


### PR DESCRIPTION
Recently we started to render "companion" keyword for static function. To understand that function is static we check its parent. This could lead to recursive `render` call in case when `IrDeclarationBase.parent` was not set.

Tested with manually written `IrValidatorTest`. Don't see the reason to introduce it with this fix.

#KT-87456 Fixed