### PR TITLE
[Wasm] unmute stepping/multiModule for multi-module mode

### DIFF
--- a/compiler/testData/debug/stepping/multiModule.kt
+++ b/compiler/testData/debug/stepping/multiModule.kt
@@ -1,6 +1,5 @@
 // WASM_IGNORE_FOR: mode=single-module
-// WASM_IGNORE_FOR: mode=multi-module
-// ^^^ Both of these: KT-88234
+// ^^^ KT-88234
 // MODULE: lib
 // FILE: a.kt
 
@@ -19,34 +18,34 @@ fun box() {
 }
 
 // EXPECTATIONS JVM_IR
+// test.kt:16 box
+// a.kt:6 a
+// test.kt:16 box
 // test.kt:17 box
-// a.kt:7 a
+// b.kt:10 b
 // test.kt:17 box
 // test.kt:18 box
-// b.kt:11 b
-// test.kt:18 box
-// test.kt:19 box
 
 // EXPECTATIONS NATIVE
+// test.kt:16 box
+// a.kt:6 a
+// test.kt:16 box
 // test.kt:17 box
-// a.kt:7 a
-// test.kt:17 box
+// b.kt:10 b
 // test.kt:18 box
-// b.kt:11 b
-// test.kt:19 box
 
 // EXPECTATIONS JS_IR
+// test.kt:16 box
+// a.kt:6 a
 // test.kt:17 box
-// a.kt:7 a
+// b.kt:10 b
 // test.kt:18 box
-// b.kt:11 b
-// test.kt:19 box
 
 // EXPECTATIONS WASM
+// test.kt:16 $box (4)
+// a.kt:6 $a (10, 13)
+// test.kt:16 $box (4)
 // test.kt:17 $box (4)
-// a.kt:7 $a (10, 13)
+// b.kt:10 $b (10, 13)
 // test.kt:17 $box (4)
-// test.kt:18 $box (4)
-// b.kt:11 $b (10, 13)
-// test.kt:18 $box (4)
-// test.kt:19 $box (1)
+// test.kt:18 $box (1)


### PR DESCRIPTION
[Wasm Test Aggregate](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_WasmTestAggregate?branch=shefer%2Funmute-multiModule-stepping&buildTypeTab=overview)

Needed to unmute after
https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_WasmTestAggregate?branch=rr%2Fbroadwaylamb%2FKT-87008&buildTypeTab=overview

related to [KT-88234](https://youtrack.jetbrains.com/projects/KT/issues/KT-88234) K/Wasm: Grouping test runner causes different output in test data of multi-module stepping tests