### PR TITLE
BTA: Support unstable Java version strings, e.g. 28-ea

### DIFF
--- a/compiler/build-tools/kotlin-build-tools-api/src/test/kotlin/JavaVersionTest.kt
+++ b/compiler/build-tools/kotlin-build-tools-api/src/test/kotlin/JavaVersionTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+import org.jetbrains.kotlin.buildtools.internal.KotlinBuildToolsInternalJdkUtils
+import org.jetbrains.kotlin.buildtools.internal.getJdkClassesClassLoader
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.api.parallel.Resources
+
+@OptIn(KotlinBuildToolsInternalJdkUtils::class)
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
+class JavaVersionTest {
+    @DisplayName("Unstable Java versions use the platform classloader")
+    @Test
+    fun testUnstableJavaVersionsUsePlatformClassLoader() {
+        assumeTrue(isCurrentRuntimeJava9OrNewer(), "Platform classloader exists only since Java 9")
+
+        for (javaVersion in listOf("28-ea", "28-beta")) {
+            withJavaVersion(javaVersion) {
+                assertSame(
+                    platformClassLoader(),
+                    getJdkClassesClassLoader(),
+                    "java.version=$javaVersion"
+                )
+            }
+        }
+    }
+
+    @DisplayName("Modern Java versions use the platform classloader")
+    @Test
+    fun testModernJavaVersionsUsePlatformClassLoader() {
+        assumeTrue(isCurrentRuntimeJava9OrNewer(), "Platform classloader exists only since Java 9")
+
+        withJavaVersion("17.0.11") {
+            assertSame(platformClassLoader(), getJdkClassesClassLoader())
+        }
+    }
+
+    @DisplayName("Legacy and malformed Java versions use the bootstrap classloader")
+    @Test
+    fun testLegacyAndMalformedJavaVersionsUseBootstrapClassLoader() {
+        for (javaVersion in listOf("1.8.0_412", "bad-version")) {
+            withJavaVersion(javaVersion) {
+                assertNull(getJdkClassesClassLoader(), "java.version=$javaVersion")
+            }
+        }
+    }
+
+    private fun withJavaVersion(javaVersion: String, action: () -> Unit) {
+        val originalJavaVersion = System.getProperty("java.version")
+        try {
+            System.setProperty("java.version", javaVersion)
+            action()
+        } finally {
+            if (originalJavaVersion == null) {
+                System.clearProperty("java.version")
+            } else {
+                System.setProperty("java.version", originalJavaVersion)
+            }
+        }
+    }
+
+    private fun platformClassLoader(): ClassLoader =
+        ClassLoader::class.java.getMethod("getPlatformClassLoader").invoke(null) as ClassLoader
+
+    private fun isCurrentRuntimeJava9OrNewer(): Boolean {
+        val specificationVersion = System.getProperty("java.specification.version")
+        val majorVersion = if (specificationVersion.startsWith("1.")) {
+            specificationVersion.substringAfter('.').toIntOrNull()
+        } else {
+            specificationVersion.substringBefore('.').toIntOrNull()
+        }
+        return (majorVersion ?: 8) > 8
+    }
+}

--- a/compiler/build-tools/kotlin-build-tools-jdk-utils/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/classLoaderUtils.kt
+++ b/compiler/build-tools/kotlin-build-tools-jdk-utils/src/main/kotlin/org/jetbrains/kotlin/buildtools/internal/classLoaderUtils.kt
@@ -20,19 +20,29 @@ private const val MINIMAL_SUPPORTED_JDK_VERSION: Int = 8
  * the value of the "minor" version part as the major version number.
  * For newer version strings (e.g., "17.0.11"), the method returns the value of the "major" version part.
  *
+ * For unstable version strings (e.g., "28-ea"), the method returns the value before '-'.
+ *
  * If any error occurs during the retrieval of the version string or its parsing, the method returns the
  * default value of [MINIMAL_SUPPORTED_JDK_VERSION] as the major version number.
  */
 private fun getJavaMajorVersion(): Int = try {
+    val isEap = System.getProperty("java.version").contains("-")
     val versionParts = System.getProperty("java.version").split(".")
-    if (isLegacyJavaVersion(versionParts)) {
-        // e.g. 1.8.0_412
-        versionParts[1].toInt()
-    } else {
-        // e.g. 17.0.11
-        versionParts[0].toInt()
+    when {
+        isEap -> {
+            // e.g. 28-ea, 28-beta
+            versionParts[0].split("-")[0].toInt()
+        }
+        isLegacyJavaVersion(versionParts) -> {
+            // e.g. 1.8.0_412
+            versionParts[1].toInt()
+        }
+        else -> {
+            // e.g. 17.0.11
+            versionParts[0].toInt()
+        }
     }
-} catch (e: Exception) {
+} catch (_: Exception) {
     MINIMAL_SUPPORTED_JDK_VERSION
 }
 


### PR DESCRIPTION
When KAPT is run on unstable JDK (28-ea), the version string does not follow 'major.minor.patch' format, which leads to default to JDK 8. However, JDK 9+ do not have tools.jar, leading to
"'tools.jar' is absent in the plugin classpath" error message from KAPT.
 #KT-88559 Fixed