### PR TITLE
Preserve Appendable Extension Receiver Type

### DIFF
--- a/libraries/stdlib/src/kotlin/text/Appendable.kt
+++ b/libraries/stdlib/src/kotlin/text/Appendable.kt
@@ -67,17 +67,17 @@ public fun <T : Appendable> T.append(vararg value: CharSequence?): T {
 /** Appends a line feed character (`\n`) to this Appendable. */
 @SinceKotlin("1.4")
 @kotlin.internal.InlineOnly
-public inline fun Appendable.appendLine(): Appendable = append('\n')
+public inline fun <T : Appendable> T.appendLine(): T = append('\n')
 
 /** Appends value to the given Appendable and a line feed character (`\n`) after it. */
 @SinceKotlin("1.4")
 @kotlin.internal.InlineOnly
-public inline fun Appendable.appendLine(value: CharSequence?): Appendable = append(value).appendLine()
+public inline fun <T : Appendable> T.appendLine(value: CharSequence?): T = append(value).appendLine()
 
 /** Appends value to the given Appendable and a line feed character (`\n`) after it. */
 @SinceKotlin("1.4")
 @kotlin.internal.InlineOnly
-public inline fun Appendable.appendLine(value: Char): Appendable = append(value).appendLine()
+public inline fun <T : Appendable> T.appendLine(value: Char): T = append(value).appendLine()
 
 
 internal fun <T> Appendable.appendElement(element: T, transform: ((T) -> CharSequence)?) {


### PR DESCRIPTION
Make `Appendable` extension functions generic and preserve the actual type to ensure proper chaining of functions.