### PR TITLE
Fix dropped additional supertypes when existing are resolved

### DIFF
--- a/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSupertypesResolution.kt
+++ b/compiler/fir/resolve/src/org/jetbrains/kotlin/fir/resolve/transformers/FirSupertypesResolution.kt
@@ -128,8 +128,15 @@ private class FirApplySupertypesTransformer(
     }
 
     private fun applyResolvedSupertypesToClass(firClass: FirClass) {
-        if (firClass.superTypeRefs.any { it !is FirResolvedTypeRef || it is FirImplicitBuiltinTypeRef }) {
-            val supertypeRefs = supertypeComputationSession.getResolvedSupertypeRefs(firClass)
+        val resolvedSupertypeRefs = supertypeComputationSession.getResolvedSupertypeRefs(firClass)
+        // Extensions may add supertypes even when every existing supertype was already resolved (i.e. implicit Enum<E> supertype).
+        // KT-88578
+        val hasGeneratedSupertypes = resolvedSupertypeRefs.size != firClass.superTypeRefs.size
+        if (
+            hasGeneratedSupertypes ||
+            firClass.superTypeRefs.any { it !is FirResolvedTypeRef || it is FirImplicitBuiltinTypeRef }
+        ) {
+            val supertypeRefs = resolvedSupertypeRefs
                 .map { supertypeComputationSession.expandTypealiasInPlace(it, session) }
             firClass.replaceSuperTypeRefs(supertypeRefs)
         }

--- a/plugins/plugin-sandbox/testData/diagnostics/supertypes/enumWithGeneratedSupertype.fir.txt
+++ b/plugins/plugin-sandbox/testData/diagnostics/supertypes/enumWithGeneratedSupertype.fir.txt
@@ -1,0 +1,27 @@
+FILE: enumWithGeneratedSupertype.kt
+    package foo
+
+    public abstract interface InterfaceWithArgument<T> : R|kotlin/Any| {
+        public open fun generate(): R|T| {
+            ^generate Null(null)!!
+        }
+
+    }
+    @R|org/jetbrains/kotlin/plugin/sandbox/SupertypeWithTypeArgument|(kClass = <getClass>(Q|kotlin/String|) [evaluated = <getClass>(Q|kotlin/String|)]) public final enum class GeneratedEnum : R|kotlin/Enum<foo/GeneratedEnum>|, R|foo/InterfaceWithArgument<kotlin/String>| {
+        private constructor(): R|foo/GeneratedEnum| {
+            super<R|kotlin/Enum<foo/GeneratedEnum>|>()
+        }
+
+        public final static fun values(): R|kotlin/Array<foo/GeneratedEnum>| {
+        }
+
+        public final static fun valueOf(value: R|kotlin/String|): R|foo/GeneratedEnum| {
+        }
+
+        public final static val entries: R|kotlin/enums/EnumEntries<foo/GeneratedEnum>|
+            public static get(): R|kotlin/enums/EnumEntries<foo/GeneratedEnum>|
+
+    }
+    public final fun test(value: R|foo/GeneratedEnum|): R|kotlin/String| {
+        ^test R|<local>/value|.R|SubstitutionOverride<foo/GeneratedEnum.generate: R|kotlin/String|>|()
+    }

--- a/plugins/plugin-sandbox/testData/diagnostics/supertypes/enumWithGeneratedSupertype.kt
+++ b/plugins/plugin-sandbox/testData/diagnostics/supertypes/enumWithGeneratedSupertype.kt
@@ -1,0 +1,17 @@
+// RUN_PIPELINE_TILL: BACKEND
+
+package foo
+
+import org.jetbrains.kotlin.plugin.sandbox.SupertypeWithTypeArgument
+
+interface InterfaceWithArgument<T> {
+    fun generate(): T = null!!
+}
+
+@SupertypeWithTypeArgument(String::class)
+enum class GeneratedEnum
+
+fun test(value: GeneratedEnum): String = value.generate()
+
+/* GENERATED_FIR_TAGS: checkNotNullCall, classReference, enumDeclaration, functionDeclaration, interfaceDeclaration,
+nullableType, typeParameter */


### PR DESCRIPTION
Ref: [KT-88578](https://youtrack.jetbrains.com/issue/KT-88578) FirSupertypeGenerationExtension additions are dropped when existing supertypes are already resolved