### PR TITLE
[Gradle] Add structured JUnit-XML test-result assertions to testbase

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppDslAssociateCompilationsIT.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/mpp/MppDslAssociateCompilationsIT.kt
@@ -5,8 +5,6 @@
 package org.jetbrains.kotlin.gradle.mpp
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.internal.impldep.com.google.common.hash.HashFunction
-import org.gradle.internal.impldep.com.google.common.hash.Hashing
 import org.gradle.testkit.runner.TaskOutcome.*
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.testbase.*
@@ -17,7 +15,6 @@ import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
-import java.util.*
 import kotlin.test.assertTrue
 
 @MppGradlePluginTests
@@ -136,53 +133,14 @@ class MppDslAssociateCompilationsIT : KGPBaseTest() {
                     )
                 }
 
-                val testReportFile = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_3)) {
-                    "build/reports/tests/${targetName}Test/classes/com.example.HelloTest.html"
-                } else {
-                    val prefix = if (targetName == "jvm") "" else "${targetName}Test."
-                    val dirName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_4) ||
-                        gradleVersion >= GradleVersion.version(TestVersions.Gradle.G_9_6)
-                    ) {
-                        "${prefix}com.example.HelloTest"
-                    } else {
-                        "${prefix}com.example.HelloTest".hashTestPathSegment()
-                    }
-                    "build/reports/tests/${targetName}Test/${dirName}/index.html"
-                }
+                val testReportFile = testClassHtmlReport("${targetName}Test", "com.example.HelloTest", gradleVersion, targetName = targetName)
+                assertFileDoesNotContain(testReportFile, "secondTest")
 
-                assertFileInProjectDoesNotContain(testReportFile, "secondTest")
-
-                val integrationTestReportFile = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_3)) {
-                    "build/reports/tests/${targetName}IntegrationTest/classes/com.example.HelloIntegrationTest.html"
-                } else {
-                    val prefix = if (targetName == "jvm") "" else "${targetName}IntegrationTest."
-                    val dirName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_4) ||
-                        gradleVersion >= GradleVersion.version(TestVersions.Gradle.G_9_6)
-                    ) {
-                        "${prefix}com.example.HelloIntegrationTest"
-                    } else {
-                        "${prefix}com.example.HelloIntegrationTest".hashTestPathSegment()
-                    }
-                    "build/reports/tests/${targetName}IntegrationTest/${dirName}/index.html"
-                }
-
-                assertFileInProjectContains(integrationTestReportFile, "test[$targetName]")
-                assertFileInProjectDoesNotContain(integrationTestReportFile, "secondTest")
-                assertFileInProjectDoesNotContain(integrationTestReportFile, "thirdTest")
+                val integrationTestReportFile = testClassHtmlReport("${targetName}IntegrationTest", "com.example.HelloIntegrationTest", gradleVersion, targetName = targetName)
+                assertFileContains(integrationTestReportFile, "test[$targetName]")
+                assertFileDoesNotContain(integrationTestReportFile, "secondTest")
+                assertFileDoesNotContain(integrationTestReportFile, "thirdTest")
             }
         }
-    }
-
-
-    // Adopted from Gradle
-    // platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestReportGenerator.java
-    // Caused by https://github.com/gradle/gradle/pull/37052
-    private fun String.hashTestPathSegment(): String {
-        val hashBytes = HASHER.hashUnencodedChars(this).asBytes()
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashBytes)
-    }
-
-    private companion object {
-        private val HASHER: HashFunction = Hashing.farmHashFingerprint64()
     }
 }

--- a/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
+++ b/libraries/tools/kotlin-gradle-plugin-integration-tests/src/test/kotlin/org/jetbrains/kotlin/gradle/testbase/testAssertions.kt
@@ -6,11 +6,15 @@
 package org.jetbrains.kotlin.gradle.testbase
 
 import com.intellij.openapi.util.JDOMUtil
+import org.gradle.internal.impldep.com.google.common.hash.HashFunction
+import org.gradle.internal.impldep.com.google.common.hash.Hashing
+import org.gradle.util.GradleVersion
 import org.jdom.Content
 import org.jdom.Element
 import org.jdom.Text
 import org.jetbrains.kotlin.test.util.trimTrailingWhitespaces
 import java.nio.file.Path
+import java.util.Base64
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.name
 import kotlin.io.path.readText
@@ -132,3 +136,61 @@ internal fun readValidateAndCleanupTestResults(
 
 internal fun prettyPrintXml(uglyXml: String): String =
     JDOMUtil.write(JDOMUtil.load(uglyXml.reader()))
+
+private fun GradleProject.testResultsAndReportsDirs(
+    taskName: String,
+    subprojectName: String? = null,
+): Pair<Path, Path> {
+    val cleanTaskName = taskName.removePrefix(":")
+    val subproject: String? = when {
+        subprojectName != null -> subprojectName
+        cleanTaskName.contains(':') -> cleanTaskName.substringBeforeLast(':').replace(':', '/')
+        else -> null
+    }
+    val simpleTaskName: String = cleanTaskName.substringAfterLast(':')
+    val buildDirLocation = if (subproject != null) {
+        projectPath.resolve(subproject)
+    } else {
+        projectPath
+    }
+    val testResultsDir = buildDirLocation.resolve("build/test-results/$simpleTaskName")
+    val testReportsDir = buildDirLocation.resolve("build/reports/tests/$simpleTaskName")
+    return testResultsDir to testReportsDir
+}
+
+fun GradleProject.testClassHtmlReport(
+    taskName: String,
+    className: String,
+    gradleVersion: GradleVersion,
+    subprojectName: String? = null,
+    targetName: String? = null,
+): Path {
+    val testReportsDir = testResultsAndReportsDirs(taskName, subprojectName).second
+    val simpleTaskName = taskName.removePrefix(":").substringAfterLast(':')
+
+    val reportRelativePath = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_3)) {
+        "classes/$className.html"
+    } else {
+        val prefix = if (targetName == "jvm") "" else "$simpleTaskName."
+        val dirName = if (gradleVersion < GradleVersion.version(TestVersions.Gradle.G_9_4) ||
+            gradleVersion >= GradleVersion.version(TestVersions.Gradle.G_9_6)
+        ) {
+            "$prefix$className"
+        } else {
+            "$prefix$className".hashTestPathSegment()
+        }
+        "$dirName/index.html"
+    }
+
+    return testReportsDir.resolve(reportRelativePath)
+}
+
+// Adopted from Gradle
+// platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestReportGenerator.java
+// Caused by https://github.com/gradle/gradle/pull/37052
+private fun String.hashTestPathSegment(): String {
+    val hashBytes = TEST_PATH_HASHER.hashUnencodedChars(this).asBytes()
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(hashBytes)
+}
+
+private val TEST_PATH_HASHER: HashFunction = Hashing.farmHashFingerprint64()


### PR DESCRIPTION
Extract the Gradle 9.3/9.4/9.6 HTML-report-path logic out of `MppDslAssociateCompilationsIT` (duplicated there) into a reusable `testClassHtmlReport`, keyed on target name to match Gradle's actual report-layout rule.                                                                                                                                                   

^KQA-3413