### PR TITLE
JVM/Tests: avoid usage of `com.sun.tools.jdi`

### DIFF
--- a/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/DebugRunner.kt
+++ b/compiler/tests-common-new/testFixtures/org/jetbrains/kotlin/test/backend/handlers/DebugRunner.kt
@@ -6,10 +6,10 @@
 package org.jetbrains.kotlin.test.backend.handlers
 
 import com.sun.jdi.*
+import com.sun.jdi.connect.AttachingConnector
 import com.sun.jdi.event.*
 import com.sun.jdi.request.EventRequest.SUSPEND_ALL
 import com.sun.jdi.request.StepRequest
-import com.sun.tools.jdi.SocketAttachingConnector
 import org.jetbrains.kotlin.codegen.inline.SourceMapper
 import org.jetbrains.kotlin.test.TargetBackend
 import org.jetbrains.kotlin.test.model.FrontendKind
@@ -186,7 +186,7 @@ abstract class DebugRunner(testServices: TestServices) : JvmBoxRunner(testServic
     }
 
     private fun attachDebugger(port: Int): VirtualMachine {
-        val connector = SocketAttachingConnector()
+        val connector = getAttachingConnector()
         val virtualMachine = connector.attach(connector.defaultArguments().toMutableMap().apply {
             getValue("port").setValue("$port")
             getValue("hostname").setValue("127.0.0.1")
@@ -261,3 +261,9 @@ class LocalVariableDebugRunner(testServices: TestServices) : DebugRunner(testSer
 
 private fun isIndyLambda(location: Location): Boolean =
     "$\$Lambda$" in location.declaringType().name()
+
+private fun getAttachingConnector(): AttachingConnector =
+    Bootstrap.virtualMachineManager()
+        .attachingConnectors()
+        .firstOrNull { it.name() == "com.sun.jdi.SocketAttach" }
+        ?: error("JDI socket attaching connector is not available")

--- a/dependencies/tools-jar-api/build.gradle.kts
+++ b/dependencies/tools-jar-api/build.gradle.kts
@@ -34,13 +34,6 @@ val toolsJarStubs = tasks.register("toolsJarStubs") {
         "com/sun/tools/javac" // javac is used in KAPT
     )
 
-    val includedNonExportedClasses = listOf(
-        // some jdi classes are used in debugger tests
-        "com/sun/tools/jdi/SocketAttachingConnector",
-        "com/sun/tools/jdi/GenericAttachingConnector",
-        "com/sun/tools/jdi/ConnectorImpl"
-    )
-
     doLast {
         val outputDirectoryFile = outDir.get().asFile
         outputDirectoryFile.deleteRecursively()
@@ -62,9 +55,7 @@ val toolsJarStubs = tasks.register("toolsJarStubs") {
                             interfaces: Array<out String>?
                         ) {
                             val isPublic = access and ACC_PUBLIC != 0
-                            if ((isPublic && includedNonExportedPackages.any { name?.startsWith(it) == true }) ||
-                                name in includedNonExportedClasses
-                            ) {
+                            if (isPublic && includedNonExportedPackages.any { name?.startsWith(it) == true }) {
                                 isExported = true
                             }
 

--- a/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/debug/AbstractDebuggerTest.kt
+++ b/plugins/compose/compiler-hosted/integration-tests/tests/androidx/compose/compiler/plugins/kotlin/debug/AbstractDebuggerTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.compiler.plugins.kotlin.debug.clientserver.TestProxy
 import androidx.compose.compiler.plugins.kotlin.facade.SourceFile
 import com.intellij.util.SystemProperties
 import com.sun.jdi.AbsentInformationException
+import com.sun.jdi.Bootstrap
 import com.sun.jdi.VirtualMachine
 import com.sun.jdi.connect.AttachingConnector
 import com.sun.jdi.event.*
@@ -100,8 +101,7 @@ abstract class AbstractDebuggerTest : AbstractCodegenTest() {
         private const val DEBUG_ADDRESS = "127.0.0.1"
 
         private fun attachDebugger(port: Int): VirtualMachine {
-            val c = Class.forName("com.sun.tools.jdi.SocketAttachingConnector")
-            val connector = c.getDeclaredConstructor().newInstance() as AttachingConnector
+            val connector = getAttachingConnector()
             return connector.attach(
                 connector.defaultArguments().apply {
                     getValue("port").setValue("$port")
@@ -320,3 +320,9 @@ private val RUNNER_SOURCES = """
                 override fun clear() {}
             }
 """.trimIndent()
+
+private fun getAttachingConnector(): AttachingConnector =
+    Bootstrap.virtualMachineManager()
+        .attachingConnectors()
+        .firstOrNull { it.name() == "com.sun.jdi.SocketAttach" }
+        ?: error("JDI socket attaching connector is not available")


### PR DESCRIPTION
Use non-internal API instead. `FirSteppingTestWithInlineScopesGenerated` was failing on JDK 17.

^KT-88173