### PR TITLE
Fir: Report a warning when annotation is dropped from INDY lambda

### DIFF
--- a/analysis/analysis-api-fir-diagnostics/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnostic.kt
+++ b/analysis/analysis-api-fir-diagnostics/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnostic.kt
@@ -8852,6 +8852,15 @@ public interface KaFirDiagnostic<PSI : PsiElement> : KaDiagnosticWithPsi<PSI> {
 
     @KaUnstableDiagnosticApi
     @SubclassOptInRequired(KaImplementationDetail::class)
+    public interface RuntimeAnnotationOnLambdaIsNotRetained : KaFirDiagnostic<KtAnnotationEntry> {
+        override val diagnosticClass: KClass<RuntimeAnnotationOnLambdaIsNotRetained>
+            get() = RuntimeAnnotationOnLambdaIsNotRetained::class
+
+        public val annotationClass: KaClassLikeSymbol
+    }
+
+    @KaUnstableDiagnosticApi
+    @SubclassOptInRequired(KaImplementationDetail::class)
     public interface LocalJvmRecord : KaFirDiagnostic<PsiElement> {
         override val diagnosticClass: KClass<LocalJvmRecord>
             get() = LocalJvmRecord::class

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDataClassConverters.kt
@@ -2603,6 +2603,13 @@ private fun KaDiagnosticConverterBuilder.addConversions56() {
             token,
         )
     }
+    add(FirJvmErrors.RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED) { firDiagnostic ->
+        RuntimeAnnotationOnLambdaIsNotRetainedImpl(
+            firSymbolBuilder.classifierBuilder.buildClassLikeSymbol(firDiagnostic.a),
+            firDiagnostic as KtPsiDiagnostic,
+            token,
+        )
+    }
 }
 
 private fun KaDiagnosticConverterBuilder.addConversions57() {

--- a/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
+++ b/analysis/analysis-api-fir/gen/org/jetbrains/kotlin/analysis/api/fir/diagnostics/KaFirDiagnosticsImpl.kt
@@ -6255,6 +6255,12 @@ internal class AnnotationTargetsOnlyInJavaImpl(
     token: KaLifetimeToken,
 ) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.AnnotationTargetsOnlyInJava
 
+internal class RuntimeAnnotationOnLambdaIsNotRetainedImpl(
+    override val annotationClass: KaClassLikeSymbol,
+    firDiagnostic: KtPsiDiagnostic,
+    token: KaLifetimeToken,
+) : KaAbstractFirDiagnostic<KtAnnotationEntry>(firDiagnostic, token), KaFirDiagnostic.RuntimeAnnotationOnLambdaIsNotRetained
+
 internal class LocalJvmRecordImpl(
     firDiagnostic: KtPsiDiagnostic,
     token: KaLifetimeToken,

--- a/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirJvmDiagnosticsList.kt
+++ b/compiler/fir/checkers/checkers-component-generator/src/org/jetbrains/kotlin/fir/checkers/generator/diagnostics/FirJvmDiagnosticsList.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.fir.checkers.generator.diagnostics.model.Positioning
 import org.jetbrains.kotlin.fir.checkers.generator.diagnostics.model.upperBoundViolatedDiagnosticInit
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFieldSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -175,6 +176,9 @@ object JVM_DIAGNOSTICS_LIST : DiagnosticList("FirJvmErrors") {
             parameter<Collection<String>>("correspondingKotlinTargets")
         }
         val ANNOTATION_TARGETS_ONLY_IN_JAVA by warning<KtAnnotationEntry>()
+        val RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED by warning<KtAnnotationEntry> {
+            parameter<FirClassLikeSymbol<*>>("annotationClass")
+        }
     }
 
     val SUPER by object : DiagnosticGroup("Super") {

--- a/compiler/fir/checkers/checkers.jvm/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/jvm/FirJvmErrors.kt
+++ b/compiler/fir/checkers/checkers.jvm/gen/org/jetbrains/kotlin/fir/analysis/diagnostics/jvm/FirJvmErrors.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.fir.analysis.diagnostics.*
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFieldSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -120,6 +121,7 @@ object FirJvmErrors : KtDiagnosticsContainer() {
     val JVM_SERIALIZABLE_LAMBDA_ON_INLINED_FUNCTION_LITERALS: KtDiagnosticFactoryForDeprecation0 = KtDiagnosticFactoryForDeprecation0("JVM_SERIALIZABLE_LAMBDA_ON_INLINED_FUNCTION_LITERALS", ForbidJvmSerializableLambdaOnInlinedFunctionLiterals, SourceElementPositioningStrategies.DEFAULT, KtAnnotationEntry::class, getRendererFactory())
     val INCOMPATIBLE_ANNOTATION_TARGETS: KtDiagnosticFactory2<Collection<String>, Collection<String>> = KtDiagnosticFactory2("INCOMPATIBLE_ANNOTATION_TARGETS", WARNING, SourceElementPositioningStrategies.DEFAULT, KtAnnotationEntry::class, getRendererFactory())
     val ANNOTATION_TARGETS_ONLY_IN_JAVA: KtDiagnosticFactory0 = KtDiagnosticFactory0("ANNOTATION_TARGETS_ONLY_IN_JAVA", WARNING, SourceElementPositioningStrategies.DEFAULT, KtAnnotationEntry::class, getRendererFactory())
+    val RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED: KtDiagnosticFactory1<FirClassLikeSymbol<*>> = KtDiagnosticFactory1("RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED", WARNING, SourceElementPositioningStrategies.DEFAULT, KtAnnotationEntry::class, getRendererFactory())
 
     // Super
     val INTERFACE_CANT_CALL_DEFAULT_METHOD_VIA_SUPER: KtDiagnosticFactory0 = KtDiagnosticFactory0("INTERFACE_CANT_CALL_DEFAULT_METHOD_VIA_SUPER", ERROR, SourceElementPositioningStrategies.REFERENCE_BY_QUALIFIED, PsiElement::class, getRendererFactory())

--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/diagnostics/jvm/FirJvmErrorsDefaultMessages.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/diagnostics/jvm/FirJvmErrorsDefaultMessages.kt
@@ -112,6 +112,7 @@ import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.REPEATABLE
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.REPEATABLE_CONTAINER_MUST_HAVE_VALUE_ARRAY_ERROR
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.REPEATABLE_CONTAINER_TARGET_SET_NOT_A_SUBSET_ERROR
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.REPEATED_ANNOTATION_WITH_CONTAINER
+import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.SPREAD_ON_SIGNATURE_POLYMORPHIC_CALL_ERROR
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.STRICTFP_ON_CLASS
 import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors.SUBCLASS_CANT_CALL_COMPANION_PROTECTED_NON_STATIC
@@ -512,6 +513,12 @@ object FirJvmErrorsDefaultMessages : BaseDiagnosticRendererFactory() {
         map.put(
             ANNOTATION_TARGETS_ONLY_IN_JAVA,
             "No Kotlin '@Target' annotation specified (implicitly targeting everything), but one exists for Java."
+        )
+        map.put(
+            RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED,
+            "Annotation ''{0}'' is not retained on the lambda instance at runtime, because the lambda is compiled to ''invokedynamic''. " +
+                    "Annotate the lambda with ''@JvmSerializableLambda'' to generate a class for it and retain the annotation.",
+            SYMBOL
         )
         map.put(
             NO_REFLECTION_IN_CLASS_PATH,

--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/JvmDeclarationCheckers.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/JvmDeclarationCheckers.kt
@@ -82,4 +82,9 @@ object JvmDeclarationCheckers : DeclarationCheckers() {
         get() = setOf(
             FirValueParameterJavaNullabilityWarningChecker
         )
+
+    override val anonymousFunctionCheckers: Set<FirAnonymousFunctionChecker>
+        get() = setOf(
+            FirJvmIndyAnnotatedLambdaChecker,
+        )
 }

--- a/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirJvmIndyAnnotatedLambdaChecker.kt
+++ b/compiler/fir/checkers/checkers.jvm/src/org/jetbrains/kotlin/fir/analysis/jvm/checkers/declaration/FirJvmIndyAnnotatedLambdaChecker.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.fir.analysis.jvm.checkers.declaration
+
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirAnonymousFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.diagnostics.jvm.FirJvmErrors
+import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
+import org.jetbrains.kotlin.fir.declarations.InlineStatus
+import org.jetbrains.kotlin.fir.declarations.getAnnotationRetention
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassLikeSymbol
+import org.jetbrains.kotlin.fir.declarations.utils.isSuspend
+import org.jetbrains.kotlin.fir.isEnabled
+import org.jetbrains.kotlin.fir.types.coneTypeOrNull
+import org.jetbrains.kotlin.fir.types.isSuspendOrKSuspendFunctionType
+import org.jetbrains.kotlin.name.JvmStandardClassIds
+
+/**
+ * INDY lambdas drop runtime annotations. Report a warning.
+ *
+ * See [LanguageFeature.JvmIndyAllowLambdasWithAnnotations].
+ */
+object FirJvmIndyAnnotatedLambdaChecker : FirAnonymousFunctionChecker(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirAnonymousFunction) {
+        if (!LanguageFeature.JvmIndyAllowLambdasWithAnnotations.isEnabled()) return
+
+        // Inlined lambdas have no instance at all, this case is covered by NON_SOURCE_ANNOTATION_ON_INLINED_LAMBDA_EXPRESSION.
+        if (declaration.inlineStatus == InlineStatus.Inline || declaration.inlineStatus == InlineStatus.CrossInline) return
+
+        // Suspend lambdas are always compiled to a class, their annotations end up on 'invokeSuspend'.
+        val isSuspend =
+            if (declaration.isLambda) declaration.typeRef.coneTypeOrNull?.isSuspendOrKSuspendFunctionType(context.session) == true
+            else declaration.isSuspend
+        if (isSuspend) return
+
+        // '@JvmSerializableLambda' forces the class generation scheme, so the annotations are retained.
+        if (declaration.hasAnnotation(JvmStandardClassIds.JVM_SERIALIZABLE_LAMBDA_ANNOTATION_CLASS_ID, context.session)) return
+
+        for (annotation in declaration.annotations) {
+            val annotationClassSymbol = annotation.toAnnotationClassLikeSymbol(context.session) ?: continue
+            if (annotationClassSymbol.getAnnotationRetention(context.session) != AnnotationRetention.RUNTIME) continue
+            reporter.reportOn(
+                annotation.source,
+                FirJvmErrors.RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED,
+                annotationClassSymbol,
+            )
+        }
+    }
+}

--- a/compiler/testData/diagnostics/tests/annotations/AnnotatedStatement.kt
+++ b/compiler/testData/diagnostics/tests/annotations/AnnotatedStatement.kt
@@ -46,7 +46,7 @@ fun foo(list: MutableList<Int>, arr: Array<String>) {
     @JavaAnnWithTarget @JavaAnn <!WRONG_ANNOTATION_TARGET!>@KotlinAnn<!>
     arr[1] += "*"
 
-    @JavaAnnWithTarget @JavaAnn @KotlinAnn
+    <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@JavaAnnWithTarget<!> <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@JavaAnn<!> <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@KotlinAnn<!>
     { bar() }
 }
 

--- a/compiler/testData/diagnostics/tests/annotations/options/functionExpression.kt
+++ b/compiler/testData/diagnostics/tests/annotations/options/functionExpression.kt
@@ -8,7 +8,7 @@ annotation class FunAnn
 
 fun foo(): Int {
     val x = @ExprAnn fun() = 1
-    val y = @FunAnn fun() = 2
+    val y = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@FunAnn<!> fun() = 2
     return x() + y()    
 }
 

--- a/compiler/testData/diagnostics/tests/annotations/options/functions.kt
+++ b/compiler/testData/diagnostics/tests/annotations/options/functions.kt
@@ -20,7 +20,7 @@ inline fun fast2(x: Int, arg: () -> Int) = x + arg()
 
 fun foo(arg: Int) {
     // Literal is annotatable
-    bar @FunAnn { arg }
+    bar <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@FunAnn<!> { arg }
     // Annotatable in principle but useless, fast is inline
     fast <!NON_SOURCE_ANNOTATION_ON_INLINED_LAMBDA_EXPRESSION!>@FunAnn<!> { arg }
     fast2(1, <!NON_SOURCE_ANNOTATION_ON_INLINED_LAMBDA_EXPRESSION!>@FunAnn<!> { arg })
@@ -31,7 +31,7 @@ fun foo(arg: Int) {
     fast @ExprAnn { arg }
     fast2(1, @ExprAnn { arg })
     // Function expression too
-    val f = @FunAnn fun(): Int { return 42 }
+    val f = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@FunAnn<!> fun(): Int { return 42 }
     // But here, f and gav should be annotated instead
     bar(<!WRONG_ANNOTATION_TARGET!>@FunAnn<!> f)
     bar(<!WRONG_ANNOTATION_TARGET!>@FunAnn<!> ::gav)

--- a/compiler/testData/diagnostics/tests/annotations/options/targets/expr.kt
+++ b/compiler/testData/diagnostics/tests/annotations/options/targets/expr.kt
@@ -10,7 +10,7 @@ fun transform(i: Int, tr: (Int) -> Int): Int = <!WRONG_ANNOTATION_TARGET!>@base<
 @base <!WRONG_ANNOTATION_TARGET!>@special<!> fun foo(i: Int): Int {
     val j = <!WRONG_ANNOTATION_TARGET!>@base<!> @special i + 1
     if (j == 1) return foo(@special <!WRONG_ANNOTATION_TARGET!>@base<!> 42)
-    return transform(@special j, @base @special { <!ANNOTATIONS_ON_BLOCK_LEVEL_EXPRESSION_ON_THE_SAME_LINE!>@special it * 2<!> })
+    return transform(@special j, <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@base<!> @special { <!ANNOTATIONS_ON_BLOCK_LEVEL_EXPRESSION_ON_THE_SAME_LINE!>@special it * 2<!> })
 }
 
 /* GENERATED_FIR_TAGS: additiveExpression, annotationDeclaration, equalityExpression, functionDeclaration,

--- a/compiler/testData/diagnostics/tests/annotations/runtimeAnnotationOnIndyLambda.kt
+++ b/compiler/testData/diagnostics/tests/annotations/runtimeAnnotationOnIndyLambda.kt
@@ -1,0 +1,47 @@
+// RUN_PIPELINE_TILL: FRONTEND
+// LANGUAGE: +JvmIndyAllowLambdasWithAnnotations
+// WITH_STDLIB
+// ISSUE: KT-87659
+
+import kotlin.jvm.JvmSerializableLambda
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RuntimeAnn
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class BinaryAnn
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+@Retention(AnnotationRetention.SOURCE)
+annotation class SourceAnn
+
+inline fun inlineArg(x: () -> Unit) = x()
+inline fun crossinlineArg(crossinline x: () -> Unit) = { x() }
+<!NOTHING_TO_INLINE!>inline<!> fun noinlineArg(noinline x: () -> Unit) = x
+
+// Annotations are dropped by the 'invokedynamic' generation scheme.
+val lambda = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@RuntimeAnn<!> {}
+val anonymousFunction = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@RuntimeAnn<!> fun () {}
+val extensionAnonymousFunction = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@RuntimeAnn<!> fun Any.() {}
+
+// Only runtime retention matters.
+val binary = @BinaryAnn {}
+val source = @SourceAnn {}
+
+// '@JvmSerializableLambda' forces the class generation scheme.
+val serializable = @JvmSerializableLambda @RuntimeAnn {}
+
+// Suspend lambdas are always compiled to a class.
+val suspendLambda: suspend () -> Unit = @RuntimeAnn {}
+
+fun test() {
+    // Inlined lambdas are covered by NON_SOURCE_ANNOTATION_ON_INLINED_LAMBDA_EXPRESSION.
+    inlineArg <!NON_SOURCE_ANNOTATION_ON_INLINED_LAMBDA_EXPRESSION!>@RuntimeAnn<!> {}
+    crossinlineArg <!NON_SOURCE_ANNOTATION_ON_INLINED_LAMBDA_EXPRESSION!>@RuntimeAnn<!> {}
+    noinlineArg <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@RuntimeAnn<!> {}
+}
+
+/* GENERATED_FIR_TAGS: annotationDeclaration, anonymousFunction, crossinline, functionDeclaration, functionalType,
+inline, lambdaLiteral, noinline, propertyDeclaration, suspend */

--- a/compiler/testData/diagnostics/tests/annotations/runtimeAnnotationOnIndyLambdaDisabled.kt
+++ b/compiler/testData/diagnostics/tests/annotations/runtimeAnnotationOnIndyLambdaDisabled.kt
@@ -1,0 +1,14 @@
+// RUN_PIPELINE_TILL: FRONTEND
+// LANGUAGE: -JvmIndyAllowLambdasWithAnnotations
+// WITH_STDLIB
+// ISSUE: KT-87659
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RuntimeAnn
+
+// With the feature disabled, annotated lambdas are compiled to a class, so nothing is reported.
+val lambda = @RuntimeAnn {}
+val anonymousFunction = @RuntimeAnn fun () {}
+
+/* GENERATED_FIR_TAGS: annotationDeclaration, anonymousFunction, lambdaLiteral, propertyDeclaration */

--- a/compiler/testData/diagnostics/tests/contextParameters/declarationAndUsages/contextualAnonymousFunction.kt
+++ b/compiler/testData/diagnostics/tests/contextParameters/declarationAndUsages/contextualAnonymousFunction.kt
@@ -8,11 +8,11 @@ fun runWithA(block: context(String) () -> Unit) {
 }
 
 val t = context(a: A) fun () { a }
-val t2 = @Ann context(a: A) fun () { a }
+val t2 = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@Ann<!> context(a: A) fun () { a }
 
 fun foo() {
     val t = context(a: A) fun () { a }
-    val t2 = @Ann context(a: A) fun () { a }
+    val t2 = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@Ann<!> context(a: A) fun () { a }
     runWithA(context(a: String) fun () { a })
 }
 

--- a/compiler/testData/diagnostics/tests/declarationChecks/FunctionWithMissingNames.kt
+++ b/compiler/testData/diagnostics/tests/declarationChecks/FunctionWithMissingNames.kt
@@ -22,7 +22,7 @@ fun outerFun() {
     fun () {}
     fun B.() {}
 
-    @a fun () {}
+    <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@a<!> fun () {}
     fun @a A.() {}
 }
 

--- a/compiler/testData/diagnostics/tests/functionAsExpression/Common.kt
+++ b/compiler/testData/diagnostics/tests/functionAsExpression/Common.kt
@@ -10,7 +10,7 @@ class A
 val withoutName = fun () {}
 val extensionWithoutName = fun A.() {}
 
-fun withAnnotation() = @ann(ok) fun () {}
+fun withAnnotation() = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@ann(ok)<!> fun () {}
 val withReturn = fun (): Int { return 5}
 val withExpression = fun() = 5
 val funfun = fun() = fun() = 5

--- a/compiler/testData/diagnostics/tests/functionAsExpression/WithoutBody.kt
+++ b/compiler/testData/diagnostics/tests/functionAsExpression/WithoutBody.kt
@@ -9,7 +9,7 @@ fun bar(a: Any) = <!NON_MEMBER_FUNCTION_NO_BODY!>fun ()<!>
 fun outer() {
     bar(<!NON_MEMBER_FUNCTION_NO_BODY!>fun ()<!>)
     bar(l@ <!NON_MEMBER_FUNCTION_NO_BODY!>fun ()<!>)
-    bar(@ann <!NON_MEMBER_FUNCTION_NO_BODY!>fun ()<!>)
+    bar(<!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@ann<!> <!NON_MEMBER_FUNCTION_NO_BODY!>fun ()<!>)
 }
 
 /* GENERATED_FIR_TAGS: annotationDeclaration, anonymousFunction, functionDeclaration, propertyDeclaration */

--- a/core/compiler.common.jvm/src/org/jetbrains/kotlin/name/JvmStandardClassIds.kt
+++ b/core/compiler.common.jvm/src/org/jetbrains/kotlin/name/JvmStandardClassIds.kt
@@ -45,6 +45,9 @@ object JvmStandardClassIds {
     val JVM_SERIALIZABLE_LAMBDA_ANNOTATION_FQ_NAME = FqName("kotlin.jvm.JvmSerializableLambda")
 
     @JvmField
+    val JVM_SERIALIZABLE_LAMBDA_ANNOTATION_CLASS_ID = ClassId.topLevel(JVM_SERIALIZABLE_LAMBDA_ANNOTATION_FQ_NAME)
+
+    @JvmField
     val JVM_SYNTHETIC_ANNOTATION_FQ_NAME = FqName("kotlin.jvm.JvmSynthetic")
 
     @JvmField

--- a/plugins/plugin-sandbox/testData/diagnostics/functionalTypes/inference.kt
+++ b/plugins/plugin-sandbox/testData/diagnostics/functionalTypes/inference.kt
@@ -6,15 +6,15 @@ fun <T : suspend () -> Unit> suspendId(f: T): T = f
 fun <T : @MyInlineable () -> Unit> InlineableId(f: T): T = f
 
 fun test_1() {
-    <!DEBUG_INFO_EXPRESSION_TYPE("some.MyInlineableFunction0<kotlin.Unit>")!>id(@MyInlineable {})<!>
-    val f: () -> Unit = id(@MyInlineable <!ARGUMENT_TYPE_MISMATCH!>{}<!>) // should be an error
+    <!DEBUG_INFO_EXPRESSION_TYPE("some.MyInlineableFunction0<kotlin.Unit>")!>id(<!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> {})<!>
+    val f: () -> Unit = id(<!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> <!ARGUMENT_TYPE_MISMATCH!>{}<!>) // should be an error
     <!DEBUG_INFO_EXPRESSION_TYPE("@MyInlineable() some.MyInlineableFunction0<kotlin.Unit>")!>InlineableId({})<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("@MyInlineable() some.MyInlineableFunction0<kotlin.Unit>")!>InlineableId(@MyInlineable {})<!>
-    <!DEBUG_INFO_EXPRESSION_TYPE("suspend () -> kotlin.Unit")!>suspendId(@MyInlineable <!ARGUMENT_TYPE_MISMATCH!>{}<!>)<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("@MyInlineable() some.MyInlineableFunction0<kotlin.Unit>")!>InlineableId(<!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> {})<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("suspend () -> kotlin.Unit")!>suspendId(<!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> <!ARGUMENT_TYPE_MISMATCH!>{}<!>)<!>
 }
 
 fun test_2() {
-    <!DEBUG_INFO_EXPRESSION_TYPE("some.MyInlineableFunction0<kotlin.String>")!>select(@MyInlineable { "a" }, { "b" })<!>
+    <!DEBUG_INFO_EXPRESSION_TYPE("some.MyInlineableFunction0<kotlin.String>")!>select(<!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> { "a" }, { "b" })<!>
 }
 
 /* GENERATED_FIR_TAGS: capturedType, checkNotNullCall, functionDeclaration, functionalType, integerLiteral,

--- a/plugins/plugin-sandbox/testData/diagnostics/functionalTypes/simple.kt
+++ b/plugins/plugin-sandbox/testData/diagnostics/functionalTypes/simple.kt
@@ -8,21 +8,21 @@ fun test_1() {
     val l0 = {}
     val l1: some.MyInlineableFunction0<Unit> = {}
     val l2: @MyInlineable (() -> Unit) = {}
-    val l3 = @MyInlineable {}
+    val l3 = <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> {}
 
     runUsual(l0) // ok
     runUsual(<!ARGUMENT_TYPE_MISMATCH!>l1<!>) // error
     runUsual(<!ARGUMENT_TYPE_MISMATCH!>l2<!>) // error
     runUsual(<!ARGUMENT_TYPE_MISMATCH!>l3<!>) // error
     runUsual {} // ok
-    runUsual @MyInlineable <!ARGUMENT_TYPE_MISMATCH!>{}<!> // error
+    runUsual <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> <!ARGUMENT_TYPE_MISMATCH!>{}<!> // error
 
     runInlineable(l0) // ok
     runInlineable(l1) // ok
     runInlineable(l2) // ok
     runInlineable(l3) // ok
     runInlineable {} // ok
-    runInlineable @MyInlineable {} // ok
+    runInlineable <!RUNTIME_ANNOTATION_ON_LAMBDA_IS_NOT_RETAINED!>@MyInlineable<!> {} // ok
 }
 
 fun runInlineable2(block: some.MyInlineableFunction1<String, Int>) {}


### PR DESCRIPTION
Non-serializable lambdas drop the annotations, which leads to bugs if frameworks read the annotations in runtime.
 #KT-87659 Fixed