### PR TITLE
[KT-88504] Gradle Integration Tests Gradle Kotlin JS with Browser tests (Windows) fails after Gradle 9.7 Bump

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/js/JsBrowserTestsIT.kt
@@ -33,7 +33,7 @@ class JsBrowserTestsIT : KGPBaseTest() {
             gradleVersion = gradleVersion,
             buildOptions = defaultBuildOptions.copy(
                 logLevel = LogLevel.DEBUG,
-            )
+            ).disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
         ) {
             addKgpToBuildScriptCompilationClasspath()
             buildScriptInjection {
@@ -166,6 +166,7 @@ class JsBrowserTestsIT : KGPBaseTest() {
         project(
             "empty",
             gradleVersion = gradleVersion,
+            buildOptions = defaultBuildOptions.disableIsolatedProjectsBecauseOfJsAndWasmKT75899()
         ) {
             plugins {
                 kotlin("multiplatform")


### PR DESCRIPTION
- Add disableIsolatedProjectsBecauseOfJsAndWasmKT75899() for failing test cases.
- Moved from https://github.com/JetBrains/kotlin/pull/7428
^KT-88504