### PR TITLE
Native: use new lowering phase creation API

### DIFF
--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/ArrayConstructorLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/ArrayConstructorLowering.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.LoweringContext
 import org.jetbrains.kotlin.backend.common.ir.asInlinable
 import org.jetbrains.kotlin.backend.common.ir.inline
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
@@ -22,6 +23,7 @@ import org.jetbrains.kotlin.util.OperatorNameConventions
 /**
  * Transforms `Array(size) { index -> value }` into a loop.
  */
+@PhasePrerequisites(UpgradeCallableReferences::class)
 class ArrayConstructorLowering(private val context: LoweringContext) : BodyLoweringPass {
     override fun lower(irBody: IrBody, container: IrDeclaration) {
         irBody.transformChildrenVoid(ArrayConstructorTransformer(context, container as IrSymbolOwner))

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/FinallyBlocksLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/FinallyBlocksLowering.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.name.Name
 val FINALLY_EXPRESSION by IrStatementOriginImpl
 val SYNTHETIC_CATCH_FOR_FINALLY_EXPRESSION by IrStatementOriginImpl
 
-class FinallyBlocksLowering(val context: CommonBackendContext, private val throwableType: IrType): FileLoweringPass, IrElementTransformerVoidWithContext() {
+open class FinallyBlocksLowering(val context: CommonBackendContext, private val throwableType: IrType): FileLoweringPass, IrElementTransformerVoidWithContext() {
 
     private interface HighLevelJump {
         fun toIr(context: CommonBackendContext, startOffset: Int, endOffset: Int, value: IrExpression): IrExpression

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InventNamesForLocalFunctions.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/InventNamesForLocalFunctions.kt
@@ -259,7 +259,7 @@ private class ScopeWithCounter(val irElement: IrElement) {
     val usedLocalFunctionNames: MutableSet<Name> = hashSetOf()
 }
 
-class KlibInventNamesForLocalFunctions(
+open class KlibInventNamesForLocalFunctions(
     override val suggestUniqueNames: Boolean = true,
 ) : InventNamesForLocalFunctions() {
     override val compatibilityModeForInlinedLocalDelegatedPropertyAccessors get() = false

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/LocalDeclarationsLowering.kt
@@ -761,6 +761,23 @@ open class LocalDeclarationsLowering(
             localClassConstructors.values.forEach {
                 createTransformedConstructorDeclaration(it)
             }
+
+            // Transformed local functions replace their originals in the IR tree during `rewriteDeclarations()`,
+            // so parents captured from the original declarations must be remapped to the transformed ones.
+            // Otherwise declarations nested inside a transformed function keep dangling references to the replaced
+            // original until `LocalDeclarationPopupLowering` moves them to their final container.
+            patchParents()
+        }
+
+        private fun patchParents() {
+            localFunctions.values.forEach {
+                val newDeclaration = it.transformedDeclaration
+                (newDeclaration.parent as? IrFunction)?.transformed?.let { newParent -> newDeclaration.parent = newParent }
+            }
+            localClasses.values.forEach {
+                val declaration = it.declaration
+                (declaration.parent as? IrFunction)?.transformed?.let { newParent -> declaration.parent = newParent }
+            }
         }
 
         /**

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/SharedVariablesPrimitiveBoxSpecializationLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/SharedVariablesPrimitiveBoxSpecializationLowering.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * of primitive types.
  */
 @PhasePrerequisites(SharedVariablesLowering::class)
-class SharedVariablesPrimitiveBoxSpecializationLowering(
+open class SharedVariablesPrimitiveBoxSpecializationLowering(
     private val context: CommonBackendContext,
     private val symbols: BackendKlibSymbols,
 ) : BodyLoweringPass {

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/StringConcatenationLowering.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/StringConcatenationLowering.kt
@@ -18,6 +18,8 @@ package org.jetbrains.kotlin.backend.common.lower
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.lower.loops.ForLoopsLowering
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.utils.atMostOne
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
@@ -36,6 +38,7 @@ import org.jetbrains.kotlin.name.Name
 /**
  * This lowering pass replaces [IrStringConcatenation]s with StringBuilder appends.
  */
+@PhasePrerequisites(FlattenStringConcatenationLowering::class, ForLoopsLowering::class)
 class StringConcatenationLowering(context: CommonBackendContext) : FileLoweringPass, IrBuildingTransformer(context) {
     override fun lower(irFile: IrFile) {
         irFile.transformChildrenVoid(this)

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/LocalClasses.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/inline/LocalClasses.kt
@@ -9,7 +9,9 @@ import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.LoweringContext
 import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationPopupLowering
 import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationsLowering
+import org.jetbrains.kotlin.backend.common.lower.SharedVariablesLowering
 import org.jetbrains.kotlin.backend.common.lower.VisibilityPolicy
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
@@ -38,6 +40,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  *    are copied. But the compiler could optimize the usage of some local classes and not copy them.
  *    So in this case all local classes MIGHT BE COPIED.
  */
+@PhasePrerequisites(SharedVariablesLowering::class)
 class LocalClassesInInlineLambdasLowering(val context: LoweringContext) : BodyLoweringPass {
     override fun lower(irFile: IrFile) {
         runOnFilePostfix(irFile)

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/IrValidationPhase.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/IrValidationPhase.kt
@@ -41,7 +41,7 @@ abstract class IrValidationPhase<Context : LoweringContext>(val context: Context
     }
 }
 
-class IrValidationAfterInliningPrivateFunctionsKlibPhase<Context : LoweringContext>(
+open class IrValidationAfterInliningPrivateFunctionsKlibPhase<Context : LoweringContext>(
     context: Context,
     private val checkInlineFunctionCallSites: InlineFunctionUseSiteChecker,
 ) : IrValidationPhase<Context>(context) {
@@ -69,7 +69,7 @@ class IrValidationAfterInliningAllFunctionsKlibFirstStagePhase<Context : Lowerin
             .withoutCheckersByName(context.configuration.disableIrCheckers)
 }
 
-class IrValidationAfterInliningAllFunctionsKlibSecondStagePhase<Context : LoweringContext>(
+open class IrValidationAfterInliningAllFunctionsKlibSecondStagePhase<Context : LoweringContext>(
     context: Context,
     private val checkInlineFunctionCallSites: InlineFunctionUseSiteChecker? = null,
 ) : IrValidationPhase<Context>(context) {

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseFactories.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseFactories.kt
@@ -36,12 +36,6 @@ fun <Context : LoweringContext> createModulePhases(
     }
 }
 
-fun <Context : LoweringContext> createModulePhase(
-    phase: ((Context) -> ModuleLoweringPass),
-    actions: Set<Action<IrElement, Context>> = DEFAULT_IR_ACTIONS,
-): NamedCompilerPhase<Context, IrModuleFragment, IrModuleFragment> =
-    ModuleLoweringPhase(phase.extractReturnTypeArgument(), phase, actions)
-
 private inline fun <ReturnType, reified FunctionType : Function<ReturnType>>
         FunctionType.extractReturnTypeArgument(): Class<out ReturnType> {
     // Using Java reflection to extract the generic type argument from the function type.

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseFactories.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseFactories.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.common.phaser
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.LoweringContext
 import org.jetbrains.kotlin.backend.common.ModuleLoweringPass
+import org.jetbrains.kotlin.config.phaser.Action
 import org.jetbrains.kotlin.config.phaser.ActionState
 import org.jetbrains.kotlin.config.phaser.NamedCompilerPhase
 import org.jetbrains.kotlin.config.phaser.PhaseConfig
@@ -18,18 +19,20 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import java.lang.reflect.ParameterizedType
 
 fun <Context : LoweringContext> createFilePhases(
-    vararg phases: ((Context) -> FileLoweringPass)?
+    vararg phases: ((Context) -> FileLoweringPass)?,
+    actions: Set<Action<IrElement, Context>> = DEFAULT_IR_ACTIONS,
 ): List<NamedCompilerPhase<Context, IrFile, IrFile>> {
     return phases.filterNotNull().map { phase ->
-        FileLoweringPhase(phase.extractReturnTypeArgument(), phase)
+        FileLoweringPhase(phase.extractReturnTypeArgument(), phase, actions)
     }
 }
 
 fun <Context : LoweringContext> createModulePhases(
-    vararg phases: ((Context) -> ModuleLoweringPass)?
+    vararg phases: ((Context) -> ModuleLoweringPass)?,
+    actions: Set<Action<IrElement, Context>> = DEFAULT_IR_ACTIONS,
 ): List<NamedCompilerPhase<Context, IrModuleFragment, IrModuleFragment>> {
     return phases.filterNotNull().map { phase ->
-        ModuleLoweringPhase(phase.extractReturnTypeArgument(), phase)
+        ModuleLoweringPhase(phase.extractReturnTypeArgument(), phase, actions)
     }
 }
 
@@ -52,7 +55,8 @@ private inline fun <ReturnType, reified FunctionType : Function<ReturnType>>
 private class FileLoweringPhase<Context : LoweringContext>(
     loweringClass: Class<out FileLoweringPass>,
     createLoweringPass: (Context) -> FileLoweringPass,
-) : LoweringPhase<Context, IrFile, FileLoweringPass>(loweringClass, createLoweringPass) {
+    actions: Set<Action<IrElement, Context>>,
+) : LoweringPhase<Context, IrFile, FileLoweringPass>(loweringClass, createLoweringPass, actions) {
     override fun phaseBody(context: Context, input: IrFile): IrFile {
         createLoweringPass(context).lower(input)
         return input
@@ -62,7 +66,8 @@ private class FileLoweringPhase<Context : LoweringContext>(
 private class ModuleLoweringPhase<Context : LoweringContext>(
     loweringClass: Class<out ModuleLoweringPass>,
     createLoweringPass: (Context) -> ModuleLoweringPass,
-) : LoweringPhase<Context, IrModuleFragment, ModuleLoweringPass>(loweringClass, createLoweringPass) {
+    actions: Set<Action<IrElement, Context>>,
+) : LoweringPhase<Context, IrModuleFragment, ModuleLoweringPass>(loweringClass, createLoweringPass, actions) {
     override fun phaseBody(context: Context, input: IrModuleFragment): IrModuleFragment {
         createLoweringPass(context).lower(input)
         return input
@@ -72,10 +77,11 @@ private class ModuleLoweringPhase<Context : LoweringContext>(
 abstract class LoweringPhase<Context : LoweringContext, Input : IrElement, Pass : ModuleLoweringPass>(
     val loweringClass: Class<out Pass>,
     protected val createLoweringPass: (Context) -> Pass,
+    actions: Set<Action<IrElement, Context>>,
 ) : NamedCompilerPhase<Context, Input, Input>(
     loweringClass.simpleName,
-    preactions = DEFAULT_IR_ACTIONS,
-    postactions = DEFAULT_IR_ACTIONS.map { f ->
+    preactions = actions,
+    postactions = actions.map { f ->
         fun(actionState: ActionState, data: Pair<Input, Input>, context: Context) = f(actionState, data.second, context)
     }.toSet(),
 ) {

--- a/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseFactories.kt
+++ b/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/phaser/PhaseFactories.kt
@@ -36,6 +36,12 @@ fun <Context : LoweringContext> createModulePhases(
     }
 }
 
+fun <Context : LoweringContext> createModulePhase(
+    phase: ((Context) -> ModuleLoweringPass),
+    actions: Set<Action<IrElement, Context>> = DEFAULT_IR_ACTIONS,
+): NamedCompilerPhase<Context, IrModuleFragment, IrModuleFragment> =
+    ModuleLoweringPhase(phase.extractReturnTypeArgument(), phase, actions)
+
 private inline fun <ReturnType, reified FunctionType : Function<ReturnType>>
         FunctionType.extractReturnTypeArgument(): Class<out ReturnType> {
     // Using Java reflection to extract the generic type argument from the function type.

--- a/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeCompilationConfig.kt
+++ b/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeCompilationConfig.kt
@@ -7,7 +7,9 @@ package org.jetbrains.kotlin.backend.konan
 
 import org.jetbrains.kotlin.backend.common.LoadedNativeKlibs
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.metadataKlib
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.konan.config.NativeConfigurationKeys
 import org.jetbrains.kotlin.konan.config.konanFriendLibraries
 import org.jetbrains.kotlin.konan.config.konanIncludedBinaries
@@ -70,3 +72,15 @@ interface NativeCompilationConfig {
     val outputPath: String
         get() = configuration.konanOutputPath?.removeSuffixIfPresent(produce.suffix(target)) ?: produce.visibleName
 }
+
+/**
+ * Modules that are compiled from sources in the current compilation:
+ * the module being compiled plus the modules of the included (`-Xinclude`) libraries.
+ *
+ * Set by the frontend phase of the second compilation stage; absent during the first (src -> klib) stage.
+ */
+val SOURCES_MODULES = CompilerConfigurationKey.create<Set<ModuleDescriptor>>("SOURCES_MODULES")
+
+var CompilerConfiguration.sourcesModules: Set<ModuleDescriptor>?
+    get() = get(SOURCES_MODULES)
+    set(value) { put(SOURCES_MODULES, requireNotNull(value) { "nullable values are not allowed" }) }

--- a/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -22,73 +22,24 @@ import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.builders.IrStatementsBuilder
+import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.builders.declarations.buildClass
+import org.jetbrains.kotlin.ir.builders.declarations.buildConstructor
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
-import org.jetbrains.kotlin.ir.builders.irBlock
-import org.jetbrains.kotlin.ir.builders.irBlockBody
-import org.jetbrains.kotlin.ir.builders.irBoolean
-import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
-import org.jetbrains.kotlin.ir.builders.irGet
-import org.jetbrains.kotlin.ir.builders.irGetObjectValue
-import org.jetbrains.kotlin.ir.builders.irReturn
-import org.jetbrains.kotlin.ir.builders.irString
-import org.jetbrains.kotlin.ir.builders.irTemporary
-import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.declarations.IrConstructor
-import org.jetbrains.kotlin.ir.declarations.IrDeclarationOriginImpl
-import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
-import org.jetbrains.kotlin.ir.declarations.IrEnumEntry
-import org.jetbrains.kotlin.ir.declarations.IrFile
-import org.jetbrains.kotlin.ir.declarations.IrFunction
-import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
-import org.jetbrains.kotlin.ir.declarations.IrParameterKind
-import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
-import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
-import org.jetbrains.kotlin.ir.declarations.moduleDescriptor
-import org.jetbrains.kotlin.ir.declarations.name
+import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetEnumValueImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrEnumEntrySymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
-import org.jetbrains.kotlin.ir.symbols.impl.IrClassSymbolImpl
-import org.jetbrains.kotlin.ir.symbols.impl.IrConstructorSymbolImpl
-import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
-import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.IrTypeSubstitutor
-import org.jetbrains.kotlin.ir.types.classifierOrNull
-import org.jetbrains.kotlin.ir.types.isBoolean
-import org.jetbrains.kotlin.ir.types.isString
-import org.jetbrains.kotlin.ir.types.isUnit
-import org.jetbrains.kotlin.ir.types.starProjectedType
-import org.jetbrains.kotlin.ir.types.typeWith
-import org.jetbrains.kotlin.ir.types.typeWithArguments
-import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
-import org.jetbrains.kotlin.ir.util.SetDeclarationsParentVisitor
-import org.jetbrains.kotlin.ir.util.addChild
-import org.jetbrains.kotlin.ir.util.addFakeOverrides
-import org.jetbrains.kotlin.ir.util.classId
-import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.ir.util.createDispatchReceiverParameterWithClassParent
-import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
-import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
-import org.jetbrains.kotlin.ir.util.hasAnnotation
-import org.jetbrains.kotlin.ir.util.hasShape
-import org.jetbrains.kotlin.ir.util.isFakeOverride
-import org.jetbrains.kotlin.ir.util.isFunction
-import org.jetbrains.kotlin.ir.util.isInterface
-import org.jetbrains.kotlin.ir.util.parentAsClass
-import org.jetbrains.kotlin.ir.util.render
-import org.jetbrains.kotlin.ir.util.simpleFunctions
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.load.kotlin.PackagePartClassUtils
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import kotlin.collections.plus
 
 class TestProcessor(
     private val context: LoweringContext,
@@ -396,37 +347,28 @@ class TestProcessor(
         objectSymbol: IrClassSymbol,
         owner: IrClass,
         getterName: Name,
-    ): IrSimpleFunction =
-        context.irFactory.createSimpleFunction(
-            owner.startOffset,
-            owner.endOffset,
-            TEST_SUITE_GENERATED_MEMBER,
-            getterName,
-            DescriptorVisibilities.PROTECTED,
-            isInline = false,
-            isExpect = false,
-            objectSymbol.starProjectedType,
-            Modality.FINAL,
-            IrSimpleFunctionSymbolImpl(),
-            isTailrec = false,
-            isSuspend = false,
-            isOperator = false,
-            isInfix = false,
-        ).apply {
-            parent = owner
+    ) = context.irFactory.buildFun {
+        startOffset = owner.startOffset
+        endOffset = owner.endOffset
+        origin = TEST_SUITE_GENERATED_MEMBER
+        name = getterName
+        visibility = DescriptorVisibilities.PROTECTED
+        returnType = objectSymbol.starProjectedType
+    }.apply {
+        parent = owner
 
-            val superFunction = baseClassSuite.simpleFunctions()
-                .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
+        val superFunction = baseClassSuite.simpleFunctions()
+            .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
 
-            parameters += createDispatchReceiverParameterWithClassParent()
-            overriddenSymbols += superFunction.symbol
+        parameters += createDispatchReceiverParameterWithClassParent()
+        overriddenSymbols += superFunction.symbol
 
-            body = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset).irBlockBody {
-                +irReturn(
-                    irGetObjectValue(objectSymbol.typeWithArguments(emptyList()), objectSymbol)
-                )
-            }
+        body = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset).irBlockBody {
+            +irReturn(
+                irGetObjectValue(objectSymbol.typeWithArguments(emptyList()), objectSymbol)
+            )
         }
+    }
 
     /**
      * Builds a method in `[testSuite]` class with name `[getterName]`
@@ -436,36 +378,27 @@ class TestProcessor(
         classSymbol: IrClassSymbol,
         owner: IrClass,
         getterName: Name,
-    ): IrSimpleFunction =
-        context.irFactory.createSimpleFunction(
-            owner.startOffset,
-            owner.endOffset,
-            TEST_SUITE_GENERATED_MEMBER,
-            getterName,
-            DescriptorVisibilities.PROTECTED,
-            isInline = false,
-            isExpect = false,
-            classSymbol.starProjectedType,
-            Modality.FINAL,
-            IrSimpleFunctionSymbolImpl(),
-            isTailrec = false,
-            isSuspend = false,
-            isOperator = false,
-            isInfix = false,
-        ).apply {
-            parent = owner
+    ) = context.irFactory.buildFun {
+        startOffset = owner.startOffset
+        endOffset = owner.endOffset
+        origin = TEST_SUITE_GENERATED_MEMBER
+        name = getterName
+        visibility = DescriptorVisibilities.PROTECTED
+        returnType = classSymbol.starProjectedType
+    }.apply {
+        parent = owner
 
-            val superFunction = baseClassSuite.simpleFunctions()
-                .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
+        val superFunction = baseClassSuite.simpleFunctions()
+            .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
 
-            parameters += createDispatchReceiverParameterWithClassParent()
-            overriddenSymbols += superFunction.symbol
+        parameters += createDispatchReceiverParameterWithClassParent()
+        overriddenSymbols += superFunction.symbol
 
-            body = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset).irBlockBody {
-                val constructor = classSymbol.owner.constructors.single { it.parameters.isEmpty() }
-                +irReturn(irCall(constructor))
-            }
+        body = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset).irBlockBody {
+            val constructor = classSymbol.owner.constructors.single { it.parameters.isEmpty() }
+            +irReturn(irCall(constructor))
         }
+    }
 
     private val baseClassSuiteConstructor = baseClassSuite.constructors.single {
         it.hasShape(
@@ -489,60 +422,54 @@ class TestProcessor(
         owner: IrClass,
         functions: Collection<TestFunction>,
         ignored: Boolean,
-    ): IrConstructor =
-        context.irFactory.createConstructor(
-            testSuite.owner.startOffset,
-            testSuite.owner.endOffset,
-            TEST_SUITE_GENERATED_MEMBER,
-            Name.special("<init>"),
-            DescriptorVisibilities.PUBLIC,
-            isInline = false,
-            isExpect = false,
-            testSuite.starProjectedType,
-            IrConstructorSymbolImpl(),
-            isPrimary = true,
-        ).apply {
-            parent = owner
+    ) = context.irFactory.buildConstructor {
+        startOffset = testSuite.owner.startOffset
+        endOffset = testSuite.owner.endOffset
+        origin = TEST_SUITE_GENERATED_MEMBER
+        returnType = testSuite.starProjectedType
+        isPrimary = true
+    }.apply {
+        parent = owner
 
-            fun IrClass.getFunction(name: String, predicate: (IrSimpleFunction) -> Boolean) =
-                simpleFunctions().single { it.name.asString() == name && predicate(it) }
+        fun IrClass.getFunction(name: String, predicate: (IrSimpleFunction) -> Boolean) =
+            simpleFunctions().single { it.name.asString() == name && predicate(it) }
 
-            val registerTestCase = baseClassSuite.getFunction("registerTestCase") {
-                it.parameters.size == 4
-                        && it.parameters[1].type.isString()    // name: String
-                        && it.parameters[2].type.isFunction()  // function: testClassType.() -> Unit
-                        && it.parameters[3].type.isBoolean()   // ignored: Boolean
-            }
-            val baseClassSuiteSubstitutor = IrTypeSubstitutor(
-                baseClassSuite.typeParameters.map { it.symbol },
-                listOf(testClassType, testCompanionType),
-            )
-            val registerTestCaseReturnType = baseClassSuiteSubstitutor.substitute(registerTestCase.returnType)
-            val registerFunction = baseClassSuite.getFunction("registerFunction") {
-                it.parameters.size == 3
-                        && it.parameters[1].type.isTestFunctionKind()  // kind: TestFunctionKind
-                        && it.parameters[2].type.isFunction()          // function: () -> Unit
-            }
-
-            val irBuilder = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset)
-            body = irBuilder.irBlockBody {
-                +irDelegatingConstructorCall(baseClassSuiteConstructor).apply {
-                    typeArguments[0] = testClassType
-                    typeArguments[1] = testCompanionType
-
-                    arguments[0] = irString(suiteName)
-                    arguments[1] = irBoolean(ignored)
-                }
-                generateFunctionRegistration(
-                    testSuite.owner.thisReceiver!!,
-                    registerTestCase,
-                    registerFunction,
-                    functions,
-                    this@apply,
-                    registerTestCaseReturnType,
-                )
-            }
+        val registerTestCase = baseClassSuite.getFunction("registerTestCase") {
+            it.parameters.size == 4
+                    && it.parameters[1].type.isString()    // name: String
+                    && it.parameters[2].type.isFunction()  // function: testClassType.() -> Unit
+                    && it.parameters[3].type.isBoolean()   // ignored: Boolean
         }
+        val baseClassSuiteSubstitutor = IrTypeSubstitutor(
+            baseClassSuite.typeParameters.map { it.symbol },
+            listOf(testClassType, testCompanionType),
+        )
+        val registerTestCaseReturnType = baseClassSuiteSubstitutor.substitute(registerTestCase.returnType)
+        val registerFunction = baseClassSuite.getFunction("registerFunction") {
+            it.parameters.size == 3
+                    && it.parameters[1].type.isTestFunctionKind()  // kind: TestFunctionKind
+                    && it.parameters[2].type.isFunction()          // function: () -> Unit
+        }
+
+        val irBuilder = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset)
+        body = irBuilder.irBlockBody {
+            +irDelegatingConstructorCall(baseClassSuiteConstructor).apply {
+                typeArguments[0] = testClassType
+                typeArguments[1] = testCompanionType
+
+                arguments[0] = irString(suiteName)
+                arguments[1] = irBoolean(ignored)
+            }
+            generateFunctionRegistration(
+                testSuite.owner.thisReceiver!!,
+                registerTestCase,
+                registerFunction,
+                functions,
+                this@apply,
+                registerTestCaseReturnType,
+            )
+        }
+    }
 
     private val IrClass.ignored: Boolean get() = annotations.hasAnnotation(IGNORE_FQ_NAME)
 
@@ -556,53 +483,48 @@ class TestProcessor(
         testCompanion: IrClass?,
         irFile: IrFile,
         functions: Collection<TestFunction>,
-    ): IrClass {
-        return context.irFactory.createClass(
-            testClass.startOffset,
-            testClass.endOffset,
-            TEST_SUITE_CLASS,
-            testClass.name.synthesizeSuiteClassName(),
-            DescriptorVisibilities.PRIVATE,
-            IrClassSymbolImpl(),
-            ClassKind.CLASS,
-            Modality.FINAL,
-        ).apply {
-            irFile.addChild(this)
-            createThisReceiverParameter()
+    ) = context.irFactory.buildClass {
+        startOffset = testClass.startOffset
+        endOffset = testClass.endOffset
+        origin = TEST_SUITE_CLASS
+        name = testClass.name.synthesizeSuiteClassName()
+        visibility = DescriptorVisibilities.PRIVATE
+    }.apply {
+        irFile.addChild(this)
+        createThisReceiverParameter()
 
-            val testClassType = testClass.defaultType
-            val testCompanionType = if (testClass.kind == ClassKind.OBJECT) {
-                testClassType
-            } else {
-                testCompanion?.defaultType ?: context.irBuiltIns.nothingType
-            }
-
-            val constructor = buildClassSuiteConstructor(
-                suiteName, testClassType, testCompanionType, symbol, this, functions, testClass.ignored
-            )
-
-            val instanceGetter: IrFunction
-            val companionGetter: IrFunction?
-
-            if (testClass.kind == ClassKind.OBJECT) {
-                instanceGetter = buildObjectGetter(testClass.symbol, this, INSTANCE_GETTER_NAME)
-                companionGetter = buildObjectGetter(testClass.symbol, this, COMPANION_GETTER_NAME)
-            } else {
-                instanceGetter = buildInstanceGetter(testClass.symbol, this, INSTANCE_GETTER_NAME)
-                companionGetter = testCompanion?.let {
-                    buildObjectGetter(it.symbol, this, COMPANION_GETTER_NAME)
-                }
-            }
-
-            declarations += constructor
-            declarations += instanceGetter
-            companionGetter?.let { declarations += it }
-
-            superTypes += symbols.baseClassSuite.typeWith(listOf(testClassType, testCompanionType))
-            addFakeOverrides(
-                (context as? NativePreSerializationLoweringContext)?.typeSystem ?: (context as CommonBackendContext).typeSystem
-            )
+        val testClassType = testClass.defaultType
+        val testCompanionType = if (testClass.kind == ClassKind.OBJECT) {
+            testClassType
+        } else {
+            testCompanion?.defaultType ?: context.irBuiltIns.nothingType
         }
+
+        val constructor = buildClassSuiteConstructor(
+            suiteName, testClassType, testCompanionType, symbol, this, functions, testClass.ignored
+        )
+
+        val instanceGetter: IrFunction
+        val companionGetter: IrFunction?
+
+        if (testClass.kind == ClassKind.OBJECT) {
+            instanceGetter = buildObjectGetter(testClass.symbol, this, INSTANCE_GETTER_NAME)
+            companionGetter = buildObjectGetter(testClass.symbol, this, COMPANION_GETTER_NAME)
+        } else {
+            instanceGetter = buildInstanceGetter(testClass.symbol, this, INSTANCE_GETTER_NAME)
+            companionGetter = testCompanion?.let {
+                buildObjectGetter(it.symbol, this, COMPANION_GETTER_NAME)
+            }
+        }
+
+        declarations += constructor
+        declarations += instanceGetter
+        companionGetter?.let { declarations += it }
+
+        superTypes += symbols.baseClassSuite.typeWith(listOf(testClassType, testCompanionType))
+        addFakeOverrides(
+            (context as? NativePreSerializationLoweringContext)?.typeSystem ?: (context as CommonBackendContext).typeSystem
+        )
     }
     //endregion
 

--- a/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.backend.konan.NativeBackendDiagnostics
 import org.jetbrains.kotlin.backend.konan.NativePreSerializationLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
 import org.jetbrains.kotlin.backend.konan.reportCompilationError
+import org.jetbrains.kotlin.backend.konan.sourcesModules
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
@@ -43,7 +44,6 @@ import org.jetbrains.kotlin.name.Name
 
 class TestProcessor(
     private val context: LoweringContext,
-    private val sourcesModules: Set<ModuleDescriptor>? = null,
 ) : FileLoweringPass {
     companion object {
         val TEST_SUITE_CLASS by IrDeclarationOriginImpl.Regular
@@ -69,6 +69,8 @@ class TestProcessor(
             val COMPANION_KINDS = listOf(BEFORE_CLASS, AFTER_CLASS)
         }
     }
+
+    private val sourcesModules: Set<ModuleDescriptor>? = context.configuration.sourcesModules
 
     private val symbols = context.symbols as PreSerializationNativeSymbols
 

--- a/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -129,9 +129,9 @@ class TestProcessor(
                 null
             else
                 symbols.testFunctionKind.owner.declarations
-                        .filterIsInstance<IrEnumEntry>()
-                        .single { it.name == Name.identifier(kind.runtimeKindString) }
-                        .symbol
+                    .filterIsInstance<IrEnumEntry>()
+                    .single { it.name == Name.identifier(kind.runtimeKindString) }
+                    .symbol
         }
     }
 
@@ -151,7 +151,8 @@ class TestProcessor(
 
     private fun MutableList<TestFunction>.registerFunction(
         function: IrFunction,
-        kinds: Collection<Pair<TestProcessorFunctionKind, /* ignored: */ Boolean>>) =
+        kinds: Collection<Pair<TestProcessorFunctionKind, /* ignored: */ Boolean>>,
+    ) =
         kinds.forEach { [kind, ignored] ->
             add(TestFunction(function, kind, ignored))
         }
@@ -159,7 +160,7 @@ class TestProcessor(
     private fun MutableList<TestFunction>.registerFunction(
         function: IrFunction,
         kind: TestProcessorFunctionKind,
-        ignored: Boolean
+        ignored: Boolean,
     ) = add(TestFunction(function, kind, ignored))
 
     private fun <T : IrElement> IrStatementsBuilder<T>.generateFunctionRegistration(
@@ -206,7 +207,7 @@ class TestProcessor(
     private data class TestFunction(
         val function: IrFunction,
         val kind: TestProcessorFunctionKind,
-        val ignored: Boolean
+        val ignored: Boolean,
     ) {
         val functionName: String get() = function.name.identifier
     }
@@ -219,7 +220,7 @@ class TestProcessor(
         val suiteName: String get() = suiteClassId.asFqNameString()
 
         fun registerFunction(function: IrFunction, kind: TestProcessorFunctionKind, ignored: Boolean) =
-                functions.registerFunction(function, kind, ignored)
+            functions.registerFunction(function, kind, ignored)
     }
 
     private inner class AnnotationCollector(val irFile: IrFile) : IrVisitorVoid() {
@@ -232,7 +233,7 @@ class TestProcessor(
         val topLevelSuiteName: String get() = topLevelSuiteClassId.asFqNameString()
 
         private fun MutableMap<IrClass, TestClass>.getTestClass(key: IrClass) =
-                getOrPut(key) { TestClass(key) }
+            getOrPut(key) { TestClass(key) }
 
         override fun visitElement(element: IrElement) {
             element.acceptChildrenVoid(this)
@@ -264,9 +265,11 @@ class TestProcessor(
                 }
         }
 
-        fun registerClassFunction(irClass: IrClass,
-                                  function: IrFunction,
-                                  kinds: Collection<Pair<TestProcessorFunctionKind, /* ignored: */ Boolean>>) {
+        fun registerClassFunction(
+            irClass: IrClass,
+            function: IrFunction,
+            kinds: Collection<Pair<TestProcessorFunctionKind, /* ignored: */ Boolean>>,
+        ) {
 
             fun warn(msg: String) = context.diagnosticReporter.at(function, irFile)
                 .report(NativeBackendDiagnostics.NATIVE_TEST_PROCESSOR_WARNING, msg)
@@ -307,8 +310,10 @@ class TestProcessor(
                                 testClasses.getTestClass(irClass).registerFunction(function, kind, ignored)
                             }
 
-                            else -> warn("Annotation $annotation is only allowed for methods of an object " +
-                                    "(named or companion) or top level functions")
+                            else -> warn(
+                                "Annotation $annotation is only allowed for methods of an object " +
+                                        "(named or companion) or top level functions"
+                            )
                         }
                     else -> throw IllegalStateException("Unreachable")
                 }
@@ -319,12 +324,12 @@ class TestProcessor(
             // Test runner requires test functions to have the following signature: () -> Unit.
             if (!returnType.isUnit()) {
                 context.reportCompilationError(
-                        "Test function must return Unit: $fqNameForIrSerialization", irFile, this
+                    "Test function must return Unit: $fqNameForIrSerialization", irFile, this
                 )
             }
             if (parameters.any { it.kind != IrParameterKind.DispatchReceiver }) {
                 context.reportCompilationError(
-                        "Test function must have no arguments: $fqNameForIrSerialization", irFile, this
+                    "Test function must have no arguments: $fqNameForIrSerialization", irFile, this
                 )
             }
         }
@@ -332,7 +337,7 @@ class TestProcessor(
         private fun warnAboutInheritedAnnotations(
             kind: TestProcessorFunctionKind,
             function: IrFunctionSymbol,
-            annotatedFunction: IrFunctionSymbol
+            annotatedFunction: IrFunctionSymbol,
         ) {
             if (function.owner != annotatedFunction.owner) {
                 context.diagnosticReporter.at(function.owner, irFile)
@@ -387,9 +392,10 @@ class TestProcessor(
      * Builds a method in `[owner]` class with name `[getterName]`
      * returning a reference to an object represented by `[objectSymbol]`.
      */
-    private fun buildObjectGetter(objectSymbol: IrClassSymbol,
-                                  owner: IrClass,
-                                  getterName: Name
+    private fun buildObjectGetter(
+        objectSymbol: IrClassSymbol,
+        owner: IrClass,
+        getterName: Name,
     ): IrSimpleFunction =
         context.irFactory.createSimpleFunction(
             owner.startOffset,
@@ -410,7 +416,7 @@ class TestProcessor(
             parent = owner
 
             val superFunction = baseClassSuite.simpleFunctions()
-                    .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
+                .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
 
             parameters += createDispatchReceiverParameterWithClassParent()
             overriddenSymbols += superFunction.symbol
@@ -426,9 +432,10 @@ class TestProcessor(
      * Builds a method in `[testSuite]` class with name `[getterName]`
      * returning a new instance of class referenced by [classSymbol].
      */
-    private fun buildInstanceGetter(classSymbol: IrClassSymbol,
-                                    owner: IrClass,
-                                    getterName: Name
+    private fun buildInstanceGetter(
+        classSymbol: IrClassSymbol,
+        owner: IrClass,
+        getterName: Name,
     ): IrSimpleFunction =
         context.irFactory.createSimpleFunction(
             owner.startOffset,
@@ -449,7 +456,7 @@ class TestProcessor(
             parent = owner
 
             val superFunction = baseClassSuite.simpleFunctions()
-                    .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
+                .single { it.name == getterName && it.hasShape(dispatchReceiver = true) }
 
             parameters += createDispatchReceiverParameterWithClassParent()
             overriddenSymbols += superFunction.symbol
@@ -461,10 +468,12 @@ class TestProcessor(
         }
 
     private val baseClassSuiteConstructor = baseClassSuite.constructors.single {
-        it.hasShape(regularParameters = 2, parameterTypes = listOf(
+        it.hasShape(
+            regularParameters = 2, parameterTypes = listOf(
                 context.irBuiltIns.stringType,   // name: String
                 context.irBuiltIns.booleanType   // ignored: Boolean
-        ))
+            )
+        )
     }
 
     /**
@@ -472,66 +481,68 @@ class TestProcessor(
      * method(s) annotated with @Test). The test suite class is a subclass of ClassTestSuite<T>
      * where T is the test class.
      */
-    private fun buildClassSuiteConstructor(suiteName: String,
-                                           testClassType: IrType,
-                                           testCompanionType: IrType,
-                                           testSuite: IrClassSymbol,
-                                           owner: IrClass,
-                                           functions: Collection<TestFunction>,
-                                           ignored: Boolean): IrConstructor =
-            context.irFactory.createConstructor(
-                testSuite.owner.startOffset,
-                testSuite.owner.endOffset,
-                TEST_SUITE_GENERATED_MEMBER,
-                Name.special("<init>"),
-                DescriptorVisibilities.PUBLIC,
-                isInline = false,
-                isExpect = false,
-                testSuite.starProjectedType,
-                IrConstructorSymbolImpl(),
-                isPrimary = true,
-            ).apply {
-                parent = owner
+    private fun buildClassSuiteConstructor(
+        suiteName: String,
+        testClassType: IrType,
+        testCompanionType: IrType,
+        testSuite: IrClassSymbol,
+        owner: IrClass,
+        functions: Collection<TestFunction>,
+        ignored: Boolean,
+    ): IrConstructor =
+        context.irFactory.createConstructor(
+            testSuite.owner.startOffset,
+            testSuite.owner.endOffset,
+            TEST_SUITE_GENERATED_MEMBER,
+            Name.special("<init>"),
+            DescriptorVisibilities.PUBLIC,
+            isInline = false,
+            isExpect = false,
+            testSuite.starProjectedType,
+            IrConstructorSymbolImpl(),
+            isPrimary = true,
+        ).apply {
+            parent = owner
 
-                fun IrClass.getFunction(name: String, predicate: (IrSimpleFunction) -> Boolean) =
-                        simpleFunctions().single { it.name.asString() == name && predicate(it) }
+            fun IrClass.getFunction(name: String, predicate: (IrSimpleFunction) -> Boolean) =
+                simpleFunctions().single { it.name.asString() == name && predicate(it) }
 
-                val registerTestCase = baseClassSuite.getFunction("registerTestCase") {
-                    it.parameters.size == 4
-                            && it.parameters[1].type.isString()    // name: String
-                            && it.parameters[2].type.isFunction()  // function: testClassType.() -> Unit
-                            && it.parameters[3].type.isBoolean()   // ignored: Boolean
-                }
-                val baseClassSuiteSubstitutor = IrTypeSubstitutor(
-                    baseClassSuite.typeParameters.map { it.symbol },
-                    listOf(testClassType, testCompanionType),
-                )
-                val registerTestCaseReturnType = baseClassSuiteSubstitutor.substitute(registerTestCase.returnType)
-                val registerFunction = baseClassSuite.getFunction("registerFunction") {
-                    it.parameters.size == 3
-                            && it.parameters[1].type.isTestFunctionKind()  // kind: TestFunctionKind
-                            && it.parameters[2].type.isFunction()          // function: () -> Unit
-                }
-
-                val irBuilder = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset)
-                body = irBuilder.irBlockBody {
-                    +irDelegatingConstructorCall(baseClassSuiteConstructor).apply {
-                        typeArguments[0] = testClassType
-                        typeArguments[1] = testCompanionType
-
-                        arguments[0] = irString(suiteName)
-                        arguments[1] = irBoolean(ignored)
-                    }
-                    generateFunctionRegistration(
-                            testSuite.owner.thisReceiver!!,
-                            registerTestCase,
-                            registerFunction,
-                            functions,
-                            this@apply,
-                            registerTestCaseReturnType,
-                    )
-                }
+            val registerTestCase = baseClassSuite.getFunction("registerTestCase") {
+                it.parameters.size == 4
+                        && it.parameters[1].type.isString()    // name: String
+                        && it.parameters[2].type.isFunction()  // function: testClassType.() -> Unit
+                        && it.parameters[3].type.isBoolean()   // ignored: Boolean
             }
+            val baseClassSuiteSubstitutor = IrTypeSubstitutor(
+                baseClassSuite.typeParameters.map { it.symbol },
+                listOf(testClassType, testCompanionType),
+            )
+            val registerTestCaseReturnType = baseClassSuiteSubstitutor.substitute(registerTestCase.returnType)
+            val registerFunction = baseClassSuite.getFunction("registerFunction") {
+                it.parameters.size == 3
+                        && it.parameters[1].type.isTestFunctionKind()  // kind: TestFunctionKind
+                        && it.parameters[2].type.isFunction()          // function: () -> Unit
+            }
+
+            val irBuilder = context.createIrBuilder(symbol, symbol.owner.startOffset, symbol.owner.endOffset)
+            body = irBuilder.irBlockBody {
+                +irDelegatingConstructorCall(baseClassSuiteConstructor).apply {
+                    typeArguments[0] = testClassType
+                    typeArguments[1] = testCompanionType
+
+                    arguments[0] = irString(suiteName)
+                    arguments[1] = irBoolean(ignored)
+                }
+                generateFunctionRegistration(
+                    testSuite.owner.thisReceiver!!,
+                    registerTestCase,
+                    registerFunction,
+                    functions,
+                    this@apply,
+                    registerTestCaseReturnType,
+                )
+            }
+        }
 
     private val IrClass.ignored: Boolean get() = annotations.hasAnnotation(IGNORE_FQ_NAME)
 
@@ -567,7 +578,7 @@ class TestProcessor(
             }
 
             val constructor = buildClassSuiteConstructor(
-                    suiteName, testClassType, testCompanionType, symbol, this, functions, testClass.ignored
+                suiteName, testClassType, testCompanionType, symbol, this, functions, testClass.ignored
             )
 
             val instanceGetter: IrFunction
@@ -588,24 +599,28 @@ class TestProcessor(
             companionGetter?.let { declarations += it }
 
             superTypes += symbols.baseClassSuite.typeWith(listOf(testClassType, testCompanionType))
-            addFakeOverrides((context as? NativePreSerializationLoweringContext)?.typeSystem ?: (context as CommonBackendContext).typeSystem)
+            addFakeOverrides(
+                (context as? NativePreSerializationLoweringContext)?.typeSystem ?: (context as CommonBackendContext).typeSystem
+            )
         }
     }
     //endregion
 
     // region IR generation methods
     private fun generateClassSuite(testClass: TestClass, irFile: IrFile) =
-            with(buildClassSuite(testClass.suiteName, testClass.ownerClass, testClass.companion, irFile, testClass.functions)) {
-                val irConstructor = constructors.single()
-                val irBuilder = context.createIrBuilder(irFile.symbol, testClass.ownerClass.startOffset, testClass.ownerClass.endOffset)
-                irBuilder.irCall(irConstructor)
-            }
+        with(buildClassSuite(testClass.suiteName, testClass.ownerClass, testClass.companion, irFile, testClass.functions)) {
+            val irConstructor = constructors.single()
+            val irBuilder = context.createIrBuilder(irFile.symbol, testClass.ownerClass.startOffset, testClass.ownerClass.endOffset)
+            irBuilder.irCall(irConstructor)
+        }
 
     /** Check if this fqName already used or not. */
     private fun checkTopLevelSuiteName(irFile: IrFile, topLevelSuiteName: String): Boolean {
         if (topLevelSuiteNames.contains(topLevelSuiteName)) {
-            context.reportCompilationError("Package '${irFile.packageFqName}' has top-level test " +
-                    "functions in several files with the same name: '${irFile.fileName}'")
+            context.reportCompilationError(
+                "Package '${irFile.packageFqName}' has top-level test " +
+                        "functions in several files with the same name: '${irFile.fileName}'"
+            )
         }
         topLevelSuiteNames.add(topLevelSuiteName)
         return true
@@ -641,11 +656,11 @@ class TestProcessor(
             }
             val testSuiteVal = irTemporary(constructorCall, "topLevelTestSuite")
             generateFunctionRegistration(
-                    testSuiteVal,
-                    topLevelSuiteRegisterTestCase,
-                    topLevelSuiteRegisterFunction,
-                    functions,
-                    irFile,
+                testSuiteVal,
+                topLevelSuiteRegisterTestCase,
+                topLevelSuiteRegisterFunction,
+                functions,
+                irFile,
             )
         }
     }
@@ -676,7 +691,11 @@ class TestProcessor(
         }
 
         if (annotationCollector.topLevelFunctions.isNotEmpty()) {
-            generateTopLevelSuite(irFile, annotationCollector.topLevelSuiteName, annotationCollector.topLevelFunctions)?.let { statements.add(it) }
+            generateTopLevelSuite(
+                irFile,
+                annotationCollector.topLevelSuiteName,
+                annotationCollector.topLevelFunctions
+            )?.let { statements.add(it) }
         }
 
         if (statements.isNotEmpty()) {
@@ -721,11 +740,11 @@ class TestProcessor(
     // endregion
 
     private fun shouldSkipFile(irFile: IrFile): Boolean =
-            irFile.hasAnnotation(symbols.testsProcessed)
-                    || irFile.moduleDescriptor.let {
-                // Process test annotations in source libraries too.
-                sourcesModules != null && it !in sourcesModules
-            }
+        irFile.hasAnnotation(symbols.testsProcessed)
+                || irFile.moduleDescriptor.let {
+            // Process test annotations in source libraries too.
+            sourcesModules != null && it !in sourcesModules
+        }
 
     override fun lower(irFile: IrFile) {
         // TODO: uses descriptors.

--- a/kotlin-native/backend.native/compiler/ir/backend.native/build.gradle.kts
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     compileOnly(project(":kotlin-metadata")) // Only to fix IDE reporting unresolved references (KTI-3323).
 
     testImplementation(kotlinTest("junit5"))
+    testImplementation(testFixtures(project(":compiler:ir.backend.common")))
 }
 
 projectTests {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -25,10 +25,10 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 
 // TODO: Find a better home for this function than Context.
-internal fun NativeBackendContext.getTypeConversion(actualType: IrType, expectedType: IrType): IrSimpleFunctionSymbol? =
+internal fun NativeLoweringContext.getTypeConversion(actualType: IrType, expectedType: IrType): IrSimpleFunctionSymbol? =
         getTypeConversionImpl(actualType.getInlinedClassNative(), expectedType.getInlinedClassNative())
 
-private fun NativeBackendContext.getTypeConversionImpl(
+private fun NativeLoweringContext.getTypeConversionImpl(
         actualInlinedClass: IrClass?,
         expectedInlinedClass: IrClass?
 ): IrSimpleFunctionSymbol? {
@@ -63,7 +63,7 @@ private fun IrClass.getParentAndFullName(): Pair<IrDeclarationParent, String> {
     return Pair(parent, classes.reversed().joinToString(".") { it.name.asString() })
 }
 
-internal fun NativeBackendContext.getBoxFunction(inlinedClass: IrClass): IrSimpleFunction = inlinedClass::boxFunction.getOrSetIfNull {
+internal fun NativeLoweringContext.getBoxFunction(inlinedClass: IrClass): IrSimpleFunction = inlinedClass::boxFunction.getOrSetIfNull {
     val [parent, fullName] = inlinedClass.getParentAndFullName()
     val isNullable = inlinedClass.inlinedClassIsNullable()
     val unboxedType = inlinedClass.defaultOrNullableType(isNullable)
@@ -87,7 +87,7 @@ internal fun NativeBackendContext.getBoxFunction(inlinedClass: IrClass): IrSimpl
     }
 }
 
-internal fun NativeBackendContext.getUnboxFunction(inlinedClass: IrClass): IrSimpleFunction = inlinedClass::unboxFunction.getOrSetIfNull {
+internal fun NativeLoweringContext.getUnboxFunction(inlinedClass: IrClass): IrSimpleFunction = inlinedClass::unboxFunction.getOrSetIfNull {
     val [parent, fullName] = inlinedClass.getParentAndFullName()
     val isNullable = inlinedClass.inlinedClassIsNullable()
     val unboxedType = inlinedClass.defaultOrNullableType(isNullable)
@@ -111,7 +111,7 @@ internal fun NativeBackendContext.getUnboxFunction(inlinedClass: IrClass): IrSim
     }
 }
 
-internal fun NativeBackendContext.getInlineClassFieldSetter(inlinedClass: IrClass): IrSimpleFunction = inlinedClass::inlineClassFieldSetter.getOrSetIfNull {
+internal fun NativeLoweringContext.getInlineClassFieldSetter(inlinedClass: IrClass): IrSimpleFunction = inlinedClass::inlineClassFieldSetter.getOrSetIfNull {
     val [parent, fullName] = inlinedClass.getParentAndFullName()
     val isNullable = inlinedClass.inlinedClassIsNullable()
     val unboxedType = inlinedClass.defaultOrNullableType(isNullable)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeBackendContext.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeBackendContext.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.backend.konan
 
 import llvm.LLVMTypeRef
 import org.jetbrains.kotlin.K1Deprecation
-import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.InlineClassesUtils
 import org.jetbrains.kotlin.backend.common.ir.KlibSharedVariablesManager
 import org.jetbrains.kotlin.config.LoggingContext
@@ -52,8 +51,8 @@ internal class NativeBackendContext(
         val irModules: Map<Path, IrModuleFragment>,
         val irLinker: KonanIrLinker,
         override val symbols: BackendNativeSymbols,
-        val symbolTable: ReferenceSymbolTable,
-) : BasicNativeBackendPhaseContext(config), CommonBackendContext {
+        override val symbolTable: ReferenceSymbolTable,
+) : BasicNativeBackendPhaseContext(config), NativeLoweringContext {
     override val configuration get() = config.configuration
 
     override val irFactory: IrFactory = IrFactoryImpl
@@ -66,9 +65,9 @@ internal class NativeBackendContext(
                 klass.isInlineClass(treatCompatibleFullValueClassesAsInline = true)
     }
     override val innerClassesSupport: NativeInnerClassesSupport by lazy { NativeInnerClassesSupport(irFactory) }
-    val bridgesSupport by lazy { BridgesSupport(irBuiltIns, symbols, irFactory) }
-    val enumsSupport by lazy { EnumsSupport(irBuiltIns, irFactory) }
-    val cachesAbiSupport by lazy { CachesAbiSupport(irFactory) }
+    override val bridgesSupport by lazy { BridgesSupport(irBuiltIns, symbols, irFactory) }
+    override val enumsSupport by lazy { EnumsSupport(irBuiltIns, irFactory) }
+    override val cachesAbiSupport by lazy { CachesAbiSupport(irFactory) }
 
     override val sharedVariablesManager by lazy {
         // Creating lazily because builtIns module seems to be incomplete during `link` test;

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeBackendContext.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeBackendContext.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.backend.konan.serialization.KonanPartialModuleDeseri
 import org.jetbrains.kotlin.backend.konan.serialization.TrivialGettersDeserializer
 import org.jetbrains.kotlin.builtins.konan.KonanBuiltIns
 import org.jetbrains.kotlin.cli.common.diagnosticsCollector
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.ValueClassBackendAgnosticApi
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.KtDiagnosticReporterWithImplicitIrBasedContext
@@ -47,7 +46,6 @@ private var IrClass.layoutBuilder: ClassLayoutBuilder? by irAttribute(copyByDefa
 
 internal class NativeBackendContext(
         config: NativeSecondStageCompilationConfig,
-        val sourcesModules: Set<ModuleDescriptor>,
         @OptIn(K1Deprecation::class)
         val builtIns: KonanBuiltIns,
         override val irBuiltIns: IrBuiltIns,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
@@ -6,12 +6,13 @@
 package org.jetbrains.kotlin.backend.konan
 
 import llvm.*
-import org.jetbrains.kotlin.backend.common.phaser.BackendContextHolder
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.serialization.FingerprintHash
 import org.jetbrains.kotlin.backend.common.serialization.Hash128Bits
 import org.jetbrains.kotlin.backend.konan.driver.BasicNativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.driver.utilities.LlvmIrHolder
+import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
 import org.jetbrains.kotlin.backend.konan.llvm.*
 import org.jetbrains.kotlin.backend.konan.llvm.runtime.RuntimeModule
 import org.jetbrains.kotlin.backend.konan.llvm.runtime.RuntimeModulesConfig
@@ -21,7 +22,9 @@ import org.jetbrains.kotlin.backend.konan.serialization.SerializedClassFields
 import org.jetbrains.kotlin.backend.konan.serialization.SerializedEagerInitializedFile
 import org.jetbrains.kotlin.backend.konan.serialization.SerializedInlineFunctionReference
 import org.jetbrains.kotlin.backend.konan.serialization.SerializedTrivialGetter
+import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.util.ReferenceSymbolTable
 import org.jetbrains.kotlin.konan.config.konanHome
 import org.jetbrains.kotlin.util.PerformanceManager
 
@@ -63,7 +66,7 @@ internal class NativeGenerationState(
         val outputFiles: OutputFiles,
         val llvmModuleName: String,
         override val performanceManager: PerformanceManager?,
-) : BasicNativeBackendPhaseContext(config), BackendContextHolder, LlvmIrHolder, BitcodePostProcessingContext {
+) : BasicNativeBackendPhaseContext(config), CommonBackendContext by context, LlvmIrHolder, BitcodePostProcessingContext {
     val outputFile = outputFiles.mainFileName
 
     var klibHash: FingerprintHash = FingerprintHash(Hash128Bits(0U, 0U))
@@ -117,6 +120,15 @@ internal class NativeGenerationState(
             context.inVerbosePhase = value
         }
 
+    override fun log(message: String) {
+        super<BasicNativeBackendPhaseContext>.log(message)
+    }
+
+    // Keep the phase-context reporter: the CommonBackendContext delegation would otherwise
+    // silently replace the one initialized in BasicNativeBackendPhaseContext with `context`'s.
+    override val diagnosticReporter: IrDiagnosticReporter
+        get() = super<BasicNativeBackendPhaseContext>.diagnosticReporter
+
     override fun dispose() {
         if (isDisposed) return
 
@@ -135,9 +147,14 @@ internal class NativeGenerationState(
         isDisposed = true
     }
 
-    override val heldBackendContext: NativeBackendContext
-        get() = context
-
     override val llvmModule: LLVMModuleRef
         get() = llvm.module
+
+    // CommonBackendContext is implemented by delegation to `context` (see the class header),
+    // but `symbols` needs an explicit override to narrow the type to BackendNativeSymbols.
+    override val symbols: BackendNativeSymbols
+        get() = context.symbols
+
+    val symbolTable: ReferenceSymbolTable
+        get() = context.symbolTable
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeGenerationState.kt
@@ -6,13 +6,11 @@
 package org.jetbrains.kotlin.backend.konan
 
 import llvm.*
-import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.serialization.FingerprintHash
 import org.jetbrains.kotlin.backend.common.serialization.Hash128Bits
 import org.jetbrains.kotlin.backend.konan.driver.BasicNativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.driver.utilities.LlvmIrHolder
-import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
 import org.jetbrains.kotlin.backend.konan.llvm.*
 import org.jetbrains.kotlin.backend.konan.llvm.runtime.RuntimeModule
 import org.jetbrains.kotlin.backend.konan.llvm.runtime.RuntimeModulesConfig
@@ -24,7 +22,6 @@ import org.jetbrains.kotlin.backend.konan.serialization.SerializedInlineFunction
 import org.jetbrains.kotlin.backend.konan.serialization.SerializedTrivialGetter
 import org.jetbrains.kotlin.ir.IrDiagnosticReporter
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.util.ReferenceSymbolTable
 import org.jetbrains.kotlin.konan.config.konanHome
 import org.jetbrains.kotlin.util.PerformanceManager
 
@@ -66,7 +63,7 @@ internal class NativeGenerationState(
         val outputFiles: OutputFiles,
         val llvmModuleName: String,
         override val performanceManager: PerformanceManager?,
-) : BasicNativeBackendPhaseContext(config), CommonBackendContext by context, LlvmIrHolder, BitcodePostProcessingContext {
+) : BasicNativeBackendPhaseContext(config), NativeLoweringContext by context, LlvmIrHolder, BitcodePostProcessingContext {
     val outputFile = outputFiles.mainFileName
 
     var klibHash: FingerprintHash = FingerprintHash(Hash128Bits(0U, 0U))
@@ -124,10 +121,11 @@ internal class NativeGenerationState(
         super<BasicNativeBackendPhaseContext>.log(message)
     }
 
-    // Keep the phase-context reporter: the CommonBackendContext delegation would otherwise
-    // silently replace the one initialized in BasicNativeBackendPhaseContext with `context`'s.
     override val diagnosticReporter: IrDiagnosticReporter
-        get() = super<BasicNativeBackendPhaseContext>.diagnosticReporter
+        get() = super.diagnosticReporter
+
+    override val config: NativeSecondStageCompilationConfig
+        get() = super.config
 
     override fun dispose() {
         if (isDisposed) return
@@ -149,12 +147,4 @@ internal class NativeGenerationState(
 
     override val llvmModule: LLVMModuleRef
         get() = llvm.module
-
-    // CommonBackendContext is implemented by delegation to `context` (see the class header),
-    // but `symbols` needs an explicit override to narrow the type to BackendNativeSymbols.
-    override val symbols: BackendNativeSymbols
-        get() = context.symbols
-
-    val symbolTable: ReferenceSymbolTable
-        get() = context.symbolTable
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeLoweringContext.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/NativeLoweringContext.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan
+
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
+import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
+import org.jetbrains.kotlin.backend.konan.lower.BridgesSupport
+import org.jetbrains.kotlin.backend.konan.lower.CachesAbiSupport
+import org.jetbrains.kotlin.backend.konan.lower.EnumsSupport
+import org.jetbrains.kotlin.ir.util.ReferenceSymbolTable
+
+/**
+ * The context type for Native second-stage lowerings.
+ *
+ * Implemented by both [NativeBackendContext] and (by delegation to it) [NativeGenerationState],
+ * so a lowering that needs nothing beyond [CommonBackendContext] plus the Native-specific members
+ * declared here should take this type instead of either concrete class.
+ */
+internal interface NativeLoweringContext : CommonBackendContext, NativeBackendPhaseContext {
+    override val symbols: BackendNativeSymbols
+
+    val symbolTable: ReferenceSymbolTable
+    val bridgesSupport: BridgesSupport
+    val enumsSupport: EnumsSupport
+    val cachesAbiSupport: CachesAbiSupport
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/NativeCompilerDriver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/NativeCompilerDriver.kt
@@ -166,7 +166,6 @@ internal class NativeCompilerDriver(private val performanceManager: PerformanceM
             additionalDataSetter: (NativeBackendContext) -> Unit = {}
     ) = NativeBackendContext(
             config,
-            moduleDescriptor.getIncludedLibraryDescriptors(config).toSet() + moduleDescriptor,
             moduleDescriptor.builtIns as KonanBuiltIns,
             linkKlibsOutput.irBuiltIns,
             linkKlibsOutput.irModules,

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Frontend.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/Frontend.kt
@@ -80,6 +80,8 @@ internal val FrontendPhase = createSimpleNamedCompilerPhase(
     val bindingContext = analysisResult.bindingContext
 
     if (analysisResult.shouldGenerateCode) {
+        context.config.configuration.sourcesModules =
+                moduleDescriptor.getIncludedLibraryDescriptors(context.config).toSet() + moduleDescriptor
         FrontendPhaseOutput.Full(moduleDescriptor, bindingContext, context.frontendServices)
     } else {
         FrontendPhaseOutput.ShouldNotGenerateCode

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -31,7 +31,6 @@ import org.jetbrains.kotlin.backend.konan.lower.NativeAssertionWrapperLowering
 import org.jetbrains.kotlin.backend.konan.optimizations.CastsOptimization
 import org.jetbrains.kotlin.backend.konan.optimizations.ComputeTypesPass
 import org.jetbrains.kotlin.konan.config.NativeConfigurationKeys
-import org.jetbrains.kotlin.util.PerformanceManager
 import org.jetbrains.kotlin.util.PhaseType
 import org.jetbrains.kotlin.util.tryMeasureDynamicPhaseTime
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
@@ -42,19 +41,17 @@ internal typealias ModuleLowering = NamedCompilerPhase<NativeGenerationState, Ir
 internal fun PhaseEngine<NativeGenerationState>.runLowerings(
         lowerings: LoweringList,
         module: IrModuleFragment,
-        performanceManager: PerformanceManager? = context.performanceManager,
-) = runLowerings(lowerings, listOf(module), performanceManager)
+) = runLowerings(lowerings, listOf(module))
 
 internal fun PhaseEngine<NativeGenerationState>.runLowerings(
         lowerings: LoweringList,
         modules: List<IrModuleFragment>,
-        performanceManager: PerformanceManager? = context.performanceManager,
 ) {
     for (module in modules) {
         for (file in module.files) {
             context.fileLowerState = FileLowerState()
             lowerings.fold(file) { loweredFile, lowering ->
-                performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
+                context.performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
                     try {
                         runPhase(lowering, loweredFile)
                     } catch (e: CompilationException) {
@@ -74,9 +71,8 @@ internal fun PhaseEngine<NativeGenerationState>.runLowerings(
 internal fun PhaseEngine<NativeGenerationState>.runModuleWisePhase(
         lowering: ModuleLowering,
         modules: List<IrModuleFragment>,
-        performanceManager: PerformanceManager?,
 ) {
-    performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
+    context.performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
         for (module in modules) {
             runPhase(lowering, module)
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.backend.konan.driver.phases
 
-import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.CompilationException
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.ir.util.isTypeOfIntrinsic
@@ -14,10 +13,8 @@ import org.jetbrains.kotlin.backend.common.lower.coroutines.AddContinuationToNon
 import org.jetbrains.kotlin.backend.common.lower.inline.InlineCallCycleCheckerLowering
 import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineLambdasLowering
 import org.jetbrains.kotlin.backend.common.lower.optimizations.PropertyAccessorInlineLowering
-import org.jetbrains.kotlin.backend.common.lower.optimizations.LivenessAnalysis
 import org.jetbrains.kotlin.backend.common.phaser.*
 import org.jetbrains.kotlin.backend.common.phaser.IrValidationBeforeLoweringsKlibSecondStagePhase
-import org.jetbrains.kotlin.backend.common.runOnFilePostfix
 import org.jetbrains.kotlin.backend.common.wrapWithCompilationException
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.utilities.getDefaultIrActions
@@ -26,11 +23,8 @@ import org.jetbrains.kotlin.backend.konan.lower.*
 import org.jetbrains.kotlin.backend.konan.lower.InitializersLowering
 import org.jetbrains.kotlin.backend.konan.optimizations.NativeForLoopsLowering
 import org.jetbrains.kotlin.config.phaser.NamedCompilerPhase
-import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
-import org.jetbrains.kotlin.ir.expressions.IrBody
-import org.jetbrains.kotlin.ir.expressions.IrSuspensionPoint
 import org.jetbrains.kotlin.ir.inline.*
 import org.jetbrains.kotlin.backend.konan.lower.NativeAssertionWrapperLowering
 import org.jetbrains.kotlin.backend.konan.optimizations.CastsOptimization
@@ -54,7 +48,16 @@ internal fun PhaseEngine<NativeGenerationState>.runLowerings(
             context.fileLowerState = FileLowerState()
             lowerings.fold(file) { loweredFile, lowering ->
                 performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
-                    runPhase(lowering, loweredFile)
+                    try {
+                        runPhase(lowering, loweredFile)
+                    } catch (e: CompilationException) {
+                        e.initializeFileDetails(loweredFile)
+                        throw e
+                    } catch (e: KotlinExceptionWithAttachments) {
+                        throw e
+                    } catch (e: Throwable) {
+                        throw e.wrapWithCompilationException("Internal error in file lowering", loweredFile, null)
+                    }
                 }
             }
         }
@@ -123,253 +126,6 @@ internal val functionsWithoutBoundCheck = createSimpleNamedCompilerPhase<NativeB
         op = { context, _ -> FunctionsWithoutBoundCheckGenerator(context).generate() }
 )
 
-private val removeExpectDeclarationsPhase = createFileLoweringPhase(
-        ::ExpectDeclarationsRemoveLowering,
-        name = "RemoveExpectDeclarations",
-)
-
-private val stripTypeAliasDeclarationsPhase = createFileLoweringPhase(
-        ::StripTypeAliasDeclarationsLowering,
-        name = "StripTypeAliasDeclarations",
-)
-
-private val annotationImplementationPhase = createFileLoweringPhase(
-        ::NativeAnnotationImplementationLowering,
-        name = "AnnotationImplementation",
-)
-
-
-private val upgradeCallableReferencesPhase = createFileLoweringPhase(
-        ::UpgradeCallableReferences,
-        name = "UpgradeCallableReferences",
-)
-
-private val arrayConstructorPhase = createFileLoweringPhase(
-        ::ArrayConstructorLowering,
-        name = "ArrayConstructor",
-        prerequisite = setOf(upgradeCallableReferencesPhase)
-)
-
-private val lateinitPhase = createFileLoweringPhase(
-        ::LateinitLowering,
-        name = "Lateinit",
-)
-
-private val sharedVariablesPhase = createFileLoweringPhase(
-        ::SharedVariablesLowering,
-        name = "SharedVariables",
-        prerequisite = setOf(lateinitPhase)
-)
-
-private val extractLocalClassesFromInlineBodies = createFileLoweringPhase(
-        ::LocalClassesInInlineLambdasLowering,
-        name = "ExtractLocalClassesFromInlineBodies",
-        prerequisite = setOf(sharedVariablesPhase),
-)
-
-private val postInlinePhase = createFileLoweringPhase(
-        { context: NativeBackendContext -> PostInlineLowering(context) },
-        name = "PostInline",
-)
-
-private val contractsDslRemovePhase = createFileLoweringPhase(
-        { context: NativeBackendContext -> ContractsDslRemover(context) },
-        name = "RemoveContractsDsl",
-)
-
-private val forLoopsPhase = createFileLoweringPhase(
-        ::NativeForLoopsLowering,
-        name = "ForLoops",
-        prerequisite = setOf(functionsWithoutBoundCheck)
-)
-
-private val flattenStringConcatenationPhase = createFileLoweringPhase(
-        ::FlattenStringConcatenationLowering,
-        name = "FlattenStringConcatenationLowering",
-)
-
-private val stringConcatenationPhase = createFileLoweringPhase(
-        ::StringConcatenationLowering,
-        name = "StringConcatenation",
-        prerequisite = setOf(flattenStringConcatenationPhase, forLoopsPhase)
-)
-
-private val stringConcatenationTypeNarrowingPhase = createFileLoweringPhase(
-        ::StringConcatenationTypeNarrowing,
-        name = "StringConcatenationTypeNarrowing",
-        prerequisite = setOf(stringConcatenationPhase)
-)
-
-private val kotlinNothingValueExceptionPhase = createFileLoweringPhase(
-        ::KotlinNothingValueExceptionLowering,
-        name = "KotlinNothingValueException",
-)
-
-private val enumConstructorsPhase = createFileLoweringPhase(
-        ::EnumConstructorsLowering,
-        name = "EnumConstructors",
-)
-
-private val initializersPhase = createFileLoweringPhase(
-        ::InitializersLowering,
-        name = "Initializers",
-        prerequisite = setOf(enumConstructorsPhase)
-)
-
-private val inventNamesForInteropBridgesPhase = createFileLoweringPhase(
-        lowering = ::InteropBridgesNameInventor,
-        name = "InventNameForInteropBridges",
-)
-
-private val localFunctionsPhase = createFileLoweringPhase(
-        op = { context, irFile ->
-            LocalDelegatedPropertiesLowering(context).lower(irFile)
-            LocalDeclarationsLowering(context).lower(irFile)
-            LocalDeclarationPopupLowering(context).lower(irFile)
-        },
-        name = "LocalFunctions",
-        prerequisite = setOf(sharedVariablesPhase, inventNamesForInteropBridgesPhase) // TODO: add "soft" dependency on inventNamesForLocalClasses
-)
-
-private val tailrecPhase = createFileLoweringPhase(
-        ::TailrecLowering,
-        name = "Tailrec",
-        prerequisite = setOf(localFunctionsPhase)
-)
-
-private val volatilePhase = createFileLoweringPhase(
-        ::VolatileFieldsLowering,
-        name = "VolatileFields",
-        prerequisite = setOf()
-)
-
-private val defaultParameterExtentPhase = createFileLoweringPhase(
-        { context, irFile ->
-            NativeDefaultArgumentStubGenerator(context).lower(irFile)
-            DefaultParameterCleaner(context, replaceDefaultValuesWithStubs = true).lower(irFile)
-            NativeDefaultParameterInjector(context).lower(irFile)
-        },
-        name = "DefaultParameterExtent",
-        prerequisite = setOf(tailrecPhase, enumConstructorsPhase)
-)
-
-private val innerClassPhase = createFileLoweringPhase(
-        ::InnerClassLowering,
-        name = "InnerClasses",
-        prerequisite = setOf(defaultParameterExtentPhase)
-)
-
-private val rangeContainsLoweringPhase = createFileLoweringPhase(
-        ::RangeContainsLowering,
-        name = "RangeContains",
-)
-
-private val dataClassesPhase = createFileLoweringPhase(
-        ::DataClassOperatorsLowering,
-        name = "DataClasses",
-)
-
-private val finallyBlocksPhase = createFileLoweringPhase(
-        { context, irFile -> FinallyBlocksLowering(context, context.irBuiltIns.throwableType).lower(irFile) },
-        name = "FinallyBlocks",
-        prerequisite = setOf(initializersPhase, localFunctionsPhase, tailrecPhase)
-)
-
-private val testProcessorPhase = createFileLoweringPhase(
-        lowering = { context: NativeBackendContext -> TestProcessor(context) },
-        name = "TestProcessor",
-)
-
-private val initTestsPhase = createFileLoweringPhase(
-        lowering = ::TestsInitializer,
-        name = "TestsInitializer",
-)
-
-private val dumpTestsPhase = createFileLoweringPhase(
-        lowering = ::TestsDumper,
-        name = "TestsDumper",
-)
-
-private val delegatedPropertyOptimizationPhase = createFileLoweringPhase(
-        lowering = ::DelegatedPropertyOptimizationLowering,
-        name = "DelegatedPropertyOptimization",
-        prerequisite = setOf()
-)
-
-private val propertyReferencePhase = createFileLoweringPhase(
-        lowering = ::PropertyReferenceLowering,
-        name = "PropertyReference",
-        prerequisite = setOf(volatilePhase, delegatedPropertyOptimizationPhase)
-)
-
-
-private val functionReferencePhase = createFileLoweringPhase(
-        lowering = ::NativeFunctionReferenceLowering,
-        name = "FunctionReference",
-)
-
-private val staticCallableReferenceOptimizationPhase = createFileLoweringPhase(
-        lowering = ::StaticCallableReferenceOptimization,
-        name = "StaticCallableReferenceOptimization",
-        prerequisite = setOf(functionReferencePhase, propertyReferencePhase)
-)
-
-private val enumWhenPhase = createFileLoweringPhase(
-        name = "EnumWhen",
-        lowering = ::NativeEnumWhenLowering,
-        prerequisite = setOf(enumConstructorsPhase, functionReferencePhase)
-)
-
-private val enumClassPhase = createFileLoweringPhase(
-        ::EnumClassLowering,
-        name = "Enums",
-        prerequisite = setOf(enumConstructorsPhase, functionReferencePhase, enumWhenPhase) // TODO: make weak dependency on `testProcessorPhase`
-)
-
-private val enumUsagePhase = createFileLoweringPhase(
-        ::EnumUsageLowering,
-        name = "EnumUsage",
-        prerequisite = setOf(enumConstructorsPhase, functionReferencePhase, enumClassPhase)
-)
-
-
-private val singleAbstractMethodPhase = createFileLoweringPhase(
-        ::NativeSingleAbstractMethodLowering,
-        name = "SingleAbstractMethod",
-        prerequisite = setOf(functionReferencePhase)
-)
-
-private val removeCastsFromNothing = createFileLoweringPhase(
-        ::RemoveCastsFromNothingLowering,
-        name = "RemoveCastsFromNothing",
-)
-
-private val builtinOperatorPhase = createFileLoweringPhase(
-        ::BuiltinOperatorLowering,
-        name = "BuiltinOperators",
-        prerequisite = setOf(defaultParameterExtentPhase, singleAbstractMethodPhase, enumWhenPhase)
-)
-
-/**
- * The first phase of inlining (inline only private functions).
- */
-private val inlineOnlyPrivateFunctionsPhase = createFileLoweringPhase(
-        lowering = ::NativePrivateFunctionInlining,
-        name = "InlineOnlyPrivateFunctions",
-)
-
-private val outerThisSpecialAccessorInInlineFunctionsPhase = createFileLoweringPhase(
-        ::OuterThisInInlineFunctionsSpecialAccessorLowering,
-        name = "OuterThisInInlineFunctionsSpecialAccessorLowering",
-        prerequisite = setOf(inlineOnlyPrivateFunctionsPhase)
-)
-
-private val syntheticAccessorGenerationPhase = createFileLoweringPhase(
-        lowering = ::SyntheticAccessorLowering,
-        name = "SyntheticAccessorGeneration",
-        prerequisite = setOf(outerThisSpecialAccessorInInlineFunctionsPhase),
-)
-
 /**
  * The second phase of inlining (inline all functions).
  */
@@ -378,169 +134,9 @@ internal val inlineAllFunctionsPhase = createFileLoweringPhase(
         name = "InlineAllFunctions",
 )
 
-private val reifiedFunctionLowering = createFileLoweringPhase(
-        lowering = ::ReifiedFunctionLowering,
-        name = "ReifiedFunctionLowering",
-)
-
-private val typeOfProcessingLowering = createFileLoweringPhase(
-        lowering = ::TypeOfProcessingLowering,
-        name = "TypeOfProcessingLowering",
-)
-
-private val specializeSharedVariableBoxes = createFileLoweringPhase(
-        lowering = { context: NativeBackendContext -> SharedVariablesPrimitiveBoxSpecializationLowering(context, context.symbols) },
-        name = "SpecializeSharedVariableBoxes",
-        prerequisite = setOf(sharedVariablesPhase),
-)
-
-private val interopPhase = createFileLoweringPhase(
-        lowering = { generationState: NativeGenerationState ->
-            InteropLowering(generationState.context, generationState.fileLowerState)
-        },
-        name = "Interop",
-        prerequisite = setOf(extractLocalClassesFromInlineBodies)
-)
-
-private val specialInteropIntrinsicsPhase = createFileLoweringPhase(
-        lowering = ::SpecialInteropIntrinsicsLowering,
-        name = "SpecialInteropIntrinsics",
-        prerequisite = setOf(inlineAllFunctionsPhase)
-)
-
-internal val specialObjCValidationPhase = createFileLoweringPhase(
-        lowering = ::SpecialObjCValidationLowering,
-        name = "SpecialObjCValidation",
-        prerequisite = setOf(inlineAllFunctionsPhase)
-)
-
-private val varargPhase = createFileLoweringPhase(
-        ::VarargInjectionLowering,
-        name = "Vararg",
-        prerequisite = setOf(functionReferencePhase, defaultParameterExtentPhase, interopPhase, functionsWithoutBoundCheck)
-)
-
-private val coroutinesPhase = createFileLoweringPhase(
-        lowering = { context: NativeGenerationState ->
-            object : FileLoweringPass {
-                override fun lower(irFile: IrFile) {
-                    NativeSuspendFunctionsLowering(context).lower(irFile)
-                    AddContinuationToNonLocalSuspendFunctionsLowering(context.context).lower(irFile)
-                    NativeAddContinuationToFunctionCallsLowering(context.context).lower(irFile)
-                    AddFunctionSupertypeToSuspendFunctionLowering(context.context).lower(irFile)
-                }
-            }
-        },
-        name = "Coroutines",
-        prerequisite = setOf(localFunctionsPhase, finallyBlocksPhase, kotlinNothingValueExceptionPhase)
-)
-
-private val coroutinesLivenessAnalysisFallbackPhase = createFileLoweringPhase(
-        lowering = ::CoroutinesLivenessAnalysisFallback,
-        name = "CoroutinesLivenessAnalysisFallback",
-        prerequisite = setOf(coroutinesPhase)
-)
-
-private val coroutinesLivenessAnalysisPhase = createFileLoweringPhase(
-        lowering = { context: NativeGenerationState ->
-            object : BodyLoweringPass {
-                override fun lower(irBody: IrBody, container: IrDeclaration) {
-                    LivenessAnalysis.run(irBody) { it is IrSuspensionPoint }
-                            .forEach { [irElement, liveVariables] ->
-                                (irElement as IrSuspensionPoint).liveVariablesAtSuspensionPoint = liveVariables
-                            }
-                    context.coroutinesLivenessAnalysisPhasePerformed = true
-                }
-            }
-        },
-        name = "CoroutinesLivenessAnalysis",
-        prerequisite = setOf(coroutinesPhase)
-)
-
 internal val CoroutinesVarSpillingPhase = createFileLoweringPhase(
         lowering = ::CoroutinesVarSpillingLowering,
         name = "CoroutinesVarSpilling",
-        prerequisite = setOf(coroutinesPhase)
-)
-
-private val typeOperatorPhase = createFileLoweringPhase(
-        ::TypeOperatorLowering,
-        name = "TypeOperators",
-        prerequisite = setOf(coroutinesPhase)
-)
-
-private val exportedBridgeNonVirtualPhase = createFileLoweringPhase(
-        ::ExportedBridgeNonVirtualLowering,
-        name = "ExportedBridgeNonVirtual",
-        prerequisite = setOf(postInlinePhase)
-)
-
-private val bridgesPhase = createFileLoweringPhase(
-        { context, irFile ->
-            BridgesBuilding(context).runOnFilePostfix(irFile)
-            WorkersBridgesBuilding(context).lower(irFile)
-        },
-        name = "Bridges",
-        prerequisite = setOf(coroutinesPhase)
-)
-
-private val eraseGenericCallsReturnTypesPhase = createFileLoweringPhase(
-        name = "EraseGenericCallsReturnTypesPhase",
-        lowering = ::GenericCallsReturnTypeEraser,
-)
-
-private val autoboxPhase = createFileLoweringPhase(
-        ::Autoboxing,
-        name = "Autobox",
-        prerequisite = setOf(bridgesPhase, coroutinesPhase, eraseGenericCallsReturnTypesPhase)
-)
-
-private val constructorsLoweringPhase = createFileLoweringPhase(
-    name = "ConstructorsLowering",
-    lowering = ::ConstructorsLowering,
-)
-
-private val lowerCastsPhase = createFileLoweringPhase(
-        name = "CastsLowering",
-        lowering = ::CastsLowering,
-)
-
-private val computeTypesPhase = createFileLoweringPhase(
-        name = "ComputeTypes",
-        lowering = { context: NativeBackendContext -> ComputeTypesPass(context) },
-        prerequisite = setOf(finallyBlocksPhase)
-)
-
-private val optimizeCastsPhase = createFileLoweringPhase(
-        name = "OptimizeCasts",
-        lowering = { context: NativeBackendContext -> CastsOptimization(context) },
-)
-
-private val expressionBodyTransformPhase = createFileLoweringPhase(
-        ::ExpressionBodyTransformer,
-        name = "ExpressionBodyTransformer",
-)
-
-private val staticInitializersPhase = createFileLoweringPhase(
-        ::StaticInitializersLowering,
-        name = "StaticInitializers",
-        prerequisite = setOf(expressionBodyTransformPhase)
-)
-
-private val ifNullExpressionsFusionPhase = createFileLoweringPhase(
-        ::IfNullExpressionsFusionLowering,
-        name = "IfNullExpressionsFusionLowering",
-)
-
-private val exportInternalAbiPhase = createFileLoweringPhase(
-        ::ExportCachesAbiVisitor,
-        name = "ExportInternalAbi",
-)
-
-private val returnsInsertionPhase = createFileLoweringPhase(
-        name = "ReturnsInsertion",
-        prerequisite = setOf(autoboxPhase, coroutinesPhase, enumClassPhase),
-        lowering = ::ReturnsInsertionLowering,
 )
 
 internal val InlineClassPropertyAccessorsPhase = createFileLoweringPhase(
@@ -555,140 +151,119 @@ internal val RedundantCoercionsCleaningPhase = createFileLoweringPhase(
 
 internal val PropertyAccessorInlinePhase = createFileLoweringPhase(
         name = "PropertyAccessorInline",
-        lowering = ::PropertyAccessorInlineLowering,
+        lowering = { context: NativeGenerationState -> PropertyAccessorInlineLowering(context) },
 )
 
 internal val UnboxInlinePhase = createFileLoweringPhase(
         name = "UnboxInline",
-        lowering = ::UnboxInlineLowering,
+        lowering = { context: NativeGenerationState -> UnboxInlineLowering(context) },
 )
 
-private val inventNamesForLocalClasses = createFileLoweringPhase(
-        lowering = ::NativeInventNamesForLocalClasses,
-        name = "InventNamesForLocalClasses",
+internal fun createNativePhases(vararg phases: ((NativeGenerationState) -> FileLoweringPass)?) =
+        createFilePhases(*phases, actions = getDefaultIrActions())
+
+internal fun getLoweringsUpToAndIncludingSyntheticAccessors() = createNativePhases(
+        ::TestProcessor,
+        ::UpgradeCallableReferences,
+        ::NativeAssertionWrapperLowering,
+        ::LateinitLowering,
+        ::SharedVariablesLowering,
+        ::LocalClassesInInlineLambdasLowering,
+        ::ArrayConstructorLowering,
+        ::NativePrivateFunctionInlining,
+        ::OuterThisInInlineFunctionsSpecialAccessorLowering,
+        ::SyntheticAccessorLowering,
 )
 
-private val inventNamesForLocalFunctions = createFileLoweringPhase(
-        lowering = { _: NativeBackendContext -> KlibInventNamesForLocalFunctions() },
-        name = "InventNamesForLocalFunctions",
-)
+internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = createNativePhases(
+        ::ConstEvaluationLowering,
+        ::ReifiedFunctionLowering,
+        ::TypeOfProcessingLowering,
+        ::NativeSharedVariablesPrimitiveBoxSpecializationLowering,
+        ::InteropLowering,
+        ::SpecialInteropIntrinsicsLowering,
+        ::TestsInitializer,
+        ::TestsDumper.takeIf { this.configuration.getNotNull(NativeConfigurationKeys.GENERATE_TEST_RUNNER) != TestRunnerKind.NONE },
+        ::ExpectDeclarationsRemoveLowering,
+        ::StripTypeAliasDeclarationsLowering,
+        ::NativeAssertionRemoverLowering,
+        ::VolatileFieldsLowering,
+        ::DelegatedPropertyOptimizationLowering,
+        ::PropertyReferenceLowering,
+        ::NativeFunctionReferenceLowering,
+        ::NativeSingleAbstractMethodLowering,
+        ::PostInlineLowering,
+        ::ExportedBridgeNonVirtualLowering,
+        ::ContractsDslRemover,
+        ::NativeAnnotationImplementationLowering,
+        ::RangeContainsLowering,
+        ::EnumConstructorsLowering,
+        ::InitializersLowering,
 
-private val useInternalAbiPhase = createSimpleNamedCompilerPhase<NativeGenerationState, IrFile, IrFile>(
-        name = "UseInternalAbi",
-        outputIfNotEnabled = { _, _, _, irFile -> irFile },
-) { context, file ->
-    ImportCachesAbiTransformer(context).lower(file)
-    file
-}
+        ::InteropBridgesNameInventor,
+        ::NativeInventNamesForLocalClasses,
+        ::NativeKlibInventNamesForLocalFunctions,
 
+        ::LocalDelegatedPropertiesLowering,
+        ::NativeLocalDeclarationsLowering,
+        ::LocalDeclarationPopupLowering,
 
-private val objectClassesPhase = createFileLoweringPhase(
-        lowering = ::ObjectClassLowering,
-        name = "ObjectClasses",
-)
+        ::NativeTailrecLowering,
+        ::NativeFinallyBlocksLowering,
+        ::ComputeTypesPass, // Inliner erases generics. Trying to restore some of the information and simplify IR.
+        ::NativeForLoopsLowering, // TODO: depends on FunctionsWithoutBoundCheckGenerator
 
-private val assertionWrapperPhase = createFileLoweringPhase(
-        lowering = ::NativeAssertionWrapperLowering,
-        name = "AssertionWrapperLowering",
-)
+        ::FlattenStringConcatenationLowering,
+        ::StringConcatenationLowering,
+        ::StringConcatenationTypeNarrowing.takeIf { this.optimizationsEnabled },
 
-private val assertionRemoverPhase = createFileLoweringPhase(
-        lowering = ::NativeAssertionRemoverLowering,
-        name = "AssertionRemoverLowering",
-        prerequisite = setOf(assertionWrapperPhase),
-)
+        ::NativeDefaultArgumentStubGenerator,
+        ::NativeDefaultParameterCleaner,
+        ::NativeDefaultParameterInjector,
 
-internal val redundantCastsRemoverPhase = createFileLoweringPhase(
-        lowering = ::RedundantCastsRemoverLowering,
-        name = "RedundantCastsRemoverLowering",
-        prerequisite = setOf(inlineAllFunctionsPhase),
-)
+        ::InnerClassLowering,
+        ::DataClassOperatorsLowering,
+        ::IfNullExpressionsFusionLowering,
+        ::StaticCallableReferenceOptimization,
 
-internal val constEvaluationPhase = createFileLoweringPhase(
-        lowering = ::ConstEvaluationLowering,
-        name = "ConstEvaluationLowering",
-        prerequisite = setOf(inlineAllFunctionsPhase)
-)
+        ::NativeEnumWhenLowering,
+        ::EnumClassLowering,
+        ::EnumUsageLowering,
 
-internal fun getLoweringsUpToAndIncludingSyntheticAccessors(): LoweringList = listOfNotNull(
-        testProcessorPhase,
-        upgradeCallableReferencesPhase,
-        assertionWrapperPhase,
-        lateinitPhase,
-        sharedVariablesPhase,
-        extractLocalClassesFromInlineBodies,
-        arrayConstructorPhase,
-        inlineOnlyPrivateFunctionsPhase,
-        outerThisSpecialAccessorInInlineFunctionsPhase,
-        syntheticAccessorGenerationPhase,
-)
+        ::VarargInjectionLowering, // TODO: depends on FunctionsWithoutBoundCheckGenerator
+        ::KotlinNothingValueExceptionLowering,
 
-internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining(): LoweringList = listOfNotNull(
-        constEvaluationPhase,
-        reifiedFunctionLowering,
-        typeOfProcessingLowering,
-        specializeSharedVariableBoxes,
-        interopPhase,
-        specialInteropIntrinsicsPhase,
-        initTestsPhase,
-        dumpTestsPhase.takeIf { this.configuration.getNotNull(NativeConfigurationKeys.GENERATE_TEST_RUNNER) != TestRunnerKind.NONE },
-        removeExpectDeclarationsPhase,
-        stripTypeAliasDeclarationsPhase,
-        assertionRemoverPhase,
-        volatilePhase,
-        delegatedPropertyOptimizationPhase,
-        propertyReferencePhase,
-        functionReferencePhase,
-        singleAbstractMethodPhase,
-        postInlinePhase,
-        exportedBridgeNonVirtualPhase,
-        contractsDslRemovePhase,
-        annotationImplementationPhase,
-        rangeContainsLoweringPhase,
-        enumConstructorsPhase,
-        initializersPhase,
-        inventNamesForInteropBridgesPhase,
-        inventNamesForLocalClasses,
-        inventNamesForLocalFunctions,
-        localFunctionsPhase,
-        tailrecPhase,
-        finallyBlocksPhase,
-        computeTypesPhase, // Inliner erases generics. Trying to restore some of the information and simplify IR.
-        forLoopsPhase,
-        flattenStringConcatenationPhase,
-        stringConcatenationPhase,
-        stringConcatenationTypeNarrowingPhase.takeIf { this.optimizationsEnabled },
-        defaultParameterExtentPhase,
-        innerClassPhase,
-        dataClassesPhase,
-        ifNullExpressionsFusionPhase,
-        staticCallableReferenceOptimizationPhase,
-        enumWhenPhase,
-        enumClassPhase,
-        enumUsagePhase,
-        varargPhase,
-        kotlinNothingValueExceptionPhase,
-        coroutinesPhase,
+        ::NativeSuspendFunctionsLowering,
+        ::AddContinuationToNonLocalSuspendFunctionsLowering,
+        ::NativeAddContinuationToFunctionCallsLowering,
+        ::AddFunctionSupertypeToSuspendFunctionLowering,
         // Either of these could be turned off without losing correctness.
-        coroutinesLivenessAnalysisPhase, // This is more optimal
-        coroutinesLivenessAnalysisFallbackPhase, // While this is simple
-        expressionBodyTransformPhase,
-        objectClassesPhase,
-        staticInitializersPhase,
+        ::CoroutinesLivenessAnalysis, // This is more optimal
+        ::CoroutinesLivenessAnalysisFallback, // While this is simple
+
+        ::ExpressionBodyTransformer,
+        ::ObjectClassLowering,
+        ::StaticInitializersLowering,
+
         // Running 2nd time not only helps the following heavy analysis but also corrects some lowerings' inaccuracies in IR types.
-        computeTypesPhase,
-        removeCastsFromNothing,
-        optimizeCastsPhase.takeIf { this.genericSafeCasts },
-        typeOperatorPhase,
-        builtinOperatorPhase,
-        bridgesPhase,
-        exportInternalAbiPhase.takeIf { this.produce.isCache },
-        useInternalAbiPhase,
-        eraseGenericCallsReturnTypesPhase,
-        autoboxPhase,
-        constructorsLoweringPhase,
-        returnsInsertionPhase,
-        lowerCastsPhase.takeUnless { this.optimizationsEnabled },
+        ::ComputeTypesPass,
+        ::RemoveCastsFromNothingLowering,
+        ::CastsOptimization.takeIf { this.genericSafeCasts },
+
+        ::TypeOperatorLowering,
+        ::BuiltinOperatorLowering,
+
+        ::BridgesBuilding,
+        ::WorkersBridgesBuilding,
+
+        ::ExportCachesAbiVisitor.takeIf { this.produce.isCache },
+        ::ImportCachesAbiTransformer,
+
+        ::GenericCallsReturnTypeEraser,
+        ::Autoboxing,
+        ::ConstructorsLowering,
+        ::ReturnsInsertionLowering,
+        ::CastsLowering.takeUnless { this.optimizationsEnabled },
 )
 
 private fun createFileLoweringPhase(
@@ -711,17 +286,6 @@ private fun createFileLoweringPhase(
         prerequisite
 ) { context, irFile ->
     lowering(context.context).lower(irFile)
-}
-
-private fun createFileLoweringPhase(
-        op: (context: NativeBackendContext, irFile: IrFile) -> Unit,
-        name: String,
-        prerequisite: Set<NamedCompilerPhase<*, *, *>> = emptySet(),
-) = createFileLoweringPhaseImpl(
-        name,
-        prerequisite
-) { context, irFile ->
-    op(context.context, irFile)
 }
 
 private fun createFileLoweringPhaseImpl(
@@ -749,4 +313,3 @@ private fun createFileLoweringPhaseImpl(
             irFile
         }
 )
-

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.backend.common.phaser.*
 import org.jetbrains.kotlin.backend.common.wrapWithCompilationException
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.utilities.getDefaultIrActions
-import org.jetbrains.kotlin.backend.konan.ir.FunctionsWithoutBoundCheckGenerator
 import org.jetbrains.kotlin.backend.konan.lower.*
 import org.jetbrains.kotlin.backend.konan.lower.InitializersLowering
 import org.jetbrains.kotlin.backend.konan.optimizations.NativeForLoopsLowering
@@ -65,8 +64,8 @@ internal fun PhaseEngine<NativeGenerationState>.runLowerings(
     }
 }
 
-internal fun PhaseEngine<NativeGenerationState>.runModuleWisePhase(
-        lowering: ModuleLowering,
+internal fun <Context : NativeLoweringContext> PhaseEngine<Context>.runModuleWisePhase(
+        lowering: NamedCompilerPhase<Context, IrModuleFragment, IrModuleFragment>,
         modules: List<IrModuleFragment>,
 ) {
     context.performanceManager.tryMeasureDynamicPhaseTime(lowering.name, PhaseType.IrLowering) {
@@ -75,19 +74,6 @@ internal fun PhaseEngine<NativeGenerationState>.runModuleWisePhase(
         }
     }
 }
-
-internal val functionsWithoutBoundCheck = createSimpleNamedCompilerPhase<NativeBackendContext, Unit>(
-        name = "FunctionsWithoutBoundCheckGenerator",
-        op = { context, _ -> FunctionsWithoutBoundCheckGenerator(context).generate() }
-)
-
-/**
- * The second phase of inlining (inline all functions).
- */
-internal val inlineAllFunctionsPhase = createFileLoweringPhase(
-        name = "InlineAllFunctions",
-        lowering = ::NativeAllFunctionInlining,
-)
 
 internal fun <Context : NativeLoweringContext> createNativePhases(vararg phases: ((Context) -> FileLoweringPass)?) =
         createFilePhases(*phases, actions = getDefaultIrActions())
@@ -224,34 +210,4 @@ internal fun getNativeLoweringPhaseListsForTests(
                 genericSafeCasts = genericSafeCasts,
                 isCache = isCache,
         ),
-)
-
-private fun createFileLoweringPhase(
-        name: String,
-        lowering: (NativeGenerationState) -> FileLoweringPass,
-) = createFileLoweringPhaseImpl(name) { context, irFile -> lowering(context).lower(irFile) }
-
-private fun createFileLoweringPhaseImpl(
-        name: String,
-        op: (NativeGenerationState, IrFile) -> Unit
-): NamedCompilerPhase<NativeGenerationState, IrFile, IrFile> = createSimpleNamedCompilerPhase(
-        name,
-        preactions = getDefaultIrActions(),
-        postactions = getDefaultIrActions(),
-        prerequisite = emptySet(),
-        outputIfNotEnabled = { _, _, _, irFile -> irFile },
-        op = { context, irFile ->
-            try {
-                op(context, irFile)
-            } catch (e: CompilationException) {
-                e.initializeFileDetails(irFile)
-                throw e
-            } catch (e: KotlinExceptionWithAttachments) {
-                throw e
-            } catch (e: Throwable) {
-                throw e.wrapWithCompilationException("Internal error in file lowering", irFile, null)
-            }
-
-            irFile
-        }
 )

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -7,13 +7,10 @@ package org.jetbrains.kotlin.backend.konan.driver.phases
 
 import org.jetbrains.kotlin.backend.common.CompilationException
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
-import org.jetbrains.kotlin.ir.util.isTypeOfIntrinsic
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.common.lower.coroutines.AddContinuationToNonLocalSuspendFunctionsLowering
-import org.jetbrains.kotlin.backend.common.lower.inline.InlineCallCycleCheckerLowering
 import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineLambdasLowering
 import org.jetbrains.kotlin.backend.common.phaser.*
-import org.jetbrains.kotlin.backend.common.phaser.IrValidationBeforeLoweringsKlibSecondStagePhase
 import org.jetbrains.kotlin.backend.common.wrapWithCompilationException
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.utilities.getDefaultIrActions
@@ -36,7 +33,7 @@ import org.jetbrains.kotlin.util.tryMeasureDynamicPhaseTime
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
 
 internal typealias LoweringList = List<NamedCompilerPhase<NativeGenerationState, IrFile, IrFile>>
-internal typealias ModuleLowering = NamedCompilerPhase<NativeGenerationState, IrModuleFragment, Unit>
+internal typealias ModuleLowering = NamedCompilerPhase<NativeGenerationState, IrModuleFragment, IrModuleFragment>
 
 internal fun PhaseEngine<NativeGenerationState>.runLowerings(
         lowerings: LoweringList,
@@ -78,51 +75,6 @@ internal fun PhaseEngine<NativeGenerationState>.runModuleWisePhase(
         }
     }
 }
-
-internal val validateIrBeforeLowering = createSimpleNamedCompilerPhase<NativeGenerationState, IrModuleFragment>(
-        name = "ValidateIrBeforeLowering",
-        op = { context, module -> IrValidationBeforeLoweringsKlibSecondStagePhase(context.context).lower(module) }
-)
-
-internal val checkInlineCallCyclesPhase = createSimpleNamedCompilerPhase<NativeGenerationState, IrModuleFragment>(
-        name = "InlineCallCycleChecker",
-        op = { context, module -> InlineCallCycleCheckerLowering(context.context).lower(module) }
-)
-
-
-internal val validateIrAfterInliningOnlyPrivateFunctions = createSimpleNamedCompilerPhase<NativeGenerationState, IrModuleFragment>(
-        name = "ValidateIrAfterInliningOnlyPrivateFunctions",
-        op = { context, module ->
-            IrValidationAfterInliningPrivateFunctionsKlibPhase(
-                    context = context.context,
-                    checkInlineFunctionCallSites = { inlineFunctionUseSite ->
-                        // Call sites of only non-private functions are allowed at this stage.
-                        !inlineFunctionUseSite.symbol.isConsideredAsPrivateForInlining()
-                    }
-            ).lower(module)
-        }
-)
-
-internal val validateIrAfterInliningAllFunctions = createSimpleNamedCompilerPhase<NativeGenerationState, IrModuleFragment>(
-        name = "ValidateIrAfterInliningAllFunctions",
-        op = { context, module ->
-            IrValidationAfterInliningAllFunctionsKlibSecondStagePhase(
-                    context = context.context,
-                    checkInlineFunctionCallSites = check@{ inlineFunctionUseSite ->
-                        // No inline function call sites should remain at this stage.
-                        val inlineFunction = inlineFunctionUseSite.symbol.owner
-                        // it's fine to have typeOf<T>, it would be ignored by inliner and handled on the second stage of compilation
-                        if (inlineFunction.symbol.isTypeOfIntrinsic()) return@check true
-                        return@check inlineFunction.body == null
-                    }
-            ).lower(module)
-        }
-)
-
-internal val validateIrAfterLowering = createSimpleNamedCompilerPhase<NativeGenerationState, IrModuleFragment>(
-        name = "ValidateIrAfterLowering",
-        op = { context, module -> IrValidationAfterLoweringsSecondStagePhase(context.context).lower(module) }
-)
 
 internal val functionsWithoutBoundCheck = createSimpleNamedCompilerPhase<NativeBackendContext, Unit>(
         name = "FunctionsWithoutBoundCheckGenerator",

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -22,6 +22,8 @@ import org.jetbrains.kotlin.backend.konan.ir.FunctionsWithoutBoundCheckGenerator
 import org.jetbrains.kotlin.backend.konan.lower.*
 import org.jetbrains.kotlin.backend.konan.lower.InitializersLowering
 import org.jetbrains.kotlin.backend.konan.optimizations.NativeForLoopsLowering
+import org.jetbrains.annotations.TestOnly
+import org.jetbrains.kotlin.config.phaser.AnyNamedPhase
 import org.jetbrains.kotlin.config.phaser.NamedCompilerPhase
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
@@ -175,7 +177,19 @@ internal fun getLoweringsUpToAndIncludingSyntheticAccessors() = createNativePhas
         ::SyntheticAccessorLowering,
 )
 
-internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = createNativePhases(
+internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = getLoweringsAfterInlining(
+        generateTestDumper = configuration.getNotNull(NativeConfigurationKeys.GENERATE_TEST_RUNNER) != TestRunnerKind.NONE,
+        optimizationsEnabled = optimizationsEnabled,
+        genericSafeCasts = genericSafeCasts,
+        isCache = produce.isCache,
+)
+
+private fun getLoweringsAfterInlining(
+        generateTestDumper: Boolean,
+        optimizationsEnabled: Boolean,
+        genericSafeCasts: Boolean,
+        isCache: Boolean,
+) = createNativePhases(
         ::ConstEvaluationLowering,
         ::ReifiedFunctionLowering,
         ::TypeOfProcessingLowering,
@@ -183,7 +197,7 @@ internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = cr
         ::InteropLowering,
         ::SpecialInteropIntrinsicsLowering,
         ::TestsInitializer,
-        ::TestsDumper.takeIf { this.configuration.getNotNull(NativeConfigurationKeys.GENERATE_TEST_RUNNER) != TestRunnerKind.NONE },
+        ::TestsDumper.takeIf { generateTestDumper },
         ::ExpectDeclarationsRemoveLowering,
         ::StripTypeAliasDeclarationsLowering,
         ::NativeAssertionRemoverLowering,
@@ -215,7 +229,7 @@ internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = cr
 
         ::FlattenStringConcatenationLowering,
         ::StringConcatenationLowering,
-        ::StringConcatenationTypeNarrowing.takeIf { this.optimizationsEnabled },
+        ::StringConcatenationTypeNarrowing.takeIf { optimizationsEnabled },
 
         ::NativeDefaultArgumentStubGenerator,
         ::NativeDefaultParameterCleaner,
@@ -248,7 +262,7 @@ internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = cr
         // Running 2nd time not only helps the following heavy analysis but also corrects some lowerings' inaccuracies in IR types.
         ::ComputeTypesPass,
         ::RemoveCastsFromNothingLowering,
-        ::CastsOptimization.takeIf { this.genericSafeCasts },
+        ::CastsOptimization.takeIf { genericSafeCasts },
 
         ::TypeOperatorLowering,
         ::BuiltinOperatorLowering,
@@ -256,14 +270,32 @@ internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = cr
         ::BridgesBuilding,
         ::WorkersBridgesBuilding,
 
-        ::ExportCachesAbiVisitor.takeIf { this.produce.isCache },
+        ::ExportCachesAbiVisitor.takeIf { isCache },
         ::ImportCachesAbiTransformer,
 
         ::GenericCallsReturnTypeEraser,
         ::Autoboxing,
         ::ConstructorsLowering,
         ::ReturnsInsertionLowering,
-        ::CastsLowering.takeUnless { this.optimizationsEnabled },
+        ::CastsLowering.takeUnless { optimizationsEnabled },
+)
+
+@TestOnly
+internal fun getNativeLoweringPhaseListsForTests(
+        generateTestDumper: Boolean,
+        optimizationsEnabled: Boolean,
+        genericSafeCasts: Boolean,
+        isCache: Boolean,
+): List<List<AnyNamedPhase>> = listOf(
+        getLoweringsUpToAndIncludingSyntheticAccessors(),
+        // Note: `inlineAllFunctionsPhase` is a physical barrier between the two lists (see how everything is called in TopLevelPhases.kt)
+        // Thus there are no prerequisites on it.
+        getLoweringsAfterInlining(
+                generateTestDumper = generateTestDumper,
+                optimizationsEnabled = optimizationsEnabled,
+                genericSafeCasts = genericSafeCasts,
+                isCache = isCache,
+        ),
 )
 
 private fun createFileLoweringPhase(

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.common.lower.coroutines.AddContinuationToNonLocalSuspendFunctionsLowering
 import org.jetbrains.kotlin.backend.common.lower.inline.InlineCallCycleCheckerLowering
 import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineLambdasLowering
-import org.jetbrains.kotlin.backend.common.lower.optimizations.PropertyAccessorInlineLowering
 import org.jetbrains.kotlin.backend.common.phaser.*
 import org.jetbrains.kotlin.backend.common.phaser.IrValidationBeforeLoweringsKlibSecondStagePhase
 import org.jetbrains.kotlin.backend.common.wrapWithCompilationException
@@ -42,8 +41,14 @@ internal typealias ModuleLowering = NamedCompilerPhase<NativeGenerationState, Ir
 
 internal fun PhaseEngine<NativeGenerationState>.runLowerings(
         lowerings: LoweringList,
+        module: IrModuleFragment,
+        performanceManager: PerformanceManager? = context.performanceManager,
+) = runLowerings(lowerings, listOf(module), performanceManager)
+
+internal fun PhaseEngine<NativeGenerationState>.runLowerings(
+        lowerings: LoweringList,
         modules: List<IrModuleFragment>,
-        performanceManager: PerformanceManager?,
+        performanceManager: PerformanceManager? = context.performanceManager,
 ) {
     for (module in modules) {
         for (file in module.files) {
@@ -136,32 +141,7 @@ internal val inlineAllFunctionsPhase = createFileLoweringPhase(
         lowering = ::NativeAllFunctionInlining,
 )
 
-internal val CoroutinesVarSpillingPhase = createFileLoweringPhase(
-        name = "CoroutinesVarSpilling",
-        lowering = ::CoroutinesVarSpillingLowering,
-)
-
-internal val InlineClassPropertyAccessorsPhase = createFileLoweringPhase(
-        name = "InlineClassPropertyAccessorsLowering",
-        lowering = ::InlineClassPropertyAccessorsLowering,
-)
-
-internal val RedundantCoercionsCleaningPhase = createFileLoweringPhase(
-        name = "RedundantCoercionsCleaning",
-        lowering = ::RedundantCoercionsCleaner,
-)
-
-internal val PropertyAccessorInlinePhase = createFileLoweringPhase(
-        name = "PropertyAccessorInline",
-        lowering = ::PropertyAccessorInlineLowering,
-)
-
-internal val UnboxInlinePhase = createFileLoweringPhase(
-        name = "UnboxInline",
-        lowering = ::UnboxInlineLowering,
-)
-
-internal fun createNativePhases(vararg phases: ((NativeGenerationState) -> FileLoweringPass)?) =
+internal fun <Context : NativeLoweringContext> createNativePhases(vararg phases: ((Context) -> FileLoweringPass)?) =
         createFilePhases(*phases, actions = getDefaultIrActions())
 
 internal fun getLoweringsUpToAndIncludingSyntheticAccessors() = createNativePhases(

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -276,7 +276,7 @@ private val finallyBlocksPhase = createFileLoweringPhase(
 )
 
 private val testProcessorPhase = createFileLoweringPhase(
-        lowering = { context: NativeBackendContext -> TestProcessor(context, context.sourcesModules) },
+        lowering = { context: NativeBackendContext -> TestProcessor(context) },
         name = "TestProcessor",
 )
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/NativeLoweringPhases.kt
@@ -130,13 +130,13 @@ internal val functionsWithoutBoundCheck = createSimpleNamedCompilerPhase<NativeB
  * The second phase of inlining (inline all functions).
  */
 internal val inlineAllFunctionsPhase = createFileLoweringPhase(
-        lowering = ::NativeAllFunctionInlining,
         name = "InlineAllFunctions",
+        lowering = ::NativeAllFunctionInlining,
 )
 
 internal val CoroutinesVarSpillingPhase = createFileLoweringPhase(
-        lowering = ::CoroutinesVarSpillingLowering,
         name = "CoroutinesVarSpilling",
+        lowering = ::CoroutinesVarSpillingLowering,
 )
 
 internal val InlineClassPropertyAccessorsPhase = createFileLoweringPhase(
@@ -151,12 +151,12 @@ internal val RedundantCoercionsCleaningPhase = createFileLoweringPhase(
 
 internal val PropertyAccessorInlinePhase = createFileLoweringPhase(
         name = "PropertyAccessorInline",
-        lowering = { context: NativeGenerationState -> PropertyAccessorInlineLowering(context) },
+        lowering = ::PropertyAccessorInlineLowering,
 )
 
 internal val UnboxInlinePhase = createFileLoweringPhase(
         name = "UnboxInline",
-        lowering = { context: NativeGenerationState -> UnboxInlineLowering(context) },
+        lowering = ::UnboxInlineLowering,
 )
 
 internal fun createNativePhases(vararg phases: ((NativeGenerationState) -> FileLoweringPass)?) =
@@ -269,34 +269,16 @@ internal fun NativeSecondStageCompilationConfig.getLoweringsAfterInlining() = cr
 private fun createFileLoweringPhase(
         name: String,
         lowering: (NativeGenerationState) -> FileLoweringPass,
-        prerequisite: Set<NamedCompilerPhase<*, *, *>> = emptySet(),
-) = createFileLoweringPhaseImpl(
-        name,
-        prerequisite
-) { context, irFile ->
-    lowering(context).lower(irFile)
-}
-
-private fun createFileLoweringPhase(
-        lowering: (NativeBackendContext) -> FileLoweringPass,
-        name: String,
-        prerequisite: Set<NamedCompilerPhase<*, *, *>> = emptySet(),
-) = createFileLoweringPhaseImpl(
-        name,
-        prerequisite
-) { context, irFile ->
-    lowering(context.context).lower(irFile)
-}
+) = createFileLoweringPhaseImpl(name) { context, irFile -> lowering(context).lower(irFile) }
 
 private fun createFileLoweringPhaseImpl(
         name: String,
-        prerequisite: Set<NamedCompilerPhase<*, *, *>>,
         op: (NativeGenerationState, IrFile) -> Unit
 ): NamedCompilerPhase<NativeGenerationState, IrFile, IrFile> = createSimpleNamedCompilerPhase(
         name,
         preactions = getDefaultIrActions(),
         postactions = getDefaultIrActions(),
-        prerequisite = prerequisite,
+        prerequisite = emptySet(),
         outputIfNotEnabled = { _, _, _, irFile -> irFile },
         op = { context, irFile ->
             try {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -6,13 +6,14 @@
 package org.jetbrains.kotlin.backend.konan.driver.phases
 
 import llvm.LLVMModuleRef
+import org.jetbrains.kotlin.backend.common.ModuleLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.RedundantCastsRemoverLowering
 import org.jetbrains.kotlin.backend.common.lower.inline.InlineCallCycleCheckerLowering
 import org.jetbrains.kotlin.backend.common.lower.optimizations.PropertyAccessorInlineLowering
 import org.jetbrains.kotlin.backend.common.phaser.IrValidationAfterLoweringsSecondStagePhase
 import org.jetbrains.kotlin.backend.common.phaser.IrValidationBeforeLoweringsKlibSecondStagePhase
 import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
-import org.jetbrains.kotlin.backend.common.phaser.createModulePhase
+import org.jetbrains.kotlin.backend.common.phaser.createModulePhases
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.PerformanceManagerContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
@@ -92,7 +93,7 @@ internal fun <T> PhaseEngine<NativeBackendPhaseContext>.linkKlibs(
 internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendContext: NativeBackendContext, irModule: IrModuleFragment, performanceManager: PerformanceManager?) {
     val config = context.config
     useContext(backendContext) { backendEngine ->
-        backendEngine.runModuleWisePhase(createModulePhase(::FunctionsWithoutBoundCheckGenerator), listOf(irModule))
+        backendEngine.runModuleWisePhase(createModulePhases(::FunctionsWithoutBoundCheckGenerator).first(), listOf(irModule))
 
         fun createGenerationState(fragment: BackendJobFragment): NativeGenerationState {
             val outputPath = config.cacheSupport.tryGetImplicitOutput(fragment.cacheDeserializationStrategy) ?: config.outputPath
@@ -131,27 +132,30 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
             }
         }
 
-        fun NativeGenerationState.runSpecifiedLowerings(fragment: BackendJobFragment, loweringsToLaunch: LoweringList) {
-            runEngineForLowerings {
-                val module = fragment.irModule
-                partiallyLowerModuleWithDependencies(module, loweringsToLaunch)
-            }
-        }
+        fun List<Pair<BackendJobFragment, NativeGenerationState>>.runSpecifiedLowerings(loweringsToLaunch: LoweringList) =
+                forEach { [fragment, state] ->
+                    state.runEngineForLowerings {
+                        val module = fragment.irModule
+                        partiallyLowerModuleWithDependencies(module, loweringsToLaunch)
+                    }
+                }
 
-        fun NativeGenerationState.runSpecifiedLowerings(fragment: BackendJobFragment, moduleLowering: ModuleLowering) {
-            runEngineForLowerings {
-                val module = fragment.irModule
-                partiallyLowerModuleWithDependencies(module, moduleLowering)
-            }
-        }
+        fun List<Pair<BackendJobFragment, NativeGenerationState>>.runSpecifiedLowering(phase: (NativeLoweringContext) -> ModuleLoweringPass) =
+                forEach { [fragment, state] ->
+                    state.runEngineForLowerings {
+                        val module = fragment.irModule
+                        partiallyLowerModuleWithDependencies(module, createModulePhases(phase).first())
+                    }
+                }
 
-        fun NativeGenerationState.finalizeLowerings(fragment: BackendJobFragment) {
-            runEngineForLowerings {
-                val module = fragment.irModule
-                val dependenciesToCompile = findDependenciesToCompile()
-                mergeDependencies(module, dependenciesToCompile)
-            }
-        }
+        fun List<Pair<BackendJobFragment, NativeGenerationState>>.finalizeLowerings() =
+                forEach { [fragment, state] ->
+                    state.runEngineForLowerings {
+                        val module = fragment.irModule
+                        val dependenciesToCompile = findDependenciesToCompile()
+                        mergeDependencies(module, dependenciesToCompile)
+                    }
+                }
 
         fun List<BackendJobFragment>.runAllLowerings(): List<NativeGenerationState> {
             val generationStates = this.map { fragment -> createGenerationState(fragment) }
@@ -164,8 +168,8 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
             // stage, because otherwise we may be actually validating a partially lowered IR that may not pass certain checks
             // (like IR visibility checks).
             // This is what we call a 'lowering synchronization point'.
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::IrValidationBeforeLoweringsKlibSecondStagePhase)) }
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::InlineCallCycleCheckerLowering)) }
+            fragmentWithState.runSpecifiedLowering(::IrValidationBeforeLoweringsKlibSecondStagePhase)
+            fragmentWithState.runSpecifiedLowering(::InlineCallCycleCheckerLowering)
 
             run {
                 // This is a so-called "KLIB Common Lowerings Prefix".
@@ -177,17 +181,19 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
                 // synthetic accessors) have been already applied.
                 // To avoid overcomplicating things and to keep running the preceding lowerings with "modify-only-lowered-file"
                 // invariant, we would like to put a synchronization point immediately before "InlineAllFunctions".
-                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, getLoweringsUpToAndIncludingSyntheticAccessors()) }
-                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::NativeIrValidationAfterInliningPrivateFunctionsKlibPhase)) }
-                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createNativePhases(::NativeAllFunctionInlining)) }
-                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createNativePhases(::SpecialObjCValidationLowering, ::RedundantCastsRemoverLowering)) }
+                fragmentWithState.runSpecifiedLowerings(getLoweringsUpToAndIncludingSyntheticAccessors())
+                fragmentWithState.runSpecifiedLowering(::NativeIrValidationAfterInliningPrivateFunctionsKlibPhase)
+                fragmentWithState.runSpecifiedLowerings(createNativePhases(::NativeAllFunctionInlining))
+                fragmentWithState.runSpecifiedLowerings(
+                        createNativePhases(::SpecialObjCValidationLowering, ::RedundantCastsRemoverLowering)
+                )
             }
 
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::NativeIrValidationAfterInliningAllFunctionsKlibSecondStagePhase)) }
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, state.context.config.getLoweringsAfterInlining()) }
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::IrValidationAfterLoweringsSecondStagePhase)) }
+            fragmentWithState.runSpecifiedLowering(::NativeIrValidationAfterInliningAllFunctionsKlibSecondStagePhase)
+            fragmentWithState.runSpecifiedLowerings(context.config.getLoweringsAfterInlining())
+            fragmentWithState.runSpecifiedLowering(::IrValidationAfterLoweringsSecondStagePhase)
 
-            fragmentWithState.forEach { [fragment, state] -> state.finalizeLowerings(fragment) }
+            fragmentWithState.finalizeLowerings()
 
             return generationStates
         }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.konan.driver.phases
 
 import llvm.LLVMModuleRef
 import org.jetbrains.kotlin.backend.common.lower.RedundantCastsRemoverLowering
+import org.jetbrains.kotlin.backend.common.lower.optimizations.PropertyAccessorInlineLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.PerformanceManagerContext
@@ -14,7 +15,7 @@ import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.driver.utilities.CExportFiles
 import org.jetbrains.kotlin.backend.konan.driver.utilities.createTempFiles
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
-import org.jetbrains.kotlin.backend.konan.lower.SpecialObjCValidationLowering
+import org.jetbrains.kotlin.backend.konan.lower.*
 import org.jetbrains.kotlin.backend.konan.serialization.CacheDeserializationStrategy
 import org.jetbrains.kotlin.backend.konan.serialization.PartialCacheInfo
 import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
@@ -537,12 +538,15 @@ private fun PhaseEngine<NativeGenerationState>.runCodegen(module: IrModuleFragme
     // It's ok to run global optimizations on a cache as long as it doesn't have other dependencies (stdlib)
     val runGlobalOptimizations = optimize && !context.config.cachedLibraries.hasStaticCaches
     val enablePreCodegenInliner = context.config.preCodegenInlineThreshold != 0U && runGlobalOptimizations
-    module.files.forEach {
-        // Have to run after link dependencies phase, because fields from dependencies can be changed during lowerings.
-        // Inline accessors only in optimized builds due to separate compilation and possibility to get broken debug information.
-        runAndMeasurePhase(PropertyAccessorInlinePhase, it, disable = !optimize)
-        runAndMeasurePhase(InlineClassPropertyAccessorsPhase, it, disable = !optimize)
-    }
+    runLowerings(
+            // Have to run after link dependencies phase, because fields from dependencies can be changed during lowerings.
+            // Inline accessors only in optimized builds due to separate compilation and possibility to get broken debug information.
+            createNativePhases(
+                    ::PropertyAccessorInlineLowering.takeIf { optimize },
+                    ::InlineClassPropertyAccessorsLowering.takeIf { optimize },
+            ),
+            module,
+    )
     val moduleDFG = runAndMeasurePhase(BuildDFGPhase, module, disable = !runGlobalOptimizations)
     runAndMeasurePhase(RemoveRedundantCallsToStaticInitializersPhase, RedundantCallsInput(moduleDFG, module), disable = !enablePreCodegenInliner)
     runAndMeasurePhase(PreCodegenInlinerPhase, PreCodegenInlinerInput(module, moduleDFG), disable = !enablePreCodegenInliner)
@@ -550,16 +554,21 @@ private fun PhaseEngine<NativeGenerationState>.runCodegen(module: IrModuleFragme
     // KT-72336: This is more optimal but contradicts with the pre-codegen inliner.
     runAndMeasurePhase(RemoveRedundantCallsToStaticInitializersPhase, RedundantCallsInput(moduleDFG, module), disable = enablePreCodegenInliner || !runGlobalOptimizations)
     runAndMeasurePhase(DevirtualizationPhase, DevirtualizationInput(module, moduleDFG), disable = !runGlobalOptimizations)
-    module.files.forEach {
-        runAndMeasurePhase(RedundantCoercionsCleaningPhase, it)
-        // depends on redundantCoercionsCleaningPhase
-        runAndMeasurePhase(UnboxInlinePhase, it, disable = !optimize)
-    }
+    runLowerings(
+            createNativePhases(
+                    ::RedundantCoercionsCleaner,
+                    ::UnboxInlineLowering.takeIf { optimize },
+            ),
+            module,
+    )
     runAndMeasurePhase(PreCodegenInlinerPhase, PreCodegenInlinerInput(module, moduleDFG), disable = !enablePreCodegenInliner)
     val dceResult = runAndMeasurePhase(DCEPhase, DCEInput(module, moduleDFG), disable = !runGlobalOptimizations)
-    module.files.forEach {
-        runAndMeasurePhase(CoroutinesVarSpillingPhase, it)
-    }
+    runLowerings(
+            createNativePhases(
+                    ::CoroutinesVarSpillingLowering,
+            ),
+            module,
+    )
     runAndMeasurePhase(CreateLLVMDeclarationsPhase, module)
     runAndMeasurePhase(GHAPhase, module, disable = !runGlobalOptimizations || context.config.produce.isCache)
     runAndMeasurePhase(RTTIPhase, RTTIInput(module, dceResult))

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.driver.phases
 
 import llvm.LLVMModuleRef
+import org.jetbrains.kotlin.backend.common.lower.RedundantCastsRemoverLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.PerformanceManagerContext
@@ -13,6 +14,7 @@ import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
 import org.jetbrains.kotlin.backend.konan.driver.utilities.CExportFiles
 import org.jetbrains.kotlin.backend.konan.driver.utilities.createTempFiles
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
+import org.jetbrains.kotlin.backend.konan.lower.SpecialObjCValidationLowering
 import org.jetbrains.kotlin.backend.konan.serialization.CacheDeserializationStrategy
 import org.jetbrains.kotlin.backend.konan.serialization.PartialCacheInfo
 import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
@@ -171,7 +173,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, getLoweringsUpToAndIncludingSyntheticAccessors()) }
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, validateIrAfterInliningOnlyPrivateFunctions) }
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, listOf(inlineAllFunctionsPhase)) }
-                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, listOf(specialObjCValidationPhase, redundantCastsRemoverPhase)) }
+                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createNativePhases(::SpecialObjCValidationLowering, ::RedundantCastsRemoverLowering)) }
             }
 
             fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, validateIrAfterInliningAllFunctions) }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -7,8 +7,12 @@ package org.jetbrains.kotlin.backend.konan.driver.phases
 
 import llvm.LLVMModuleRef
 import org.jetbrains.kotlin.backend.common.lower.RedundantCastsRemoverLowering
+import org.jetbrains.kotlin.backend.common.lower.inline.InlineCallCycleCheckerLowering
 import org.jetbrains.kotlin.backend.common.lower.optimizations.PropertyAccessorInlineLowering
+import org.jetbrains.kotlin.backend.common.phaser.IrValidationAfterLoweringsSecondStagePhase
+import org.jetbrains.kotlin.backend.common.phaser.IrValidationBeforeLoweringsKlibSecondStagePhase
 import org.jetbrains.kotlin.backend.common.phaser.PhaseEngine
+import org.jetbrains.kotlin.backend.common.phaser.createModulePhase
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.PerformanceManagerContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
@@ -158,8 +162,8 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
             // stage, because otherwise we may be actually validating a partially lowered IR that may not pass certain checks
             // (like IR visibility checks).
             // This is what we call a 'lowering synchronization point'.
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, validateIrBeforeLowering) }
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, checkInlineCallCyclesPhase) }
+            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::IrValidationBeforeLoweringsKlibSecondStagePhase)) }
+            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::InlineCallCycleCheckerLowering)) }
 
             run {
                 // This is a so-called "KLIB Common Lowerings Prefix".
@@ -172,14 +176,14 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
                 // To avoid overcomplicating things and to keep running the preceding lowerings with "modify-only-lowered-file"
                 // invariant, we would like to put a synchronization point immediately before "InlineAllFunctions".
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, getLoweringsUpToAndIncludingSyntheticAccessors()) }
-                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, validateIrAfterInliningOnlyPrivateFunctions) }
+                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::NativeIrValidationAfterInliningPrivateFunctionsKlibPhase)) }
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, listOf(inlineAllFunctionsPhase)) }
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createNativePhases(::SpecialObjCValidationLowering, ::RedundantCastsRemoverLowering)) }
             }
 
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, validateIrAfterInliningAllFunctions) }
+            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::NativeIrValidationAfterInliningAllFunctionsKlibSecondStagePhase)) }
             fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, state.context.config.getLoweringsAfterInlining()) }
-            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, validateIrAfterLowering) }
+            fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::IrValidationAfterLoweringsSecondStagePhase)) }
 
             fragmentWithState.forEach { [fragment, state] -> state.finalizeLowerings(fragment) }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -128,14 +128,14 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
         fun NativeGenerationState.runSpecifiedLowerings(fragment: BackendJobFragment, loweringsToLaunch: LoweringList) {
             runEngineForLowerings {
                 val module = fragment.irModule
-                partiallyLowerModuleWithDependencies(module, loweringsToLaunch, performanceManager)
+                partiallyLowerModuleWithDependencies(module, loweringsToLaunch)
             }
         }
 
         fun NativeGenerationState.runSpecifiedLowerings(fragment: BackendJobFragment, moduleLowering: ModuleLowering) {
             runEngineForLowerings {
                 val module = fragment.irModule
-                partiallyLowerModuleWithDependencies(module, moduleLowering, performanceManager)
+                partiallyLowerModuleWithDependencies(module, moduleLowering)
             }
         }
 
@@ -463,27 +463,25 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.compileAndLink(
 internal fun PhaseEngine<NativeGenerationState>.partiallyLowerModuleWithDependencies(
         module: IrModuleFragment,
         loweringList: LoweringList,
-        performanceManager: PerformanceManager?,
 ) {
     val dependenciesToCompile = findDependenciesToCompile()
     // TODO: KonanLibraryResolver.TopologicalLibraryOrder actually returns libraries in the reverse topological order.
     // TODO: Does the order of files really matter with the new MM? (and with lazy top-levels initialization?)
     val allModulesToLower = listOf(module) + dependenciesToCompile.reversed()
 
-    runLowerings(loweringList, allModulesToLower, performanceManager)
+    runLowerings(loweringList, allModulesToLower)
 }
 
 internal fun PhaseEngine<NativeGenerationState>.partiallyLowerModuleWithDependencies(
         module: IrModuleFragment,
         lowering: ModuleLowering,
-        performanceManager: PerformanceManager?,
 ) {
     val dependenciesToCompile = findDependenciesToCompile()
     // TODO: KonanLibraryResolver.TopologicalLibraryOrder actually returns libraries in the reverse topological order.
     // TODO: Does the order of files really matter with the new MM? (and with lazy top-levels initialization?)
     val allModulesToLower = listOf(module) + dependenciesToCompile.reversed()
 
-    runModuleWisePhase(lowering, allModulesToLower, performanceManager)
+    runModuleWisePhase(lowering, allModulesToLower)
 }
 
 internal fun PhaseEngine<NativeGenerationState>.runBackendCodegen(module: IrModuleFragment, irBuiltIns: IrBuiltIns, cExportFiles: CExportFiles?) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/driver/phases/TopLevelPhases.kt
@@ -16,8 +16,10 @@ import org.jetbrains.kotlin.backend.common.phaser.createModulePhase
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.driver.PerformanceManagerContext
 import org.jetbrains.kotlin.backend.konan.driver.NativeBackendPhaseContext
+import org.jetbrains.kotlin.backend.konan.driver.phases.runModuleWisePhase
 import org.jetbrains.kotlin.backend.konan.driver.utilities.CExportFiles
 import org.jetbrains.kotlin.backend.konan.driver.utilities.createTempFiles
+import org.jetbrains.kotlin.backend.konan.ir.FunctionsWithoutBoundCheckGenerator
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.lower.*
 import org.jetbrains.kotlin.backend.konan.serialization.CacheDeserializationStrategy
@@ -90,7 +92,7 @@ internal fun <T> PhaseEngine<NativeBackendPhaseContext>.linkKlibs(
 internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendContext: NativeBackendContext, irModule: IrModuleFragment, performanceManager: PerformanceManager?) {
     val config = context.config
     useContext(backendContext) { backendEngine ->
-        backendEngine.runAndMeasurePhase(functionsWithoutBoundCheck)
+        backendEngine.runModuleWisePhase(createModulePhase(::FunctionsWithoutBoundCheckGenerator), listOf(irModule))
 
         fun createGenerationState(fragment: BackendJobFragment): NativeGenerationState {
             val outputPath = config.cacheSupport.tryGetImplicitOutput(fragment.cacheDeserializationStrategy) ?: config.outputPath
@@ -177,7 +179,7 @@ internal fun <C : NativeBackendPhaseContext> PhaseEngine<C>.runBackend(backendCo
                 // invariant, we would like to put a synchronization point immediately before "InlineAllFunctions".
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, getLoweringsUpToAndIncludingSyntheticAccessors()) }
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createModulePhase(::NativeIrValidationAfterInliningPrivateFunctionsKlibPhase)) }
-                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, listOf(inlineAllFunctionsPhase)) }
+                fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createNativePhases(::NativeAllFunctionInlining)) }
                 fragmentWithState.forEach { [fragment, state] -> state.runSpecifiedLowerings(fragment, createNativePhases(::SpecialObjCValidationLowering, ::RedundantCastsRemoverLowering)) }
             }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/FunctionsWithoutBoundCheckGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/FunctionsWithoutBoundCheckGenerator.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan.ir
 
+import org.jetbrains.kotlin.backend.common.ModuleLoweringPass
 import org.jetbrains.kotlin.backend.konan.BinaryType
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.KonanFqNames
@@ -13,6 +14,7 @@ import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.addMember
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
@@ -24,7 +26,7 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
 // Generate additional functions for array set and get operators without bounds checking.
-internal class FunctionsWithoutBoundCheckGenerator(val context: NativeBackendContext) {
+internal class FunctionsWithoutBoundCheckGenerator(val context: NativeBackendContext) : ModuleLoweringPass {
     private fun generateFunction(baseFunction: IrSimpleFunction, delegatingToFunction: IrSimpleFunction?, functionName: Name) =
             context.irFactory.createSimpleFunction(
                     startOffset = baseFunction.startOffset,
@@ -60,7 +62,7 @@ internal class FunctionsWithoutBoundCheckGenerator(val context: NativeBackendCon
                 function.annotations = setWithoutBEAnnotations
             }
 
-    fun generate() {
+    override fun lower(irModule: IrModuleFragment) {
         context.irBuiltIns.arrays.forEach { classSymbol ->
             val underlyingClass = (classSymbol.defaultType.computeBinaryType() as BinaryType.Reference)
                     .types.single().takeIf { classSymbol.owner.isInlineClass }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/AssertRemovalLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/AssertRemovalLowering.kt
@@ -8,10 +8,11 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.lower.KlibAssertionRemoverLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 
 @PhasePrerequisites(NativeAssertionWrapperLowering::class)
-internal class NativeAssertionRemoverLowering(context: NativeGenerationState) : KlibAssertionRemoverLowering(
+internal class NativeAssertionRemoverLowering(context: NativeLoweringContext) : KlibAssertionRemoverLowering(
         context, context.config.assertsEnabled, context.config.assertsEnabled
 ) {
     override val isAssertionThrowingErrorEnabled: IrSimpleFunctionSymbol = context.symbols.isAssertionThrowingErrorEnabled

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/AssertRemovalLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/AssertRemovalLowering.kt
@@ -6,10 +6,12 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.KlibAssertionRemoverLowering
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 
-internal class NativeAssertionRemoverLowering(context: NativeBackendContext) : KlibAssertionRemoverLowering(
+@PhasePrerequisites(NativeAssertionWrapperLowering::class)
+internal class NativeAssertionRemoverLowering(context: NativeGenerationState) : KlibAssertionRemoverLowering(
         context, context.config.assertsEnabled, context.config.assertsEnabled
 ) {
     override val isAssertionThrowingErrorEnabled: IrSimpleFunctionSymbol = context.symbols.isAssertionThrowingErrorEnabled

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.backend.common.linkage.partial.ClassifierPartialLink
 import org.jetbrains.kotlin.backend.common.linkage.partial.partialLinkageStatus
 import org.jetbrains.kotlin.utils.atMostOne
 import org.jetbrains.kotlin.backend.common.lower.*
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.ir.*
 import org.jetbrains.kotlin.backend.konan.optimizations.STATEMENT_ORIGIN_NO_CAST_NEEDED
@@ -39,13 +40,14 @@ import org.jetbrains.kotlin.ir.objcinterop.isObjCClass
 /**
  * Boxes and unboxes values of value types when necessary.
  */
-internal class Autoboxing(val context: NativeBackendContext) : FileLoweringPass {
+@PhasePrerequisites(BridgesBuilding::class, NativeSuspendFunctionsLowering::class, GenericCallsReturnTypeEraser::class)
+internal class Autoboxing(val context: NativeGenerationState) : FileLoweringPass {
 
-    private val transformer = AutoboxingTransformer(context)
+    private val transformer = AutoboxingTransformer(context.context)
 
     override fun lower(irFile: IrFile) {
         irFile.transformChildrenVoid(transformer)
-        irFile.transform(InlineClassTransformer(context), data = null)
+        irFile.transform(InlineClassTransformer(context.context), data = null)
     }
 
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -41,18 +41,18 @@ import org.jetbrains.kotlin.ir.objcinterop.isObjCClass
  * Boxes and unboxes values of value types when necessary.
  */
 @PhasePrerequisites(BridgesBuilding::class, NativeSuspendFunctionsLowering::class, GenericCallsReturnTypeEraser::class)
-internal class Autoboxing(val context: NativeGenerationState) : FileLoweringPass {
+internal class Autoboxing(val context: NativeLoweringContext) : FileLoweringPass {
 
-    private val transformer = AutoboxingTransformer(context.context)
+    private val transformer = AutoboxingTransformer(context)
 
     override fun lower(irFile: IrFile) {
         irFile.transformChildrenVoid(transformer)
-        irFile.transform(InlineClassTransformer(context.context), data = null)
+        irFile.transform(InlineClassTransformer(context), data = null)
     }
 
 }
 
-private class AutoboxingTransformer(val context: NativeBackendContext) : AbstractValueUsageTransformer(
+private class AutoboxingTransformer(val context: NativeLoweringContext) : AbstractValueUsageTransformer(
         context.symbols,
         context.irBuiltIns
 ) {
@@ -288,10 +288,8 @@ private class AutoboxingTransformer(val context: NativeBackendContext) : Abstrac
 
 }
 
-private class InlineClassTransformer(private val context: NativeBackendContext) : IrBuildingTransformer(context) {
-
+private class InlineClassTransformer(private val context: NativeLoweringContext) : IrBuildingTransformer(context) {
     private val symbols = context.symbols
-    private val irBuiltIns = context.irBuiltIns
 
     private val builtSpecialFunctions = mutableListOf<IrFunction>()
 
@@ -629,7 +627,7 @@ private class InlineClassTransformer(private val context: NativeBackendContext) 
 
 private var IrConstructor.loweredInlineClassConstructor: IrSimpleFunction? by irAttribute(copyByDefault = false)
 
-private fun NativeBackendContext.getLoweredInlineClassConstructor(irConstructor: IrConstructor): IrSimpleFunction = irConstructor::loweredInlineClassConstructor.getOrSetIfNull {
+private fun NativeLoweringContext.getLoweredInlineClassConstructor(irConstructor: IrConstructor): IrSimpleFunction = irConstructor::loweredInlineClassConstructor.getOrSetIfNull {
     require(irConstructor.constructedClass.isInlined())
 
     val returnType = if (irConstructor.isPrimary) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -10,13 +10,13 @@ import org.jetbrains.kotlin.backend.common.DeclarationContainerLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlockBody
 import org.jetbrains.kotlin.backend.common.lower.irIfThen
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
-import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
+import org.jetbrains.kotlin.backend.konan.descriptors.*
 import org.jetbrains.kotlin.backend.konan.ir.*
 import org.jetbrains.kotlin.backend.konan.llvm.computeFunctionName
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
@@ -144,7 +144,7 @@ internal class BridgesSupport(val irBuiltIns: IrBuiltIns, val symbols: BackendNa
         }
     }
 }
-internal class WorkersBridgesBuilding(val context: NativeBackendContext) : DeclarationContainerLoweringPass, IrElementTransformerVoid() {
+internal class WorkersBridgesBuilding(val context: NativeGenerationState) : DeclarationContainerLoweringPass, IrElementTransformerVoid() {
     private val bridgesPolicy = context.config.bridgesPolicy
     val symbols = context.symbols
     lateinit var runtimeJobFunction: IrSimpleFunction
@@ -236,7 +236,7 @@ internal class WorkersBridgesBuilding(val context: NativeBackendContext) : Decla
     }
 }
 
-internal class BridgesBuilding(val context: NativeBackendContext) : ClassLoweringPass {
+internal class BridgesBuilding(val context: NativeGenerationState) : ClassLoweringPass {
     private val bridgesPolicy = context.config.bridgesPolicy
 
     override fun lower(irClass: IrClass) {
@@ -340,11 +340,11 @@ private fun IrBlockBodyBuilder.buildTypeSafeBarrier(function: IrFunction,
     }
 }
 
-private fun NativeBackendContext.buildBridge(startOffset: Int, endOffset: Int,
+private fun NativeGenerationState.buildBridge(startOffset: Int, endOffset: Int,
                                              overriddenFunction: OverriddenFunctionInfo, targetSymbol: IrSimpleFunctionSymbol,
                                              superQualifierSymbol: IrClassSymbol? = null): IrFunction {
     val target = targetSymbol.owner.target
-    val bridge = bridgesSupport.getBridge(overriddenFunction)
+    val bridge = context.bridgesSupport.getBridge(overriddenFunction)
 
     if (bridge.modality == Modality.ABSTRACT) {
         return bridge

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.computeFunctionName
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrBuiltIns
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.declarations.*
@@ -144,7 +144,8 @@ internal class BridgesSupport(val irBuiltIns: IrBuiltIns, val symbols: BackendNa
         }
     }
 }
-internal class WorkersBridgesBuilding(val context: NativeGenerationState) : DeclarationContainerLoweringPass, IrElementTransformerVoid() {
+
+internal class WorkersBridgesBuilding(val context: NativeLoweringContext) : DeclarationContainerLoweringPass, IrElementTransformerVoid() {
     private val bridgesPolicy = context.config.bridgesPolicy
     val symbols = context.symbols
     lateinit var runtimeJobFunction: IrSimpleFunction
@@ -236,7 +237,7 @@ internal class WorkersBridgesBuilding(val context: NativeGenerationState) : Decl
     }
 }
 
-internal class BridgesBuilding(val context: NativeGenerationState) : ClassLoweringPass {
+internal class BridgesBuilding(val context: NativeLoweringContext) : ClassLoweringPass {
     private val bridgesPolicy = context.config.bridgesPolicy
 
     override fun lower(irClass: IrClass) {
@@ -340,11 +341,11 @@ private fun IrBlockBodyBuilder.buildTypeSafeBarrier(function: IrFunction,
     }
 }
 
-private fun NativeGenerationState.buildBridge(startOffset: Int, endOffset: Int,
+private fun NativeLoweringContext.buildBridge(startOffset: Int, endOffset: Int,
                                              overriddenFunction: OverriddenFunctionInfo, targetSymbol: IrSimpleFunctionSymbol,
                                              superQualifierSymbol: IrClassSymbol? = null): IrFunction {
     val target = targetSymbol.owner.target
-    val bridge = context.bridgesSupport.getBridge(overriddenFunction)
+    val bridge = bridgesSupport.getBridge(overriddenFunction)
 
     if (bridge.modality == Modality.ABSTRACT) {
         return bridge

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.utils.atMostOne
 import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.irNot
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.ir.isInlineClass
 import org.jetbrains.kotlin.ir.builders.*
@@ -32,7 +33,8 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 /**
  * This lowering pass lowers some calls to [IrBuiltinOperatorDescriptor]s.
  */
-internal class BuiltinOperatorLowering(val context: NativeBackendContext) : FileLoweringPass, IrBuildingTransformer(context) {
+@PhasePrerequisites(NativeDefaultParameterInjector::class, NativeSingleAbstractMethodLowering::class, NativeEnumWhenLowering::class)
+internal class BuiltinOperatorLowering(val context: NativeGenerationState) : FileLoweringPass, IrBuildingTransformer(context) {
 
     private val irBuiltins = context.irBuiltIns
     private val symbols = context.symbols

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
@@ -34,8 +34,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * This lowering pass lowers some calls to [IrBuiltinOperatorDescriptor]s.
  */
 @PhasePrerequisites(NativeDefaultParameterInjector::class, NativeSingleAbstractMethodLowering::class, NativeEnumWhenLowering::class)
-internal class BuiltinOperatorLowering(val context: NativeGenerationState) : FileLoweringPass, IrBuildingTransformer(context) {
-
+internal class BuiltinOperatorLowering(val context: NativeLoweringContext) : FileLoweringPass, IrBuildingTransformer(context) {
     private val irBuiltins = context.irBuiltIns
     private val symbols = context.symbols
 
@@ -55,8 +54,8 @@ internal class BuiltinOperatorLowering(val context: NativeGenerationState) : Fil
 
             irBuiltins.noWhenBranchMatchedExceptionSymbol -> IrCallImpl.fromSymbolOwner(
                     expression.startOffset, expression.endOffset,
-                    context.symbols.throwNoWhenBranchMatchedException.owner.returnType,
-                    context.symbols.throwNoWhenBranchMatchedException)
+                    symbols.throwNoWhenBranchMatchedException.owner.returnType,
+                    symbols.throwNoWhenBranchMatchedException)
 
             irBuiltins.linkageErrorSymbol -> with(symbols.throwIrLinkageError) { irCall(expression, this, newReturnType = owner.returnType) }
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CachesAbiLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CachesAbiLowering.kt
@@ -7,8 +7,8 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.allOverriddenFunctions
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -176,8 +176,8 @@ internal class CachesAbiSupport(private val irFactory: IrFactory) {
 /**
  * Adds accessors to private entities.
  */
-internal class ExportCachesAbiVisitor(val context: NativeGenerationState) : FileLoweringPass {
-    private val cachesAbiSupport = context.context.cachesAbiSupport
+internal class ExportCachesAbiVisitor(val context: NativeLoweringContext) : FileLoweringPass {
+    private val cachesAbiSupport = context.cachesAbiSupport
 
     override fun lower(irFile: IrFile) {
         irFile.acceptChildrenVoid(visitor)
@@ -280,8 +280,8 @@ internal class ImportCachesAbiTransformer(val generationState: NativeGenerationS
     }
 
     private inner class Transformer(val irFile: IrFile) : IrElementTransformerVoid() {
-        private val cachesAbiSupport = generationState.context.cachesAbiSupport
-        private val innerClassesSupport = generationState.context.innerClassesSupport
+        private val cachesAbiSupport = generationState.cachesAbiSupport
+        private val innerClassesSupport = generationState.innerClassesSupport
         private val dependenciesTracker = generationState.dependenciesTracker
 
         override fun visitCall(expression: IrCall): IrExpression {
@@ -309,7 +309,7 @@ internal class ImportCachesAbiTransformer(val generationState: NativeGenerationS
 
             // Actual scope for builder is the current function that we don't have access to. So we put a new symbol as scope here,
             // but it will not affect the result because we are not creating any declarations here.
-            fun createIrBuilder() = generationState.context.irBuiltIns.createIrBuilder(
+            fun createIrBuilder() = generationState.irBuiltIns.createIrBuilder(
                     IrSimpleFunctionSymbolImpl(), expression.startOffset, expression.endOffset
             )
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CachesAbiLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CachesAbiLowering.kt
@@ -176,8 +176,8 @@ internal class CachesAbiSupport(private val irFactory: IrFactory) {
 /**
  * Adds accessors to private entities.
  */
-internal class ExportCachesAbiVisitor(val context: NativeBackendContext) : FileLoweringPass {
-    private val cachesAbiSupport = context.cachesAbiSupport
+internal class ExportCachesAbiVisitor(val context: NativeGenerationState) : FileLoweringPass {
+    private val cachesAbiSupport = context.context.cachesAbiSupport
 
     override fun lower(irFile: IrFile) {
         irFile.acceptChildrenVoid(visitor)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CastsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CastsLowering.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.builders.irBoolean
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -35,7 +36,7 @@ internal fun IrType.isSuperClassCastTo(dstClass: IrClass): Boolean =
         dstClass.isAny() || (this.classifierOrNull !is IrTypeParameterSymbol // Due to unsafe casts, see unchecked_cast8.kt as an example.
                 && this.isSubtypeOfClass(dstClass.symbol))
 
-internal class CastsLowering(val context: NativeGenerationState) : BodyLoweringPass {
+internal class CastsLowering(val context: NativeLoweringContext) : BodyLoweringPass {
     override fun lower(irBody: IrBody, container: IrDeclaration) {
         val irBuilder = context.createIrBuilder(container.symbol)
         irBody.transformChildrenVoid(object : IrElementTransformerVoid() {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CastsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CastsLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.builders.irBoolean
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -35,7 +35,7 @@ internal fun IrType.isSuperClassCastTo(dstClass: IrClass): Boolean =
         dstClass.isAny() || (this.classifierOrNull !is IrTypeParameterSymbol // Due to unsafe casts, see unchecked_cast8.kt as an example.
                 && this.isSubtypeOfClass(dstClass.symbol))
 
-internal class CastsLowering(val context: NativeBackendContext) : BodyLoweringPass {
+internal class CastsLowering(val context: NativeGenerationState) : BodyLoweringPass {
     override fun lower(irBody: IrBody, container: IrDeclaration) {
         val irBuilder = context.createIrBuilder(container.symbol)
         irBody.transformChildrenVoid(object : IrElementTransformerVoid() {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ConstructorsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ConstructorsLowering.kt
@@ -9,8 +9,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.ir.createExtensionReceiver
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.isArray
 import org.jetbrains.kotlin.backend.konan.isInlined
 import org.jetbrains.kotlin.ir.IrElement
@@ -35,7 +34,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 internal var IrConstructor.loweredConstructorFunction: IrSimpleFunction? by irAttribute(copyByDefault = false)
 internal var IrSimpleFunction.originalConstructor: IrConstructor? by irAttribute(copyByDefault = false)
 
-internal fun NativeBackendContext.getLoweredConstructorFunction(irConstructor: IrConstructor): IrSimpleFunction =
+internal fun NativeLoweringContext.getLoweredConstructorFunction(irConstructor: IrConstructor): IrSimpleFunction =
         irConstructor::loweredConstructorFunction.getOrSetIfNull {
             irFactory.buildFun {
                 name = irConstructor.name
@@ -75,7 +74,7 @@ internal val LOWERED_DELEGATING_CONSTRUCTOR_CALL by IrStatementOriginImpl
 /**
  * Replaces constructor calls by (alloc + static call).
  */
-internal class ConstructorsLowering(private val context: NativeGenerationState) : FileLoweringPass, IrTransformer<IrDeclaration?>() {
+internal class ConstructorsLowering(private val context: NativeLoweringContext) : FileLoweringPass, IrTransformer<IrDeclaration?>() {
     private val createUninitializedInstance = context.symbols.createUninitializedInstance
     private val createUninitializedArray = context.symbols.createUninitializedArray
     private val createEmptyString = context.symbols.createEmptyString
@@ -113,7 +112,7 @@ internal class ConstructorsLowering(private val context: NativeGenerationState) 
         if (constructedClass.isInlined())
             return null
 
-        val loweredConstructorFunction = context.context.getLoweredConstructorFunction(constructor)
+        val loweredConstructorFunction = context.getLoweredConstructorFunction(constructor)
         if (body != null) {
             loweredConstructorFunction.body = body as IrBlockBody
             body.setDeclarationsParent(loweredConstructorFunction)
@@ -151,7 +150,7 @@ internal class ConstructorsLowering(private val context: NativeGenerationState) 
                         val callee = expression.symbol.owner
                         if (callee.constructedClass.isAny() || callee.constructedClass.isExternalObjCClass())
                             irComposite { }
-                        else irCall(this@ConstructorsLowering.context.context.getLoweredConstructorFunction(callee),
+                        else irCall(this@ConstructorsLowering.context.getLoweredConstructorFunction(callee),
                                 origin = LOWERED_DELEGATING_CONSTRUCTOR_CALL
                         ).apply {
                             dispatchReceiver = irGet(loweredConstructorFunction.dispatchReceiverParameter!!)
@@ -170,7 +169,7 @@ internal class ConstructorsLowering(private val context: NativeGenerationState) 
         val constructor = expression.symbol.owner
         require(constructor.parameters.none { it.kind == IrParameterKind.ExtensionReceiver }) { "A constructor call cannot have the extension receiver: ${expression.render()}" }
         val constructedType = constructor.constructedClassType
-        val loweredConstructorFunction = context.context.getLoweredConstructorFunction(constructor)
+        val loweredConstructorFunction = context.getLoweredConstructorFunction(constructor)
         val irBuilder = context.createIrBuilder(data!!.symbol, expression.startOffset, expression.endOffset)
         return when {
             constructor.constructedClass.isObjCClass() -> {
@@ -211,7 +210,7 @@ internal class ConstructorsLowering(private val context: NativeGenerationState) 
 
         val instance = expression.arguments[0]
         val constructorCall = expression.arguments[1] as IrConstructorCall
-        val loweredConstructorFunction = context.context.getLoweredConstructorFunction(constructorCall.symbol.owner)
+        val loweredConstructorFunction = context.getLoweredConstructorFunction(constructorCall.symbol.owner)
         val irBuilder = context.createIrBuilder(data!!.symbol, expression.startOffset, expression.endOffset)
         return irBuilder.irCall(loweredConstructorFunction).apply {
             dispatchReceiver = instance

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ConstructorsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ConstructorsLowering.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.ir.createExtensionReceiver
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.ir.isArray
 import org.jetbrains.kotlin.backend.konan.isInlined
 import org.jetbrains.kotlin.ir.IrElement
@@ -74,7 +75,7 @@ internal val LOWERED_DELEGATING_CONSTRUCTOR_CALL by IrStatementOriginImpl
 /**
  * Replaces constructor calls by (alloc + static call).
  */
-internal class ConstructorsLowering(private val context: NativeBackendContext) : FileLoweringPass, IrTransformer<IrDeclaration?>() {
+internal class ConstructorsLowering(private val context: NativeGenerationState) : FileLoweringPass, IrTransformer<IrDeclaration?>() {
     private val createUninitializedInstance = context.symbols.createUninitializedInstance
     private val createUninitializedArray = context.symbols.createUninitializedArray
     private val createEmptyString = context.symbols.createEmptyString
@@ -112,7 +113,7 @@ internal class ConstructorsLowering(private val context: NativeBackendContext) :
         if (constructedClass.isInlined())
             return null
 
-        val loweredConstructorFunction = context.getLoweredConstructorFunction(constructor)
+        val loweredConstructorFunction = context.context.getLoweredConstructorFunction(constructor)
         if (body != null) {
             loweredConstructorFunction.body = body as IrBlockBody
             body.setDeclarationsParent(loweredConstructorFunction)
@@ -150,7 +151,7 @@ internal class ConstructorsLowering(private val context: NativeBackendContext) :
                         val callee = expression.symbol.owner
                         if (callee.constructedClass.isAny() || callee.constructedClass.isExternalObjCClass())
                             irComposite { }
-                        else irCall(this@ConstructorsLowering.context.getLoweredConstructorFunction(callee),
+                        else irCall(this@ConstructorsLowering.context.context.getLoweredConstructorFunction(callee),
                                 origin = LOWERED_DELEGATING_CONSTRUCTOR_CALL
                         ).apply {
                             dispatchReceiver = irGet(loweredConstructorFunction.dispatchReceiverParameter!!)
@@ -169,7 +170,7 @@ internal class ConstructorsLowering(private val context: NativeBackendContext) :
         val constructor = expression.symbol.owner
         require(constructor.parameters.none { it.kind == IrParameterKind.ExtensionReceiver }) { "A constructor call cannot have the extension receiver: ${expression.render()}" }
         val constructedType = constructor.constructedClassType
-        val loweredConstructorFunction = context.getLoweredConstructorFunction(constructor)
+        val loweredConstructorFunction = context.context.getLoweredConstructorFunction(constructor)
         val irBuilder = context.createIrBuilder(data!!.symbol, expression.startOffset, expression.endOffset)
         return when {
             constructor.constructedClass.isObjCClass() -> {
@@ -210,7 +211,7 @@ internal class ConstructorsLowering(private val context: NativeBackendContext) :
 
         val instance = expression.arguments[0]
         val constructorCall = expression.arguments[1] as IrConstructorCall
-        val loweredConstructorFunction = context.getLoweredConstructorFunction(constructorCall.symbol.owner)
+        val loweredConstructorFunction = context.context.getLoweredConstructorFunction(constructorCall.symbol.owner)
         val irBuilder = context.createIrBuilder(data!!.symbol, expression.startOffset, expression.endOffset)
         return irBuilder.irCall(loweredConstructorFunction).apply {
             dispatchReceiver = instance

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ContractsDslRemover.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ContractsDslRemover.kt
@@ -6,14 +6,14 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.DeclarationContainerLoweringPass
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.LoweringContext
 import org.jetbrains.kotlin.resolve.ContractsDslNames
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationContainer
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.transformFlat
 
-internal class ContractsDslRemover(val context: NativeBackendContext) : DeclarationContainerLoweringPass {
+internal class ContractsDslRemover(val context: LoweringContext) : DeclarationContainerLoweringPass {
     override fun lower(irDeclarationContainer: IrDeclarationContainer) {
         irDeclarationContainer.declarations.transformFlat {
             if (it is IrClass && it.annotations.hasAnnotation(ContractsDslNames.CONTRACTS_DSL_ANNOTATION_FQN))

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CoroutinesLivenessAnalysis.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CoroutinesLivenessAnalysis.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.lower
+
+import org.jetbrains.kotlin.backend.common.BodyLoweringPass
+import org.jetbrains.kotlin.backend.common.lower.optimizations.LivenessAnalysis
+import org.jetbrains.kotlin.backend.common.peek
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.common.pop
+import org.jetbrains.kotlin.backend.common.push
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrCatch
+import org.jetbrains.kotlin.ir.expressions.IrContainerExpression
+import org.jetbrains.kotlin.ir.expressions.IrSuspensionPoint
+import org.jetbrains.kotlin.ir.expressions.isTransparentScope
+import org.jetbrains.kotlin.ir.irAttribute
+import org.jetbrains.kotlin.ir.util.overrides
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+
+internal var IrSuspensionPoint.liveVariablesAtSuspensionPoint: List<IrVariable>? by irAttribute(copyByDefault = false)
+internal var IrSuspensionPoint.visibleVariablesAtSuspensionPoint: List<IrVariable>? by irAttribute(copyByDefault = false)
+
+/**
+ * Computes live variables at suspension points.
+ */
+@PhasePrerequisites(NativeSuspendFunctionsLowering::class)
+internal class CoroutinesLivenessAnalysis(val context: NativeGenerationState) : BodyLoweringPass {
+    override fun lower(irBody: IrBody, container: IrDeclaration) {
+        LivenessAnalysis.run(irBody) { it is IrSuspensionPoint }
+                .forEach { [irElement, liveVariables] ->
+                    (irElement as IrSuspensionPoint).liveVariablesAtSuspensionPoint = liveVariables
+                }
+        context.coroutinesLivenessAnalysisPhasePerformed = true
+    }
+}
+
+/**
+ * Computes visible variables at suspension points.
+ */
+@PhasePrerequisites(NativeSuspendFunctionsLowering::class)
+internal class CoroutinesLivenessAnalysisFallback(val generationState: NativeGenerationState) : BodyLoweringPass {
+    private val invokeSuspendFunction = generationState.context.symbols.invokeSuspendFunction
+
+    override fun lower(irBody: IrBody, container: IrDeclaration) {
+        if (generationState.coroutinesLivenessAnalysisPhasePerformed)
+            return
+
+        val thisReceiver = (container as? IrSimpleFunction)?.dispatchReceiverParameter
+        if (thisReceiver == null || !container.overrides(invokeSuspendFunction.owner))
+            return
+
+        computeVisibleVariablesAtSuspensionPoints(irBody)
+    }
+
+    private fun computeVisibleVariablesAtSuspensionPoints(body: IrBody) {
+        body.acceptChildrenVoid(object : IrVisitorVoid() {
+            val scopeStack = mutableListOf<MutableSet<IrVariable>>(mutableSetOf())
+
+            override fun visitElement(element: IrElement) {
+                element.acceptChildrenVoid(this)
+            }
+
+            override fun visitContainerExpression(expression: IrContainerExpression) {
+                if (!expression.isTransparentScope)
+                    scopeStack.push(mutableSetOf())
+                super.visitContainerExpression(expression)
+                if (!expression.isTransparentScope)
+                    scopeStack.pop()
+            }
+
+            override fun visitCatch(aCatch: IrCatch) {
+                scopeStack.push(mutableSetOf())
+                super.visitCatch(aCatch)
+                scopeStack.pop()
+            }
+
+            override fun visitVariable(declaration: IrVariable) {
+                super.visitVariable(declaration)
+                scopeStack.peek()!!.add(declaration)
+            }
+
+            override fun visitSuspensionPoint(expression: IrSuspensionPoint) {
+                // Skip suspensionPointIdParameter, because we don't want to save it.
+                expression.result.acceptChildrenVoid(this)
+                expression.resumeResult.acceptChildrenVoid(this)
+
+                val visibleVariables = mutableListOf<IrVariable>()
+                scopeStack.forEach { visibleVariables += it }
+                expression.visibleVariablesAtSuspensionPoint = visibleVariables
+            }
+        })
+    }
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CoroutinesVarSpillingLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CoroutinesVarSpillingLowering.kt
@@ -8,37 +8,32 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
-import org.jetbrains.kotlin.backend.common.peek
-import org.jetbrains.kotlin.backend.common.pop
-import org.jetbrains.kotlin.backend.common.push
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
-import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.builders.irSet
 import org.jetbrains.kotlin.ir.builders.irSetField
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.*
-import org.jetbrains.kotlin.ir.irAttribute
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrSuspensionPoint
 import org.jetbrains.kotlin.ir.symbols.IrVariableSymbol
 import org.jetbrains.kotlin.ir.util.addChild
 import org.jetbrains.kotlin.ir.util.overrides
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
-import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
-import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 
 internal val DECLARATION_ORIGIN_COROUTINE_VAR_SPILLING = IrDeclarationOriginImpl("COROUTINE_VAR_SPILLING")
-
-internal var IrSuspensionPoint.liveVariablesAtSuspensionPoint: List<IrVariable>? by irAttribute(copyByDefault = false)
-internal var IrSuspensionPoint.visibleVariablesAtSuspensionPoint: List<IrVariable>? by irAttribute(copyByDefault = false)
 
 /**
  * Saves/restores coroutines variables before/after suspension.
  */
+@PhasePrerequisites(NativeSuspendFunctionsLowering::class)
 internal class CoroutinesVarSpillingLowering(val generationState: NativeGenerationState) : BodyLoweringPass {
     private val context = generationState.context
     private val irFactory = context.irFactory
@@ -107,62 +102,5 @@ internal class CoroutinesVarSpillingLowering(val generationState: NativeGenerati
                 }
             }
         }, data = emptyList())
-    }
-}
-
-/**
- * Computes visible variables at suspension points.
- */
-internal class CoroutinesLivenessAnalysisFallback(val generationState: NativeGenerationState) : BodyLoweringPass {
-    private val invokeSuspendFunction = generationState.context.symbols.invokeSuspendFunction
-
-    override fun lower(irBody: IrBody, container: IrDeclaration) {
-        if (generationState.coroutinesLivenessAnalysisPhasePerformed)
-            return
-
-        val thisReceiver = (container as? IrSimpleFunction)?.dispatchReceiverParameter
-        if (thisReceiver == null || !container.overrides(invokeSuspendFunction.owner))
-            return
-
-        computeVisibleVariablesAtSuspensionPoints(irBody)
-    }
-
-    private fun computeVisibleVariablesAtSuspensionPoints(body: IrBody) {
-        body.acceptChildrenVoid(object : IrVisitorVoid() {
-            val scopeStack = mutableListOf<MutableSet<IrVariable>>(mutableSetOf())
-
-            override fun visitElement(element: IrElement) {
-                element.acceptChildrenVoid(this)
-            }
-
-            override fun visitContainerExpression(expression: IrContainerExpression) {
-                if (!expression.isTransparentScope)
-                    scopeStack.push(mutableSetOf())
-                super.visitContainerExpression(expression)
-                if (!expression.isTransparentScope)
-                    scopeStack.pop()
-            }
-
-            override fun visitCatch(aCatch: IrCatch) {
-                scopeStack.push(mutableSetOf())
-                super.visitCatch(aCatch)
-                scopeStack.pop()
-            }
-
-            override fun visitVariable(declaration: IrVariable) {
-                super.visitVariable(declaration)
-                scopeStack.peek()!!.add(declaration)
-            }
-
-            override fun visitSuspensionPoint(expression: IrSuspensionPoint) {
-                // Skip suspensionPointIdParameter, because we don't want to save it.
-                expression.result.acceptChildrenVoid(this)
-                expression.resumeResult.acceptChildrenVoid(this)
-
-                val visibleVariables = mutableListOf<IrVariable>()
-                scopeStack.forEach { visibleVariables += it }
-                expression.visibleVariablesAtSuspensionPoint = visibleVariables
-            }
-        })
     }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CoroutinesVarSpillingLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CoroutinesVarSpillingLowering.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.builders.irGet
@@ -34,8 +34,7 @@ internal val DECLARATION_ORIGIN_COROUTINE_VAR_SPILLING = IrDeclarationOriginImpl
  * Saves/restores coroutines variables before/after suspension.
  */
 @PhasePrerequisites(NativeSuspendFunctionsLowering::class)
-internal class CoroutinesVarSpillingLowering(val generationState: NativeGenerationState) : BodyLoweringPass {
-    private val context = generationState.context
+internal class CoroutinesVarSpillingLowering(val context: NativeLoweringContext) : BodyLoweringPass {
     private val irFactory = context.irFactory
     private val symbols = context.symbols
     private val invokeSuspendFunction = symbols.invokeSuspendFunction

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DataClassOperatorsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DataClassOperatorsLowering.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irCallWithSubstitutedType
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
-internal class DataClassOperatorsLowering(val context: NativeGenerationState) : FileLoweringPass, IrTransformer<IrFunction?>() {
+internal class DataClassOperatorsLowering(val context: NativeLoweringContext) : FileLoweringPass, IrTransformer<IrFunction?>() {
     private val irBuiltins = context.irBuiltIns
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DataClassOperatorsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DataClassOperatorsLowering.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irCallWithSubstitutedType
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
-internal class DataClassOperatorsLowering(val context: NativeBackendContext) : FileLoweringPass, IrTransformer<IrFunction?>() {
+internal class DataClassOperatorsLowering(val context: NativeGenerationState) : FileLoweringPass, IrTransformer<IrFunction?>() {
     private val irBuiltins = context.irBuiltIns
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.ir.createArrayOfExpression
 import org.jetbrains.kotlin.backend.common.lower.*
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.IntrinsicType
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
@@ -66,6 +67,7 @@ internal class EnumsSupport(
 
 internal val DECLARATION_ORIGIN_ENUM = IrDeclarationOriginImpl("ENUM")
 
+@PhasePrerequisites(EnumConstructorsLowering::class, NativeFunctionReferenceLowering::class)
 internal class NativeEnumWhenLowering(private val generationState: NativeGenerationState) : EnumWhenLowering(generationState.context) {
     override fun mapConstEnumEntry(entry: IrEnumEntry): Int {
         // The ordinal is baked into the caller's bitcode as a constant, so the lowered IR
@@ -77,8 +79,9 @@ internal class NativeEnumWhenLowering(private val generationState: NativeGenerat
     }
 }
 
-internal class EnumUsageLowering(val context: NativeBackendContext) : IrTransformer<IrBuilderWithScope?>(), FileLoweringPass {
-    private val enumsSupport = context.enumsSupport
+@PhasePrerequisites(EnumClassLowering::class)
+internal class EnumUsageLowering(val context: NativeGenerationState) : IrTransformer<IrBuilderWithScope?>(), FileLoweringPass {
+    private val enumsSupport = context.context.enumsSupport
 
     override fun lower(irFile: IrFile) {
         visitFile(irFile, data = null)
@@ -153,8 +156,9 @@ internal class EnumUsageLowering(val context: NativeBackendContext) : IrTransfor
 
 }
 
-internal class EnumClassLowering(val context: NativeBackendContext) : FileLoweringPass {
-    private val enumsSupport = context.enumsSupport
+@PhasePrerequisites(EnumWhenLowering::class)
+internal class EnumClassLowering(val context: NativeGenerationState) : FileLoweringPass {
+    private val enumsSupport = context.context.enumsSupport
     private val symbols = context.symbols
     private val createUninitializedInstance = symbols.createUninitializedInstance
     private val createEnumEntries = symbols.createEnumEntries

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
@@ -10,8 +10,8 @@ import org.jetbrains.kotlin.backend.common.ir.createArrayOfExpression
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.IntrinsicType
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.KonanNameConventions
 import org.jetbrains.kotlin.backend.konan.ir.tryGetIntrinsicType
@@ -80,8 +80,8 @@ internal class NativeEnumWhenLowering(private val generationState: NativeGenerat
 }
 
 @PhasePrerequisites(EnumClassLowering::class)
-internal class EnumUsageLowering(val context: NativeGenerationState) : IrTransformer<IrBuilderWithScope?>(), FileLoweringPass {
-    private val enumsSupport = context.context.enumsSupport
+internal class EnumUsageLowering(val context: NativeLoweringContext) : IrTransformer<IrBuilderWithScope?>(), FileLoweringPass {
+    private val enumsSupport = context.enumsSupport
 
     override fun lower(irFile: IrFile) {
         visitFile(irFile, data = null)
@@ -157,8 +157,8 @@ internal class EnumUsageLowering(val context: NativeGenerationState) : IrTransfo
 }
 
 @PhasePrerequisites(EnumWhenLowering::class)
-internal class EnumClassLowering(val context: NativeGenerationState) : FileLoweringPass {
-    private val enumsSupport = context.context.enumsSupport
+internal class EnumClassLowering(val context: NativeLoweringContext) : FileLoweringPass {
+    private val enumsSupport = context.enumsSupport
     private val symbols = context.symbols
     private val createUninitializedInstance = symbols.createUninitializedInstance
     private val createEnumEntries = symbols.createEnumEntries

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.enumEntriesMap
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrStatement
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.name.Name
 
-internal class EnumConstructorsLowering(val context: NativeBackendContext) : ClassLoweringPass {
+internal class EnumConstructorsLowering(val context: NativeGenerationState) : ClassLoweringPass {
 
     fun run(irFile: IrFile) {
         runOnFilePostfix(irFile)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.enumEntriesMap
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrStatement
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.name.Name
 
-internal class EnumConstructorsLowering(val context: NativeGenerationState) : ClassLoweringPass {
+internal class EnumConstructorsLowering(val context: NativeLoweringContext) : ClassLoweringPass {
 
     fun run(irFile: IrFile) {
         runOnFilePostfix(irFile)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ExportedBridgeNonVirtualLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ExportedBridgeNonVirtualLowering.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.annotations.exportedBridgeNonVirtualTargetMethod
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * `@ExportedBridge(..., nonVirtualTargetMethod = "<method>")` so that every call to said method gets dispatched non-virtually,
  */
 @PhasePrerequisites(PostInlineLowering::class)
-internal class ExportedBridgeNonVirtualLowering(val context: NativeGenerationState) : FileLoweringPass {
+internal class ExportedBridgeNonVirtualLowering(val context: NativeLoweringContext) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         for (function in irFile.declarations.filterIsInstance<IrSimpleFunction>()) {
             val targetMethod = function.exportedBridgeNonVirtualTargetMethod ?: continue

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ExportedBridgeNonVirtualLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ExportedBridgeNonVirtualLowering.kt
@@ -6,7 +6,8 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.ir.annotations.exportedBridgeNonVirtualTargetMethod
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -25,7 +26,8 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * Rewrites the call to the target method inside a Swift Export forward bridge marked with
  * `@ExportedBridge(..., nonVirtualTargetMethod = "<method>")` so that every call to said method gets dispatched non-virtually,
  */
-internal class ExportedBridgeNonVirtualLowering(val context: NativeBackendContext) : FileLoweringPass {
+@PhasePrerequisites(PostInlineLowering::class)
+internal class ExportedBridgeNonVirtualLowering(val context: NativeGenerationState) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         for (function in irFile.declarations.filterIsInstance<IrSimpleFunction>()) {
             val targetMethod = function.exportedBridgeNonVirtualTargetMethod ?: continue

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/GenericCallsReturnTypeEraser.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/GenericCallsReturnTypeEraser.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irImplicitCoercionToUnit
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.optimizations.STATEMENT_ORIGIN_NO_CAST_NEEDED
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irImplicitCast
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * The idea here is that by the end of the pipeline all the types are considered erased and a function call is just
  * a pure and simple function call with no conversions/coercions of the return type and the parameter types.
  */
-internal class GenericCallsReturnTypeEraser(val context: NativeGenerationState) : BodyLoweringPass {
+internal class GenericCallsReturnTypeEraser(val context: NativeLoweringContext) : BodyLoweringPass {
     private val reinterpret = context.symbols.reinterpret.owner
     private val createUninitializedInstance = context.symbols.createUninitializedInstance.owner
     private val anyType = context.irBuiltIns.anyType

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/GenericCallsReturnTypeEraser.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/GenericCallsReturnTypeEraser.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irImplicitCoercionToUnit
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.optimizations.STATEMENT_ORIGIN_NO_CAST_NEEDED
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irImplicitCast
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * The idea here is that by the end of the pipeline all the types are considered erased and a function call is just
  * a pure and simple function call with no conversions/coercions of the return type and the parameter types.
  */
-internal class GenericCallsReturnTypeEraser(val context: NativeBackendContext) : BodyLoweringPass {
+internal class GenericCallsReturnTypeEraser(val context: NativeGenerationState) : BodyLoweringPass {
     private val reinterpret = context.symbols.reinterpret.owner
     private val createUninitializedInstance = context.symbols.createUninitializedInstance.owner
     private val anyType = context.irBuiltIns.anyType

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.compilationException
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.Modality
@@ -21,6 +22,7 @@ import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
+@PhasePrerequisites(EnumConstructorsLowering::class)
 internal class InitializersLowering(val context: CommonBackendContext) : ClassLoweringPass {
     companion object {
         val STATEMENT_ORIGIN_ANONYMOUS_INITIALIZER = IrStatementOriginImpl("ANONYMOUS_INITIALIZER")

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InlineClassPropertyAccessorsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InlineClassPropertyAccessorsLowering.kt
@@ -9,7 +9,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
 import org.jetbrains.kotlin.backend.common.lower.at
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.isInlineClass
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 /**
  * Boxes and unboxes values of value types when necessary.
  */
-internal class InlineClassPropertyAccessorsLowering(val context: NativeBackendContext) : FileLoweringPass {
+internal class InlineClassPropertyAccessorsLowering(val context: NativeLoweringContext) : FileLoweringPass {
 
     private val transformer = InlineClassAccessorsTransformer(context)
 
@@ -32,8 +32,7 @@ internal class InlineClassPropertyAccessorsLowering(val context: NativeBackendCo
 
 }
 
-private class InlineClassAccessorsTransformer(private val context: NativeBackendContext) : IrBuildingTransformer(context) {
-
+private class InlineClassAccessorsTransformer(context: NativeLoweringContext) : IrBuildingTransformer(context) {
     private val symbols = context.symbols
 
     override fun visitCall(expression: IrCall): IrExpression {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InnerClassLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InnerClassLowering.kt
@@ -11,7 +11,8 @@ import org.jetbrains.kotlin.backend.common.lower.ConstructorDelegationKind
 import org.jetbrains.kotlin.backend.common.lower.InnerClassesSupport
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.delegationKind
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrStatement
@@ -61,7 +62,8 @@ internal class NativeInnerClassesSupport(private val irFactory: IrFactory) : Inn
     override fun getInnerClassOriginalPrimaryConstructorOrNull(innerClass: IrClass): IrConstructor = shouldNotBeCalled()
 }
 
-internal class InnerClassLowering(val context: NativeBackendContext) : ClassLoweringPass {
+@PhasePrerequisites(NativeDefaultParameterInjector::class)
+internal class InnerClassLowering(val context: NativeGenerationState) : ClassLoweringPass {
     override fun lower(irClass: IrClass) {
         if (!irClass.isInner) return
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InnerClassLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InnerClassLowering.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.backend.common.lower.InnerClassesSupport
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.delegationKind
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrStatement
@@ -63,7 +63,7 @@ internal class NativeInnerClassesSupport(private val irFactory: IrFactory) : Inn
 }
 
 @PhasePrerequisites(NativeDefaultParameterInjector::class)
-internal class InnerClassLowering(val context: NativeGenerationState) : ClassLoweringPass {
+internal class InnerClassLowering(val context: NativeLoweringContext) : ClassLoweringPass {
     override fun lower(irClass: IrClass) {
         if (!irClass.isInner) return
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -7,6 +7,8 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.*
 import org.jetbrains.kotlin.backend.common.lower.*
+import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineLambdasLowering
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.cgen.*
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
@@ -41,16 +43,17 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.NativeStandardInteropNames.objCActionClassId
 import org.jetbrains.kotlin.native.interop.ObjCMethodInfo
 
-internal class InteropLowering(val context: NativeBackendContext, val fileLowerState: FileLowerState) : FileLoweringPass, BodyLoweringPass {
+@PhasePrerequisites(LocalClassesInInlineLambdasLowering::class)
+internal class InteropLowering(val generationState: NativeGenerationState) : FileLoweringPass, BodyLoweringPass {
     override fun lower(irFile: IrFile) {
         // TODO: merge these lowerings.
-        InteropLoweringPart1(context, fileLowerState).lower(irFile)
-        InteropLoweringPart2(context, fileLowerState).lower(irFile)
+        InteropLoweringPart1(generationState.context, generationState.fileLowerState).lower(irFile)
+        InteropLoweringPart2(generationState.context, generationState.fileLowerState).lower(irFile)
     }
 
     override fun lower(irBody: IrBody, container: IrDeclaration) {
-        InteropLoweringPart1(context, fileLowerState).lower(irBody, container)
-        InteropLoweringPart2(context, fileLowerState).lower(irBody, container)
+        InteropLoweringPart1(generationState.context, generationState.fileLowerState).lower(irBody, container)
+        InteropLoweringPart2(generationState.context, generationState.fileLowerState).lower(irBody, container)
     }
 
     companion object {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -47,13 +47,13 @@ import org.jetbrains.kotlin.native.interop.ObjCMethodInfo
 internal class InteropLowering(val generationState: NativeGenerationState) : FileLoweringPass, BodyLoweringPass {
     override fun lower(irFile: IrFile) {
         // TODO: merge these lowerings.
-        InteropLoweringPart1(generationState.context, generationState.fileLowerState).lower(irFile)
-        InteropLoweringPart2(generationState.context, generationState.fileLowerState).lower(irFile)
+        InteropLoweringPart1(generationState, generationState.fileLowerState).lower(irFile)
+        InteropLoweringPart2(generationState, generationState.fileLowerState).lower(irFile)
     }
 
     override fun lower(irBody: IrBody, container: IrDeclaration) {
-        InteropLoweringPart1(generationState.context, generationState.fileLowerState).lower(irBody, container)
-        InteropLoweringPart2(generationState.context, generationState.fileLowerState).lower(irBody, container)
+        InteropLoweringPart1(generationState, generationState.fileLowerState).lower(irBody, container)
+        InteropLoweringPart2(generationState, generationState.fileLowerState).lower(irBody, container)
     }
 
     companion object {
@@ -79,7 +79,7 @@ private class NameCounter {
 }
 
 private abstract class BaseInteropIrTransformer(
-        protected val context: NativeBackendContext,
+        protected val context: NativeLoweringContext,
         protected val fileLowerState: FileLowerState,
         protected val irFile: IrFile?,
 ) : IrBuildingTransformer(context) {
@@ -169,7 +169,7 @@ private abstract class BaseInteropIrTransformer(
             renderCompilerError(irFile, element, message)
 }
 
-private class InteropLoweringPart1(val context: NativeBackendContext, val fileLowerState: FileLowerState) : FileLoweringPass, BodyLoweringPass {
+private class InteropLoweringPart1(val context: NativeLoweringContext, val fileLowerState: FileLowerState) : FileLoweringPass, BodyLoweringPass {
     private var topLevelInitializersCounter = 0
 
     override fun lower(irFile: IrFile) {
@@ -213,7 +213,7 @@ private class InteropLoweringPart1(val context: NativeBackendContext, val fileLo
 }
 
 private class InteropTransformerPart1(
-        context: NativeBackendContext,
+        context: NativeLoweringContext,
         fileLowerState: FileLowerState,
         irFile: IrFile?,
 ) : BaseInteropIrTransformer(context, fileLowerState, irFile) {
@@ -726,7 +726,7 @@ private class InteropTransformerPart1(
 /**
  * Lowers some interop intrinsic calls.
  */
-private class InteropLoweringPart2(val context: NativeBackendContext, val fileLowerState: FileLowerState) : FileLoweringPass, BodyLoweringPass {
+private class InteropLoweringPart2(val context: NativeLoweringContext, val fileLowerState: FileLowerState) : FileLoweringPass, BodyLoweringPass {
     override fun lower(irFile: IrFile) {
         val transformer = InteropTransformerPart2(context, fileLowerState, irFile)
         irFile.transformChildrenVoid(transformer)
@@ -739,7 +739,7 @@ private class InteropLoweringPart2(val context: NativeBackendContext, val fileLo
 }
 
 private class InteropTransformerPart2(
-        context: NativeBackendContext,
+        context: NativeLoweringContext,
         fileLowerState: FileLowerState,
         irFile: IrFile?,
 ) : BaseInteropIrTransformer(context, fileLowerState, irFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAddContinuationToFunctionCallsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAddContinuationToFunctionCallsLowering.kt
@@ -6,12 +6,12 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.coroutines.AbstractAddContinuationToFunctionCallsLowering
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.util.overrides
 
 internal class NativeAddContinuationToFunctionCallsLowering(
-        override val context: NativeGenerationState
+        override val context: NativeLoweringContext
 ) : AbstractAddContinuationToFunctionCallsLowering() {
     /*
      * In complex cases suspend functions are converted to state-machine class with invokeSuspend method.

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAddContinuationToFunctionCallsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAddContinuationToFunctionCallsLowering.kt
@@ -6,12 +6,12 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.coroutines.AbstractAddContinuationToFunctionCallsLowering
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.util.overrides
 
 internal class NativeAddContinuationToFunctionCallsLowering(
-        override val context: NativeBackendContext
+        override val context: NativeGenerationState
 ) : AbstractAddContinuationToFunctionCallsLowering() {
     /*
      * In complex cases suspend functions are converted to state-machine class with invokeSuspend method.

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAnnotationImplementationLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAnnotationImplementationLowering.kt
@@ -18,11 +18,11 @@ import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 
-internal class NativeAnnotationImplementationLowering(context: NativeBackendContext) : AnnotationImplementationLowering(
+internal class NativeAnnotationImplementationLowering(context: NativeGenerationState) : AnnotationImplementationLowering(
     { NativeAnnotationImplementationTransformer(context, it) }
 )
 
-private class NativeAnnotationImplementationTransformer(context: NativeBackendContext, irFile: IrFile) :
+private class NativeAnnotationImplementationTransformer(context: NativeGenerationState, irFile: IrFile) :
         AnnotationImplementationTransformer(context, context.symbolTable, irFile) {
 
     private val arrayContentEqualsMap = context.symbols.arraysContentEquals

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAnnotationImplementationLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeAnnotationImplementationLowering.kt
@@ -18,11 +18,11 @@ import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 
-internal class NativeAnnotationImplementationLowering(context: NativeGenerationState) : AnnotationImplementationLowering(
+internal class NativeAnnotationImplementationLowering(context: NativeLoweringContext) : AnnotationImplementationLowering(
     { NativeAnnotationImplementationTransformer(context, it) }
 )
 
-private class NativeAnnotationImplementationTransformer(context: NativeGenerationState, irFile: IrFile) :
+private class NativeAnnotationImplementationTransformer(context: NativeLoweringContext, irFile: IrFile) :
         AnnotationImplementationTransformer(context, context.symbolTable, irFile) {
 
     private val arrayContentEqualsMap = context.symbols.arraysContentEquals

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultArgumentStubGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultArgumentStubGenerator.kt
@@ -11,9 +11,11 @@ import org.jetbrains.kotlin.backend.common.lower.DefaultParameterCleaner
 import org.jetbrains.kotlin.backend.common.lower.TailrecLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 
 internal class NativeDefaultParameterCleaner(context: CommonBackendContext) : DefaultParameterCleaner(context, replaceDefaultValuesWithStubs = true)
 
@@ -31,4 +33,7 @@ internal class NativeDefaultArgumentStubGenerator(context: CommonBackendContext)
         val value = irIfThenElse(parameter.type, irNotEquals(defaultFlag, irInt(0)), default, irGet(parameter))
         return createTmpVariable(value, nameHint = parameter.name.asString())
     }
+
+    override fun IrExpression.prepareToBeUsedIn(function: IrFunction): IrExpression =
+            deepCopyWithSymbols(function)
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultArgumentStubGenerator.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultArgumentStubGenerator.kt
@@ -5,14 +5,20 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.lower.DefaultArgumentStubGenerator
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.lower.DefaultParameterCleaner
+import org.jetbrains.kotlin.backend.common.lower.TailrecLowering
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 
-internal class NativeDefaultArgumentStubGenerator(context: NativeBackendContext) : DefaultArgumentStubGenerator<NativeBackendContext>(
+internal class NativeDefaultParameterCleaner(context: CommonBackendContext) : DefaultParameterCleaner(context, replaceDefaultValuesWithStubs = true)
+
+@PhasePrerequisites(TailrecLowering::class, EnumConstructorsLowering::class)
+internal class NativeDefaultArgumentStubGenerator(context: CommonBackendContext) : DefaultArgumentStubGenerator<CommonBackendContext>(
         context = context,
         factory = NativeDefaultArgumentFunctionFactory(context),
         skipInlineMethods = false

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultParameterInjector.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultParameterInjector.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.DefaultParameterInjector
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.PrimitiveBinaryType
 import org.jetbrains.kotlin.backend.konan.computePrimitiveBinaryTypeOrNull
 import org.jetbrains.kotlin.backend.konan.getInlinedClassNative
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
 
-internal class NativeDefaultParameterInjector(context: NativeBackendContext) : DefaultParameterInjector<NativeBackendContext>(
+internal class NativeDefaultParameterInjector(context: NativeGenerationState) : DefaultParameterInjector<NativeGenerationState>(
         context = context,
         factory = NativeDefaultArgumentFunctionFactory(context),
         skipInline = false

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultParameterInjector.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeDefaultParameterInjector.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.DefaultParameterInjector
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.PrimitiveBinaryType
 import org.jetbrains.kotlin.backend.konan.computePrimitiveBinaryTypeOrNull
 import org.jetbrains.kotlin.backend.konan.getInlinedClassNative
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
 
-internal class NativeDefaultParameterInjector(context: NativeGenerationState) : DefaultParameterInjector<NativeGenerationState>(
+internal class NativeDefaultParameterInjector(context: NativeLoweringContext) : DefaultParameterInjector<NativeLoweringContext>(
         context = context,
         factory = NativeDefaultArgumentFunctionFactory(context),
         skipInline = false

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeFinallyBlocksLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeFinallyBlocksLowering.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.lower
+
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.common.lower.FinallyBlocksLowering
+import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationPopupLowering
+import org.jetbrains.kotlin.backend.common.lower.TailrecLowering
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+
+@PhasePrerequisites(InitializersLowering::class, LocalDeclarationPopupLowering::class, TailrecLowering::class)
+internal class NativeFinallyBlocksLowering(context: CommonBackendContext) : FinallyBlocksLowering(context, context.irBuiltIns.throwableType)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeFunctionReferenceLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeFunctionReferenceLowering.kt
@@ -106,7 +106,7 @@ internal class NativeFunctionReferenceLowering(val generationState: NativeGenera
 
     private fun IrBuilderWithScope.irKFunctionDescription(functionReference: IrRichFunctionReference, description: KFunctionDescription, reflectionTargetLinkageError: PartialLinkageCase?): IrConstantValue {
         if (reflectionTargetLinkageError != null) {
-            val errorMessage = generationState.context.partialLinkageSupport.renderAndLogLinkageError(
+            val errorMessage = generationState.partialLinkageSupport.renderAndLogLinkageError(
                     reflectionTargetLinkageError,
                     functionReference,
                     PLFile.determineFileFor(functionReference.invokeFunction),

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeInlineFunctionResolver.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeInlineFunctionResolver.kt
@@ -11,8 +11,8 @@ import org.jetbrains.kotlin.backend.common.lower.LateinitLowering
 import org.jetbrains.kotlin.backend.common.lower.SharedVariablesLowering
 import org.jetbrains.kotlin.backend.common.lower.UpgradeCallableReferences
 import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineLambdasLowering
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.inline.InlineFunctionResolverReplacingCoroutineIntrinsics
@@ -27,8 +27,8 @@ private var IrFunction.wasLowered: Boolean? by irAttribute(copyByDefault = true)
 internal class NativeInlineFunctionResolver(
         val generationState: NativeGenerationState,
         inlineMode: InlineMode,
-) : InlineFunctionResolverReplacingCoroutineIntrinsics<NativeBackendContext>(
-        context = generationState.context,
+) : InlineFunctionResolverReplacingCoroutineIntrinsics<NativeLoweringContext>(
+        context = generationState,
         inlineMode = inlineMode,
 ) {
     override fun getFunctionDeclaration(symbol: IrFunctionSymbol): IrFunction? {
@@ -44,7 +44,7 @@ internal class NativeInlineFunctionResolver(
             return function
         }
 
-        context.getInlineFunctionDeserializer(function).deserializeInlineFunction(function)
+        generationState.context.getInlineFunctionDeserializer(function).deserializeInlineFunction(function)
         lower(function)
         function.wasLowered = true
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeIrInliner.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeIrInliner.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irTemporary
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -25,16 +26,16 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
 internal class NativePrivateFunctionInlining(generationState: NativeGenerationState) : FunctionInlining(
-        context = generationState.context,
+        context = generationState,
         NativeInlineFunctionResolver(generationState, inlineMode = InlineMode.PRIVATE_INLINE_FUNCTIONS),
 )
 
 internal class NativeAllFunctionInlining(generationState: NativeGenerationState) : FunctionInlining(
-        context = generationState.context,
+        context = generationState,
         NativeInlineFunctionResolver(generationState, inlineMode = InlineMode.ALL_INLINE_FUNCTIONS),
 )
 
-internal class PreCodegenFunctionInlining(val context: NativeBackendContext, val functionsToInline: Set<IrFunction>) {
+internal class PreCodegenFunctionInlining(val context: NativeLoweringContext, val functionsToInline: Set<IrFunction>) {
     fun run(irFunction: IrSimpleFunction) {
         val irBuilder = context.createIrBuilder(irFunction.symbol)
         irFunction.body!!.transformChildrenVoid(object : IrElementTransformerVoid() {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeIrValidationPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeIrValidationPhases.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.inline.isConsideredAsPrivateForInlining
 import org.jetbrains.kotlin.ir.util.isTypeOfIntrinsic
 
+// TODO: KT-88761. Remove these (the base class's constructor call sites are identical).
 internal class NativeIrValidationAfterInliningPrivateFunctionsKlibPhase(
         context: NativeLoweringContext
 ) : IrValidationAfterInliningPrivateFunctionsKlibPhase<NativeLoweringContext>(

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeIrValidationPhases.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeIrValidationPhases.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.lower
+
+import org.jetbrains.kotlin.backend.common.phaser.IrValidationAfterInliningAllFunctionsKlibSecondStagePhase
+import org.jetbrains.kotlin.backend.common.phaser.IrValidationAfterInliningPrivateFunctionsKlibPhase
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
+import org.jetbrains.kotlin.ir.inline.isConsideredAsPrivateForInlining
+import org.jetbrains.kotlin.ir.util.isTypeOfIntrinsic
+
+internal class NativeIrValidationAfterInliningPrivateFunctionsKlibPhase(
+        context: NativeLoweringContext
+) : IrValidationAfterInliningPrivateFunctionsKlibPhase<NativeLoweringContext>(
+        context = context,
+        checkInlineFunctionCallSites = { inlineFunctionUseSite ->
+            // Call sites of only non-private functions are allowed at this stage.
+            !inlineFunctionUseSite.symbol.isConsideredAsPrivateForInlining()
+        }
+)
+
+internal class NativeIrValidationAfterInliningAllFunctionsKlibSecondStagePhase(
+        context: NativeLoweringContext
+) : IrValidationAfterInliningAllFunctionsKlibSecondStagePhase<NativeLoweringContext>(
+        context = context,
+        checkInlineFunctionCallSites = check@{ inlineFunctionUseSite ->
+            // No inline function call sites should remain at this stage.
+            val inlineFunction = inlineFunctionUseSite.symbol.owner
+            // it's fine to have typeOf<T>, it would be ignored by inliner and handled on the second stage of compilation
+            if (inlineFunction.symbol.isTypeOfIntrinsic()) return@check true
+            return@check inlineFunction.body == null
+        }
+)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeLowerLocalDeclarations.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeLowerLocalDeclarations.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.backend.common.lower.LocalDelegatedPropertiesLowerin
 import org.jetbrains.kotlin.backend.common.lower.SharedVariablesLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.irFlag
@@ -22,12 +23,12 @@ import org.jetbrains.kotlin.name.Name
 @PhasePrerequisites(SharedVariablesLowering::class, LocalDelegatedPropertiesLowering::class, InteropBridgesNameInventor::class)
 internal class NativeLocalDeclarationsLowering(context: LoweringContext) : LocalDeclarationsLowering(context)
 
-internal class NativeKlibInventNamesForLocalFunctions(@Suppress("unused") context: NativeGenerationState) : KlibInventNamesForLocalFunctions()
+internal class NativeKlibInventNamesForLocalFunctions(@Suppress("unused") context: NativeLoweringContext) : KlibInventNamesForLocalFunctions()
 
 internal var IrClass.hasSyntheticNameToBeHiddenInReflection by irFlag(copyByDefault = true)
 
 // TODO: consider replacing '$' by another delimeter that can't be used in class name specified with backticks (``)
-internal class NativeInventNamesForLocalClasses(val generationState: NativeGenerationState) : InventNamesForLocalClasses() {
+internal class NativeInventNamesForLocalClasses(@Suppress("unused") context: NativeLoweringContext) : InventNamesForLocalClasses() {
     override fun computeTopLevelClassName(clazz: IrClass): String = clazz.name.asString()
     override fun sanitizeNameIfNeeded(name: String) = name
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeLowerLocalDeclarations.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeLowerLocalDeclarations.kt
@@ -5,13 +5,24 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
+import org.jetbrains.kotlin.backend.common.LoweringContext
 import org.jetbrains.kotlin.backend.common.lower.InventNamesForLocalClasses
+import org.jetbrains.kotlin.backend.common.lower.KlibInventNamesForLocalFunctions
+import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationsLowering
+import org.jetbrains.kotlin.backend.common.lower.LocalDelegatedPropertiesLowering
+import org.jetbrains.kotlin.backend.common.lower.SharedVariablesLowering
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.irFlag
 import org.jetbrains.kotlin.ir.util.isAnonymousObject
 import org.jetbrains.kotlin.name.Name
+
+@PhasePrerequisites(SharedVariablesLowering::class, LocalDelegatedPropertiesLowering::class, InteropBridgesNameInventor::class)
+internal class NativeLocalDeclarationsLowering(context: LoweringContext) : LocalDeclarationsLowering(context)
+
+internal class NativeKlibInventNamesForLocalFunctions(@Suppress("unused") context: NativeGenerationState) : KlibInventNamesForLocalFunctions()
 
 internal var IrClass.hasSyntheticNameToBeHiddenInReflection by irFlag(copyByDefault = true)
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSharedVariablesPrimitiveBoxSpecializationLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSharedVariablesPrimitiveBoxSpecializationLowering.kt
@@ -8,8 +8,8 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.lower.SharedVariablesLowering
 import org.jetbrains.kotlin.backend.common.lower.SharedVariablesPrimitiveBoxSpecializationLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 
 @PhasePrerequisites(SharedVariablesLowering::class)
-internal class NativeSharedVariablesPrimitiveBoxSpecializationLowering(context: NativeGenerationState)
+internal class NativeSharedVariablesPrimitiveBoxSpecializationLowering(context: NativeLoweringContext)
     : SharedVariablesPrimitiveBoxSpecializationLowering(context, context.symbols)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSharedVariablesPrimitiveBoxSpecializationLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSharedVariablesPrimitiveBoxSpecializationLowering.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.lower
+
+import org.jetbrains.kotlin.backend.common.lower.SharedVariablesLowering
+import org.jetbrains.kotlin.backend.common.lower.SharedVariablesPrimitiveBoxSpecializationLowering
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+
+@PhasePrerequisites(SharedVariablesLowering::class)
+internal class NativeSharedVariablesPrimitiveBoxSpecializationLowering(context: NativeGenerationState)
+    : SharedVariablesPrimitiveBoxSpecializationLowering(context, context.symbols)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSingleAbstractMethodLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSingleAbstractMethodLowering.kt
@@ -8,7 +8,8 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.ScopeWithIr
 import org.jetbrains.kotlin.backend.common.suspendFunction
 import org.jetbrains.kotlin.backend.common.lower.SingleAbstractMethodLowering
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
@@ -17,7 +18,8 @@ import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.render
 
-internal class NativeSingleAbstractMethodLowering(context: NativeBackendContext) : SingleAbstractMethodLowering(context) {
+@PhasePrerequisites(NativeFunctionReferenceLowering::class)
+internal class NativeSingleAbstractMethodLowering(context: NativeGenerationState) : SingleAbstractMethodLowering(context) {
     override fun getWrapperVisibility(expression: IrTypeOperatorCall, scopes: List<ScopeWithIr>) =
             DescriptorVisibilities.PRIVATE
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSingleAbstractMethodLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSingleAbstractMethodLowering.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.ScopeWithIr
 import org.jetbrains.kotlin.backend.common.suspendFunction
 import org.jetbrains.kotlin.backend.common.lower.SingleAbstractMethodLowering
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.render
 
 @PhasePrerequisites(NativeFunctionReferenceLowering::class)
-internal class NativeSingleAbstractMethodLowering(context: NativeGenerationState) : SingleAbstractMethodLowering(context) {
+internal class NativeSingleAbstractMethodLowering(context: NativeLoweringContext) : SingleAbstractMethodLowering(context) {
     override fun getWrapperVisibility(expression: IrTypeOperatorCall, scopes: List<ScopeWithIr>) =
             DescriptorVisibilities.PRIVATE
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -5,12 +5,12 @@ import org.jetbrains.kotlin.backend.common.collectTailSuspendCalls
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.common.isRestrictedSuspensionFunction
 import org.jetbrains.kotlin.backend.common.lower.*
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.name.Name
 @PhasePrerequisites(LocalDeclarationPopupLowering::class, FinallyBlocksLowering::class, KotlinNothingValueExceptionLowering::class)
 internal class NativeSuspendFunctionsLowering(
         generationState: NativeGenerationState
-) : AbstractSuspendFunctionsLowering<NativeBackendContext>(generationState.context), FileLoweringPass {
+) : AbstractSuspendFunctionsLowering<NativeLoweringContext>(generationState), FileLoweringPass {
     private val irBuiltIns = context.irBuiltIns
     private val symbols = context.symbols
     private val fileLowerState = generationState.fileLowerState

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -3,13 +3,14 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.collectTailSuspendCalls
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
+import org.jetbrains.kotlin.backend.common.isRestrictedSuspensionFunction
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.backend.common.isRestrictedSuspensionFunction
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
@@ -24,8 +25,8 @@ import org.jetbrains.kotlin.ir.types.makeNotNull
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.*
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.resolve.calls.checkers.isRestrictedSuspendFunction
 
+@PhasePrerequisites(LocalDeclarationPopupLowering::class, FinallyBlocksLowering::class, KotlinNothingValueExceptionLowering::class)
 internal class NativeSuspendFunctionsLowering(
         generationState: NativeGenerationState
 ) : AbstractSuspendFunctionsLowering<NativeBackendContext>(generationState.context), FileLoweringPass {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeTailrecLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeTailrecLowering.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.lower
+
+import org.jetbrains.kotlin.backend.common.LoweringContext
+import org.jetbrains.kotlin.backend.common.lower.LocalDeclarationPopupLowering
+import org.jetbrains.kotlin.backend.common.lower.TailrecLowering
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+
+@PhasePrerequisites(LocalDeclarationPopupLowering::class)
+internal class NativeTailrecLowering(context: LoweringContext) : TailrecLowering(context)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ObjectClassLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ObjectClassLowering.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.konan.*
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
 import org.jetbrains.kotlin.backend.konan.ir.isUnit
@@ -28,7 +27,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.getOrSetIfNull
 
 private var IrClass.objectClassInstanceFunction: IrSimpleFunction? by irAttribute(copyByDefault = false)
 
-internal fun NativeBackendContext.getObjectClassInstanceFunction(clazz: IrClass) = clazz::objectClassInstanceFunction.getOrSetIfNull {
+internal fun NativeLoweringContext.getObjectClassInstanceFunction(clazz: IrClass) = clazz::objectClassInstanceFunction.getOrSetIfNull {
     when {
         clazz.isUnit() -> symbols.theUnitInstance.owner
         clazz.isCompanion -> {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PostInlineLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PostInlineLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.renderCompilerError
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.*
@@ -28,8 +28,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
  *     - Convert immutableBlobOf() arguments to special IrConst.
  *     - Convert `obj::class` and `Class::class` to calls.
  */
-internal class PostInlineLowering(val context: NativeGenerationState) : BodyLoweringPass {
-
+internal class PostInlineLowering(val context: NativeLoweringContext) : BodyLoweringPass {
     private val symbols get() = context.symbols
 
     override fun lower(irBody: IrBody, container: IrDeclaration) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PostInlineLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PostInlineLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.renderCompilerError
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.*
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.shouldNotBeCalled
  *     - Convert immutableBlobOf() arguments to special IrConst.
  *     - Convert `obj::class` and `Class::class` to calls.
  */
-internal class PostInlineLowering(val context: NativeBackendContext) : BodyLoweringPass {
+internal class PostInlineLowering(val context: NativeGenerationState) : BodyLoweringPass {
 
     private val symbols get() = context.symbols
 

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PropertyReferenceLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PropertyReferenceLowering.kt
@@ -7,8 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.expressions.*
@@ -40,7 +39,7 @@ internal val BackendNativeSymbols.mutablePropertiesConstructors
     )
 
 @PhasePrerequisites(VolatileFieldsLowering::class, DelegatedPropertyOptimizationLowering::class)
-internal class PropertyReferenceLowering(generationState: NativeGenerationState) : AbstractPropertyReferenceLowering<NativeBackendContext>(generationState.context) {
+internal class PropertyReferenceLowering(context: NativeLoweringContext) : AbstractPropertyReferenceLowering<NativeLoweringContext>(context) {
     private val symbols = context.symbols
     private val immutableSymbols = symbols.immutablePropertiesConstructors
     private val mutableSymbols = symbols.mutablePropertiesConstructors

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PropertyReferenceLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PropertyReferenceLowering.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.*
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
@@ -38,6 +39,7 @@ internal val BackendNativeSymbols.mutablePropertiesConstructors
             listOf(kMutableProperty0Impl, kMutableProperty1Impl, kMutableProperty2Impl)
     )
 
+@PhasePrerequisites(VolatileFieldsLowering::class, DelegatedPropertyOptimizationLowering::class)
 internal class PropertyReferenceLowering(generationState: NativeGenerationState) : AbstractPropertyReferenceLowering<NativeBackendContext>(generationState.context) {
     private val symbols = context.symbols
     private val immutableSymbols = symbols.immutablePropertiesConstructors

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RedundantCoercionsCleaner.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RedundantCoercionsCleaner.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.backend.common.push
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.isBox
 import org.jetbrains.kotlin.backend.konan.ir.isBoxOrUnboxCall
 import org.jetbrains.kotlin.backend.konan.ir.isUnbox
@@ -53,7 +53,7 @@ import org.jetbrains.kotlin.ir.visitors.*
  *   - There might be also some casts in between matching box/unbox pair, the algorithm assumes that in the correct IR
  *     such casts are redundant and eliminates them.
  */
-internal class RedundantCoercionsCleaner(val context: NativeBackendContext) : FileLoweringPass {
+internal class RedundantCoercionsCleaner(val context: NativeLoweringContext) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         irFile.transformChildren(transformer, null)
     }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReifiedFunctionLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReifiedFunctionLowering.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irThrow
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
 import org.jetbrains.kotlin.ir.util.toIrConst
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
-internal class ReifiedFunctionLowering(private val backendContext: NativeBackendContext) : FileLoweringPass, IrElementTransformerVoid() {
+internal class ReifiedFunctionLowering(private val backendContext: NativeGenerationState) : FileLoweringPass, IrElementTransformerVoid() {
     companion object {
         val IrSimpleFunction.isReifiedInline: Boolean
             get() = isInline && typeParameters.any { it.isReified }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReifiedFunctionLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReifiedFunctionLowering.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irThrow
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
 import org.jetbrains.kotlin.ir.util.toIrConst
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
-internal class ReifiedFunctionLowering(private val backendContext: NativeGenerationState) : FileLoweringPass, IrElementTransformerVoid() {
+internal class ReifiedFunctionLowering(private val backendContext: NativeLoweringContext) : FileLoweringPass, IrElementTransformerVoid() {
     companion object {
         val IrSimpleFunction.isReifiedInline: Boolean
             get() = isInline && typeParameters.any { it.isReified }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RemoveCastsFromNothingLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RemoveCastsFromNothingLowering.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.LoweringContext
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.ir.types.isNothing
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
-internal class RemoveCastsFromNothingLowering(val context: NativeBackendContext) : BodyLoweringPass {
+internal class RemoveCastsFromNothingLowering(val context: LoweringContext) : BodyLoweringPass {
     override fun lower(irBody: IrBody, container: IrDeclaration) {
         container.transformChildrenVoid(object : IrElementTransformerVoid() {
             override fun visitTypeOperator(expression: IrTypeOperatorCall): IrExpression {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReturnsInsertionLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReturnsInsertionLowering.kt
@@ -7,7 +7,8 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irReturn
@@ -23,7 +24,8 @@ import org.jetbrains.kotlin.ir.visitors.acceptVoid
 /**
  * Generates [IrReturn]s for `Unit`-returning functions.
  */
-internal class ReturnsInsertionLowering(val context: NativeBackendContext) : FileLoweringPass {
+@PhasePrerequisites(Autoboxing::class, NativeSuspendFunctionsLowering::class, EnumClassLowering::class)
+internal class ReturnsInsertionLowering(val context: NativeGenerationState) : FileLoweringPass {
     private val symbols = context.symbols
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReturnsInsertionLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReturnsInsertionLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irReturn
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.ir.visitors.acceptVoid
  * Generates [IrReturn]s for `Unit`-returning functions.
  */
 @PhasePrerequisites(Autoboxing::class, NativeSuspendFunctionsLowering::class, EnumClassLowering::class)
-internal class ReturnsInsertionLowering(val context: NativeGenerationState) : FileLoweringPass {
+internal class ReturnsInsertionLowering(val context: NativeLoweringContext) : FileLoweringPass {
     private val symbols = context.symbols
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialInteropIntrinsicsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialInteropIntrinsicsLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
 import org.jetbrains.kotlin.backend.common.lower.at
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.error
 import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * These intrinsics must be lowered separately from the interop lowering
  * as their proper handling requires inlining phase to have been applied.
  */
-internal class SpecialInteropIntrinsicsLowering(val context: NativeBackendContext) : FileLoweringPass {
+internal class SpecialInteropIntrinsicsLowering(val context: NativeGenerationState) : FileLoweringPass {
     private val symbols = context.symbols
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialInteropIntrinsicsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialInteropIntrinsicsLowering.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
 import org.jetbrains.kotlin.backend.common.lower.at
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.error
 import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * These intrinsics must be lowered separately from the interop lowering
  * as their proper handling requires inlining phase to have been applied.
  */
-internal class SpecialInteropIntrinsicsLowering(val context: NativeGenerationState) : FileLoweringPass {
+internal class SpecialInteropIntrinsicsLowering(val context: NativeLoweringContext) : FileLoweringPass {
     private val symbols = context.symbols
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialObjCValidationLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialObjCValidationLowering.kt
@@ -6,8 +6,8 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.InteropFqNames
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.reportCompilationError
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
 
-internal class SpecialObjCValidationLowering(val context: NativeBackendContext) : FileLoweringPass {
+internal class SpecialObjCValidationLowering(val context: NativeGenerationState) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         irFile.acceptChildrenVoid(object : IrVisitorVoid() {
             override fun visitElement(element: IrElement) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialObjCValidationLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialObjCValidationLowering.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.konan.InteropFqNames
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.reportCompilationError
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
 
-internal class SpecialObjCValidationLowering(val context: NativeGenerationState) : FileLoweringPass {
+internal class SpecialObjCValidationLowering(val context: NativeLoweringContext) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         irFile.acceptChildrenVoid(object : IrVisitorVoid() {
             override fun visitElement(element: IrElement) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticCallableReferenceOptimization.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticCallableReferenceOptimization.kt
@@ -8,7 +8,8 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.lower.NativeFunctionReferenceLowering.Companion.isLoweredFunctionReference
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
@@ -27,7 +28,8 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * In some cases the object instantiated doesn't capture any context and in fact can be replaced with a constant object.
  * That's what this optimization pass does.
  */
-internal class StaticCallableReferenceOptimization(val context: NativeBackendContext) : FileLoweringPass {
+@PhasePrerequisites(NativeFunctionReferenceLowering::class, PropertyReferenceLowering::class)
+internal class StaticCallableReferenceOptimization(val context: NativeGenerationState) : FileLoweringPass {
     private val allPropertyReferenceSymbols = buildList {
         val immutableSymbols = context.symbols.immutablePropertiesConstructors
         addAll(immutableSymbols.byRecieversCount)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticCallableReferenceOptimization.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticCallableReferenceOptimization.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.lower.NativeFunctionReferenceLowering.Companion.isLoweredFunctionReference
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * That's what this optimization pass does.
  */
 @PhasePrerequisites(NativeFunctionReferenceLowering::class, PropertyReferenceLowering::class)
-internal class StaticCallableReferenceOptimization(val context: NativeGenerationState) : FileLoweringPass {
+internal class StaticCallableReferenceOptimization(val context: NativeLoweringContext) : FileLoweringPass {
     private val allPropertyReferenceSymbols = buildList {
         val immutableSymbols = context.symbols.immutablePropertiesConstructors
         addAll(immutableSymbols.byRecieversCount)

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
@@ -74,7 +74,7 @@ internal fun ConfigChecks.shouldBeInitializedEagerly(irField: IrField): Boolean 
 internal var IrClass.clinitTriggerFunction: IrSimpleFunctionSymbol? by irAttribute(copyByDefault = false)
 
 @PhasePrerequisites(ExpressionBodyTransformer::class)
-internal class StaticInitializersLowering(val context: NativeGenerationState) : FileLoweringPass {
+internal class StaticInitializersLowering(val context: NativeLoweringContext) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         irFile.acceptVoid(object : IrVisitorVoid() {
             override fun visitElement(element: IrElement) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StaticInitializersLowering.kt
@@ -6,7 +6,9 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.lower.ExpressionBodyTransformer
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.binaryTypeIsReference
 import org.jetbrains.kotlin.backend.konan.ir.getSuperClassNotAny
@@ -71,7 +73,8 @@ internal fun ConfigChecks.shouldBeInitializedEagerly(irField: IrField): Boolean 
 
 internal var IrClass.clinitTriggerFunction: IrSimpleFunctionSymbol? by irAttribute(copyByDefault = false)
 
-internal class StaticInitializersLowering(val context: NativeBackendContext) : FileLoweringPass {
+@PhasePrerequisites(ExpressionBodyTransformer::class)
+internal class StaticInitializersLowering(val context: NativeGenerationState) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         irFile.acceptVoid(object : IrVisitorVoid() {
             override fun visitElement(element: IrElement) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StringConcatenationTypeNarrowing.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/StringConcatenationTypeNarrowing.kt
@@ -5,10 +5,12 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
+import org.jetbrains.kotlin.backend.common.lower.StringConcatenationLowering
 import org.jetbrains.kotlin.backend.common.lower.at
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrCall
@@ -34,7 +36,8 @@ import org.jetbrains.kotlin.util.OperatorNameConventions
  * - "if (arg==null) null else arg.toString()"  to pass to StringBuilder.append(String?)
  * - "if (arg==null) "null" else arg.toString()"  to pass to other methods as non-nullable String
  */
-internal class StringConcatenationTypeNarrowing(val context: NativeBackendContext) : FileLoweringPass, IrBuildingTransformer(context) {
+@PhasePrerequisites(StringConcatenationLowering::class)
+internal class StringConcatenationTypeNarrowing(val context: CommonBackendContext) : FileLoweringPass, IrBuildingTransformer(context) {
 
     private val string = context.irBuiltIns.stringClass.owner
     private val stringBuilder = context.symbols.stringBuilder.owner

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsDumper.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsDumper.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.ir.superClasses
+import org.jetbrains.kotlin.backend.konan.sourcesModules
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrField
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -27,8 +28,11 @@ internal class TestsDumper(private val context: NativeBackendContext) : FileLowe
     private val baseClassSuite = symbols.baseClassSuite
     private val topLevelSuite = symbols.topLevelSuite
 
+    private val sourcesModules = context.configuration.sourcesModules
+            ?: error("sourcesModules must have been set in the configuration by the frontend phase")
+
     private fun shouldProcessFile(irFile: IrFile): Boolean =
-            irFile.moduleDescriptor in context.sourcesModules // Process test annotations in source libraries too.
+            irFile.moduleDescriptor in sourcesModules // Process test annotations in source libraries too.
 
     override fun lower(irFile: IrFile) {
         val testDumpFile = context.config.testDumpFile ?: return

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsDumper.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsDumper.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.superClasses
 import org.jetbrains.kotlin.backend.konan.sourcesModules
 import org.jetbrains.kotlin.ir.IrStatement
@@ -22,7 +22,7 @@ import kotlin.io.path.appendLines
 import kotlin.io.path.createFile
 import kotlin.io.path.exists
 
-internal class TestsDumper(private val context: NativeGenerationState) : FileLoweringPass {
+internal class TestsDumper(private val context: NativeLoweringContext) : FileLoweringPass {
     private val symbols = context.symbols
 
     private val baseClassSuite = symbols.baseClassSuite

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsDumper.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsDumper.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.ir.superClasses
 import org.jetbrains.kotlin.backend.konan.sourcesModules
 import org.jetbrains.kotlin.ir.IrStatement
@@ -22,7 +22,7 @@ import kotlin.io.path.appendLines
 import kotlin.io.path.createFile
 import kotlin.io.path.exists
 
-internal class TestsDumper(private val context: NativeBackendContext) : FileLoweringPass {
+internal class TestsDumper(private val context: NativeGenerationState) : FileLoweringPass {
     private val symbols = context.symbols
 
     private val baseClassSuite = symbols.baseClassSuite

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsInitializer.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsInitializer.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.ir.util.SetDeclarationsParentVisitor
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import kotlin.collections.plus
 
-internal class TestsInitializer(private val context: NativeGenerationState) : FileLoweringPass {
+internal class TestsInitializer(private val context: NativeLoweringContext) : FileLoweringPass {
     private val symbols = context.symbols
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsInitializer.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestsInitializer.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.builders.declarations.buildField
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.ir.util.SetDeclarationsParentVisitor
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import kotlin.collections.plus
 
-internal class TestsInitializer(private val context: NativeBackendContext) : FileLoweringPass {
+internal class TestsInitializer(private val context: NativeGenerationState) : FileLoweringPass {
     private val symbols = context.symbols
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOfProcessingLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOfProcessingLowering.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.getCompilerMessageLocation
 import org.jetbrains.kotlin.ir.util.isTypeOfIntrinsic
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.BackendNativeSymbols
 import org.jetbrains.kotlin.backend.konan.reportCompilationError
 import org.jetbrains.kotlin.ir.IrBuiltIns
@@ -23,12 +23,12 @@ import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.util.file
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
-internal class TypeOfProcessingLowering(val generationState: NativeGenerationState) : FileLoweringPass {
+internal class TypeOfProcessingLowering(val context: NativeLoweringContext) : FileLoweringPass {
     override fun lower(irFile: IrFile) {
         Transformer(
-                generationState.context.irBuiltIns,
-                generationState.context.symbols,
-                generationState.context
+                context.irBuiltIns,
+                context.symbols,
+                context
         ).visitFile(irFile, null)
     }
 }

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOperatorLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOperatorLowering.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.IrBuildingTransformer
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.irBlock
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.optimizations.STATEMENT_ORIGIN_NO_CAST_NEEDED
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -23,6 +24,7 @@ import org.jetbrains.kotlin.ir.types.mergeNullability
 import org.jetbrains.kotlin.ir.util.eraseTypeParameters
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
+@PhasePrerequisites(NativeSuspendFunctionsLowering::class)
 internal class TypeOperatorLowering(val context: CommonBackendContext) : FileLoweringPass, IrBuildingTransformer(context) {
 
     override fun lower(irFile: IrFile) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/UnboxInlineLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/UnboxInlineLowering.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.getUnboxFunction
 import org.jetbrains.kotlin.backend.konan.ir.isUnbox
@@ -23,6 +24,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * In case the body of <T-unbox> is exactly RETURN(GET_FIELD(IrExpression, backing_field)), it is inlined.
  * So, the snippets `CALL 'public final fun <T-unbox> (IrExpression)` are transformed to 'GET_FIELD(IrExpression, backing_field)'.
  */
+@PhasePrerequisites(RedundantCoercionsCleaner::class)
 internal class UnboxInlineLowering(
         private val context: NativeLoweringContext,
 ) : BodyLoweringPass {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/UnboxInlineLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/UnboxInlineLowering.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.backend.common.BodyLoweringPass
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.getUnboxFunction
 import org.jetbrains.kotlin.backend.konan.ir.isUnbox
 import org.jetbrains.kotlin.ir.builders.irGetField
@@ -25,7 +26,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * So, the snippets `CALL 'public final fun <T-unbox> (IrExpression)` are transformed to 'GET_FIELD(IrExpression, backing_field)'.
  */
 internal class UnboxInlineLowering(
-        private val context: CommonBackendContext,
+        private val context: NativeGenerationState,
 ) : BodyLoweringPass {
 
     override fun lower(irBody: IrBody, container: IrDeclaration) {
@@ -33,9 +34,7 @@ internal class UnboxInlineLowering(
     }
 }
 
-private class AccessorInliner(commonBackendContext: CommonBackendContext) : IrElementTransformerVoid() {
-    private val context = commonBackendContext as NativeBackendContext
-
+private class AccessorInliner(private val context: NativeGenerationState) : IrElementTransformerVoid() {
     private fun IrFunction.isEasyInlineableUnbox(): Boolean = !returnType.isNullable() && isUnbox()
 
     override fun visitCall(expression: IrCall): IrExpression {
@@ -48,7 +47,7 @@ private class AccessorInliner(commonBackendContext: CommonBackendContext) : IrEl
 
     private fun tryInlineUnbox(call: IrCall): IrExpression? {
         val returnClass = call.type.getClass()!!
-        val singleStatement = context.getUnboxFunction(returnClass).body?.statements?.singleOrNull()
+        val singleStatement = context.context.getUnboxFunction(returnClass).body?.statements?.singleOrNull()
         return if (singleStatement is IrReturn) {
             val retVal = singleStatement.value
             if (retVal is IrGetField) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/UnboxInlineLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/UnboxInlineLowering.kt
@@ -6,10 +6,8 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
-import org.jetbrains.kotlin.backend.common.CommonBackendContext
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.getUnboxFunction
 import org.jetbrains.kotlin.backend.konan.ir.isUnbox
 import org.jetbrains.kotlin.ir.builders.irGetField
@@ -26,7 +24,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
  * So, the snippets `CALL 'public final fun <T-unbox> (IrExpression)` are transformed to 'GET_FIELD(IrExpression, backing_field)'.
  */
 internal class UnboxInlineLowering(
-        private val context: NativeGenerationState,
+        private val context: NativeLoweringContext,
 ) : BodyLoweringPass {
 
     override fun lower(irBody: IrBody, container: IrDeclaration) {
@@ -34,7 +32,7 @@ internal class UnboxInlineLowering(
     }
 }
 
-private class AccessorInliner(private val context: NativeGenerationState) : IrElementTransformerVoid() {
+private class AccessorInliner(private val context: NativeLoweringContext) : IrElementTransformerVoid() {
     private fun IrFunction.isEasyInlineableUnbox(): Boolean = !returnType.isNullable() && isUnbox()
 
     override fun visitCall(expression: IrCall): IrExpression {
@@ -47,7 +45,7 @@ private class AccessorInliner(private val context: NativeGenerationState) : IrEl
 
     private fun tryInlineUnbox(call: IrCall): IrExpression? {
         val returnClass = call.type.getClass()!!
-        val singleStatement = context.context.getUnboxFunction(returnClass).body?.statements?.singleOrNull()
+        val singleStatement = context.getUnboxFunction(returnClass).body?.statements?.singleOrNull()
         return if (singleStatement is IrReturn) {
             val retVal = singleStatement.value
             if (retVal is IrGetField) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
@@ -20,7 +20,8 @@ import org.jetbrains.kotlin.backend.common.DeclarationContainerLoweringPass
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedString
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.ir.KonanNameConventions
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.builtins.UnsignedType
@@ -39,7 +40,8 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
-internal class VarargInjectionLowering(val context: NativeBackendContext) : DeclarationContainerLoweringPass {
+@PhasePrerequisites(NativeFunctionReferenceLowering::class, NativeDefaultParameterInjector::class, InteropLowering::class)
+internal class VarargInjectionLowering(val context: NativeGenerationState) : DeclarationContainerLoweringPass {
     override fun lower(irDeclarationContainer: IrDeclarationContainer) {
         irDeclarationContainer.declarations.forEach {
             when (it) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.backend.common.descriptors.synthesizedString
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
 import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
-import org.jetbrains.kotlin.backend.konan.NativeGenerationState
+import org.jetbrains.kotlin.backend.konan.NativeLoweringContext
 import org.jetbrains.kotlin.backend.konan.ir.KonanNameConventions
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.builtins.UnsignedType
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
 @PhasePrerequisites(NativeFunctionReferenceLowering::class, NativeDefaultParameterInjector::class, InteropLowering::class)
-internal class VarargInjectionLowering(val context: NativeGenerationState) : DeclarationContainerLoweringPass {
+internal class VarargInjectionLowering(val context: NativeLoweringContext) : DeclarationContainerLoweringPass {
     override fun lower(irDeclarationContainer: IrDeclarationContainer) {
         irDeclarationContainer.declarations.forEach {
             when (it) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VolatileFieldsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VolatileFieldsLowering.kt
@@ -38,7 +38,7 @@ enum class AtomicFunctionType {
 private var IrField.atomicFunction: MutableMap<AtomicFunctionType, IrSimpleFunction>? by irAttribute(copyByDefault = false)
 internal var IrSimpleFunction.volatileField: IrField? by irAttribute(copyByDefault = false)
 
-internal class VolatileFieldsLowering(val context: NativeGenerationState) : FileLoweringPass {
+internal class VolatileFieldsLowering(val context: NativeLoweringContext) : FileLoweringPass {
     private val symbols = context.symbols
     private val irBuiltins = context.irBuiltIns
     private fun IrBuilderWithScope.irByteToBool(expression: IrExpression) = irCall(symbols.areEqualByValue[PrimitiveBinaryType.BYTE]!!).apply {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VolatileFieldsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VolatileFieldsLowering.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.konan.*
-import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
 import org.jetbrains.kotlin.backend.konan.IntrinsicType
 import org.jetbrains.kotlin.backend.konan.ir.tryGetIntrinsicType
@@ -39,7 +38,7 @@ enum class AtomicFunctionType {
 private var IrField.atomicFunction: MutableMap<AtomicFunctionType, IrSimpleFunction>? by irAttribute(copyByDefault = false)
 internal var IrSimpleFunction.volatileField: IrField? by irAttribute(copyByDefault = false)
 
-internal class VolatileFieldsLowering(val context: NativeBackendContext) : FileLoweringPass {
+internal class VolatileFieldsLowering(val context: NativeGenerationState) : FileLoweringPass {
     private val symbols = context.symbols
     private val irBuiltins = context.irBuiltIns
     private fun IrBuilderWithScope.irByteToBool(expression: IrExpression) = irCall(symbols.areEqualByValue[PrimitiveBinaryType.BYTE]!!).apply {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/CastsOptimization.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/CastsOptimization.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.backend.common.push
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
+import org.jetbrains.kotlin.backend.konan.NativeGenerationState
 import org.jetbrains.kotlin.backend.konan.getInlinedClassNative
 import org.jetbrains.kotlin.backend.konan.logMultiple
 import org.jetbrains.kotlin.backend.konan.util.CustomBitSet
@@ -360,7 +361,7 @@ private object Predicates {
 private const val MAX_LOOPS_DEPTH = 5
 private const val MAX_LOOP_ITERATIONS = 10
 
-internal class CastsOptimization(val context: NativeBackendContext) : BodyLoweringPass {
+internal class CastsOptimization(val context: NativeGenerationState) : BodyLoweringPass {
     private val not = context.irBuiltIns.booleanNotSymbol
     private val eqeq = context.irBuiltIns.eqeqSymbol
     private val eqeqeq = context.irBuiltIns.eqeqeqSymbol
@@ -1418,7 +1419,7 @@ internal class CastsOptimization(val context: NativeBackendContext) : BodyLoweri
             val callee = expression.symbol.owner
             val correspondingProperty = callee.correspondingPropertySymbol?.owner
             val backingField = correspondingProperty?.backingField
-            return if (backingField != null && callee.isTrivialValGetter(context)) {
+            return if (backingField != null && callee.isTrivialValGetter(context.context)) {
                 val receiverResult = expression.dispatchReceiver?.accept(this, data)
                 val phantomVariable = if (receiverResult == null) {
                     topLevelPropertyPhantomVariables.getOrPut(correspondingProperty) {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/ComputeTypesPass.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/ComputeTypesPass.kt
@@ -6,9 +6,12 @@
 package org.jetbrains.kotlin.backend.konan.optimizations
 
 import org.jetbrains.kotlin.backend.common.BodyLoweringPass
+import org.jetbrains.kotlin.backend.common.LoweringContext
 import org.jetbrains.kotlin.backend.common.ir.isUnconditional
+import org.jetbrains.kotlin.backend.common.lower.FinallyBlocksLowering
 import org.jetbrains.kotlin.backend.common.lower.at
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.backend.common.phaser.PhasePrerequisites
 import org.jetbrains.kotlin.backend.konan.NativeBackendContext
 import org.jetbrains.kotlin.backend.konan.getInlinedClassNative
 import org.jetbrains.kotlin.backend.konan.logMultiple
@@ -62,7 +65,8 @@ import org.jetbrains.kotlin.utils.forEachBit
 import org.jetbrains.kotlin.utils.mapEachBit
 import java.util.BitSet
 
-internal class ComputeTypesPass(val context: NativeBackendContext) : BodyLoweringPass {
+@PhasePrerequisites(FinallyBlocksLowering::class)
+internal class ComputeTypesPass(val context: LoweringContext) : BodyLoweringPass {
     private val unitType = context.irBuiltIns.unitType
 
     private fun IrClass.superClassesHierarchy(): List<IrClass> {

--- a/kotlin-native/backend.native/compiler/ir/backend.native/test/org/jetbrains/kotlin/backend/konan/lowering/NativeLoweringPrerequisitesTest.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/test/org/jetbrains/kotlin/backend/konan/lowering/NativeLoweringPrerequisitesTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.lowering
+
+import org.jetbrains.kotlin.backend.common.LoweringPrerequisitesTest
+import org.jetbrains.kotlin.backend.konan.driver.phases.getNativeLoweringPhaseListsForTests
+import kotlin.test.Test
+
+class NativeLoweringPrerequisitesTest : LoweringPrerequisitesTest() {
+    @Test
+    fun checkPrerequisites() {
+        for (generateTestDumper in listOf(false, true)) {
+            for (optimizationsEnabled in listOf(false, true)) {
+                for (genericSafeCasts in listOf(false, true)) {
+                    for (isCache in listOf(false, true)) {
+                        checkPrerequisites(
+                                getNativeLoweringPhaseListsForTests(
+                                        generateTestDumper = generateTestDumper,
+                                        optimizationsEnabled = optimizationsEnabled,
+                                        genericSafeCasts = genericSafeCasts,
+                                        isCache = isCache,
+                                ).flatten()
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
@@ -305,8 +305,8 @@ class BuildReportsIT : KGPBaseTest() {
 
     val nativeBuildExpectedMetrics = arrayOf(
         CustomBuildTimeMetric.createIfDoesNotExistAndReturn("InlineFunctionSerializationPreProcessing", IR_PRE_LOWERING),
-        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrBeforeLowering", IR_LOWERING),
-        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrAfterLowering", IR_LOWERING),
+        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("IrValidationBeforeLoweringsKlibSecondStagePhase", IR_LOWERING),
+        CustomBuildTimeMetric.createIfDoesNotExistAndReturn("IrValidationAfterLoweringsSecondStagePhase", IR_LOWERING),
         CustomBuildTimeMetric.createIfDoesNotExistAndReturn("llvm-default.AlwaysInlinerPass", BACKEND),
         CustomBuildTimeMetric.createIfDoesNotExistAndReturn("InlineFunctionSerializationPreProcessing", IR_PRE_LOWERING),
         RUN_COMPILATION_IN_WORKER,
@@ -1043,11 +1043,11 @@ class BuildReportsIT : KGPBaseTest() {
             build("linkDebugExecutableHost", "-Pkotlin.build.report.json.directory=${projectPath.resolve("report").pathString}") {
                 validateJsonReport(
                     taskName = null, NATIVE_IN_PROCESS,
-                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrBeforeLowering", IR_LOWERING),
+                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("IrValidationBeforeLoweringsKlibSecondStagePhase", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("TestProcessor", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("Autoboxing", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ConstructorsLowering", IR_LOWERING),
-                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrAfterLowering", IR_LOWERING),
+                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("IrValidationAfterLoweringsSecondStagePhase", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("UpgradeCallableReferences", IR_PRE_LOWERING),
                     KlibSizeMetric.createIfDoesNotExistAndReturn("KLIB directory cumulative size"),
                     KlibSizeMetric.createIfDoesNotExistAndReturn("KLIB directory cumulative size/IR (main)"),

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/BuildReportsIT.kt
@@ -1045,7 +1045,7 @@ class BuildReportsIT : KGPBaseTest() {
                     taskName = null, NATIVE_IN_PROCESS,
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrBeforeLowering", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("TestProcessor", IR_LOWERING),
-                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("Autobox", IR_LOWERING),
+                    CustomBuildTimeMetric.createIfDoesNotExistAndReturn("Autoboxing", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ConstructorsLowering", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("ValidateIrAfterLowering", IR_LOWERING),
                     CustomBuildTimeMetric.createIfDoesNotExistAndReturn("UpgradeCallableReferences", IR_PRE_LOWERING),

--- a/native/native.tests/testData/codegen/fileCheck/kt86948.kt
+++ b/native/native.tests/testData/codegen/fileCheck/kt86948.kt
@@ -1,13 +1,13 @@
 // TARGET_BACKEND: NATIVE
 // FILECHECK_STAGE: CStubs
-// FREE_COMPILER_ARGS: -Xbinary=genericSafeCasts=true -Xdisable-phases=ComputeTypes
+// FREE_COMPILER_ARGS: -Xbinary=genericSafeCasts=true -Xdisable-phases=ComputeTypesPass
 // IGNORE_NATIVE: optimizationMode=OPT && cacheMode=STATIC_ONLY_DIST
 // IGNORE_NATIVE: optimizationMode=OPT && cacheMode=STATIC_EVERYWHERE
 
 // KT-86948: CastsOptimization must not merge a type check/cast result across loop
 // iterations as if a node reached on one iteration is reached on every one.
-// ComputeTypes is disabled so that CastsOptimization is tested in isolation
-// (ComputeTypes mishandles the same case, see KT-86949).
+// ComputeTypesPass is disabled so that CastsOptimization is tested in isolation
+// (ComputeTypesPass mishandles the same case, see KT-86949).
 
 class A
 

--- a/native/native.tests/testData/codegen/fileCheck/kt86949.kt
+++ b/native/native.tests/testData/codegen/fileCheck/kt86949.kt
@@ -1,12 +1,12 @@
 // TARGET_BACKEND: NATIVE
 // FILECHECK_STAGE: CStubs
-// FREE_COMPILER_ARGS: -Xbinary=genericSafeCasts=true -Xdisable-phases=OptimizeCasts
+// FREE_COMPILER_ARGS: -Xbinary=genericSafeCasts=true -Xdisable-phases=CastsOptimization
 // IGNORE_NATIVE: optimizationMode=OPT && cacheMode=STATIC_ONLY_DIST
 // IGNORE_NATIVE: optimizationMode=OPT && cacheMode=STATIC_EVERYWHERE
 
 // KT-86949: ComputeTypesPass must not narrow a control flow merge point's type to a
 // final class across loop iterations as if a node reached on one iteration is reached
-// on every one. OptimizeCasts is disabled so that ComputeTypesPass is
+// on every one. CastsOptimization is disabled so that ComputeTypesPass is
 // tested in isolation (it mishandles the same case, see KT-86948).
 
 class A


### PR DESCRIPTION
This should simplify the code (remove a lot of boilerplate)  and align Native backend with others.