### PR TITLE
[ai] Fix `@get:Option` args in the build script for auto-code-review

### DIFF
--- a/repo/auto-code-review/build.gradle.kts
+++ b/repo/auto-code-review/build.gradle.kts
@@ -42,16 +42,16 @@ sourceSets {
 
 abstract class CodeReviewTask : JavaExec() {
     @get:Option(
-        "base",
-        "The base git revision to compare the sources against. For example, origin/master (default) or HEAD~2"
+        option = "base",
+        description = "The base git revision to compare the sources against. For example, origin/master (default) or HEAD~2"
     )
     @get:Input
     @get:Optional
     abstract val base: Property<String>
 
     @get:Option(
-        "output",
-        "The path to the output Markdown file"
+        option = "output",
+        description = "The path to the output Markdown file"
     )
     @get:OutputFile
     abstract val output: RegularFileProperty


### PR DESCRIPTION
The Gradle build script for repo/auto-code-review defines task options for the `reviewCode` task using `@get:Option`. The annotation has two arguments -- `option` and `description`, and the build script supplied both without specifying argument names.

d488b06 updated Gradle to 9.7.0, and that broke this case incompatibly: before, the first argument was the option, the second one was the description, and now it is the opposite. So, the option description string literal got passed as the option name argument, and that made the value validation fail.

This went unnoticed because the failure happens only when the task receives an option. Which is always the case when running the tool on the CI (see KT-87721).

This commit fixes the problem by specifying the argument names in `@get:Option` in the auto-code-review build script.