### PR TITLE
[Native] Preparations to switch to `KlibLoader` on 2nd compilation stage

### DIFF
--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibResolvedModuleDescriptorsFactory.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibResolvedModuleDescriptorsFactory.kt
@@ -6,23 +6,16 @@ import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.storage.StorageManager
 import java.nio.file.Path
+import kotlin.io.path.Path
 
 interface KlibResolvedModuleDescriptorsFactory {
 
     val moduleDescriptorFactory: KlibMetadataModuleDescriptorFactory
 
-    /**
-     * Given the [resolvedLibraries] creates the list of [ModuleDescriptorImpl]s with properly installed
-     * inter-dependencies. The result of this method is returned in a form of [KlibResolvedModuleDescriptors] instance.
-     *
-     * Please use this method with care: Unless this method accepts `null` for [builtIns], it is not recommended to
-     * invoke it this way. If you are compiling a source module, please supply the non-null [builtIns] from the
-     * source module, so that all modules created in your compilation session will share the same built-ins instance.
-     *
-     * Otherwise (if `null` was supplied), a new instance of [KotlinBuiltIns] will be created. The created built-ins
-     * instance will be shared by all modules created in this method. But this instance will have no connection
-     * with probably existing built-ins instance of your source module(s).
-     */
+    @Deprecated(
+        "Preserved for binary compatibility with existing versions of the kotlinx-benchmarks Gradle plugin. See KT-82882.",
+        level = DeprecationLevel.HIDDEN
+    )
     @Suppress("DEPRECATION_ERROR")
     fun createResolved(
         resolvedLibraries: KotlinLibraryResolveResult,
@@ -34,14 +27,32 @@ interface KlibResolvedModuleDescriptorsFactory {
         includedLibraryFiles: Set<org.jetbrains.kotlin.konan.file.File>,
         additionalDependencyModules: Iterable<ModuleDescriptorImpl>,
         isForMetadataCompilation: Boolean,
-    ): KotlinResolvedModuleDescriptors
+    ): KotlinResolvedModuleDescriptors = createResolved2(
+        resolvedLibraries = resolvedLibraries,
+        storageManager = storageManager,
+        builtIns = builtIns,
+        languageVersionSettings = languageVersionSettings,
+        friendModuleFiles = friendModuleFiles.mapTo(hashSetOf()) { Path(it.path) },
+        refinesModuleFiles = refinesModuleFiles.mapTo(hashSetOf()) { Path(it.path) },
+        includedLibraryFiles = includedLibraryFiles.mapTo(hashSetOf()) { Path(it.path) },
+        additionalDependencyModules = additionalDependencyModules,
+        isForMetadataCompilation = isForMetadataCompilation
+    )
 
     /**
-     * A duplicate of [createResolved], which accepts [java.nio.file.Path] instead of [org.jetbrains.kotlin.konan.file.File].
+     * Given the [resolvedLibraries] creates the list of [ModuleDescriptorImpl]s with properly installed
+     * inter-dependencies. The result of this method is returned in a form of [KotlinResolvedModuleDescriptors] instance.
+     *
+     * Please use this method with care: Unless this method accepts `null` for [builtIns], it is not recommended to
+     * invoke it this way. If you are compiling a source module, please supply the non-null [builtIns] from the
+     * source module, so that all modules created in your compilation session will share the same built-ins instance.
+     *
+     * Otherwise (if `null` was supplied), a new instance of [KotlinBuiltIns] will be created. The created built-ins
+     * instance will be shared by all modules created in this method. But this instance will have no connection
+     * with probably existing built-ins instance of your source module(s).
      *
      * FYI: No much attention to naming of this function, anyway it's going to be removed soon as a part of K1.
      */
-    @Suppress("DEPRECATION_ERROR")
     fun createResolved2(
         resolvedLibraries: KotlinLibraryResolveResult,
         storageManager: StorageManager,
@@ -52,17 +63,7 @@ interface KlibResolvedModuleDescriptorsFactory {
         includedLibraryFiles: Set<Path>,
         additionalDependencyModules: Iterable<ModuleDescriptorImpl>,
         isForMetadataCompilation: Boolean,
-    ): KotlinResolvedModuleDescriptors = createResolved(
-        resolvedLibraries = resolvedLibraries,
-        storageManager = storageManager,
-        builtIns = builtIns,
-        languageVersionSettings = languageVersionSettings,
-        friendModuleFiles = friendModuleFiles.mapTo(hashSetOf()) { org.jetbrains.kotlin.konan.file.File(it) },
-        refinesModuleFiles = refinesModuleFiles.mapTo(hashSetOf()) { org.jetbrains.kotlin.konan.file.File(it) },
-        includedLibraryFiles = includedLibraryFiles.mapTo(hashSetOf()) { org.jetbrains.kotlin.konan.file.File(it) },
-        additionalDependencyModules = additionalDependencyModules,
-        isForMetadataCompilation = isForMetadataCompilation,
-    )
+    ): KotlinResolvedModuleDescriptors
 }
 
 class KotlinResolvedModuleDescriptors(

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibResolvedModuleDescriptorsFactory.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/KlibResolvedModuleDescriptorsFactory.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlin.library.metadata
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.storage.StorageManager
 import java.nio.file.Path
@@ -28,7 +29,7 @@ interface KlibResolvedModuleDescriptorsFactory {
         additionalDependencyModules: Iterable<ModuleDescriptorImpl>,
         isForMetadataCompilation: Boolean,
     ): KotlinResolvedModuleDescriptors = createResolved2(
-        resolvedLibraries = resolvedLibraries,
+        libraries = resolvedLibraries.getFullList(),
         storageManager = storageManager,
         builtIns = builtIns,
         languageVersionSettings = languageVersionSettings,
@@ -40,7 +41,7 @@ interface KlibResolvedModuleDescriptorsFactory {
     )
 
     /**
-     * Given the [resolvedLibraries] creates the list of [ModuleDescriptorImpl]s with properly installed
+     * Given the [libraries] creates the list of [ModuleDescriptorImpl]s with properly installed
      * inter-dependencies. The result of this method is returned in a form of [KotlinResolvedModuleDescriptors] instance.
      *
      * Please use this method with care: Unless this method accepts `null` for [builtIns], it is not recommended to
@@ -54,7 +55,7 @@ interface KlibResolvedModuleDescriptorsFactory {
      * FYI: No much attention to naming of this function, anyway it's going to be removed soon as a part of K1.
      */
     fun createResolved2(
-        resolvedLibraries: KotlinLibraryResolveResult,
+        libraries: List<KotlinLibrary>,
         storageManager: StorageManager,
         builtIns: KotlinBuiltIns?,
         languageVersionSettings: LanguageVersionSettings,

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibResolvedModuleDescriptorsFactoryImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibResolvedModuleDescriptorsFactoryImpl.kt
@@ -126,7 +126,7 @@ class KlibResolvedModuleDescriptorsFactoryImpl(
         )
     }
 
-    fun createForwardDeclarationsModule(
+    private fun createForwardDeclarationsModule(
         builtIns: KotlinBuiltIns?,
         storageManager: StorageManager,
         isExpect: Boolean
@@ -231,8 +231,7 @@ class ForwardDeclarationsPackageFragmentDescriptor(
             findCinteropClassOrNull(NativeStandardInteropNames.ExperimentalForeignApi)?.defaultType
         }
 
-        private fun findCinteropClass(name: Name): ClassDescriptor = findCinteropClassOrNull(name) ?:
-          error("Class $name is not found")
+        private fun findCinteropClass(name: Name): ClassDescriptor = findCinteropClassOrNull(name) ?: error("Class $name is not found")
 
         private fun findCinteropClassOrNull(name: Name): ClassDescriptor? {
             return builtIns.builtInsModule.getPackage(NativeStandardInteropNames.cInteropPackage)

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibResolvedModuleDescriptorsFactoryImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibResolvedModuleDescriptorsFactoryImpl.kt
@@ -36,21 +36,21 @@ import org.jetbrains.kotlin.storage.StorageManager
 import org.jetbrains.kotlin.storage.getValue
 import org.jetbrains.kotlin.util.profile
 import org.jetbrains.kotlin.utils.Printer
+import java.nio.file.Path
 
 // TODO: eliminate Native specifics.
 class KlibResolvedModuleDescriptorsFactoryImpl(
     override val moduleDescriptorFactory: KlibMetadataModuleDescriptorFactory
 ) : KlibResolvedModuleDescriptorsFactory {
 
-    @Suppress("DEPRECATION_ERROR")
-    override fun createResolved(
+    override fun createResolved2(
         resolvedLibraries: KotlinLibraryResolveResult,
         storageManager: StorageManager,
         builtIns: KotlinBuiltIns?,
         languageVersionSettings: LanguageVersionSettings,
-        friendModuleFiles: Set<org.jetbrains.kotlin.konan.file.File>,
-        refinesModuleFiles: Set<org.jetbrains.kotlin.konan.file.File>,
-        includedLibraryFiles: Set<org.jetbrains.kotlin.konan.file.File>,
+        friendModuleFiles: Set<Path>,
+        refinesModuleFiles: Set<Path>,
+        includedLibraryFiles: Set<Path>,
         additionalDependencyModules: Iterable<ModuleDescriptorImpl>,
         isForMetadataCompilation: Boolean,
     ): KotlinResolvedModuleDescriptors {
@@ -75,13 +75,11 @@ class KlibResolvedModuleDescriptorsFactoryImpl(
                 builtIns = moduleDescriptor.builtIns
                 moduleDescriptors.add(moduleDescriptor)
 
-                val libraryFile = org.jetbrains.kotlin.konan.file.File(library.path)
-
-                if (refinesModuleFiles.contains(libraryFile))
+                if (refinesModuleFiles.contains(library.path))
                     refinesModuleDescriptors.add(moduleDescriptor)
-                if (friendModuleFiles.contains(libraryFile))
+                if (friendModuleFiles.contains(library.path))
                     friendModuleDescriptors.add(moduleDescriptor)
-                if (includedLibraryFiles.contains(libraryFile))
+                if (includedLibraryFiles.contains(library.path))
                     includedLibraryDescriptors.add(moduleDescriptor)
             }
         }

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibResolvedModuleDescriptorsFactoryImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/impl/KlibResolvedModuleDescriptorsFactoryImpl.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.library.metadata.*
 import org.jetbrains.kotlin.library.metadata.KlibModuleOrigin
 import org.jetbrains.kotlin.library.metadata.impl.KlibResolvedModuleDescriptorsFactoryImpl.Companion.FORWARD_DECLARATIONS_MODULE_NAME
 import org.jetbrains.kotlin.library.metadata.isCInteropLibrary
-import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.NativeForwardDeclarationKind
@@ -44,7 +43,7 @@ class KlibResolvedModuleDescriptorsFactoryImpl(
 ) : KlibResolvedModuleDescriptorsFactory {
 
     override fun createResolved2(
-        resolvedLibraries: KotlinLibraryResolveResult,
+        libraries: List<KotlinLibrary>,
         storageManager: StorageManager,
         builtIns: KotlinBuiltIns?,
         languageVersionSettings: LanguageVersionSettings,
@@ -65,7 +64,7 @@ class KlibResolvedModuleDescriptorsFactoryImpl(
         val includedLibraryDescriptors = mutableSetOf<ModuleDescriptorImpl>()
 
         // Build module descriptors.
-        resolvedLibraries.forEach { library ->
+        libraries.forEach { library ->
             profile("Loading ${library.path}") {
 
                 // MutableModuleContext needs ModuleDescriptorImpl, rather than ModuleDescriptor.

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/KotlinLibraryResolver.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/KotlinLibraryResolver.kt
@@ -93,6 +93,4 @@ interface KotlinLibraryResolveResult {
      * Returns the list of libraries in reverse topological order.
      */
     fun getFullList(): List<KotlinLibrary>
-
-    fun forEach(action: (KotlinLibrary) -> Unit)
 }

--- a/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/impl/KotlinLibraryResolverImpl.kt
+++ b/compiler/util-klib-metadata/src/org/jetbrains/kotlin/library/metadata/resolver/impl/KotlinLibraryResolverImpl.kt
@@ -213,9 +213,5 @@ class KotlinLibraryResolverResultImpl(
      */
     override fun getFullList(): List<KotlinLibrary> = all.map { it.library }
 
-    override fun forEach(action: (KotlinLibrary) -> Unit) {
-        all.forEach { action(it.library) }
-    }
-
     override fun toString() = "roots=$roots, all=$all"
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheBuilder.kt
@@ -72,7 +72,11 @@ class CacheBuilder(
             && (config.isFinalBinary || config.produce.isFullCache)
             && (autoCacheableFrom.isNotEmpty() || icEnabled)
 
+    // Note: The order of libraries is not important here.
     private val allLibraries by lazy { config.resolvedLibraries.getFullList() }
+
+    // Note: It's not totally clear, but likely the libraries in `uniqueNameToLibrary` should be in the reverse topo-order.
+    // TODO(KT-61096): Use RTO of libraries here after switching to KlibLoader.
     private val uniqueNameToLibrary by lazy { allLibraries.associateBy { it.uniqueName } }
     private val uniqueNameToHash = mutableMapOf<String, FingerprintHash>()
 
@@ -156,6 +160,8 @@ class CacheBuilder(
         val icedLibraries = mutableListOf<KotlinLibrary>()
         val lastRebuiltArchives = mutableListOf<Path>()
 
+        // Note: The libraries should be in the reverse topo-order here!
+        // TODO(KT-61096): Use RTO of libraries here after switching to KlibLoader.
         allLibraries.forEach { library ->
             // For MinGW target avoid compiling caches for anything except stdlib.
             if (config.target == KonanTarget.MINGW_X64 && !library.isNativeStdlib) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
@@ -72,7 +72,7 @@ class CacheSupport(
         target: KonanTarget,
         val produce: CompilerOutputKind
 ) {
-    // TODO: consider using [FeaturedLibraries.kt].
+    // Note: The order of libraries is not important here.
     private val pathToLibrary = allLibraries.associateBy { it.path }
 
     private val autoCacheableFrom = configuration[NativeConfigurationKeys.AUTO_CACHEABLE_FROM]!!
@@ -173,6 +173,8 @@ class CacheSupport(
         // Ensure dependencies of every cached library are cached too:
         val dependenciesMap = LegacyKlibDependencies(allLibraries)
 
+        // Note: The libraries should be in the reverse topo-order here.
+        // TODO(KT-61096): Use RTO of libraries here after switching to KlibLoader.
         for (library in allLibraries) {
             val cache = cachedLibraries.getLibraryCache(library)
             if (cache != null || library == libraryToCache?.klib) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CacheSupport.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.konan.target.CompilerOutputKind
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.components.irOrFail
-import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.protobuf.ExtensionRegistryLite
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -65,7 +64,7 @@ fun KotlinLibrary.getFileFqNames(filePaths: List<String>): List<String> {
 
 class CacheSupport(
         private val configuration: CompilerConfiguration,
-        private val resolvedLibraries: KotlinLibraryResolveResult,
+        private val allLibraries: List<KotlinLibrary>,
         ignoreCacheReason: String?,
         systemCacheDirectory: Path,
         autoCacheDirectory: Path,
@@ -73,8 +72,6 @@ class CacheSupport(
         target: KonanTarget,
         val produce: CompilerOutputKind
 ) {
-    private val allLibraries = resolvedLibraries.getFullList()
-
     // TODO: consider using [FeaturedLibraries.kt].
     private val pathToLibrary = allLibraries.associateBy { it.path }
 
@@ -174,10 +171,9 @@ class CacheSupport(
 
     fun checkConsistency() {
         // Ensure dependencies of every cached library are cached too:
-        val libraries = resolvedLibraries.getFullList()
-        val dependenciesMap = LegacyKlibDependencies(libraries)
+        val dependenciesMap = LegacyKlibDependencies(allLibraries)
 
-        for (library in libraries) {
+        for (library in allLibraries) {
             val cache = cachedLibraries.getLibraryCache(library)
             if (cache != null || library == libraryToCache?.klib) {
                 val dependencies = dependenciesMap.getDependenciesFor(library)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/DependenciesTracker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/DependenciesTracker.kt
@@ -75,6 +75,11 @@ private sealed class FileOrigin {
     class CertainFile(val library: KotlinLibrary, val fqName: String, val filePath: String) : FileOrigin()
 }
 
+// TODO(KT-61096): The "dependencies tracker" is created lately in the 2nd phase pipeline. We have an assumption that it may implicitly
+//  rely on the RTO of klibs stored in `NativeSecondStageCompilationConfig.resolvedLibraries`. In order to make the transition to
+//  KlibLoader safe we need make the dependency on RTO to be explicit, and make it with no additional cost.
+//  This can be achieved if we would keep the list of `IrModuleFragment`s in RTO after the IR linkage stage, and extract the knowledge
+//  about the RTO from `IrModuleFragment` not `KotlinLibrary`s.
 internal class DependenciesTrackerImpl(
         private val llvmModuleSpecification: LlvmModuleSpecification,
         private val config: NativeSecondStageCompilationConfig,
@@ -173,10 +178,12 @@ internal class DependenciesTrackerImpl(
                     usedWeakBitcodeOfFile.map { UsedLibraryFile(it, weak = true) }
 
     private val topSortedLibraries by lazy {
+        // Note: In general, it's unclear, whether the order of libraries is important or not.
         context.config.resolvedLibraries.getFullList()
     }
 
     private inner class CachedBitcodeDependenciesComputer {
+        // Note: The order of libraries is not important.
         private val allLibraries = topSortedLibraries.associateBy { it.uniqueName }
         private val usedBitcode = usedBitcode().groupBy { it.file.library }
 
@@ -186,6 +193,7 @@ internal class DependenciesTrackerImpl(
         val allDependencies: List<DependenciesTracker.ResolvedDependency>
 
         init {
+            // Note: Unclear, whether the order of libraries is important or not.
             val immediateBitcodeDependencies = topSortedLibraries
                     .filter { it.isExplicitlySpecifiedByUserInCLIArgument || bitcodeIsUsed(it) }
             for (library in immediateBitcodeDependencies) {
@@ -285,6 +293,8 @@ internal class DependenciesTrackerImpl(
             val bitcodeFileDependencies = mutableListOf<DependenciesTracker.ResolvedDependency>()
             val libraryToCache = config.cacheSupport.libraryToCache
             val strategy = libraryToCache?.strategy as? CacheDeserializationStrategy.SingleFile
+
+            // Note: Unclear, whether the order of libraries is important or not.
             topSortedLibraries.forEach { library ->
                 val filesUsed = usedBitcode[library]
                 if (filesUsed == null && bitcodeIsUsed(library) && library != libraryToCache?.klib /* Skip loops */) {
@@ -316,15 +326,18 @@ internal class DependenciesTrackerImpl(
             // This list is used in particular to build the libraries' initializers chain.
             // The initializers must be called in the topological order, so make sure that the
             // libraries list being returned is also toposorted.
+            // Note: Unclear, whether the order of libraries is important or not.
             topSortedLibraries.mapNotNull { allBitcodeDependencies[it] }
         }
 
+        // Note: Unclear, whether the order of libraries is important or not.
         val nativeDependenciesToLink = topSortedLibraries.filter { it.isExplicitlySpecifiedByUserInCLIArgument || it in usedNativeDependencies }
 
         val allNativeDependencies = (nativeDependenciesToLink +
                 allCachedBitcodeDependencies.map { it.library } // Native dependencies are per library
                 ).distinct()
 
+        // Note: Unclear, whether the order of libraries is important or not.
         val bitcodeToLink = topSortedLibraries.filter { shouldContainBitcode(it) }
 
         private fun shouldContainBitcode(library: KotlinLibrary): Boolean {
@@ -448,7 +461,7 @@ data class DependenciesTrackingResult(
             val allNativeLibs = DependenciesSerializer.deserialize(path, dependencies.subList(allNativeDepsIndex + 1, allCachedBitcodeDepsIndex)).map { it.libName }
             val allCachedBitcodeDeps = DependenciesSerializer.deserialize(path, dependencies.subList(allCachedBitcodeDepsIndex + 1, dependencies.size))
 
-            val topSortedLibraries = config.resolvedLibraries.getFullList()
+            val topSortedLibraries = config.resolvedLibraries.getFullList() // Note: Unclear, whether the order of libraries is important or not.
             val nativeDependenciesToLink = topSortedLibraries.mapNotNull { if (it.uniqueName in nativeLibsToLink) it else null }
             val allNativeDependencies = topSortedLibraries.mapNotNull { if (it.uniqueName in allNativeLibs) it else null }
             val allCachedBitcodeDependencies = allCachedBitcodeDeps.map { unresolvedDep ->

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -154,6 +154,7 @@ class KonanDriver(
 
     private fun ensureModuleName(config: NativeSecondStageCompilationConfig) {
         if (environment.getSourceFiles().isEmpty()) {
+            // Note: The order of libraries is not important.
             val libraries = config.resolvedLibraries.getFullList()
             val moduleName = config.moduleId
             if (libraries.any { it.uniqueName == moduleName }) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Linker.kt
@@ -201,6 +201,7 @@ internal fun runLinkerCommands(context: NativeBackendPhaseContext, commands: Lis
     } else null
 
     val extraUserSetupInfo = run {
+        // Note: The order of libraries is not important.
         context.config.resolvedLibraries.getFullList()
                 .filter { it.isCInteropLibrary() }
                 .mapNotNull { library ->

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -629,7 +629,7 @@ class NativeSecondStageCompilationConfig(
 
     private fun createCacheSupport() = CacheSupport(
             configuration = configuration,
-            resolvedLibraries = resolvedLibraries,
+            allLibraries = resolvedLibraries.getFullList(),
             ignoreCacheReason = ignoreCacheReason,
             systemCacheDirectory = systemCacheDirectory,
             autoCacheDirectory = autoCacheDirectory,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeSecondStageCompilationConfig.kt
@@ -392,6 +392,10 @@ class NativeSecondStageCompilationConfig(
     /**
      * Returns the list of libraries in reverse topological order.
      */
+    // TODO(KT-61096): This is a form of DCE to avoid loading ALL platform libraries from the Kotlin/Native distribution.
+    //  We should not use it. Instead, we should load all libraries, then run the IR linkage cycle and figure out which
+    //  platform libraries were actually not "touched" and filter them out. There should not be relevant `IrModuleFragment`s
+    //  down the pipeline after the IR linkage phase.
     fun librariesWithDependencies(): List<KotlinLibrary> {
         return resolvedLibraries.filterRoots {
             // Let's leave only those dependencies (roots) that have been explicitly specified by the used in compiler's CLI.
@@ -410,6 +414,7 @@ class NativeSecondStageCompilationConfig(
     override val loadedKlibs = loadNativeKlibs(configuration, target).let { original ->
         // Avoid having duplicates of the same `KotlinLibrary` loaded by the KLIB resolver and `KlibLoader`.
         // TODO(KT-61096): Drop this `let { ... }` block when completely switching to `KlibLoader`.
+        // Note: The order of libraries is not important.
         val canonicalPathToLibraryLoadedByKlibResolver: Map<Path, KotlinLibrary> = resolvedLibraries.getFullList().associateBy { it.canonicalPath }
 
         val substituted = LoadedNativeKlibs(
@@ -629,7 +634,7 @@ class NativeSecondStageCompilationConfig(
 
     private fun createCacheSupport() = CacheSupport(
             configuration = configuration,
-            allLibraries = resolvedLibraries.getFullList(),
+            allLibraries = resolvedLibraries.getFullList(), // Note: There is the need to have RTO of libs in certain cases inside CacheSupport.
             ignoreCacheReason = ignoreCacheReason,
             systemCacheDirectory = systemCacheDirectory,
             autoCacheDirectory = autoCacheDirectory,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -54,6 +54,7 @@ internal object TopDownAnalyzerFacadeForKonan {
         val moduleContext = MutableModuleContextImpl(module, projectContext)
 
         val resolvedModuleDescriptors = nativeFactories.DefaultResolvedDescriptorsFactory.createResolved2(
+                // Note: The order of libraries is not important except for stdlib, which should go the first.
                 libraries = config.resolvedLibraries.getFullList(),
                 storageManager = projectContext.storageManager,
                 builtIns = module.builtIns,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -54,10 +54,16 @@ internal object TopDownAnalyzerFacadeForKonan {
         val moduleContext = MutableModuleContextImpl(module, projectContext)
 
         val resolvedModuleDescriptors = nativeFactories.DefaultResolvedDescriptorsFactory.createResolved2(
-                config.resolvedLibraries.getFullList(), projectContext.storageManager, module.builtIns, config.languageVersionSettings,
-                config.friendModuleFiles, config.refinesModuleFiles,
-                config.loadedKlibs.included.map { it.path }.toSet(), listOf(module),
-                isForMetadataCompilation = config.metadataKlib)
+                libraries = config.resolvedLibraries.getFullList(),
+                storageManager = projectContext.storageManager,
+                builtIns = module.builtIns,
+                languageVersionSettings = config.languageVersionSettings,
+                friendModuleFiles = config.friendModuleFiles,
+                refinesModuleFiles = config.refinesModuleFiles,
+                includedLibraryFiles = config.loadedKlibs.included.map { it.path }.toSet(),
+                additionalDependencyModules = listOf(module),
+                isForMetadataCompilation = config.metadataKlib
+        )
 
         val additionalPackages = mutableListOf<PackageFragmentProvider>()
         if (!module.isNativeStdlib()) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -54,7 +54,7 @@ internal object TopDownAnalyzerFacadeForKonan {
         val moduleContext = MutableModuleContextImpl(module, projectContext)
 
         val resolvedModuleDescriptors = nativeFactories.DefaultResolvedDescriptorsFactory.createResolved2(
-                config.resolvedLibraries, projectContext.storageManager, module.builtIns, config.languageVersionSettings,
+                config.resolvedLibraries.getFullList(), projectContext.storageManager, module.builtIns, config.languageVersionSettings,
                 config.friendModuleFiles, config.refinesModuleFiles,
                 config.loadedKlibs.included.map { it.path }.toSet(), listOf(module),
                 isForMetadataCompilation = config.metadataKlib)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Frontend.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Frontend.kt
@@ -53,7 +53,11 @@ internal val FrontendPhase = createSimpleNamedCompilerPhase(
 
         val sourceFiles = input.getSourceFiles()
 
-        require(context.config.produce == CompilerOutputKind.LIBRARY || sourceFiles.isEmpty()) {
+        check(context.config.produce != CompilerOutputKind.LIBRARY) {
+            "Internal error: An attempt to run the 2nd compilation stage to produce ${CompilerOutputKind.LIBRARY}"
+        }
+
+        check(sourceFiles.isEmpty()) {
             "Internal error: no source files should have been passed here (${sourceFiles.first().virtualFilePath} in particular)\n" +
                     "to produce binary (e.g. a ${context.config.produce.name.toLowerCaseAsciiOnly()})\n" +
                     "KonanDriver.kt::splitOntoTwoStages() must transform such compilation into two-stage compilation. Please report this here: https://kotl.in/issue"

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -148,7 +148,7 @@ private fun LinkKlibsContext.createIrLinker(moduleDescriptor: ModuleDescriptor, 
 
     // TODO Don't use file names in friend modules detection. Should be done in scope of KT-61096
     val canonicalFriendPaths = config.friendModuleFiles.mapToSetOrEmpty { it.canonicalPathString() }
-    val friendModules = config.resolvedLibraries.getFullList()
+    val friendModules = config.resolvedLibraries.getFullList() // TODO(KT-61096): rewrite this code to make it simpler
             .filter { it.path.canonicalPathString() in canonicalFriendPaths }
             .map { it.uniqueName }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/linkKlibs.kt
@@ -36,9 +36,7 @@ import org.jetbrains.kotlin.resolve.CommonCompilerDeserializationConfiguration
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.serialization.deserialization.DeserializationConfiguration
 import org.jetbrains.kotlin.utils.DFS
-import org.jetbrains.kotlin.utils.mapToSetOrEmpty
 import java.nio.file.Path
-import org.jetbrains.kotlin.io.canonicalPathString
 
 internal interface LinkKlibsContext : NativeBackendPhaseContext {
     val symbolTable: SymbolTable?
@@ -146,16 +144,11 @@ private fun LinkKlibsContext.createIrLinker(moduleDescriptor: ModuleDescriptor, 
 
     val forwardDeclarationsModuleDescriptor = moduleDescriptor.allDependencyModules.firstOrNull { it.isForwardDeclarationModule }
 
-    // TODO Don't use file names in friend modules detection. Should be done in scope of KT-61096
-    val canonicalFriendPaths = config.friendModuleFiles.mapToSetOrEmpty { it.canonicalPathString() }
-    val friendModules = config.resolvedLibraries.getFullList() // TODO(KT-61096): rewrite this code to make it simpler
-            .filter { it.path.canonicalPathString() in canonicalFriendPaths }
-            .map { it.uniqueName }
+    val friendModuleUniqueNames = config.loadedKlibs.friends.map { it.uniqueName }
+    val includedModuleUniqueNames = config.loadedKlibs.included.map { it.uniqueName }
 
-    val friendModulesMap = (
-            listOf(moduleDescriptor.name.asStringStripSpecialMarkers()) +
-                    config.loadedKlibs.included.map { it.uniqueName }
-            ).associateWith { friendModules }
+    val friendModulesMap: Map<String, List<String>> =
+            (listOf(moduleDescriptor.name.asStringStripSpecialMarkers()) + includedModuleUniqueNames).associateWith { friendModuleUniqueNames }
 
     val irDiagnosticReporter = KtDiagnosticReporterWithImplicitIrBasedContext(
             config.configuration.diagnosticsCollector,


### PR DESCRIPTION
[KT-61096](https://youtrack.jetbrains.com/issue/KT-61096) [KLIB Resolve] Drop KLIB resolve inside the Kotlin/Native compiler
[KT-81624](https://youtrack.jetbrains.com/issue/KT-81624) [KLIB Resolve] Kotlin/Native: -no-default-libs may lead to the final binary depending on a lot of system frameworks