### PR TITLE
[K/N][tests] Update tvOS and watchOS simulator device IDs for Xcode 27

### DIFF
--- a/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/XcodeSimulatorExecutor.kt
+++ b/native/executors/src/main/kotlin/org/jetbrains/kotlin/native/executors/XcodeSimulatorExecutor.kt
@@ -14,9 +14,9 @@ import kotlin.jvm.Volatile
 import kotlin.jvm.Synchronized
 
 private fun defaultDeviceId(target: KonanTarget) = when (target.family) {
-    Family.TVOS -> "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-4K"
+    Family.TVOS -> "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K"
     Family.IOS -> "com.apple.CoreSimulator.SimDeviceType.iPhone-14"
-    Family.WATCHOS -> "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-6-40mm"
+    Family.WATCHOS -> "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-10-42mm"
     else -> error("Unexpected simulation target: $target")
 }
 


### PR DESCRIPTION
^KT-88524 Fixed

When running K/N compiler tests on tvOS and watchOS simulators with Xcode 27, they failed with
```text
Runtime is not available for the selected <...>. Check Xcode installation.
sdkVersion = 26.4
```

The reason is that `XcodeSimulatorExecutor`, which handles the execution of compiled binaries on simulators, requires simulators for specific pre-defined device IDs. The ones used for tvOS and watchOS are simply no longer supported in Xcode 27 simulator runtimes. Which is likely related to the fact that the respective real devices don't support tvOS 27 and watchOS 27 either.

To fix the problem, this commit updates the device IDs:
* From Apple TV 4K first generation to third generation.
* From Apple Watch Series 6 to Series 10.

The first one is the newest tvOS device (so we won't need to update the ID for quite some time), but was released in 2022 (so all recent Xcode versions should support it).

The second one is more modern (2024), but it is the second oldest still supported device. We could have used the oldest, but then we'd need to update the ID sooner next time.