### PR TITLE
[Wasm, Tests] Cleanup after tests by default (^KT-88543 Fixed)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -185,3 +185,11 @@ kotlin.build.internal.gradle.setup=true
 #   - All from previous.
 #   - Dump IR after each phase.
 #fd.kotlin.wasm.debugMode=debug
+# By default, Wasm test output is cleaned if `fd.kotlin.wasm.debugMode` isn't set.
+# To still prevent cleaning of the Wasm test output directory, even if  `debugMode` isn't set,
+# use this property; possible values:
+# * false (default)
+#  - No behavior change: Test output may or may not be cleaned, depending on `debugMode`
+# * true
+#  - Guarantee that the test output directory will not be cleaned
+#fd.kotlin.wasm.neverCleanTestOutput=true

--- a/wasm/wasm.tests/build.gradle.kts
+++ b/wasm/wasm.tests/build.gradle.kts
@@ -307,6 +307,19 @@ val createJscRunner = tasks.register<CreateJscRunner>("createJscRunner") {
     inputDirectory.set(unzipJsc.flatMap { it.into })
 }
 
+val maybeCleanWasmTestOutputTask = tasks.register<Delete>("maybeCleanWasmTestOutput") {
+    description = "Clean the Wasm test output directory if needed"
+    delete(layout.buildDirectory.dir("out"))
+
+    // see <repo-root>/gradle.properties which documents the possible values of fd.kotlin.wasm.debugMode, and fd.kotlin.wasm.neverCleanTestOutput
+    val debugMode = kotlinBuildProperties.stringProperty("fd.kotlin.wasm.debugMode").map { it !in listOf("none", "false", "0") }
+    val neverCleanTestOutput = kotlinBuildProperties.booleanProperty("fd.kotlin.wasm.neverCleanTestOutput")
+
+    onlyIf("Only clean test output directory, if we're NOT in debug mode, and neverCleanTestOutput has NOT been specified") {
+        !debugMode.getOrElse(false) && !neverCleanTestOutput.getOrElse(false)
+    }
+}
+
 fun Test.setupSpiderMonkey() {
     val jsShellExecutablePath = unzipJsShell
         .map { it.destinationDir }
@@ -390,6 +403,8 @@ projectTests {
             addAbsoluteDirectoryProperty(node.nodeProjectDir, "kotlin.wasm.test.node.dir")
             body()
             dependsOn(npmInstall)
+
+            finalizedBy(maybeCleanWasmTestOutputTask)
         }
     }
 


### PR DESCRIPTION
I'm an absolute Gradle noob, so this might be breaking all the rules; please correct me in that case ^^'.

See KT-88543.