### PR TITLE
[Gradle] Deprecate KotlinJsIrTarget secondary constructor as ERROR

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/ir/KotlinJsIrTarget.kt
@@ -60,7 +60,10 @@ internal constructor(
     KotlinJsSubTargetContainerDsl,
     KotlinWasmSubTargetContainerDsl {
 
-    @Deprecated("Creating new KotlinJsIrTarget instances outside of Kotlin Gradle plugin is deprecated. Scheduled for removal in Kotlin 2.7.")
+    @Deprecated(
+        "Creating new KotlinJsIrTarget instances outside of Kotlin Gradle plugin is deprecated. Scheduled for removal in Kotlin 2.7.",
+        level = DeprecationLevel.ERROR,
+    )
     constructor(
         project: Project,
         platformType: KotlinPlatformType,


### PR DESCRIPTION
^KT-86112 Verification Pending