### PR TITLE
KT-85576: PL tests with companion blocks and companion extensions

### DIFF
--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
@@ -57,7 +57,7 @@ class NewBlock {
 class RemovedClass(val value: Int)
 
 class B {
-    companion object {
+    companion {
         val removedCompanionVal = 42
         var removedCompanionVar = 42
         fun removedCompanionFun() = "removedCompanionFun"

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
@@ -30,6 +30,14 @@ companion fun A.companionToRegularExtension() = "companionToRegularExtension"
 fun A.regularToCompanionExtension() = "regularToCompanionExtension"
 fun A.regularExtensionToBlock() = "regularExtensionToBlock"
 
+companion val A.extensionValChange = "extensionPropertyChange.v1"
+companion val A.removedExtensionVal = 42
+companion var A.extensionVarChange = A.extensionValChange
+companion var A.removedExtensionVar = 42
+
+companion fun A.extensionFunBodyChange() = "extensionFunBodyChange.v1"
+companion fun A.removedExtensionFun() {}
+
 class RemovedBlock {
     companion {
         fun sameFun() = "block"

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
@@ -16,12 +16,19 @@ class A {
 
     companion {
         fun blockToObject() = "blockToObject"
+        fun blockToCompanionExtension() = "blockToCompanionExtension"
+        fun blockToRegularExtension() = "blockToRegularExtension"
     }
 
     companion object {
         fun objectToBlock() = "objectToBlock"
     }
 }
+
+companion fun A.companionExtensionToBlock() = "companionExtensionToBlock"
+companion fun A.companionToRegularExtension() = "companionToRegularExtension"
+fun A.regularToCompanionExtension() = "regularToCompanionExtension"
+fun A.regularExtensionToBlock() = "regularExtensionToBlock"
 
 class RemovedBlock {
     companion {

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt
@@ -55,3 +55,11 @@ class B {
         fun removedCompanionFun() = "removedCompanionFun"
     }
 }
+
+class PrivateClass
+companion fun PrivateClass.privateClassFun() = "privateClassFun"
+
+typealias TA = A
+companion fun TA.aliasFun() = "aliasFun"
+companion fun TA.aliasToClassFun() = "aliasToClassFun"
+companion fun B.classToAliasFun() = "classToAliasFun"

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
@@ -30,6 +30,14 @@ fun A.blockToRegularExtension() = "blockToRegularExtension"
 fun A.companionToRegularExtension() = "companionToRegularExtension"
 companion fun A.regularToCompanionExtension() = "regularToCompanionExtension"
 
+companion val A.extensionValChange = "extensionPropertyChange.v2"
+//companion val A.removedExtensionVal = 42
+companion var A.extensionVarChange = A.extensionValChange
+//companion var A.removedExtensionVar = 42
+
+companion fun A.extensionFunBodyChange() = "extensionFunBodyChange.v2"
+//companion fun A.removedExtensionFun() {}
+
 class RemovedBlock {
     //companion {
         //fun sameFun() = "block"

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
@@ -20,8 +20,15 @@ class A {
 
     companion {
         fun objectToBlock() = "objectToBlock"
+        fun companionExtensionToBlock() = "companionExtensionToBlock"
+        fun regularExtensionToBlock() = "regularExtensionToBlock"
     }
 }
+
+companion fun A.blockToCompanionExtension() = "blockToCompanionExtension"
+fun A.blockToRegularExtension() = "blockToRegularExtension"
+fun A.companionToRegularExtension() = "companionToRegularExtension"
+companion fun A.regularToCompanionExtension() = "regularToCompanionExtension"
 
 class RemovedBlock {
     //companion {

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
@@ -61,7 +61,7 @@ class NewBlock {
 //class RemovedClass(val value: Int)
 
 class B {
-    //companion object {
+    //companion {
         //val removedCompanionVal = 42
         //var removedCompanionVar = 42
         //fun removedCompanionFun() = "removedCompanionFun"

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib1/l1.kt.1
@@ -59,3 +59,11 @@ class B {
         //fun removedCompanionFun() = "removedCompanionFun"
     //}
 }
+
+private class PrivateClass
+private companion fun PrivateClass.privateClassFun() = "privateClassFun"
+
+typealias TA = B
+companion fun TA.aliasFun() = "aliasFun"
+companion fun A.aliasToClassFun() = "aliasToClassFun"
+companion fun TA.classToAliasFun() = "classToAliasFun"

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
@@ -31,6 +31,12 @@ fun removedCompanionFunCall() = B.removedCompanionFun()
 
 fun blockToObjectCall() = A.blockToObject()
 fun objectToBlockCall() = A.objectToBlock()
+fun blockToCompanionExtensionCall() = A.blockToCompanionExtension()
+fun companionExtensionToBlockCall() = A.companionExtensionToBlock()
+fun companionToRegularExtensionCall() = A.companionToRegularExtension()
+fun regularToCompanionExtensionCall() = A().regularToCompanionExtension()
+fun blockToRegularExtensionCall() = A.blockToRegularExtension()
+fun regularExtensionToBlockCall() = A().regularExtensionToBlock()
 
 fun noBlockSameFunCall() = RemovedBlock.sameFun()
 fun newBlockSameFunCall() = NewBlock.sameFun()

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
@@ -40,3 +40,8 @@ fun regularExtensionToBlockCall() = A().regularExtensionToBlock()
 
 fun noBlockSameFunCall() = RemovedBlock.sameFun()
 fun newBlockSameFunCall() = NewBlock.sameFun()
+
+fun privateClassCall() = PrivateClass.privateClassFun()
+fun aliasCall() = A.aliasFun()
+fun aliasToClassFunCall() = A.aliasToClassFun()
+fun classToAliasFunCall() = B.classToAliasFun()

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
@@ -47,6 +47,9 @@ fun removedCompanionVarSet() {
     B.removedCompanionVar = 0
 }
 fun removedCompanionFunCall() = B.removedCompanionFun()
+val removedCompanionFunRef = B::removedCompanionFun
+val removedCompanionValRef = B::removedCompanionVal
+val removedCompanionVarRef = B::removedCompanionVar
 
 fun blockToObjectCall() = A.blockToObject()
 fun objectToBlockCall() = A.objectToBlock()

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/lib2/l2.kt
@@ -17,6 +17,25 @@ fun removedFunCall() = A.removedFun()
 val bodyChangeRef = A::bodyChange
 val removedFunRef = A::removedFun
 
+fun extensionValChangeGet() = A.extensionValChange
+fun removedExtensionValGet() = A.removedExtensionVal
+fun extensionVarChangeGet() = A.extensionVarChange
+fun removedExtensionVarGet() = A.removedExtensionVar
+fun removedExtensionVarSet() {
+    A.removedExtensionVar = 0
+}
+
+val extensionValChangeRef = A::extensionValChange
+val removedExtensionValRef = A::removedExtensionVal
+val extensionVarChangeRef = A::extensionVarChange
+val removedExtensionVarRef = A::removedExtensionVar
+
+fun extensionFunBodyChangeCall() = A.extensionFunBodyChange()
+fun removedExtensionFunCall() = A.removedExtensionFun()
+
+val extensionFunBodyChangeRef = A::extensionFunBodyChange
+val removedExtensionFunRef = A::removedExtensionFun
+
 fun removedClassCall() = A.removedClass()
 fun removedClassValueCall() = A.removedClassValue()
 fun removedClassParameterCall() = A.removedClassParameter(RemovedClass(42))

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
@@ -30,6 +30,12 @@ fun box() = abiTest {
 
     expectFailure(linkage("Function 'blockToObject' can not be called: No function found for symbol '/A.blockToObject'")) { blockToObjectCall() }
     expectFailure(linkage("Function 'objectToBlock' can not be called: No function found for symbol '/A.Companion.objectToBlock'")) { objectToBlockCall() }
+    expectFailure(linkage("Function 'blockToCompanionExtension' can not be called: No function found for symbol '/A.blockToCompanionExtension'")) { blockToCompanionExtensionCall() }
+    expectFailure(linkage("Function 'companionExtensionToBlock' can not be called: No function found for symbol '/companionExtensionToBlock'")) { companionExtensionToBlockCall() }
+    expectFailure(linkage("Function 'companionToRegularExtension' can not be called: No function found for symbol '/companionToRegularExtension'")) { companionToRegularExtensionCall() }
+    expectFailure(linkage("Function 'regularToCompanionExtension' can not be called: No function found for symbol '/regularToCompanionExtension'")) { regularToCompanionExtensionCall() }
+    expectFailure(linkage("Function 'blockToRegularExtension' can not be called: No function found for symbol '/A.blockToRegularExtension'")) { blockToRegularExtensionCall() }
+    expectFailure(linkage("Function 'regularExtensionToBlock' can not be called: No function found for symbol '/regularExtensionToBlock'")) { regularExtensionToBlockCall() }
 
     expectFailure(linkage("Function 'sameFun' can not be called: No function found for symbol '/RemovedBlock.sameFun'")) { noBlockSameFunCall() }
     expectSuccess("object") { newBlockSameFunCall() }

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
@@ -40,10 +40,14 @@ fun box() = abiTest {
     expectFailure(linkage("Constructor 'RemovedClass.<init>' can not be called: No constructor found for symbol '/RemovedClass.<init>'")) { removedClassParameterCall() }
     expectFailure(linkage("Function 'removedClassTypeParameter' can not be called: No function found for symbol '/A.removedClassTypeParameter'")) { removedClassTypeParameterCall() }
 
-    expectFailure(linkage("Can not get instance of singleton 'Companion': No class found for symbol '/B.Companion'")) { removedCompanionValCall() }
-    expectFailure(linkage("Can not get instance of singleton 'Companion': No class found for symbol '/B.Companion'")) { removedCompanionVarCall() }
-    expectFailure(linkage("Can not get instance of singleton 'Companion': No class found for symbol '/B.Companion'")) { removedCompanionVarSet() }
-    expectFailure(linkage("Can not get instance of singleton 'Companion': No class found for symbol '/B.Companion'")) { removedCompanionFunCall() }
+    expectFailure(linkage("Property accessor 'removedCompanionVal.<get-removedCompanionVal>' can not be called: No property accessor found for symbol '/B.removedCompanionVal.<get-removedCompanionVal>'")) { removedCompanionValCall() }
+    expectFailure(linkage("Property accessor 'removedCompanionVar.<get-removedCompanionVar>' can not be called: No property accessor found for symbol '/B.removedCompanionVar.<get-removedCompanionVar>'")) { removedCompanionVarCall() }
+    expectFailure(linkage("Property accessor 'removedCompanionVar.<set-removedCompanionVar>' can not be called: No property accessor found for symbol '/B.removedCompanionVar.<set-removedCompanionVar>'")) { removedCompanionVarSet() }
+    expectFailure(linkage("Function 'removedCompanionFun' can not be called: No function found for symbol '/B.removedCompanionFun'")) { removedCompanionFunCall() }
+    expectFailure(linkage("Property accessor 'removedCompanionVal.<get-removedCompanionVal>' can not be called: No property accessor found for symbol '/B.removedCompanionVal.<get-removedCompanionVal>'")) { removedCompanionValRef.invoke() }
+    expectFailure(linkage("Property accessor 'removedCompanionVar.<get-removedCompanionVar>' can not be called: No property accessor found for symbol '/B.removedCompanionVar.<get-removedCompanionVar>'")) { removedCompanionVarRef.invoke() }
+    expectFailure(linkage("Function 'removedCompanionFun' can not be called: No function found for symbol '/B.removedCompanionFun'")) { removedCompanionFunRef.invoke() }
+
 
     expectFailure(linkage("Function 'blockToObject' can not be called: No function found for symbol '/A.blockToObject'")) { blockToObjectCall() }
     expectFailure(linkage("Function 'objectToBlock' can not be called: No function found for symbol '/A.Companion.objectToBlock'")) { objectToBlockCall() }

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
@@ -18,6 +18,23 @@ fun box() = abiTest {
     expectSuccess("bodyChange.v2") { bodyChangeRef.invoke() }
     expectFailure(linkage("Function 'removedFun' can not be called: No function found for symbol '/A.removedFun'")) { removedFunRef.invoke() }
 
+    expectSuccess("extensionPropertyChange.v2") { extensionValChangeGet() }
+    expectFailure(linkage("Property accessor 'removedExtensionVal.<get-removedExtensionVal>' can not be called: No property accessor found for symbol '/removedExtensionVal.<get-removedExtensionVal>'")) { removedExtensionValGet() }
+    expectSuccess("extensionPropertyChange.v2") { extensionVarChangeGet() }
+    expectFailure(linkage("Property accessor 'removedExtensionVar.<get-removedExtensionVar>' can not be called: No property accessor found for symbol '/removedExtensionVar.<get-removedExtensionVar>'")) { removedExtensionVarGet() }
+    expectFailure(linkage("Property accessor 'removedExtensionVar.<set-removedExtensionVar>' can not be called: No property accessor found for symbol '/removedExtensionVar.<set-removedExtensionVar>'")) { removedExtensionVarSet() }
+
+    expectSuccess("extensionPropertyChange.v2") { extensionValChangeRef.invoke() }
+    expectFailure(linkage("Property accessor 'removedExtensionVal.<get-removedExtensionVal>' can not be called: No property accessor found for symbol '/removedExtensionVal.<get-removedExtensionVal>'")) { removedExtensionValRef.invoke() }
+    expectSuccess("extensionPropertyChange.v2") { extensionVarChangeRef.invoke() }
+    expectFailure(linkage("Property accessor 'removedExtensionVar.<get-removedExtensionVar>' can not be called: No property accessor found for symbol '/removedExtensionVar.<get-removedExtensionVar>'")) { removedExtensionVarRef.invoke() }
+
+    expectSuccess("extensionFunBodyChange.v2") { extensionFunBodyChangeCall() }
+    expectFailure(linkage("Function 'removedExtensionFun' can not be called: No function found for symbol '/removedExtensionFun'")) { removedExtensionFunCall() }
+
+    expectSuccess("extensionFunBodyChange.v2") { extensionFunBodyChangeRef.invoke() }
+    expectFailure(linkage("Function 'removedExtensionFun' can not be called: No function found for symbol '/removedExtensionFun'")) { removedExtensionFunRef.invoke() }
+
     expectSuccess("removedClass") { removedClassCall() }
     expectSuccess(42) { removedClassValueCall() }
     expectFailure(linkage("Constructor 'RemovedClass.<init>' can not be called: No constructor found for symbol '/RemovedClass.<init>'")) { removedClassParameterCall() }

--- a/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
+++ b/compiler/testData/klib/partial-linkage/companionBlocksAndExtensions/main/m.kt
@@ -39,4 +39,9 @@ fun box() = abiTest {
 
     expectFailure(linkage("Function 'sameFun' can not be called: No function found for symbol '/RemovedBlock.sameFun'")) { noBlockSameFunCall() }
     expectSuccess("object") { newBlockSameFunCall() }
+
+    expectFailure(linkage("Function 'privateClassFun' can not be called: No function found for symbol '/privateClassFun'")) { privateClassCall() }
+    expectFailure(linkage("Function 'aliasFun' can not be called: No function found for symbol '/aliasFun'")) { aliasCall() }
+    expectSuccess("aliasToClassFun") { aliasToClassFunCall() }
+    expectSuccess("classToAliasFun") { classToAliasFunCall() }
 }


### PR DESCRIPTION
For companion extensions there are no receivers in the dumps: this should be fixed by [KT-88556](https://youtrack.jetbrains.com/issue/KT-88556).