### PR TITLE
[test] Convert `AnalysisApiBasedDtsGenerationHandler` back to a facade

### DIFF
--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/AnalysisApiBasedDtsGeneratorFacade.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/converters/AnalysisApiBasedDtsGeneratorFacade.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.js.test.converters
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.config.moduleName
+import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.TranslationMode
 import org.jetbrains.kotlin.js.config.ModuleKind
 import org.jetbrains.kotlin.js.config.WebArtifactConfiguration
 import org.jetbrains.kotlin.js.config.moduleKind
@@ -16,29 +17,33 @@ import org.jetbrains.kotlin.js.tsexport.TypeScriptModuleConfig
 import org.jetbrains.kotlin.js.tsexport.createTypeScriptExportInputModule
 import org.jetbrains.kotlin.js.tsexport.runTypeScriptExport
 import org.jetbrains.kotlin.library.metadata.KlibInputModule
-import org.jetbrains.kotlin.test.backend.handlers.KlibArtifactHandler
 import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives.TS_COMPILATION_STRATEGY
-import org.jetbrains.kotlin.test.model.ArtifactKinds
-import org.jetbrains.kotlin.test.model.BinaryArtifacts
-import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.model.*
 import org.jetbrains.kotlin.test.services.*
 import org.jetbrains.kotlin.test.services.configuration.JsEnvironmentConfigurator
 import kotlin.io.path.Path
 
-// TODO(KT-87384): Convert this to a facade when the test infra supports forking
-class AnalysisApiBasedDtsGenerationHandler(testServices: TestServices) : KlibArtifactHandler(testServices) {
-    override fun processModule(module: TestModule, info: BinaryArtifacts.KLib) {}
+class AnalysisApiBasedDtsGeneratorFacade(
+    private val testServices: TestServices,
+) : AbstractTestFacade<BinaryArtifacts.KLib, BinaryArtifacts.Js>() {
+    override val inputKind: TestArtifactKind<BinaryArtifacts.KLib>
+        get() = ArtifactKinds.KLib
 
-    override fun processAfterAllModules(someAssertionWasFailed: Boolean) {
-        val module = JsEnvironmentConfigurator.getMainModule(testServices)
+    override val outputKind: TestArtifactKind<BinaryArtifacts.Js>
+        get() = ArtifactKinds.Js
+
+    override fun shouldTransform(module: TestModule): Boolean =
+        JsEnvironmentConfigurator.isMainModule(module, testServices)
+
+    override fun transform(module: TestModule, inputArtifact: BinaryArtifacts.KLib): BinaryArtifacts.Js {
         val configuration = testServices.compilerConfigurationProvider.getCompilerConfiguration(module, CompilationStage.FIRST)
         val moduleKind = configuration.moduleKind ?: ModuleKind.PLAIN
 
         val tsCompilationStrategy = testServices.moduleStructure.allDirectives[TS_COMPILATION_STRATEGY].last()
         val translationModes = JsEnvironmentConfigurator.getTypeScriptExportTranslationModes(testServices, module)
 
-        for (mode in translationModes) {
+        val result = translationModes.associateWith { mode ->
             val config = TypeScriptExportConfig(
                 targetPlatform = testServices.targetPlatformProvider.getTargetPlatform(module),
                 artifactConfiguration = WebArtifactConfiguration(
@@ -75,6 +80,10 @@ class AnalysisApiBasedDtsGenerationHandler(testServices: TestServices) : KlibArt
 
             runTypeScriptExport(inputModules, config)
         }
+
+        // TODO(KT-88562): This result is not used down the pipeline, so it doesn't matter what we put here. We need to refactor this
+        //   so `JsTypeScriptArtifact` stores a list of files for each translation mode.
+        return JsTypeScriptArtifact(result[TranslationMode.FULL_DEV]?.first() ?: result.values.first().first())
     }
 
     private fun createInputModule(libraryPath: String): KlibInputModule<TypeScriptModuleConfig> =

--- a/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/tsexport/AbstractAnalysisApiTypeScriptExportTest.kt
+++ b/js/js.tests/testFixtures/org/jetbrains/kotlin/js/test/runners/tsexport/AbstractAnalysisApiTypeScriptExportTest.kt
@@ -5,14 +5,13 @@
 
 package org.jetbrains.kotlin.js.test.runners.tsexport
 
-import org.jetbrains.kotlin.js.test.converters.AnalysisApiBasedDtsGenerationHandler
+import org.jetbrains.kotlin.js.test.converters.AnalysisApiBasedDtsGeneratorFacade
 import org.jetbrains.kotlin.js.test.runners.AbstractJsES6Test
 import org.jetbrains.kotlin.js.test.runners.AbstractJsTest
 import org.jetbrains.kotlin.js.test.utils.configureJsTypeScriptExportTest
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.TargetBackend
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
-import org.jetbrains.kotlin.test.builders.configureKlibArtifactsHandlersStep
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.IGNORE_ANALYSIS_API_BASED_TYPESCRIPT_EXPORT
 import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.DIAGNOSTICS
 import org.jetbrains.kotlin.test.directives.model.ValueDirective
@@ -54,7 +53,7 @@ abstract class AbstractJsES6AnalysisApiTypeScriptExportTest(
     override val customIgnoreDirective: ValueDirective<TargetBackend>?
         get() = IGNORE_ANALYSIS_API_BASED_TYPESCRIPT_EXPORT
 
-    override fun configure(builder: TestConfigurationBuilder) = with(builder) {
+    override fun configure(builder: TestConfigurationBuilder) {
         super.configure(builder)
         builder.configureJsAnalysisApiTypeScriptExportTest(isWholeFileJsExport)
     }
@@ -69,8 +68,6 @@ private fun TestConfigurationBuilder.configureJsAnalysisApiTypeScriptExportTest(
     defaultDirectives {
         DIAGNOSTICS with "-warnings"
     }
-    configureKlibArtifactsHandlersStep {
-        useHandlers(::AnalysisApiBasedDtsGenerationHandler)
-    }
+    facadeStep(::AnalysisApiBasedDtsGeneratorFacade)
     configureJsTypeScriptExportTest(isWholeFileJsExport, expectedDtsSuffix = "aa")
 }


### PR DESCRIPTION
Originally it was a facade, but in 164873d2de66910b52bfd7790cbda54a11282480 it was converted to an artifact handler, because our test infra didn't support non-linear pipelines.

After KT-87384 was fixed in c3ec26bc51bd762960d47c856e4fe659a61ec41c, we can now convert it back.