### PR TITLE
[AFU] Support companion atomics on Native and enable tests for all targets

### DIFF
--- a/compiler/testData/codegen/box/volatile/intrinsicsOnCompanionBlocks.kt
+++ b/compiler/testData/codegen/box/volatile/intrinsicsOnCompanionBlocks.kt
@@ -1,0 +1,85 @@
+// LANGUAGE: +CompanionBlocks
+// TARGET_BACKEND: NATIVE
+// DISABLE_IR_VISIBILITY_CHECKS: ANY
+
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
+import kotlin.native.concurrent.*
+import kotlin.concurrent.*
+import kotlin.native.internal.*
+import kotlin.reflect.KMutableProperty0
+
+val a = "1"
+val b = "2"
+val c = "3"
+
+class C {
+    companion {
+        @Volatile var byte: Byte = 1
+        @Volatile var short: Short = 1
+        @Volatile var x: Int = 1
+        @Volatile var y: Long = 1L
+        @Volatile var z: String = a
+        @Volatile var t: Boolean = true
+    }
+}
+
+fun box() : String {
+    if (C::byte.compareAndSetField(1.toByte(), 2.toByte()) != true) return "FAIL Byte: 1"
+    if (C::byte.compareAndSetField(1.toByte(), 2.toByte()) != false) return "FAIL Byte: 2"
+    if (C::byte.compareAndExchangeField(2.toByte(), 1.toByte()) != 2.toByte()) return "FAIL Byte: 3"
+    if (C::byte.compareAndExchangeField(2.toByte(), 1.toByte()) != 1.toByte()) return "FAIL Byte: 4"
+    if (C::byte.getAndSetField(3.toByte()) != 1.toByte()) return "FAIL Byte: 5"
+    if (C::byte.getAndSetField(1.toByte()) != 3.toByte()) return "FAIL Byte: 6"
+    if (C::byte.getAndAddField(1.toByte()) != 1.toByte()) return "FAIL Byte: 7"
+    if (C::byte.getAndAddField(1.toByte()) != 2.toByte()) return "FAIL Byte: 8"
+    if (C.byte != 3.toByte()) return "FAIL Byte: 9"
+
+    if (C::short.compareAndSetField(1.toShort(), 2.toShort()) != true) return "FAIL Short: 1"
+    if (C::short.compareAndSetField(1.toShort(), 2.toShort()) != false) return "FAIL Short: 2"
+    if (C::short.compareAndExchangeField(2.toShort(), 1.toShort()) != 2.toShort()) return "FAIL Short: 3"
+    if (C::short.compareAndExchangeField(2.toShort(), 1.toShort()) != 1.toShort()) return "FAIL Short: 4"
+    if (C::short.getAndSetField(3.toShort()) != 1.toShort()) return "FAIL Short: 5"
+    if (C::short.getAndSetField(1.toShort()) != 3.toShort()) return "FAIL Short: 6"
+    if (C::short.getAndAddField(1.toShort()) != 1.toShort()) return "FAIL Short: 7"
+    if (C::short.getAndAddField(1.toShort()) != 2.toShort()) return "FAIL Short: 8"
+    if (C.short != 3.toShort()) return "FAIL Short: 9"
+
+    if (C::x.compareAndSetField(1, 2) != true) return "FAIL Int: 1"
+    if (C::x.compareAndSetField(1, 2) != false) return "FAIL Int: 2"
+    if (C::x.compareAndExchangeField(2, 1) != 2) return "FAIL Int: 3"
+    if (C::x.compareAndExchangeField(2, 1) != 1) return "FAIL Int: 4"
+    if (C::x.getAndSetField(3) != 1) return "FAIL Int: 5"
+    if (C::x.getAndSetField(1) != 3) return "FAIL Int: 6"
+    if (C::x.getAndAddField(1) != 1) return "FAIL Int: 7"
+    if (C::x.getAndAddField(1) != 2) return "FAIL Int: 8"
+    if (C.x != 3) return "FAIL Int: 9"
+
+    if (C::y.compareAndSetField(1L, 2L) != true) return "FAIL Long: 1"
+    if (C::y.compareAndSetField(1L, 2L) != false) return "FAIL Long: 2"
+    if (C::y.compareAndExchangeField(2L, 1L) != 2L) return "FAIL Long: 3"
+    if (C::y.compareAndExchangeField(2L, 1L) != 1L) return "FAIL Long: 4"
+    if (C::y.getAndSetField(3L) != 1L) return "FAIL Long: 5"
+    if (C::y.getAndSetField(1L) != 3L) return "FAIL Long: 6"
+    if (C::y.getAndAddField(1L) != 1L) return "FAIL Long: 7"
+    if (C::y.getAndAddField(1L) != 2L) return "FAIL Long: 8"
+    if (C.y != 3L) return "FAIL Long: 9"
+
+    if (C::z.compareAndSetField(a, b) != true) return "FAIL String: 1"
+    if (C::z.compareAndSetField(a, b) != false) return "FAIL String: 2"
+    if (C::z.compareAndExchangeField(b, a) != b) return "FAIL String: 3"
+    if (C::z.compareAndExchangeField(b, a) != a) return "FAIL String: 4"
+    if (C::z.getAndSetField(c) != a) return "FAIL String: 5"
+    if (C::z.getAndSetField(a) != c) return "FAIL String: 6"
+    if (C.z != a) return "FAIL String: 7"
+
+    if (C::t.compareAndSetField(true, false) != true) return "FAIL Bool: 1"
+    if (C::t.compareAndSetField(true, false) != false) return "FAIL Bool: 2"
+    if (C::t.compareAndExchangeField(false, true) != false) return "FAIL Bool: 3"
+    if (C::t.compareAndExchangeField(false, true) != true) return "FAIL Bool: 4"
+    if (C::t.getAndSetField(false) != true) return "FAIL Bool: 5"
+    if (C::t.getAndSetField(true) != false) return "FAIL Bool: 6"
+    if (C.t != true) return "FAIL Bool: 7"
+
+    return "OK"
+}

--- a/compiler/testData/codegen/box/volatile/intrinsicsOnCompanionExtensions.kt
+++ b/compiler/testData/codegen/box/volatile/intrinsicsOnCompanionExtensions.kt
@@ -1,0 +1,83 @@
+// LANGUAGE: +CompanionExtensions +CompanionBlocks
+// TARGET_BACKEND: NATIVE
+// DISABLE_IR_VISIBILITY_CHECKS: ANY
+
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
+import kotlin.native.concurrent.*
+import kotlin.concurrent.*
+import kotlin.native.internal.*
+import kotlin.reflect.KMutableProperty0
+
+val a = "1"
+val b = "2"
+val c = "3"
+
+class C
+
+companion @Volatile var C.byte: Byte = 1
+companion @Volatile var C.short: Short = 1
+companion @Volatile var C.x: Int = 1
+companion @Volatile var C.y: Long = 1L
+companion @Volatile var C.z: String = a
+companion @Volatile var C.t: Boolean = true
+
+fun box() : String {
+    if (C::byte.compareAndSetField(1.toByte(), 2.toByte()) != true) return "FAIL Byte: 1"
+    if (C::byte.compareAndSetField(1.toByte(), 2.toByte()) != false) return "FAIL Byte: 2"
+    if (C::byte.compareAndExchangeField(2.toByte(), 1.toByte()) != 2.toByte()) return "FAIL Byte: 3"
+    if (C::byte.compareAndExchangeField(2.toByte(), 1.toByte()) != 1.toByte()) return "FAIL Byte: 4"
+    if (C::byte.getAndSetField(3.toByte()) != 1.toByte()) return "FAIL Byte: 5"
+    if (C::byte.getAndSetField(1.toByte()) != 3.toByte()) return "FAIL Byte: 6"
+    if (C::byte.getAndAddField(1.toByte()) != 1.toByte()) return "FAIL Byte: 7"
+    if (C::byte.getAndAddField(1.toByte()) != 2.toByte()) return "FAIL Byte: 8"
+    if (C.byte != 3.toByte()) return "FAIL Byte: 9"
+
+    if (C::short.compareAndSetField(1.toShort(), 2.toShort()) != true) return "FAIL Short: 1"
+    if (C::short.compareAndSetField(1.toShort(), 2.toShort()) != false) return "FAIL Short: 2"
+    if (C::short.compareAndExchangeField(2.toShort(), 1.toShort()) != 2.toShort()) return "FAIL Short: 3"
+    if (C::short.compareAndExchangeField(2.toShort(), 1.toShort()) != 1.toShort()) return "FAIL Short: 4"
+    if (C::short.getAndSetField(3.toShort()) != 1.toShort()) return "FAIL Short: 5"
+    if (C::short.getAndSetField(1.toShort()) != 3.toShort()) return "FAIL Short: 6"
+    if (C::short.getAndAddField(1.toShort()) != 1.toShort()) return "FAIL Short: 7"
+    if (C::short.getAndAddField(1.toShort()) != 2.toShort()) return "FAIL Short: 8"
+    if (C.short != 3.toShort()) return "FAIL Short: 9"
+
+    if (C::x.compareAndSetField(1, 2) != true) return "FAIL Int: 1"
+    if (C::x.compareAndSetField(1, 2) != false) return "FAIL Int: 2"
+    if (C::x.compareAndExchangeField(2, 1) != 2) return "FAIL Int: 3"
+    if (C::x.compareAndExchangeField(2, 1) != 1) return "FAIL Int: 4"
+    if (C::x.getAndSetField(3) != 1) return "FAIL Int: 5"
+    if (C::x.getAndSetField(1) != 3) return "FAIL Int: 6"
+    if (C::x.getAndAddField(1) != 1) return "FAIL Int: 7"
+    if (C::x.getAndAddField(1) != 2) return "FAIL Int: 8"
+    if (C.x != 3) return "FAIL Int: 9"
+
+    if (C::y.compareAndSetField(1L, 2L) != true) return "FAIL Long: 1"
+    if (C::y.compareAndSetField(1L, 2L) != false) return "FAIL Long: 2"
+    if (C::y.compareAndExchangeField(2L, 1L) != 2L) return "FAIL Long: 3"
+    if (C::y.compareAndExchangeField(2L, 1L) != 1L) return "FAIL Long: 4"
+    if (C::y.getAndSetField(3L) != 1L) return "FAIL Long: 5"
+    if (C::y.getAndSetField(1L) != 3L) return "FAIL Long: 6"
+    if (C::y.getAndAddField(1L) != 1L) return "FAIL Long: 7"
+    if (C::y.getAndAddField(1L) != 2L) return "FAIL Long: 8"
+    if (C.y != 3L) return "FAIL Long: 9"
+
+    if (C::z.compareAndSetField(a, b) != true) return "FAIL String: 1"
+    if (C::z.compareAndSetField(a, b) != false) return "FAIL String: 2"
+    if (C::z.compareAndExchangeField(b, a) != b) return "FAIL String: 3"
+    if (C::z.compareAndExchangeField(b, a) != a) return "FAIL String: 4"
+    if (C::z.getAndSetField(c) != a) return "FAIL String: 5"
+    if (C::z.getAndSetField(a) != c) return "FAIL String: 6"
+    if (C.z != a) return "FAIL String: 7"
+
+    if (C::t.compareAndSetField(true, false) != true) return "FAIL Bool: 1"
+    if (C::t.compareAndSetField(true, false) != false) return "FAIL Bool: 2"
+    if (C::t.compareAndExchangeField(false, true) != false) return "FAIL Bool: 3"
+    if (C::t.compareAndExchangeField(false, true) != true) return "FAIL Bool: 4"
+    if (C::t.getAndSetField(false) != true) return "FAIL Bool: 5"
+    if (C::t.getAndSetField(true) != false) return "FAIL Bool: 6"
+    if (C.t != true) return "FAIL Bool: 7"
+
+    return "OK"
+}

--- a/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VolatileFieldsLowering.kt
+++ b/kotlin-native/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VolatileFieldsLowering.kt
@@ -66,9 +66,10 @@ internal class VolatileFieldsLowering(val context: NativeBackendContext) : FileL
         require(scope != null)
         require(scope is IrClass || scope is IrFile)
         parent = scope
-        if (scope is IrClass) {
+        val receiverParameter = property.getter?.dispatchReceiverParameter
+        if (receiverParameter != null) {
             parameters += buildReceiverParameter {
-                type = scope.defaultType
+                type = receiverParameter.type
                 startOffset = irField.startOffset
                 endOffset = irField.endOffset
             }

--- a/libraries/stdlib/js-ir-minimal-for-test/js-src/minimalTestAssertions.kt
+++ b/libraries/stdlib/js-ir-minimal-for-test/js-src/minimalTestAssertions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -21,8 +21,12 @@ fun assertFalse(x: Boolean) {
 
 @Suppress("UNUSED_PARAMETER")
 fun <T : Any> assertNotNull(actual: T?, message: String? = null): T {
-    if (actual == null) throw Exception("")
+    if (actual == null) throw Exception("${if (message == null) "" else "$message. "}Expected value to be not null")
     return actual
 }
 
+@Suppress("UNUSED_PARAMETER")
+fun assertNull(actual: Any?, message: String? = null) {
+    if (actual != null) throw Exception("${if (message == null) "" else "$message. "}Expected value to be null, but was: <$actual>.")
+}
 

--- a/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
+++ b/plugins/atomicfu/atomicfu-compiler/src/org/jetbrains/kotlinx/atomicfu/compiler/backend/common/AbstractAtomicfuIrBuilder.kt
@@ -172,7 +172,7 @@ abstract class AbstractAtomicfuIrBuilder(
             volatileField,
             atomicfuProperty.visibility,
             isVar = true,
-            isStatic = false,
+            isStatic = atomicfuProperty.hasStaticBackingField,
             parentContainer
         )
         return VolatilePropertyReference(volatileProperty)
@@ -331,7 +331,7 @@ abstract class AbstractAtomicfuIrBuilder(
 
     fun irPropertyReference(property: IrProperty, classReceiver: IrExpression?): IrPropertyReferenceImpl {
         val backingField = requireNotNull(property.backingField) { "Backing field of the property $property should not be null" }
-        val isInstanceProperty = property.parentClassOrNull != null
+        val isInstanceProperty = property.parentClassOrNull != null && !backingField.isStatic
         val receiversCount = if (isInstanceProperty && classReceiver == null) 1 else 0
         val kPropertyClass = irBuiltIns.getKPropertyClass(property.isVar, receiversCount).owner
         val substitutionMap = mutableMapOf<IrTypeParameterSymbol, IrType>()

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.ir.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.ir.txt
@@ -1,0 +1,137 @@
+FILE fqName:<root> fileName:/ComanionTraces.kt
+  PROPERTY name:extTrace visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:extTrace type:kotlinx.atomicfu.TraceBase visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun Trace (size: kotlin.Int, format: kotlinx.atomicfu.TraceFormat): kotlinx.atomicfu.TraceBase declared in kotlinx.atomicfu' type=kotlinx.atomicfu.TraceBase origin=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-extTrace> visibility:private modality:FINAL returnType:kotlinx.atomicfu.TraceBase
+      correspondingProperty: PROPERTY name:extTrace visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:TraceTest modality:FINAL visibility:public superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-extTrace> (): kotlinx.atomicfu.TraceBase declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:extTrace type:kotlinx.atomicfu.TraceBase visibility:private [final,static]' type=kotlinx.atomicfu.TraceBase origin=null
+  PROPERTY name:a visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Int, trace: kotlinx.atomicfu.TraceBase): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+          ARG initial: CONST Int type=kotlin.Int value=42
+          ARG trace: CALL 'private final fun <get-extTrace> (): kotlinx.atomicfu.TraceBase declared in <root>' type=kotlinx.atomicfu.TraceBase origin=GET_PROPERTY
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicInt
+      correspondingProperty: PROPERTY name:a visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:TraceTest modality:FINAL visibility:public superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]' type=kotlinx.atomicfu.AtomicInt origin=null
+  CLASS CLASS name:TraceTest modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TraceTest
+    PROPERTY name:defaultTrace visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:defaultTrace type:kotlinx.atomicfu.TraceBase visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun Trace (size: kotlin.Int, format: kotlinx.atomicfu.TraceFormat): kotlinx.atomicfu.TraceBase declared in kotlinx.atomicfu' type=kotlinx.atomicfu.TraceBase origin=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-defaultTrace> visibility:private modality:FINAL returnType:kotlinx.atomicfu.TraceBase [companion]
+        correspondingProperty: PROPERTY name:defaultTrace visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-defaultTrace> (): kotlinx.atomicfu.TraceBase declared in <root>.TraceTest'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:defaultTrace type:kotlinx.atomicfu.TraceBase visibility:private [final,static]' type=kotlinx.atomicfu.TraceBase origin=null
+    PROPERTY name:a1 visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:a1 type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Int, trace: kotlinx.atomicfu.TraceBase): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG initial: CONST Int type=kotlin.Int value=5
+            ARG trace: CALL 'private final fun <get-defaultTrace> (): kotlinx.atomicfu.TraceBase declared in <root>.TraceTest' type=kotlinx.atomicfu.TraceBase origin=GET_PROPERTY
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a1> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicInt [companion]
+        correspondingProperty: PROPERTY name:a1 visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-a1> (): kotlinx.atomicfu.AtomicInt declared in <root>.TraceTest'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a1 type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]' type=kotlinx.atomicfu.AtomicInt origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.TraceTest [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TraceTest modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:testCompanionTrace visibility:public modality:FINAL returnType:kotlin.Unit [companion]
+      BLOCK_BODY
+        VAR name:oldValue type:kotlin.Int [val]
+          CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-a1> (): kotlinx.atomicfu.AtomicInt declared in <root>.TraceTest' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+        CALL 'public final fun invoke (event: kotlin.Function0<kotlin.Any>): kotlin.Unit declared in kotlinx.atomicfu.TraceBase' type=kotlin.Unit origin=null
+          ARG <this>: CALL 'private final fun <get-defaultTrace> (): kotlinx.atomicfu.TraceBase declared in <root>.TraceTest' type=kotlinx.atomicfu.TraceBase origin=GET_PROPERTY
+          ARG event: FUN_EXPR type=kotlin.Function0<kotlin.Any> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Any declared in <root>.TraceTest.testCompanionTrace'
+                  STRING_CONCATENATION type=kotlin.String
+                    CONST String type=kotlin.String value="before CAS value = "
+                    GET_VAR 'val oldValue: kotlin.Int declared in <root>.TraceTest.testCompanionTrace' type=kotlin.Int origin=null
+        VAR name:res type:kotlin.Boolean [val]
+          CALL 'public final fun compareAndSet (expect: kotlin.Int, update: kotlin.Int): kotlin.Boolean declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Boolean origin=null
+            ARG <this>: CALL 'private final fun <get-a1> (): kotlinx.atomicfu.AtomicInt declared in <root>.TraceTest' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+            ARG expect: GET_VAR 'val oldValue: kotlin.Int declared in <root>.TraceTest.testCompanionTrace' type=kotlin.Int origin=null
+            ARG update: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+              ARG <this>: GET_VAR 'val oldValue: kotlin.Int declared in <root>.TraceTest.testCompanionTrace' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=10
+        VAR name:newValue type:kotlin.Int [val]
+          CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+            ARG <this>: CALL 'private final fun <get-a1> (): kotlinx.atomicfu.AtomicInt declared in <root>.TraceTest' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+        CALL 'public final fun invoke (event: kotlin.Function0<kotlin.Any>): kotlin.Unit declared in kotlinx.atomicfu.TraceBase' type=kotlin.Unit origin=null
+          ARG <this>: CALL 'private final fun <get-defaultTrace> (): kotlinx.atomicfu.TraceBase declared in <root>.TraceTest' type=kotlinx.atomicfu.TraceBase origin=GET_PROPERTY
+          ARG event: FUN_EXPR type=kotlin.Function0<kotlin.Any> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Any declared in <root>.TraceTest.testCompanionTrace'
+                  STRING_CONCATENATION type=kotlin.String
+                    CONST String type=kotlin.String value="after CAS value = "
+                    GET_VAR 'val newValue: kotlin.Int declared in <root>.TraceTest.testCompanionTrace' type=kotlin.Int origin=null
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'private final fun test (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+  FUN name:test visibility:private modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+      CALL 'public final fun testCompanionTrace (): kotlin.Unit declared in <root>.TraceTest' type=kotlin.Unit origin=null
+      CALL 'public final fun testExtensionTrace (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+  FUN name:testExtensionTrace visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+      VAR name:oldValue type:kotlin.Int [val]
+        CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun invoke (event: kotlin.Function0<kotlin.Any>): kotlin.Unit declared in kotlinx.atomicfu.TraceBase' type=kotlin.Unit origin=null
+        ARG <this>: CALL 'private final fun <get-extTrace> (): kotlinx.atomicfu.TraceBase declared in <root>' type=kotlinx.atomicfu.TraceBase origin=GET_PROPERTY
+        ARG event: FUN_EXPR type=kotlin.Function0<kotlin.Any> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Any declared in <root>.testExtensionTrace'
+                STRING_CONCATENATION type=kotlin.String
+                  CONST String type=kotlin.String value="before CAS value = "
+                  GET_VAR 'val oldValue: kotlin.Int declared in <root>.testExtensionTrace' type=kotlin.Int origin=null
+      VAR name:res type:kotlin.Boolean [val]
+        CALL 'public final fun compareAndSet (expect: kotlin.Int, update: kotlin.Int): kotlin.Boolean declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Boolean origin=null
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+          ARG expect: GET_VAR 'val oldValue: kotlin.Int declared in <root>.testExtensionTrace' type=kotlin.Int origin=null
+          ARG update: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=MUL
+            ARG <this>: GET_VAR 'val oldValue: kotlin.Int declared in <root>.testExtensionTrace' type=kotlin.Int origin=null
+            ARG other: CONST Int type=kotlin.Int value=10
+      VAR name:newValue type:kotlin.Int [val]
+        CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun invoke (event: kotlin.Function0<kotlin.Any>): kotlin.Unit declared in kotlinx.atomicfu.TraceBase' type=kotlin.Unit origin=null
+        ARG <this>: CALL 'private final fun <get-extTrace> (): kotlinx.atomicfu.TraceBase declared in <root>' type=kotlinx.atomicfu.TraceBase origin=GET_PROPERTY
+        ARG event: FUN_EXPR type=kotlin.Function0<kotlin.Any> origin=LAMBDA
+          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Any declared in <root>.testExtensionTrace'
+                STRING_CONCATENATION type=kotlin.String
+                  CONST String type=kotlin.String value="after CAS value = "
+                  GET_VAR 'val newValue: kotlin.Int declared in <root>.testExtensionTrace' type=kotlin.Int origin=null

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +CompanionBlocks +CompanionExtensions
-// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/ComanionTraces.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocks +CompanionExtensions
-// TARGET_BACKEND: JVM_IR
+// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.ir.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.ir.txt
@@ -1,0 +1,95 @@
+FILE fqName:<root> fileName:/CompanionBlockProperties.kt
+  CLASS CLASS name:Outer modality:FINAL visibility:private superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Outer
+    PROPERTY name:i visibility:internal modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:i type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG initial: CONST Int type=kotlin.Int value=1
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-i> visibility:internal modality:FINAL returnType:kotlinx.atomicfu.AtomicInt [companion]
+        correspondingProperty: PROPERTY name:i visibility:internal modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='internal final fun <get-i> (): kotlinx.atomicfu.AtomicInt declared in <root>.Outer'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:i type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]' type=kotlinx.atomicfu.AtomicInt origin=null
+    PROPERTY name:b visibility:internal modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:b type:kotlinx.atomicfu.AtomicRef<kotlin.Any?> visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic <T> (initial: T of kotlinx.atomicfu.atomic): kotlinx.atomicfu.AtomicRef<T of kotlinx.atomicfu.atomic> declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=null
+            TYPE_ARG T: kotlin.Any?
+            ARG initial: CONST Null type=kotlin.Nothing? value=null
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-b> visibility:internal modality:FINAL returnType:kotlinx.atomicfu.AtomicRef<kotlin.Any?> [companion]
+        correspondingProperty: PROPERTY name:b visibility:internal modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='internal final fun <get-b> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>.Outer'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:b type:kotlinx.atomicfu.AtomicRef<kotlin.Any?> visibility:private [final,static]' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=null
+    PROPERTY name:arr visibility:internal modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:arr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final,static]
+        EXPRESSION_BODY
+          CONSTRUCTOR_CALL 'public constructor <init> (size: kotlin.Int) declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicIntArray origin=null
+            ARG size: CONST Int type=kotlin.Int value=2
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-arr> visibility:internal modality:FINAL returnType:kotlinx.atomicfu.AtomicIntArray [companion]
+        correspondingProperty: PROPERTY name:arr visibility:internal modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='internal final fun <get-arr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>.Outer'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:arr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final,static]' type=kotlinx.atomicfu.AtomicIntArray origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Outer [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Outer modality:FINAL visibility:private superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun testCompanionBlock (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+  FUN name:testCompanionBlock visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=1
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'internal final fun <get-i> (): kotlinx.atomicfu.AtomicInt declared in <root>.Outer' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=2
+        ARG b: CALL 'public final fun incrementAndGet (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+          ARG <this>: CALL 'internal final fun <get-i> (): kotlinx.atomicfu.AtomicInt declared in <root>.Outer' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertNull (actual: kotlin.Any?, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG actual: CALL 'public final fun <get-value> (): T of kotlinx.atomicfu.AtomicRef declared in kotlinx.atomicfu.AtomicRef' type=kotlin.Any? origin=GET_PROPERTY
+          ARG <this>: CALL 'internal final fun <get-b> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>.Outer' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=GET_PROPERTY
+      CALL 'public final fun assertTrue (x: kotlin.Boolean): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG x: CALL 'public final fun compareAndSet (expect: T of kotlinx.atomicfu.AtomicRef, update: T of kotlinx.atomicfu.AtomicRef): kotlin.Boolean declared in kotlinx.atomicfu.AtomicRef' type=kotlin.Boolean origin=null
+          ARG <this>: CALL 'internal final fun <get-b> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>.Outer' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=GET_PROPERTY
+          ARG expect: CONST Null type=kotlin.Nothing? value=null
+          ARG update: CONST String type=kotlin.String value="value"
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG a: CONST String type=kotlin.String value="value"
+        ARG b: CALL 'public final fun <get-value> (): T of kotlinx.atomicfu.AtomicRef declared in kotlinx.atomicfu.AtomicRef' type=kotlin.Any? origin=GET_PROPERTY
+          ARG <this>: CALL 'internal final fun <get-b> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>.Outer' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=0
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+            ARG <this>: CALL 'internal final fun <get-arr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>.Outer' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+            ARG index: CONST Int type=kotlin.Int value=0
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=1
+        ARG b: CALL 'public final fun incrementAndGet (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+          ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+            ARG <this>: CALL 'internal final fun <get-arr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>.Outer' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+            ARG index: CONST Int type=kotlin.Int value=0

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +CompanionBlocks
-// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionBlockProperties.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocks
-// TARGET_BACKEND: JVM_IR
+// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.ir.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.ir.txt
@@ -1,0 +1,98 @@
+FILE fqName:<root> fileName:/CompanionExtensionProperties.kt
+  PROPERTY name:cA visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:cA type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+          ARG initial: CONST Int type=kotlin.Int value=1
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-cA> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicInt
+      correspondingProperty: PROPERTY name:cA visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:Outer modality:FINAL visibility:public superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-cA> (): kotlinx.atomicfu.AtomicInt declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:cA type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]' type=kotlinx.atomicfu.AtomicInt origin=null
+  PROPERTY name:cB visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:cB type:kotlinx.atomicfu.AtomicRef<kotlin.Any?> visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic <T> (initial: T of kotlinx.atomicfu.atomic): kotlinx.atomicfu.AtomicRef<T of kotlinx.atomicfu.atomic> declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=null
+          TYPE_ARG T: kotlin.Any?
+          ARG initial: CONST Null type=kotlin.Nothing? value=null
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-cB> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicRef<kotlin.Any?>
+      correspondingProperty: PROPERTY name:cB visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:Outer modality:FINAL visibility:public superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-cB> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:cB type:kotlinx.atomicfu.AtomicRef<kotlin.Any?> visibility:private [final,static]' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=null
+  PROPERTY name:cArr visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:cArr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (size: kotlin.Int) declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicIntArray origin=null
+          ARG size: CONST Int type=kotlin.Int value=2
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-cArr> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicIntArray
+      correspondingProperty: PROPERTY name:cArr visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:Outer modality:FINAL visibility:public superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-cArr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:cArr type:kotlinx.atomicfu.AtomicIntArray visibility:private [final,static]' type=kotlinx.atomicfu.AtomicIntArray origin=null
+  CLASS CLASS name:Outer modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Outer
+    CONSTRUCTOR visibility:public returnType:<root>.Outer [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Outer modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun testCompanionExt (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+  FUN name:testCompanionExt visibility:public modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=1
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-cA> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=2
+        ARG b: CALL 'public final fun incrementAndGet (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+          ARG <this>: CALL 'private final fun <get-cA> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertNull (actual: kotlin.Any?, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG actual: CALL 'public final fun <get-value> (): T of kotlinx.atomicfu.AtomicRef declared in kotlinx.atomicfu.AtomicRef' type=kotlin.Any? origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-cB> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=GET_PROPERTY
+      CALL 'public final fun assertTrue (x: kotlin.Boolean): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG x: CALL 'public final fun compareAndSet (expect: T of kotlinx.atomicfu.AtomicRef, update: T of kotlinx.atomicfu.AtomicRef): kotlin.Boolean declared in kotlinx.atomicfu.AtomicRef' type=kotlin.Boolean origin=null
+          ARG <this>: CALL 'private final fun <get-cB> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=GET_PROPERTY
+          ARG expect: CONST Null type=kotlin.Nothing? value=null
+          ARG update: CONST String type=kotlin.String value="value"
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG a: CONST String type=kotlin.String value="value"
+        ARG b: CALL 'public final fun <get-value> (): T of kotlinx.atomicfu.AtomicRef declared in kotlinx.atomicfu.AtomicRef' type=kotlin.Any? origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-cB> (): kotlinx.atomicfu.AtomicRef<kotlin.Any?> declared in <root>' type=kotlinx.atomicfu.AtomicRef<kotlin.Any?> origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=0
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+            ARG <this>: CALL 'private final fun <get-cArr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+            ARG index: CONST Int type=kotlin.Int value=0
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=1
+        ARG b: CALL 'public final fun incrementAndGet (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+          ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu.AtomicIntArray' type=kotlinx.atomicfu.AtomicInt origin=GET_ARRAY_ELEMENT
+            ARG <this>: CALL 'private final fun <get-cArr> (): kotlinx.atomicfu.AtomicIntArray declared in <root>' type=kotlinx.atomicfu.AtomicIntArray origin=GET_PROPERTY
+            ARG index: CONST Int type=kotlin.Int value=0

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionExtensions +CompanionBlocks
-// TARGET_BACKEND: JVM_IR
+// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionExtensionProperties.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +CompanionExtensions +CompanionBlocks
-// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.ir.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.ir.txt
@@ -1,0 +1,93 @@
+FILE fqName:<root> fileName:/CompanionFunctions.kt
+  PROPERTY name:a visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicLong visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Long): kotlinx.atomicfu.AtomicLong declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicLong origin=null
+          ARG initial: CONST Long type=kotlin.Long value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicLong
+      correspondingProperty: PROPERTY name:a visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-a> (): kotlinx.atomicfu.AtomicLong declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicLong visibility:private [final,static]' type=kotlinx.atomicfu.AtomicLong origin=null
+  PROPERTY name:arr visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:arr type:kotlinx.atomicfu.AtomicLongArray visibility:private [final,static]
+      EXPRESSION_BODY
+        CONSTRUCTOR_CALL 'public constructor <init> (size: kotlin.Int) declared in kotlinx.atomicfu.AtomicLongArray' type=kotlinx.atomicfu.AtomicLongArray origin=null
+          ARG size: CONST Int type=kotlin.Int value=10
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-arr> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicLongArray
+      correspondingProperty: PROPERTY name:arr visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-arr> (): kotlinx.atomicfu.AtomicLongArray declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:arr type:kotlinx.atomicfu.AtomicLongArray visibility:private [final,static]' type=kotlinx.atomicfu.AtomicLongArray origin=null
+  CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.C
+    PROPERTY name:x visibility:private modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:x type:kotlinx.atomicfu.AtomicLong visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Long): kotlinx.atomicfu.AtomicLong declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicLong origin=null
+            ARG initial: CONST Long type=kotlin.Long value=42
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-x> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicLong [companion]
+        correspondingProperty: PROPERTY name:x visibility:private modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='private final fun <get-x> (): kotlinx.atomicfu.AtomicLong declared in <root>.C'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlinx.atomicfu.AtomicLong visibility:private [final,static]' type=kotlinx.atomicfu.AtomicLong origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.C [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:test visibility:public modality:FINAL returnType:kotlin.Long [companion]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun test (): kotlin.Long declared in <root>.C'
+          CALL 'private final fun inc (<this>: kotlinx.atomicfu.AtomicLong): kotlin.Long declared in <root>' type=kotlin.Long origin=null
+            ARG <this>: CALL 'private final fun <get-x> (): kotlinx.atomicfu.AtomicLong declared in <root>.C' type=kotlinx.atomicfu.AtomicLong origin=GET_PROPERTY
+  FUN name:aInc visibility:private modality:FINAL returnType:kotlin.Long
+    companionExtension: CLASS CLASS name:C modality:FINAL visibility:public superTypes:[kotlin.Any]
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun aInc (): kotlin.Long declared in <root>'
+        CALL 'public final fun incrementAndGet (): kotlin.Long declared in kotlinx.atomicfu.AtomicLong' type=kotlin.Long origin=null
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicLong declared in <root>' type=kotlinx.atomicfu.AtomicLong origin=GET_PROPERTY
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Long
+        ARG a: CONST Long type=kotlin.Long value=1
+        ARG b: CALL 'private final fun inc (<this>: kotlinx.atomicfu.AtomicLong): kotlin.Long declared in <root>' type=kotlin.Long origin=null
+          ARG <this>: CALL 'private final fun <get-a> (): kotlinx.atomicfu.AtomicLong declared in <root>' type=kotlinx.atomicfu.AtomicLong origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Long
+        ARG a: CONST Long type=kotlin.Long value=43
+        ARG b: CALL 'public final fun test (): kotlin.Long declared in <root>.C' type=kotlin.Long origin=null
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Long
+        ARG a: CONST Long type=kotlin.Long value=2
+        ARG b: CALL 'private final fun aInc (): kotlin.Long declared in <root>' type=kotlin.Long origin=null
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Long
+        ARG a: CONST Long type=kotlin.Long value=1
+        ARG b: CALL 'private final fun inc (<this>: kotlinx.atomicfu.AtomicLong): kotlin.Long declared in <root>' type=kotlin.Long origin=null
+          ARG <this>: CALL 'public final fun get (index: kotlin.Int): kotlinx.atomicfu.AtomicLong declared in kotlinx.atomicfu.AtomicLongArray' type=kotlinx.atomicfu.AtomicLong origin=GET_ARRAY_ELEMENT
+            ARG <this>: CALL 'private final fun <get-arr> (): kotlinx.atomicfu.AtomicLongArray declared in <root>' type=kotlinx.atomicfu.AtomicLongArray origin=GET_PROPERTY
+            ARG index: CONST Int type=kotlin.Int value=0
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+  FUN name:inc visibility:private modality:FINAL returnType:kotlin.Long [inline]
+    VALUE_PARAMETER kind:ExtensionReceiver name:<this> index:0 type:kotlinx.atomicfu.AtomicLong
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='private final fun inc (<this>: kotlinx.atomicfu.AtomicLong): kotlin.Long declared in <root>'
+        CALL 'public final fun incrementAndGet (): kotlin.Long declared in kotlinx.atomicfu.AtomicLong' type=kotlin.Long origin=null
+          ARG <this>: GET_VAR '<this>: kotlinx.atomicfu.AtomicLong declared in <root>.inc' type=kotlinx.atomicfu.AtomicLong origin=null

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +CompanionBlocks +CompanionExtensions
-// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/CompanionFunctions.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocks +CompanionExtensions
-// TARGET_BACKEND: JVM_IR
+// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.accessors.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.accessors.txt
@@ -1,0 +1,1 @@
+/* empty dump */

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.ir.txt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.ir.txt
@@ -1,0 +1,210 @@
+FILE fqName:<root> fileName:/DelegatedCompanionProperties.kt
+  PROPERTY name:tA visibility:private modality:FINAL [val]
+    FIELD PROPERTY_BACKING_FIELD name:tA type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+          ARG initial: CONST Int type=kotlin.Int value=0
+    FUN DEFAULT_PROPERTY_ACCESSOR name:<get-tA> visibility:private modality:FINAL returnType:kotlinx.atomicfu.AtomicInt
+      correspondingProperty: PROPERTY name:tA visibility:private modality:FINAL [val]
+      companionExtension: CLASS CLASS name:DelegatedProperties modality:FINAL visibility:private superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-tA> (): kotlinx.atomicfu.AtomicInt declared in <root>'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:tA type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]' type=kotlinx.atomicfu.AtomicInt origin=null
+  PROPERTY name:tdA visibility:private modality:FINAL [delegated,var]
+    FIELD PROPERTY_DELEGATE name:tdA$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'private final fun <get-tA> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+    FUN DELEGATED_PROPERTY_ACCESSOR name:<get-tdA> visibility:private modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:tdA visibility:private modality:FINAL [delegated,var]
+      companionExtension: CLASS CLASS name:DelegatedProperties modality:FINAL visibility:private superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-tdA> (): kotlin.Int declared in <root>'
+          CALL 'public final fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:tdA$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+            ARG property: PROPERTY_REFERENCE 'private final tdA: kotlin.Int declared in <root>' field=null getter='private final fun <get-tdA> (): kotlin.Int declared in <root>' setter='private final fun <set-tdA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+    FUN DELEGATED_PROPERTY_ACCESSOR name:<set-tdA> visibility:private modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:tdA visibility:private modality:FINAL [delegated,var]
+      companionExtension: CLASS CLASS name:DelegatedProperties modality:FINAL visibility:private superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <set-tdA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>'
+          CALL 'public final fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: kotlin.Int): kotlin.Unit declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Unit origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:tdA$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+            ARG property: PROPERTY_REFERENCE 'private final tdA: kotlin.Int declared in <root>' field=null getter='private final fun <get-tdA> (): kotlin.Int declared in <root>' setter='private final fun <set-tdA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+            ARG value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-tdA>' type=kotlin.Int origin=null
+  PROPERTY name:tD visibility:private modality:FINAL [delegated,var]
+    FIELD PROPERTY_DELEGATE name:tD$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+      EXPRESSION_BODY
+        CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+          ARG initial: CONST Int type=kotlin.Int value=0
+    FUN DELEGATED_PROPERTY_ACCESSOR name:<get-tD> visibility:private modality:FINAL returnType:kotlin.Int
+      correspondingProperty: PROPERTY name:tD visibility:private modality:FINAL [delegated,var]
+      companionExtension: CLASS CLASS name:DelegatedProperties modality:FINAL visibility:private superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <get-tD> (): kotlin.Int declared in <root>'
+          CALL 'public final fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:tD$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+            ARG property: PROPERTY_REFERENCE 'private final tD: kotlin.Int declared in <root>' field=null getter='private final fun <get-tD> (): kotlin.Int declared in <root>' setter='private final fun <set-tD> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+    FUN DELEGATED_PROPERTY_ACCESSOR name:<set-tD> visibility:private modality:FINAL returnType:kotlin.Unit
+      VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+      correspondingProperty: PROPERTY name:tD visibility:private modality:FINAL [delegated,var]
+      companionExtension: CLASS CLASS name:DelegatedProperties modality:FINAL visibility:private superTypes:[kotlin.Any]
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='private final fun <set-tD> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>'
+          CALL 'public final fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: kotlin.Int): kotlin.Unit declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Unit origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:tD$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+            ARG property: PROPERTY_REFERENCE 'private final tD: kotlin.Int declared in <root>' field=null getter='private final fun <get-tD> (): kotlin.Int declared in <root>' setter='private final fun <set-tD> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+            ARG value: GET_VAR '<set-?>: kotlin.Int declared in <root>.<set-tD>' type=kotlin.Int origin=null
+  CLASS CLASS name:DelegatedProperties modality:FINAL visibility:private superTypes:[kotlin.Any]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.DelegatedProperties
+    PROPERTY name:a visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG initial: CONST Int type=kotlin.Int value=0
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-a> visibility:public modality:FINAL returnType:kotlinx.atomicfu.AtomicInt [companion]
+        correspondingProperty: PROPERTY name:a visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>.DelegatedProperties'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:a type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]' type=kotlinx.atomicfu.AtomicInt origin=null
+    PROPERTY name:dA visibility:public modality:FINAL [delegated,var]
+      FIELD PROPERTY_DELEGATE name:dA$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>.DelegatedProperties' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<get-dA> visibility:public modality:FINAL returnType:kotlin.Int [companion]
+        correspondingProperty: PROPERTY name:dA visibility:public modality:FINAL [delegated,var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-dA> (): kotlin.Int declared in <root>.DelegatedProperties'
+            CALL 'public final fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:dA$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>.DelegatedProperties' type=kotlinx.atomicfu.AtomicInt origin=null
+              ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+              ARG property: PROPERTY_REFERENCE 'public final dA: kotlin.Int declared in <root>.DelegatedProperties' field=null getter='public final fun <get-dA> (): kotlin.Int declared in <root>.DelegatedProperties' setter='public final fun <set-dA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<set-dA> visibility:public modality:FINAL returnType:kotlin.Unit [companion]
+        VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+        correspondingProperty: PROPERTY name:dA visibility:public modality:FINAL [delegated,var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <set-dA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties'
+            CALL 'public final fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: kotlin.Int): kotlin.Unit declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Unit origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:dA$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>.DelegatedProperties' type=kotlinx.atomicfu.AtomicInt origin=null
+              ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+              ARG property: PROPERTY_REFERENCE 'public final dA: kotlin.Int declared in <root>.DelegatedProperties' field=null getter='public final fun <get-dA> (): kotlin.Int declared in <root>.DelegatedProperties' setter='public final fun <set-dA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+              ARG value: GET_VAR '<set-?>: kotlin.Int declared in <root>.DelegatedProperties.<set-dA>' type=kotlin.Int origin=null
+    PROPERTY name:d visibility:public modality:FINAL [delegated,var]
+      FIELD PROPERTY_DELEGATE name:d$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static]
+        EXPRESSION_BODY
+          CALL 'public final fun atomic (initial: kotlin.Int): kotlinx.atomicfu.AtomicInt declared in kotlinx.atomicfu' type=kotlinx.atomicfu.AtomicInt origin=null
+            ARG initial: CONST Int type=kotlin.Int value=0
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<get-d> visibility:public modality:FINAL returnType:kotlin.Int [companion]
+        correspondingProperty: PROPERTY name:d visibility:public modality:FINAL [delegated,var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-d> (): kotlin.Int declared in <root>.DelegatedProperties'
+            CALL 'public final fun getValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:d$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>.DelegatedProperties' type=kotlinx.atomicfu.AtomicInt origin=null
+              ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+              ARG property: PROPERTY_REFERENCE 'public final d: kotlin.Int declared in <root>.DelegatedProperties' field=null getter='public final fun <get-d> (): kotlin.Int declared in <root>.DelegatedProperties' setter='public final fun <set-d> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+      FUN DELEGATED_PROPERTY_ACCESSOR name:<set-d> visibility:public modality:FINAL returnType:kotlin.Unit [companion]
+        VALUE_PARAMETER kind:Regular name:<set-?> index:0 type:kotlin.Int
+        correspondingProperty: PROPERTY name:d visibility:public modality:FINAL [delegated,var]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <set-d> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties'
+            CALL 'public final fun setValue (thisRef: kotlin.Any?, property: kotlin.reflect.KProperty<*>, value: kotlin.Int): kotlin.Unit declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Unit origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_DELEGATE name:d$delegate type:kotlinx.atomicfu.AtomicInt visibility:private [final,static] declared in <root>.DelegatedProperties' type=kotlinx.atomicfu.AtomicInt origin=null
+              ARG thisRef: CONST Null type=kotlin.Nothing? value=null
+              ARG property: PROPERTY_REFERENCE 'public final d: kotlin.Int declared in <root>.DelegatedProperties' field=null getter='public final fun <get-d> (): kotlin.Int declared in <root>.DelegatedProperties' setter='public final fun <set-d> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties' type=kotlin.reflect.KMutableProperty0<kotlin.Int> origin=PROPERTY_REFERENCE_FOR_DELEGATE
+              ARG value: GET_VAR '<set-?>: kotlin.Int declared in <root>.DelegatedProperties.<set-d>' type=kotlin.Int origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.DelegatedProperties [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:DelegatedProperties modality:FINAL visibility:private superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      CALL 'private final fun testDelegates (): kotlin.Unit declared in <root>' type=kotlin.Unit origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"
+  FUN name:testDelegates visibility:private modality:FINAL returnType:kotlin.Unit
+    BLOCK_BODY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=0
+        ARG b: CALL 'public final fun <get-dA> (): kotlin.Int declared in <root>.DelegatedProperties' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'public final fun <set-dA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties' type=kotlin.Unit origin=EQ
+        ARG <set-?>: CONST Int type=kotlin.Int value=2
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=2
+        ARG b: CALL 'public final fun <get-dA> (): kotlin.Int declared in <root>.DelegatedProperties' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=2
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'public final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>.DelegatedProperties' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=3
+        ARG b: CALL 'public final fun incrementAndGet (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+          ARG <this>: CALL 'public final fun <get-a> (): kotlinx.atomicfu.AtomicInt declared in <root>.DelegatedProperties' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=3
+        ARG b: CALL 'public final fun <get-dA> (): kotlin.Int declared in <root>.DelegatedProperties' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=0
+        ARG b: CALL 'public final fun <get-d> (): kotlin.Int declared in <root>.DelegatedProperties' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'public final fun <set-d> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>.DelegatedProperties' type=kotlin.Unit origin=EQ
+        ARG <set-?>: CONST Int type=kotlin.Int value=42
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=42
+        ARG b: CALL 'public final fun <get-d> (): kotlin.Int declared in <root>.DelegatedProperties' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=0
+        ARG b: CALL 'private final fun <get-tdA> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'private final fun <set-tdA> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+        ARG <set-?>: CONST Int type=kotlin.Int value=2
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=2
+        ARG b: CALL 'private final fun <get-tdA> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=2
+        ARG b: CALL 'public final fun <get-value> (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=GET_PROPERTY
+          ARG <this>: CALL 'private final fun <get-tA> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=3
+        ARG b: CALL 'public final fun incrementAndGet (): kotlin.Int declared in kotlinx.atomicfu.AtomicInt' type=kotlin.Int origin=null
+          ARG <this>: CALL 'private final fun <get-tA> (): kotlinx.atomicfu.AtomicInt declared in <root>' type=kotlinx.atomicfu.AtomicInt origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=3
+        ARG b: CALL 'private final fun <get-tdA> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=0
+        ARG b: CALL 'private final fun <get-tD> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY
+      CALL 'private final fun <set-tD> (<set-?>: kotlin.Int): kotlin.Unit declared in <root>' type=kotlin.Unit origin=EQ
+        ARG <set-?>: CONST Int type=kotlin.Int value=42
+      CALL 'public final fun assertEquals <T> (a: T of kotlin.test.assertEquals, b: T of kotlin.test.assertEquals): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Int
+        ARG a: CONST Int type=kotlin.Int value=42
+        ARG b: CALL 'private final fun <get-tD> (): kotlin.Int declared in <root>' type=kotlin.Int origin=GET_PROPERTY

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.kt
@@ -1,5 +1,4 @@
 // LANGUAGE: +CompanionBlocks +CompanionExtensions
-// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*

--- a/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.kt
+++ b/plugins/atomicfu/atomicfu-compiler/testData/box/companion_blocks/DelegatedCompanionProperties.kt
@@ -1,5 +1,5 @@
 // LANGUAGE: +CompanionBlocks +CompanionExtensions
-// TARGET_BACKEND: JVM_IR
+// TARGET_BACKEND: JVM_IR, NATIVE
 
 import kotlinx.atomicfu.*
 import kotlin.test.*


### PR DESCRIPTION
Implemented companion atomics support on Native [KT-87978](https://youtrack.jetbrains.com/issue/KT-87978) and enabled corresponding tests for all targets (so for JS it seems like everything should work out of the box [KT-87984](https://youtrack.jetbrains.com/issue/KT-87984)).