### PR TITLE
CastsOptimizationPass: break aliases cycles

### DIFF
--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/CastsOptimization.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/CastsOptimization.kt
@@ -1331,6 +1331,14 @@ internal class CastsOptimization(val context: NativeBackendContext) : BodyLoweri
             VisitorResult(resultPredicate, result.variable)
         }
 
+        fun IrValueDeclaration.aliasesTo(variable: IrVariable): Boolean {
+            var current: IrValueDeclaration? = this
+            while (current != variable && current != null)
+                current = variableAliases[current]
+
+            return current == variable
+        }
+
         fun setVariable(variable: IrVariable, value: IrExpression, data: Predicate): Predicate {
             return if (variable.type.isBoolean()) {
                 val booleanPredicate = usingUpperLevelPredicate(data) { buildBooleanPredicate(value) }
@@ -1348,7 +1356,7 @@ internal class CastsOptimization(val context: NativeBackendContext) : BodyLoweri
                 val result = VisitorResult()
                 val nullablePredicate = usingUpperLevelPredicate(data) { buildNullablePredicate(value, result) }
                 val predicate = Predicates.and(data, result.predicate)
-                val alias = result.variable
+                val alias = result.variable?.takeIf { !it.aliasesTo(variable) } // Break possible aliases cycle.
                         ?: if (variable.isMutable) createPhantomVariable(variable, value) else variable
                 if (alias != variable)
                     variableAliases[variable] = alias
@@ -1365,7 +1373,7 @@ internal class CastsOptimization(val context: NativeBackendContext) : BodyLoweri
                 }
             } else {
                 (val predicate, val delegatedVariable = variable) = value.accept(this, data)
-                val alias = delegatedVariable
+                val alias = delegatedVariable?.takeIf { !it.aliasesTo(variable) } // Break possible aliases cycle.
                         ?: if (variable.isMutable) createPhantomVariable(variable, value) else variable
                 if (alias != variable)
                     variableAliases[variable] = alias

--- a/native/native.tests/testData/codegen/controlflow/castsOptimizationAliasCycle.kt
+++ b/native/native.tests/testData/codegen/controlflow/castsOptimizationAliasCycle.kt
@@ -1,3 +1,5 @@
+// IGNORE_KLIB_BACKEND_ERRORS_WITH_CUSTOM_SECOND_STAGE: Native:2.4
+
 fun f(a: String?) {
     var p = a
     while (p != null) {

--- a/native/native.tests/testData/codegen/controlflow/castsOptimizationAliasCycle.kt
+++ b/native/native.tests/testData/codegen/controlflow/castsOptimizationAliasCycle.kt
@@ -1,0 +1,16 @@
+fun f(a: String?) {
+    var p = a
+    while (p != null) {
+        var q: String? = p
+        while (q != null) {
+            q = null
+        }
+        p = q
+    }
+}
+
+fun box(): String {
+    f(null)
+    f("hello")
+    return "OK"
+}


### PR DESCRIPTION
This PR breaks cycles in aliases during the analysis. Without it, having a cycle in variable writes within a loop might lead to SOE.