### PR TITLE
[Tests][Wasm] Mute tail call tests for the 2.4 compatibility checks

### DIFF
--- a/compiler/testData/codegen/box/wasm-ir-checks/wasmIrCheckForTailCalls.kt
+++ b/compiler/testData/codegen/box/wasm-ir-checks/wasmIrCheckForTailCalls.kt
@@ -1,5 +1,7 @@
 // TARGET_BACKEND: WASM
 // ENABLE_TAIL_CALLS
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.4
+// ^ `-Xwasm-enable-tail-calls` was introduced in 2.5
 
 // Direct static tail call
 // WASM_CHECK_INSTRUCTION_IN_FUNCTION: instruction=return_call inFunction=staticTailCaller

--- a/compiler/testData/codegen/box/wasm-ir-checks/wasmTailCallStress.kt
+++ b/compiler/testData/codegen/box/wasm-ir-checks/wasmTailCallStress.kt
@@ -1,5 +1,7 @@
 // TARGET_BACKEND: WASM
 // ENABLE_TAIL_CALLS
+// IGNORE_KLIB_RUNTIME_ERRORS_WITH_CUSTOM_SECOND_STAGE: Wasm-JS:2.4
+// ^ `-Xwasm-enable-tail-calls` was introduced in 2.5
 
 // Stress test for native Wasm tail call emission. Each pattern recurses at a depth that would
 // stack-overflow on the host JS engine if the calls were not lowered to `return_call` / `return_call_ref`.


### PR DESCRIPTION
The deep recursion in `box` needs native tail calls, which the 2.4 compiler cannot emit because `-Xwasm-enable-tail-calls` was only introduced in 2.5.