### PR TITLE
[Wasm] Enable JavaScriptCore on Windows by flag

### DIFF
--- a/wasm/wasm.tests/build.gradle.kts
+++ b/wasm/wasm.tests/build.gradle.kts
@@ -338,6 +338,11 @@ fun Test.setupJsc() {
         classpath.from(jscRunnerExecutablePath)
         property.set("javascript.engine.path.JavaScriptCore")
     }
+
+    systemProperty(
+        "javascript.engine.JavaScriptCore.EnableOnWindows",
+        kotlinBuildProperties.booleanProperty("kotlin.enable.tests.jsc.on.windows").get()
+    )
 }
 
 testsJar {}

--- a/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/handlers/WasmBoxRunnerBase.kt
+++ b/wasm/wasm.tests/testFixtures/org/jetbrains/kotlin/wasm/test/handlers/WasmBoxRunnerBase.kt
@@ -30,10 +30,10 @@ abstract class WasmBoxRunnerBase(
         listOfNotNull(WasmVM.V8)
     } else {
         // KT-82392 [Wasm] Investigate and fix JSC test run on windows
-        val jscOfNotWindows = WasmVM.JavaScriptCore.takeIf {
-            !System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
-        }
-        listOfNotNull(WasmVM.V8, WasmVM.SpiderMonkey, jscOfNotWindows)
+        val isNotWindows = !System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+        val isForcedOnWindows = System.getProperty("javascript.engine.JavaScriptCore.EnableOnWindows") == "true"
+        val jscIfNeeded = WasmVM.JavaScriptCore.takeIf { isNotWindows || isForcedOnWindows }
+        listOfNotNull(WasmVM.V8, WasmVM.SpiderMonkey, jscIfNeeded)
     }
 
     fun saveAdditionalFilesAndRun(


### PR DESCRIPTION
Use kotlin.enable.tests.jsc.on.windows to enable tests on Windows

WIP of KT-82392