### PR TITLE
[NI] Disable default test task

### DIFF
--- a/prepare/compiler-native-image/build.gradle.kts
+++ b/prepare/compiler-native-image/build.gradle.kts
@@ -188,6 +188,11 @@ projectTests {
     withMockJdkRuntime()
 }
 
+// Disable default test task to not interfere with compiler tests
+tasks.test {
+    enabled = false
+}
+
 val currentOs = OperatingSystem.current()
 
 val generateBundledPluginsInfo = tasks.register("generateBundledPluginsInfo") {


### PR DESCRIPTION
Default test task can interfere with other compiler tests (e.g. when running them via devkit plugin) causing a build failure. This commit disables the default test task, so native image tests can only be executed intentionally

Note: this is a non-functional change, so I don't think we need a YT ticket for that. But I can create one if you think it would be better to document the change