### PR TITLE
[Serialization] Warn on inapplicable serial info annotation targets

### DIFF
--- a/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/FirSerializationErrors.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/FirSerializationErrors.kt
@@ -56,6 +56,8 @@ object FirSerializationErrors : KtDiagnosticsContainer() {
     val INCONSISTENT_INHERITABLE_SERIALINFO by error2<KtElement, ConeKotlinType, ConeKotlinType>()
     val META_SERIALIZABLE_NOT_APPLICABLE by error0<KtElement>()
     val INHERITABLE_SERIALINFO_CANT_BE_REPEATABLE by error0<KtElement>()
+    val SERIALINFO_INAPPLICABLE_TARGET by warning1<KtElement, String>()
+    val INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET by warning1<KtElement, String>()
 
     val EXTERNAL_SERIALIZER_USELESS by warning1<KtElement, FirClassSymbol<*>>()
     val EXTERNAL_CLASS_NOT_SERIALIZABLE by error2<KtElement, FirClassSymbol<*>, ConeKotlinType>()

--- a/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/FirSerializationPluginClassChecker.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/FirSerializationPluginClassChecker.kt
@@ -9,12 +9,14 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.descriptors.annotations.KotlinTarget
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.FirTypeRefSource
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.getAllowedAnnotationTargets
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
 import org.jetbrains.kotlin.fir.declarations.*
@@ -60,6 +62,7 @@ object FirSerializationPluginClassChecker : FirClassChecker(MppCheckerKind.Commo
             val classSymbol = declaration.symbol
             checkMetaSerializableApplicable(classSymbol, reporter)
             checkInheritableSerialInfoNotRepeatable(classSymbol, reporter)
+            checkSerialInfoTargets(classSymbol, reporter)
             checkEnum(classSymbol, reporter)
             checkExternalSerializer(classSymbol, reporter)
             checkKeepGeneratedSerializer(classSymbol, reporter)
@@ -97,6 +100,30 @@ object FirSerializationPluginClassChecker : FirClassChecker(MppCheckerKind.Commo
             .find { it.toAnnotationClassId(session) == SerializationAnnotations.inheritableSerialInfoClassId }
             ?: return
         reporter.reportOn(anno.source, FirSerializationErrors.INHERITABLE_SERIALINFO_CANT_BE_REPEATABLE)
+    }
+
+    // @SerialInfo is meaningful only on class- or property-targeted annotations; @InheritableSerialInfo only on class-targeted ones.
+    private val SERIAL_INFO_ALLOWED_TARGETS = setOf(KotlinTarget.CLASS, KotlinTarget.PROPERTY)
+    private val INHERITABLE_SERIAL_INFO_ALLOWED_TARGETS = setOf(KotlinTarget.CLASS)
+
+    private fun CheckerContext.checkSerialInfoTargets(classSymbol: FirClassSymbol<FirClass>, reporter: DiagnosticReporter) {
+        if (classSymbol.classKind != ClassKind.ANNOTATION_CLASS) return
+        val allowedTargets = classSymbol.getAllowedAnnotationTargets(session)
+        val annotations = classSymbol.resolvedAnnotationsWithClassIds
+
+        fun inapplicableTargets(permitted: Set<KotlinTarget>): String? =
+            allowedTargets.filter { it !in permitted }.sorted().takeIf { it.isNotEmpty() }?.joinToString { it.name }
+
+        annotations.find { it.toAnnotationClassId(session) == SerializationAnnotations.serialInfoClassId }?.let { anno ->
+            inapplicableTargets(SERIAL_INFO_ALLOWED_TARGETS)?.let {
+                reporter.reportOn(anno.source, FirSerializationErrors.SERIALINFO_INAPPLICABLE_TARGET, it)
+            }
+        }
+        annotations.find { it.toAnnotationClassId(session) == SerializationAnnotations.inheritableSerialInfoClassId }?.let { anno ->
+            inapplicableTargets(INHERITABLE_SERIAL_INFO_ALLOWED_TARGETS)?.let {
+                reporter.reportOn(anno.source, FirSerializationErrors.INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET, it)
+            }
+        }
     }
 
     private fun CheckerContext.checkExternalSerializer(classSymbol: FirClassSymbol<*>, reporter: DiagnosticReporter) {

--- a/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/KtDefaultErrorMessagesSerialization.kt
+++ b/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/KtDefaultErrorMessagesSerialization.kt
@@ -191,6 +191,20 @@ object KtDefaultErrorMessagesSerialization : BaseDiagnosticRendererFactory() {
             FirSerializationErrors.INHERITABLE_SERIALINFO_CANT_BE_REPEATABLE,
             "Repeatable serial info annotations cannot be inheritable. Either remove @Repeatable or use a regular @SerialInfo annotation."
         )
+        map.put(
+            FirSerializationErrors.SERIALINFO_INAPPLICABLE_TARGET,
+            "@SerialInfo is only meaningful on class- or property-targeted annotations, but this annotation is also applicable to: {0}. " +
+                    "Applying it to these targets has no effect and may lead to behavior changes in future versions. " +
+                    "Restrict its @Target to CLASS and/or PROPERTY.",
+            CommonRenderers.STRING
+        )
+        map.put(
+            FirSerializationErrors.INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET,
+            "@InheritableSerialInfo is only supported on class-targeted annotations, but this annotation is also applicable to: {0}. " +
+                    "Allowing it on these targets has no effect and may lead to behavior changes in future versions. " +
+                    "Restrict its @Target to CLASS.",
+            CommonRenderers.STRING
+        )
 
         map.put(
             FirSerializationErrors.EXTERNAL_SERIALIZER_USELESS,

--- a/plugins/kotlinx-serialization/testData/diagnostics/InheritableInfo.kt
+++ b/plugins/kotlinx-serialization/testData/diagnostics/InheritableInfo.kt
@@ -4,12 +4,12 @@
 import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
-@InheritableSerialInfo
+<!INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET!>@InheritableSerialInfo<!>
 annotation class I(val value: String)
 
 enum class E { A, B }
 
-@InheritableSerialInfo
+<!INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET!>@InheritableSerialInfo<!>
 annotation class I2(val e: E, val k: KClass<*>)
 
 @Serializable

--- a/plugins/kotlinx-serialization/testData/diagnostics/SerialInfoTargets.kt
+++ b/plugins/kotlinx-serialization/testData/diagnostics/SerialInfoTargets.kt
@@ -1,0 +1,47 @@
+// WITH_STDLIB
+// FULL_JDK
+
+import kotlinx.serialization.*
+
+// @SerialInfo applicable to class/property targets is fine
+@SerialInfo
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
+annotation class SerialInfoOnClassAndProperty(val value: Int)
+
+// @SerialInfo restricted to a single allowed target is fine
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY)
+annotation class SerialInfoOnProperty(val value: Int)
+
+// @SerialInfo without explicit @Target: default targets include inapplicable ones (field, parameter, ...) -> reported
+<!SERIALINFO_INAPPLICABLE_TARGET!>@SerialInfo<!>
+annotation class SerialInfoNoTarget(val value: Int)
+
+// @SerialInfo applicable to a TYPE target is reported
+<!SERIALINFO_INAPPLICABLE_TARGET!>@SerialInfo<!>
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+annotation class SerialInfoOnType(val value: Int)
+
+// @SerialInfo applicable to a value-parameter target is reported
+<!SERIALINFO_INAPPLICABLE_TARGET!>@SerialInfo<!>
+@Target(AnnotationTarget.CLASS, AnnotationTarget.VALUE_PARAMETER)
+annotation class SerialInfoOnParameter(val value: Int)
+
+// @SerialInfo applicable to an annotation-class target is reported
+<!SERIALINFO_INAPPLICABLE_TARGET!>@SerialInfo<!>
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+annotation class SerialInfoOnAnnotationClass(val value: Int)
+
+// @InheritableSerialInfo restricted to the class target is fine
+@InheritableSerialInfo
+@Target(AnnotationTarget.CLASS)
+annotation class InheritableOnClass(val value: Int)
+
+// @InheritableSerialInfo without explicit @Target: default targets include property etc. -> reported
+<!INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET!>@InheritableSerialInfo<!>
+annotation class InheritableNoTarget(val value: Int)
+
+// @InheritableSerialInfo applicable to a property target is reported
+<!INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET!>@InheritableSerialInfo<!>
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
+annotation class InheritableOnProperty(val value: Int)

--- a/plugins/kotlinx-serialization/testData/diagnostics/repeatableSerialInfo.kt
+++ b/plugins/kotlinx-serialization/testData/diagnostics/repeatableSerialInfo.kt
@@ -4,12 +4,12 @@
 
 import kotlinx.serialization.*
 
-<!INHERITABLE_SERIALINFO_CANT_BE_REPEATABLE!>@InheritableSerialInfo<!>
+<!INHERITABLE_SERIALINFO_CANT_BE_REPEATABLE, INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET!>@InheritableSerialInfo<!>
 @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
 @Repeatable
 annotation class RepeatableSerialInfo(val value: Int)
 
-<!INHERITABLE_SERIALINFO_CANT_BE_REPEATABLE!>@InheritableSerialInfo<!>
+<!INHERITABLE_SERIALINFO_CANT_BE_REPEATABLE, INHERITABLE_SERIALINFO_INAPPLICABLE_TARGET!>@InheritableSerialInfo<!>
 @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
 @java.lang.annotation.Repeatable(JavaRepeatableContainer::class)
 annotation class JavaRepeatable(val value2: Int)

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLReversedSerializationDiagnosticsTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLReversedSerializationDiagnosticsTestGenerated.java
@@ -211,6 +211,12 @@ public class LLReversedSerializationDiagnosticsTestGenerated extends AbstractLLR
     }
 
     @Test
+    @TestMetadata("SerialInfoTargets.kt")
+    public void testSerialInfoTargets() {
+      run("SerialInfoTargets.kt");
+    }
+
+    @Test
     @TestMetadata("serializableCompanionOfSerializable.kt")
     public void testSerializableCompanionOfSerializable() {
       run("serializableCompanionOfSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLSerializationDiagnosticsTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/LLSerializationDiagnosticsTestGenerated.java
@@ -211,6 +211,12 @@ public class LLSerializationDiagnosticsTestGenerated extends AbstractLLSerializa
     }
 
     @Test
+    @TestMetadata("SerialInfoTargets.kt")
+    public void testSerialInfoTargets() {
+      run("SerialInfoTargets.kt");
+    }
+
+    @Test
     @TestMetadata("serializableCompanionOfSerializable.kt")
     public void testSerializableCompanionOfSerializable() {
       run("serializableCompanionOfSerializable.kt");

--- a/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationFirPsiDiagnosticTestGenerated.java
+++ b/plugins/kotlinx-serialization/tests-gen/org/jetbrains/kotlinx/serialization/runners/SerializationFirPsiDiagnosticTestGenerated.java
@@ -211,6 +211,12 @@ public class SerializationFirPsiDiagnosticTestGenerated extends AbstractSerializ
     }
 
     @Test
+    @TestMetadata("SerialInfoTargets.kt")
+    public void testSerialInfoTargets() {
+      run("SerialInfoTargets.kt");
+    }
+
+    @Test
     @TestMetadata("serializableCompanionOfSerializable.kt")
     public void testSerializableCompanionOfSerializable() {
       run("serializableCompanionOfSerializable.kt");


### PR DESCRIPTION
@SerialInfo is only meaningful on class- or property-targeted annotations, and @InheritableSerialInfo only on class-targeted ones. Declaring such an annotation with a broader @Target (or relying on the default target set, which includes fields, parameters, etc.) silently has no effect today and risks behavior changes once these targets gain meaning. To surface these accidental misuses early, report a warning from the FIR class checker.

^KT-88540 Fixed