### PR TITLE
Remove obsolete JDK 6/7 check from preloader

### DIFF
--- a/compiler/preloader/src/org/jetbrains/kotlin/preloading/Preloader.java
+++ b/compiler/preloader/src/org/jetbrains/kotlin/preloading/Preloader.java
@@ -33,13 +33,6 @@ public class Preloader {
     public static final int DEFAULT_CLASS_NUMBER_ESTIMATE = 4096;
 
     public static void main(String[] args) throws Exception {
-        String javaVersion = System.getProperty("java.specification.version");
-        if (javaVersion.equals("1.6") || javaVersion.equals("1.7")) {
-            System.err.println("error: running the Kotlin compiler under Java " + javaVersion + " is not supported. " +
-                               "Java 1.8 or later is required");
-            System.exit(1);
-        }
-
         try {
             run(args);
         }


### PR DESCRIPTION
The check is obsolete because the preloader is compiled against JDK 8, and running on 6/7 fails with `java.lang.UnsupportedClassVersionError`.