### PR TITLE
Strip LocalVariableTable from the distribution to reduce its size

### DIFF
--- a/prepare/compiler/compiler.pro
+++ b/prepare/compiler/compiler.pro
@@ -121,7 +121,11 @@
 -dontprocesskotlinmetadata
 -keep class kotlin.Metadata
 -dontoptimize
--dontobfuscate
+
+# same as -dontobfuscate, but allows to filter attributes
+-keepnames class ** { *; }
+# strip local variable names to reduce distribution size
+-keepattributes !LocalVariableTable,!LocalVariableTypeTable,*
 
 -keep class org.fusesource.** { *; }
 -keep class com.sun.jna.** { *; }


### PR DESCRIPTION
This PR strips LocalVariableTable from the release distribution for both kotlin-compiler and kotlin-compiler-embeddable. IIUC, this table is only useful during debugging, and dev builds are not affected by this change since ProGuard is only applied for release (TeamCity) builds.

Removing it reduces the size of kotlin-compiler-embeddable by ~9%: from 56.25 Mb to 50.65 Mb.

Context:
I'm currently investigating ways to reduce the size of the Gradle distribution.

kotlin-compiler-embeddable is the largest entry shipped with it. 